### PR TITLE
bugfix: only set one response header when enabled `enable_debug=true`

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -312,7 +312,7 @@ function _M.http_access_phase()
             api_ctx.conf_id = global_rule.value.id
 
             core.table.clear(plugins)
-            api_ctx.plugins = plugin.filter(global_rule, plugins)
+            api_ctx.plugins = plugin.filter(global_rule, plugins, true)
             run_plugin("rewrite", plugins, api_ctx)
             run_plugin("access", plugins, api_ctx)
         end
@@ -552,8 +552,7 @@ local function common_phase(phase_name)
         local plugins = core.tablepool.fetch("plugins", 32, 0)
         local values = api_ctx.global_rules.values
         for _, global_rule in config_util.iterate_values(values) do
-            core.table.clear(plugins)
-            plugins = plugin.filter(global_rule, plugins)
+            plugins = plugin.filter(global_rule, plugins, true)
             run_plugin(phase_name, plugins, api_ctx)
         end
         core.tablepool.release("plugins", plugins)

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -239,6 +239,7 @@ local function set_response_header_by_debug_flag(plugins, dry_run)
 
     if #plugins == 0 then
         core.response.set_header("Apisix-Plugins", "no plugin")
+        return
     end
 
     local t = {}

--- a/t/node/global-rule-debug.t
+++ b/t/node/global-rule-debug.t
@@ -1,0 +1,163 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+BEGIN {
+    if ($ENV{TEST_NGINX_CHECK_LEAK}) {
+        $SkipReason = "unavailable for the hup tests";
+
+    } else {
+        $ENV{TEST_NGINX_USE_HUP} = 1;
+        undef $ENV{TEST_NGINX_USE_STAP};
+    }
+}
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+log_level('info');
+worker_connections(256);
+no_root_location();
+no_shuffle();
+
+sub read_file($) {
+    my $infile = shift;
+    open my $in, $infile
+        or die "cannot open $infile for reading: $!";
+    my $cert = do { local $/; <$in> };
+    close $in;
+    $cert;
+}
+
+our $yaml_config = read_file("conf/config.yaml");
+$yaml_config =~ s/enable_debug: false/enable_debug: true/;
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: set global rule
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/global_rules/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "limit-count": {
+                            "count": 2,
+                            "time_window": 60,
+                            "rejected_code": 503,
+                            "key": "remote_addr"
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: delete route(id: 1)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_DELETE)
+
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: /not_found
+--- yaml_config eval: $::yaml_config
+--- request
+GET /not_found
+--- error_code: 404
+--- response_body
+{"error_msg":"failed to match any routes"}
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: /not_found
+--- yaml_config eval: $::yaml_config
+--- request
+GET /hello
+--- error_code: 404
+--- response_body
+{"error_msg":"failed to match any routes"}
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: /not_found
+--- yaml_config eval: $::yaml_config
+--- request
+GET /hello
+--- error_code: 503
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: delete global rule
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/global_rules/1', ngx.HTTP_DELETE)
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+
+            local code, body = t('/not_found', ngx.HTTP_GET)
+            ngx.say(code)
+            local code, body = t('/not_found', ngx.HTTP_GET)
+            ngx.say(code)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+404
+404
+--- no_error_log
+[error]


### PR DESCRIPTION
    and `global rules`.

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fix #1667

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
