### PR TITLE
feature: accept ":" in id (#1955)

### DIFF
--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -30,7 +30,7 @@ local id_schema = {
     anyOf = {
         {
             type = "string", minLength = 1, maxLength = 64,
-            pattern = [[^[a-zA-Z0-9-_]+$]]
+            pattern = [[^[a-zA-Z0-9-_:]+$]]
         },
         {type = "integer", minimum = 1}
     }


### PR DESCRIPTION
### What this PR does / why we need it:
Sometimes we might hope the id in the following format: 
- upstream:payment:project_a
- upstream:message_system:project_b
etc.

fix #1955