### PR TITLE
chore: should improve the prometheus metric naming

### DIFF
--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -69,6 +69,14 @@ function _M.init()
 
     clear_tab(metrics)
 
+    -- Newly added metrics should follow the naming best pratices described in
+    -- https://prometheus.io/docs/practices/naming/#metric-names
+    -- For example,
+    -- 1. Add unit as the suffix
+    -- 2. Add `_total` as the suffix if the metric type is counter
+    -- 3. Use base unit
+    -- We keep the old metric names for the compatibility.
+
     -- across all services
     prometheus = base_prometheus.init("prometheus-metrics", "apisix_")
     metrics.connections = prometheus:gauge("nginx_http_current_connections",
@@ -93,11 +101,12 @@ function _M.init()
             {"code", "route", "service", "node"})
 
     metrics.latency = prometheus:histogram("http_latency",
-        "HTTP request latency per service in APISIX",
+        "HTTP request latency in milliseconds per service in APISIX",
         {"type", "service", "node"}, DEFAULT_BUCKETS)
 
     metrics.overhead = prometheus:histogram("http_overhead",
-        "HTTP request overhead per service in APISIX",
+        "HTTP request overhead added by APISIX in milliseconds per service " ..
+        "in APISIX",
         {"type", "service", "node"}, DEFAULT_BUCKETS)
 
     metrics.bandwidth = prometheus:counter("bandwidth",


### PR DESCRIPTION
By looking at name like `apisix_bandwidth` or `apisix_http_latency`,
it is hard to guess their units. Also, it is not so clear for where does
the overhead come from for `apisix_http_overhead` at the first glance.

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
