### PR TITLE
Correct directory after cloning repo

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -46,13 +46,13 @@ Let's deconstruct the above URL.
 ## Step 1: Install APISIX
 
 APISIX is available to install in multiple operating environments. The [following document](how-to-build.md#installation-via-source-release) shows the installation steps in multiple platforms.
-For the quick start let's use the docker based set up. To start the APISIX server, clone the following [repository](https://github.com/apache/incubator-apisix-docker) and navigate to the example folder and execute the following commands.
+For the quick start let's use the docker based set up. To start the APISIX server, clone the following [repository](https://github.com/apache/apisix-docker) and navigate to the example folder and execute the following commands.
 
 This command will start the APISIX server and the admin API will be available in 9080 port (HTTPS port: 9443).
 
 ```bash
-$ git clone https://github.com/apache/incubator-apisix-docker.git
-$ cd example
+$ git clone https://github.com/apache/apisix-docker.git
+$ cd apisix-docker/example
 $ docker-compose -p docker-apisix up -d
 ```
 
@@ -79,7 +79,7 @@ The following will be the response from the Admin API.
 
 ## Step 2: Create a Route in APISIX
 
-APISIX provides a powerful Admin API and a [dashboard](https://github.com/apache/incubator-apisix-dashboard) for configuring the routes/services/plugins.
+APISIX provides a powerful Admin API and a [dashboard](https://github.com/apache/apisix-dashboard) for configuring the routes/services/plugins.
 The quickstart guide will use the Admin API for configuring the routes.
 
 A micro-service can be configured via APISIX through the relationship between several entities such as routes, services, upstream, and plugins.
@@ -244,7 +244,7 @@ curl -i -X GET http://127.0.0.1:9080/samplePrefix/get?param1=foo&param2=bar -H '
 
 As of now the API calls to the APISIX has been orchestrated by using the Admin API. However, APISIX also provides
 a web application to perform the similar. The dashboard is available in the following
-[repository](https://github.com/apache/incubator-apisix). The dashboard is intuitive and you can orchestrate the
+[repository](https://github.com/apache/apisix). The dashboard is intuitive and you can orchestrate the
 same route configurations via the dashboard as well.
 
 ![Dashboard](images/dashboard.png)

--- a/doc/zh-cn/getting-started.md
+++ b/doc/zh-cn/getting-started.md
@@ -44,13 +44,13 @@ $ curl --location --request GET "https://httpbin.org/get?foo1=bar1&foo2=bar2"
 ## 第一步: 安装 APISIX
 
 Apache APISIX 可以多种操作环境中安装。[如何安装文档](how-to-build.md#installation-via-source-release) 显示了多个平台中的安装步骤。
-为了快速入门，让我们基于 docker 容器的安装方式进行安装。启动 Apache APISIX 服务，我们可以参照这个镜像文件[repository](https://github.com/apache/incubator-apisix-docker) 并切换到 example 文件夹下执行如下命令。
+为了快速入门，让我们基于 docker 容器的安装方式进行安装。启动 Apache APISIX 服务，我们可以参照这个镜像文件[repository](https://github.com/apache/apisix-docker) 并切换到 example 文件夹下执行如下命令。
 
 如下命令会启动 Apache APISIX 服务并默认在 9080 端口（ https 请求是 9443 端口） 提供 admin API 接口服务
 
 ```bash
-$ git clone https://github.com/apache/incubator-apisix-docker.git
-$ cd example
+$ git clone https://github.com/apache/apisix-docker.git
+$ cd apisix-docker/example
 $ docker-compose -p docker-apisix up -d
 ```
 
@@ -76,7 +76,7 @@ $ curl "http://127.0.0.1:9080/apisix/admin/services/" -H 'X-API-KEY: edd1c9f0343
 
 ## 第二步: 在 Apache APISIX 中创建 Route
 
-为了配置各种 routes / services / plugins ，APISIX 提供了强大的 Admin API 和一个[ web控制台 ](https://github.com/apache/incubator-apisix-dashboard)。
+为了配置各种 routes / services / plugins ，APISIX 提供了强大的 Admin API 和一个[ web控制台 ](https://github.com/apache/apisix-dashboard)。
 本指南将会使用到 Admin API 接口。
 
 一个微服务可以通过 APISIX 的路由、服务、上游和插件等多个实体之间的关系进行配置。
@@ -238,7 +238,7 @@ curl -i -X GET http://127.0.0.1:9080/samplePrefix/get?param1=foo&param2=bar -H '
 ## Apache APISIX 控制台
 
 到目前为止，已经通过使用 admin API 接口编排对 Apache APISIX 的 API 的调用。然而，Apache APISIX 还提供执行类似操作的一个 web 应用，就是web控制台。
-可以在[repository](https://github.com/apache/incubator-apisix)中使用。控制台是直观的，您可以通过它编排同样的路由配置。
+可以在[repository](https://github.com/apache/apisix)中使用。控制台是直观的，您可以通过它编排同样的路由配置。
 
 ![Dashboard](../images/dashboard.png)
 


### PR DESCRIPTION
The cd command after cloning the repo would fail as it is not yet in the incubator-apisix-docker directory.

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
The Getting Started steps in the documentation, if ran exactly as shown would not work.  This corrects the `cd` path to that they will work.
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases? **N/A**
* [X] Have you modified the corresponding document?
* [X] Is this PR backward compatible?
