### PR TITLE
fixed deps check openresty-debug to openresty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ LUAROCKS_VER ?= $(shell luarocks --version | grep -E -o  "luarocks [0-9]+.")
 .PHONY: default
 default:
 ifeq ($(OR_EXEC), )
-ifeq ("$(wildcard /usr/local/openresty-debug/bin/openresty)", "")
+ifeq ("$(wildcard /usr/local/openresty/bin/openresty)", "")
 	@echo "ERROR: OpenResty not found. You have to install OpenResty and add the binary file to PATH before install Apache APISIX."
 	exit 1
 endif


### PR DESCRIPTION
### What this PR does / why we need it:

源码编译安装时，make deps依赖openresty-debug，找不到debug。

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible?
