### PR TITLE
perf: no longer generate unnecessary nginx conf for better performance.

### DIFF
--- a/benchmark/fake-apisix/conf/nginx.conf
+++ b/benchmark/fake-apisix/conf/nginx.conf
@@ -51,7 +51,7 @@ http {
             apisix.http_balancer_phase()
         }
 
-        keepalive 32;
+        keepalive 320;
     }
 
     server {
@@ -100,6 +100,33 @@ http {
             proxy_set_header   X-Real-IP         $remote_addr;
             proxy_pass_header  Server;
             proxy_pass_header  Date;
+
+            ### the following x-forwarded-* headers is to send to upstream server
+
+            set $var_x_forwarded_for        $remote_addr;
+            set $var_x_forwarded_proto      $scheme;
+            set $var_x_forwarded_host       $host;
+            set $var_x_forwarded_port       $server_port;
+
+            if ($http_x_forwarded_for != "") {
+                set $var_x_forwarded_for "${http_x_forwarded_for}, ${realip_remote_addr}";
+            }
+            if ($http_x_forwarded_proto != "") {
+                set $var_x_forwarded_proto $http_x_forwarded_proto;
+            }
+            if ($http_x_forwarded_host != "") {
+                set $var_x_forwarded_host $http_x_forwarded_host;
+            }
+            if ($http_x_forwarded_port != "") {
+                set $var_x_forwarded_port $http_x_forwarded_port;
+            }
+
+            proxy_set_header   X-Forwarded-For      $var_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto    $var_x_forwarded_proto;
+            proxy_set_header   X-Forwarded-Host     $var_x_forwarded_host;
+            proxy_set_header   X-Forwarded-Port     $var_x_forwarded_port;
+
+            # proxy pass
             proxy_pass         $upstream_scheme://apisix_backend$upstream_uri;
 
             header_filter_by_lua_block {

--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -28,6 +28,8 @@ mkdir -p benchmark/fake-apisix/logs
 
 sudo openresty -p $PWD/benchmark/server || exit 1
 
+make init
+
 trap 'onCtrlC' INT
 function onCtrlC () {
     sudo killall wrk
@@ -57,7 +59,7 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
     "upstream": {
         "type": "roundrobin",
         "nodes": {
-            "127.0.0.1:80": 1
+            "127.0.0.1:1980": 1
         }
     }
 }'
@@ -90,7 +92,7 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
     "upstream": {
         "type": "roundrobin",
         "nodes": {
-            "127.0.0.1:80": 1
+            "127.0.0.1:1980": 1
         }
     }
 }'

--- a/benchmark/server/conf/nginx.conf
+++ b/benchmark/server/conf/nginx.conf
@@ -32,7 +32,7 @@ worker_shutdown_timeout 3;
 
 http {
     server {
-        listen 80;
+        listen 1980;
 
         access_log off;
         location = /hello {

--- a/bin/apisix
+++ b/bin/apisix
@@ -194,14 +194,14 @@ http {
     {% end %}
     {% end %}
 
-    {% if proxy_cache then %}
+    {% if enabled_plugins["proxy-cache"] then %}
     # for proxy cache
     {% for _, cache in ipairs(proxy_cache.zones) do %}
     proxy_cache_path {* cache.disk_path *} levels={* cache.cache_levels *} keys_zone={* cache.name *}:{* cache.memory_size *} inactive=1d max_size={* cache.disk_size *};
     {% end %}
     {% end %}
 
-    {% if proxy_cache then %}
+    {% if enabled_plugins["proxy-cache"] then %}
     # for proxy cache
     map $upstream_cache_zone $upstream_cache_zone_info {
     {% for _, cache in ipairs(proxy_cache.zones) do %}
@@ -459,7 +459,7 @@ http {
             proxy_set_header   X-Forwarded-Host     $var_x_forwarded_host;
             proxy_set_header   X-Forwarded-Port     $var_x_forwarded_port;
 
-            {% if proxy_cache then %}
+            {% if enabled_plugins["proxy-cache"] then %}
             ###  the following configuration is to cache response content from upstream server
 
             set $upstream_cache_zone            off;
@@ -487,7 +487,10 @@ http {
             {% end %}
 
             proxy_pass      $upstream_scheme://apisix_backend$upstream_uri;
+
+            {% if enabled_plugins["proxy-mirror"] then %}
             mirror          /proxy_mirror;
+            {% end %}
 
             header_filter_by_lua_block {
                 apisix.http_header_filter_phase()
@@ -525,6 +528,7 @@ http {
             }
         }
 
+        {% if enabled_plugins["proxy-mirror"] then %}
         location = /proxy_mirror {
             internal;
 
@@ -534,6 +538,7 @@ http {
 
             proxy_pass $upstream_mirror_host$request_uri;
         }
+        {% end %}
     }
 }
 ]=]
@@ -686,6 +691,15 @@ local function init()
         with_module_status = false
     end
 
+    local enabled_plugins = {}
+    for i, name in ipairs(yaml_conf.plugins) do
+        enabled_plugins[name] = true
+    end
+
+    if enabled_plugins["proxy-cache"] and not yaml_conf.apisix.proxy_cache then
+        error("missing apisix.proxy_cache for plugin proxy-cache")
+    end
+
     -- Using template.render
     local sys_conf = {
         lua_path = pkg_path_org,
@@ -694,6 +708,7 @@ local function init()
         apisix_lua_home = apisix_home,
         with_module_status = with_module_status,
         error_log = {level = "warn"},
+        enabled_plugins = enabled_plugins,
     }
 
     if not yaml_conf.apisix then

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -142,8 +142,6 @@ etcd:
 #    read: 5000                    # default 5000ms
 
 plugins:                          # plugin list
-  # - proxy-cache
-  # - proxy-mirror
   - example-plugin
   - limit-req
   - limit-count
@@ -177,6 +175,8 @@ plugins:                          # plugin list
   - authz-keycloak
   - uri-blocker
   - request-validation
+  # - proxy-cache
+  # - proxy-mirror
 
 stream_plugins:
   - mqtt-proxy

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -142,6 +142,8 @@ etcd:
 #    read: 5000                    # default 5000ms
 
 plugins:                          # plugin list
+  # - proxy-cache
+  # - proxy-mirror
   - example-plugin
   - limit-req
   - limit-count
@@ -163,9 +165,7 @@ plugins:                          # plugin list
   - fault-injection
   - udp-logger
   - wolf-rbac
-  - proxy-cache
   - tcp-logger
-  - proxy-mirror
   - kafka-logger
   - cors
   - consumer-restriction

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -76,6 +76,7 @@ my $test2_crt = read_file("conf/cert/test2.crt");
 my $test2_key = read_file("conf/cert/test2.key");
 $yaml_config =~ s/node_listen: 9080/node_listen: 1984/;
 $yaml_config =~ s/  # stream_proxy:/  stream_proxy:\n    tcp:\n      - 9100/;
+$yaml_config =~ s/admin_key:/disable_admin_key:/;
 $yaml_config =~ s/  # - proxy-cache/  - proxy-cache/;
 $yaml_config =~ s/  # - proxy-mirror/  - proxy-mirror/;
 

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -76,7 +76,8 @@ my $test2_crt = read_file("conf/cert/test2.crt");
 my $test2_key = read_file("conf/cert/test2.key");
 $yaml_config =~ s/node_listen: 9080/node_listen: 1984/;
 $yaml_config =~ s/  # stream_proxy:/  stream_proxy:\n    tcp:\n      - 9100/;
-$yaml_config =~ s/admin_key:/disable_admin_key:/;
+$yaml_config =~ s/  # - proxy-cache/  - proxy-cache/;
+$yaml_config =~ s/  # - proxy-mirror/  - proxy-mirror/;
 
 my $etcd_enable_auth = $ENV{"ETCD_ENABLE_AUTH"} || "false";
 

--- a/t/debug/debug-mode.t
+++ b/t/debug/debug-mode.t
@@ -32,6 +32,8 @@ sub read_file($) {
 our $yaml_config = read_file("conf/config.yaml");
 $yaml_config =~ s/node_listen: 9080/node_listen: 1984/;
 $yaml_config =~ s/enable_debug: false/enable_debug: true/;
+$yaml_config =~ s/  # - proxy-cache/  - proxy-cache/;
+$yaml_config =~ s/  # - proxy-mirror/  - proxy-mirror/;
 
 
 run_tests;


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

as title.

Single-core QPS increased from 20118.64 to 22448.23, an increase of about 12%.
And the QPS of this version is 89% of [fake apisix](https://github.com/apache/apisix/tree/master/benchmark/fake-apisix).

![image](https://user-images.githubusercontent.com/6814606/89114996-47621200-d4b5-11ea-9c72-ca5bd737c98a.png)


### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [ ] Is this PR backward compatible?
  disable two plugins by default(proxy-cache, proxy-mirror), if the user wants to enable them, need to modify the `conf/config.yaml` by manual. 
