### PR TITLE
add apisix-version info to headers

### DIFF
--- a/apisix/core/response.lua
+++ b/apisix/core/response.lua
@@ -100,6 +100,7 @@ function _M.set_header(...)
         for k, v in pairs(headers) do
             ngx_header[k] = v
         end
+        ngx_header['server'] = ("APISIX/" .. core.version)
 
         return
     end
@@ -107,6 +108,8 @@ function _M.set_header(...)
     for i = 1, count, 2 do
         ngx_header[select(i, ...)] = select(i + 1, ...)
     end
+    ngx_header['server'] = ("APISIX/" .. core.version)
+
 end
 
 

--- a/apisix/core/response.lua
+++ b/apisix/core/response.lua
@@ -100,7 +100,6 @@ function _M.set_header(...)
         for k, v in pairs(headers) do
             ngx_header[k] = v
         end
-        ngx_header['server'] = ("APISIX/" .. core.version)
 
         return
     end
@@ -108,8 +107,6 @@ function _M.set_header(...)
     for i = 1, count, 2 do
         ngx_header[select(i, ...)] = select(i + 1, ...)
     end
-    ngx_header['server'] = ("APISIX/" .. core.version)
-
 end
 
 

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -22,7 +22,7 @@ local service_fetch = require("apisix.http.service").get
 local admin_init    = require("apisix.admin.init")
 local get_var       = require("resty.ngxvar").fetch
 local router        = require("apisix.router")
-local set_upstream = require("apisix.upstream").set_by_route
+local set_upstream  = require("apisix.upstream").set_by_route
 local ipmatcher     = require("resty.ipmatcher")
 local ngx           = ngx
 local get_method    = ngx.req.get_method
@@ -39,6 +39,7 @@ local load_balancer
 local local_conf
 local dns_resolver
 local lru_resolved_domain
+local ver_header    = "APISIX/" .. core.version.VERSION
 
 
 local function parse_args(args)
@@ -298,6 +299,8 @@ function _M.http_access_phase()
     end
 
     core.ctx.set_vars_meta(api_ctx)
+
+    core.response.set_header("server", ver_header)
 
     -- load and run global rule
     if router.global_rules and router.global_rules.values

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -300,7 +300,7 @@ function _M.http_access_phase()
 
     core.ctx.set_vars_meta(api_ctx)
 
-    core.response.set_header("server", ver_header)
+    core.response.set_header("Server", ver_header)
 
     -- load and run global rule
     if router.global_rules and router.global_rules.values

--- a/t/node/remote-addr-ipv6.t
+++ b/t/node/remote-addr-ipv6.t
@@ -114,7 +114,7 @@ request sent: 59
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/(\d+)\.(\d+)\.(\d+)
+received: Server: APISIX/([\d\.]+)(\d)$
 received: Server: \w+
 received: 
 received: hello world

--- a/t/node/remote-addr-ipv6.t
+++ b/t/node/remote-addr-ipv6.t
@@ -114,6 +114,7 @@ request sent: 59
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
+received: Server: APISIX/1.4.1
 received: Server: \w+
 received: 
 received: hello world

--- a/t/node/remote-addr-ipv6.t
+++ b/t/node/remote-addr-ipv6.t
@@ -114,7 +114,7 @@ request sent: 59
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/1.4.1
+received: Server: APISIX/(\d+)\.(\d+)\.(\d+)
 received: Server: \w+
 received: 
 received: hello world

--- a/t/node/remote-addr-ipv6.t
+++ b/t/node/remote-addr-ipv6.t
@@ -114,7 +114,7 @@ request sent: 59
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/\d\.\d+(\.\d+)?$
+received: Server: APISIX/\d\.\d+(\.\d+)?
 received: Server: \w+
 received: 
 received: hello world

--- a/t/node/remote-addr-ipv6.t
+++ b/t/node/remote-addr-ipv6.t
@@ -114,7 +114,7 @@ request sent: 59
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/([\d\.]+)(\d)$
+received: Server: APISIX/\d\.\d+(\.\d+)?$
 received: Server: \w+
 received: 
 received: hello world

--- a/t/plugin/redirect.t
+++ b/t/plugin/redirect.t
@@ -669,7 +669,7 @@ sent http request: 58 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/1.4.1
+received: Server: APISIX/(\d+)\.(\d+)\.(\d+)
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}

--- a/t/plugin/redirect.t
+++ b/t/plugin/redirect.t
@@ -669,7 +669,7 @@ sent http request: 58 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/([\d\.]+)(\d)$
+received: Server: APISIX/\d\.\d+(\.\d+)?$
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}

--- a/t/plugin/redirect.t
+++ b/t/plugin/redirect.t
@@ -669,7 +669,7 @@ sent http request: 58 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/(\d+)\.(\d+)\.(\d+)
+received: Server: APISIX/([\d\.]+)(\d)$
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}

