### PR TITLE
revert: enable proxy-cache and proxy-mirror plugins by default.

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -175,8 +175,8 @@ plugins:                          # plugin list
   - authz-keycloak
   - uri-blocker
   - request-validation
-  # - proxy-cache
-  # - proxy-mirror
+  - proxy-cache
+  - proxy-mirror
 
 stream_plugins:
   - mqtt-proxy

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -77,8 +77,6 @@ my $test2_key = read_file("conf/cert/test2.key");
 $yaml_config =~ s/node_listen: 9080/node_listen: 1984/;
 $yaml_config =~ s/  # stream_proxy:/  stream_proxy:\n    tcp:\n      - 9100/;
 $yaml_config =~ s/admin_key:/disable_admin_key:/;
-$yaml_config =~ s/  # - proxy-cache/  - proxy-cache/;
-$yaml_config =~ s/  # - proxy-mirror/  - proxy-mirror/;
 
 my $etcd_enable_auth = $ENV{"ETCD_ENABLE_AUTH"} || "false";
 

--- a/t/debug/debug-mode.t
+++ b/t/debug/debug-mode.t
@@ -32,9 +32,6 @@ sub read_file($) {
 our $yaml_config = read_file("conf/config.yaml");
 $yaml_config =~ s/node_listen: 9080/node_listen: 1984/;
 $yaml_config =~ s/enable_debug: false/enable_debug: true/;
-$yaml_config =~ s/  # - proxy-cache/  - proxy-cache/;
-$yaml_config =~ s/  # - proxy-mirror/  - proxy-mirror/;
-
 
 run_tests;
 


### PR DESCRIPTION
### What this PR does / why we need it:
enable proxy-cache and proxy-mirror by default.

resolve  #1987
