### PR TITLE
Resolves #1902 Different upstreams use different discovery and customize the discovery schema

### DIFF
--- a/apisix/balancer.lua
+++ b/apisix/balancer.lua
@@ -156,11 +156,26 @@ local function pick_server(route, ctx)
     core.log.info("route: ", core.json.delay_encode(route, true))
     core.log.info("ctx: ", core.json.delay_encode(ctx, true))
     local up_conf = ctx.upstream_conf
+
+    -- adapt to old business
     if up_conf.service_name then
-        if not discovery then
+        local dis = discovery.eureka
+        if not dis then
             return nil, "discovery is uninitialized"
         end
-        up_conf.nodes = discovery.nodes(up_conf.service_name)
+        up_conf.nodes = dis.nodes(up_conf)
+    end
+
+    if up_conf.type == "discovery" then
+        if not up_conf.discovery_type then
+            return nil, "discovery server need appoint"
+        end
+
+        local dis = discovery[up_conf.discovery_type]
+        if not dis then
+            return nil, "discovery is uninitialized"
+        end
+        up_conf.nodes = dis.nodes(up_conf)
     end
 
     local nodes_count = up_conf.nodes and #up_conf.nodes or 0

--- a/apisix/discovery/eureka.lua
+++ b/apisix/discovery/eureka.lua
@@ -220,13 +220,18 @@ local function fetch_full_registry(premature)
 end
 
 
-function _M.nodes(service_name)
-    if not applications then
-        log.error("failed to fetch nodes for : ", service_name)
+function _M.nodes(up_conf)
+
+    if not up_conf.service_name then
         return
     end
 
-    return applications[service_name]
+    if not applications then
+        log.error("failed to fetch nodes for : ", up_conf.service_name)
+        return
+    end
+
+    return applications[up_conf.service_name]
 end
 
 

--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -14,6 +14,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 --
+local discovery = require('apisix.discovery').discovery
 local schema    = require('apisix.core.schema')
 local setmetatable = setmetatable
 local error     = error
@@ -306,7 +307,7 @@ local upstream_schema = {
         type = {
             description = "algorithms of load balancing",
             type = "string",
-            enum = {"chash", "roundrobin"}
+            enum = {"chash", "roundrobin","discovery"}
         },
         checks = health_checker,
         hash_on = {
@@ -327,6 +328,10 @@ local upstream_schema = {
             description = "enable websocket for request",
             type        = "boolean"
         },
+        discovery_type = {
+            description = "discovery type",
+            type = "string",
+        },
         name = {type = "string", maxLength = 50},
         desc = {type = "string", maxLength = 256},
         service_name = {type = "string", maxLength = 50},
@@ -336,9 +341,16 @@ local upstream_schema = {
         {required = {"type", "nodes"}},
         {required = {"type", "k8s_deployment_info"}},
         {required = {"type", "service_name"}},
+        {required = {"type", "discovery_type"}},
     },
     additionalProperties = false,
 }
+
+if discovery and discovery.schema then
+    for name, v in pairs(discovery.schema) do
+        upstream_schema.properties[name] = v
+    end
+end
 
 -- TODO: add more nginx variable support
 _M.upstream_hash_vars_schema = {

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -99,7 +99,10 @@ apisix:
     key_encrypt_salt: "edd1c9f0985e76a2"    #  If not set, will save origin ssl key into etcd.
                                             #  If set this, must be a string of length 16. And it will encrypt ssl key with AES-128-CBC
                                             #  !!! So do not change it after saving your ssl, it can't decrypt the ssl keys have be saved if you change !!
-#  discovery: eureka               # service discovery center
+  # discovery:
+    # - eureka
+    # - etcd
+
 nginx_config:                     # config for render the template to genarate nginx.conf
   error_log: "logs/error.log"
   error_log_level: "warn"         # warn,error

--- a/t/discovery/etcd.t
+++ b/t/discovery/etcd.t
@@ -35,6 +35,7 @@ $yaml_config =~ s/node_listen: 9080/node_listen: 1984/;
 $yaml_config =~ s/config_center: etcd/config_center: yaml/;
 $yaml_config =~ s/enable_admin: true/enable_admin: false/;
 $yaml_config =~ s/enable_admin: true/enable_admin: false/;
+$yaml_config =~ s/  discovery:/#  discovery:/;
 $yaml_config =~ s/error_log_level: "warn"/error_log_level: "info"/;
 
 
@@ -52,7 +53,7 @@ __DATA__
     location /t {
         content_by_lua_block {
             local etcd = require('apisix.core.etcd')
-            etcd.set(discovery_key, { test_service_name = { host = "127.0.0.1", port = 9080} })
+            etcd.set("service_dicovery", { test_service_name = { host = "127.0.0.1", port = 9080} })
         }
     }
 --- request

--- a/t/discovery/etcd.t
+++ b/t/discovery/etcd.t
@@ -1,0 +1,110 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+log_level('info');
+no_root_location();
+no_shuffle();
+
+sub read_file($) {
+    my $infile = shift;
+    open my $in, $infile
+        or die "cannot open $infile for reading: $!";
+    my $cert = do { local $/; <$in> };
+    close $in;
+    $cert;
+}
+
+our $yaml_config = read_file("conf/config.yaml");
+$yaml_config =~ s/node_listen: 9080/node_listen: 1984/;
+$yaml_config =~ s/config_center: etcd/config_center: yaml/;
+$yaml_config =~ s/enable_admin: true/enable_admin: false/;
+$yaml_config =~ s/enable_admin: true/enable_admin: false/;
+$yaml_config =~ s/error_log_level: "warn"/error_log_level: "info"/;
+
+
+$yaml_config .= <<_EOC_;
+discovery:
+  - etcd
+_EOC_
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: set test data
+--- config
+    location /t {
+        content_by_lua_block {
+            local etcd = require('apisix.core.etcd')
+            etcd.set(discovery_key, { test_service_name = { host = "127.0.0.1", port = 9080} })
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+--- no_error_log
+[error]
+
+
+=== TEST 2: add rount
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "upstream": {
+                        "discovery_type": "etcd",
+                        "etcd": {
+                            "service_name": "test_service_name"
+                        },
+                        "type": "discovery"
+                    },
+                    "uri": "/test_etcd"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: access
+--- request
+GET /test_etcd
+--- response_body chomp
+{"error_msg":"failed to match any routes"}
+--- no_error_log
+[error]
+--- wait: 0.2
+
+
+


### PR DESCRIPTION
### What this PR does / why we need it:
1. Now discovery can only use one of them at the same time
2. Parameter can only use ‘service_ name’, this does not fit all service discovery

Fix #1902

### Pre-submission checklist:

- modify schema_ def.lua to load it into the discovery schema to adapt to the customized parameters of different discovery.
- modify config.yaml Type of file discovery (changed to list)
- modify the balancer.lua to get IP according to the specified discovery
- modify discovery/init.lua, load them in the discovery resgistered in the config.yaml