--- a/t/plugin/redirect.t
+++ b/t/plugin/redirect.t
@@ -669,6 +669,7 @@ sent http request: 58 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
+received: Server: APISIX/1.4.1
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}

--- a/t/plugin/redirect.t
+++ b/t/plugin/redirect.t
@@ -669,7 +669,7 @@ sent http request: 58 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/\d\.\d+(\.\d+)?$
+received: Server: APISIX/\d\.\d+(\.\d+)?
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}

--- a/t/router/multi-ssl-certs.t
+++ b/t/router/multi-ssl-certs.t
@@ -160,7 +160,7 @@ sent http request: 62 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/\d\.\d+(\.\d+)?$
+received: Server: APISIX/\d\.\d+(\.\d+)?
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}

--- a/t/router/multi-ssl-certs.t
+++ b/t/router/multi-ssl-certs.t
@@ -160,7 +160,7 @@ sent http request: 62 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/1.4.1
+received: Server: APISIX/(\d+)\.(\d+)\.(\d+)
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}

--- a/t/router/multi-ssl-certs.t
+++ b/t/router/multi-ssl-certs.t
@@ -160,7 +160,7 @@ sent http request: 62 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/(\d+)\.(\d+)\.(\d+)
+received: Server: APISIX/([\d\.]+)(\d)$
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}

--- a/t/router/multi-ssl-certs.t
+++ b/t/router/multi-ssl-certs.t
@@ -160,6 +160,7 @@ sent http request: 62 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
+received: Server: APISIX/1.4.1
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}

--- a/t/router/multi-ssl-certs.t
+++ b/t/router/multi-ssl-certs.t
@@ -160,7 +160,7 @@ sent http request: 62 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/([\d\.]+)(\d)$
+received: Server: APISIX/\d\.\d+(\.\d+)?$
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}

--- a/t/router/radixtree-sni.t
+++ b/t/router/radixtree-sni.t
@@ -160,7 +160,7 @@ sent http request: 62 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/1.4.1
+received: Server: APISIX/(\d+)\.(\d+)\.(\d+)
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}
@@ -314,7 +314,7 @@ sent http request: 62 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/1.4.1
+received: Server: APISIX/(\d+)\.(\d+)\.(\d+)
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}
@@ -428,7 +428,7 @@ sent http request: 58 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/1.4.1
+received: Server: APISIX/(\d+)\.(\d+)\.(\d+)
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}

--- a/t/router/radixtree-sni.t
+++ b/t/router/radixtree-sni.t
@@ -160,6 +160,7 @@ sent http request: 62 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
+received: Server: APISIX/1.4.1
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}
@@ -313,6 +314,7 @@ sent http request: 62 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
+received: Server: APISIX/1.4.1
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}
@@ -426,6 +428,7 @@ sent http request: 58 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
+received: Server: APISIX/1.4.1
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}

--- a/t/router/radixtree-sni.t
+++ b/t/router/radixtree-sni.t
@@ -160,7 +160,7 @@ sent http request: 62 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/(\d+)\.(\d+)\.(\d+)
+received: Server: APISIX/([\d\.]+)(\d)$
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}
@@ -314,7 +314,7 @@ sent http request: 62 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/(\d+)\.(\d+)\.(\d+)
+received: Server: APISIX/([\d\.]+)(\d)$
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}
@@ -428,7 +428,7 @@ sent http request: 58 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/(\d+)\.(\d+)\.(\d+)
+received: Server: APISIX/([\d\.]+)(\d)$
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}

--- a/t/router/radixtree-sni.t
+++ b/t/router/radixtree-sni.t
@@ -160,7 +160,7 @@ sent http request: 62 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/([\d\.]+)(\d)$
+received: Server: APISIX/\d\.\d+(\.\d+)?$
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}
@@ -314,7 +314,7 @@ sent http request: 62 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/([\d\.]+)(\d)$
+received: Server: APISIX/\d\.\d+(\.\d+)?$
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}
@@ -428,7 +428,7 @@ sent http request: 58 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/([\d\.]+)(\d)$
+received: Server: APISIX/\d\.\d+(\.\d+)?$
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}

--- a/t/router/radixtree-sni.t
+++ b/t/router/radixtree-sni.t
@@ -160,7 +160,7 @@ sent http request: 62 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/\d\.\d+(\.\d+)?$
+received: Server: APISIX/\d\.\d+(\.\d+)?
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}
@@ -314,7 +314,7 @@ sent http request: 62 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/\d\.\d+(\.\d+)?$
+received: Server: APISIX/\d\.\d+(\.\d+)?
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}
@@ -428,7 +428,7 @@ sent http request: 58 bytes.
 received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Connection: close
-received: Server: APISIX/\d\.\d+(\.\d+)?$
+received: Server: APISIX/\d\.\d+(\.\d+)?
 received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}


### PR DESCRIPTION
### What this PR does / why we need it:
We should pass the APISIX version in the response headers
fixes : https://github.com/apache/incubator-apisix/issues/1877

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible?
