### PR TITLE
fix: proxy_set_header Host $host may lose port info

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -317,7 +317,7 @@ http {
         # admin configuration snippet ends
 
         set $upstream_scheme             'http';
-        set $upstream_host               $host;
+        set $upstream_host               $http_host;
         set $upstream_uri                '';
 
         location /apisix/admin {
@@ -410,7 +410,7 @@ http {
         # http server configuration snippet ends
 
         set $upstream_scheme             'http';
-        set $upstream_host               $host;
+        set $upstream_host               $http_host;
         set $upstream_uri                '';
         set $ctx_ref                     '';
 

--- a/benchmark/fake-apisix/conf/nginx.conf
+++ b/benchmark/fake-apisix/conf/nginx.conf
@@ -84,7 +84,7 @@ http {
 
         location / {
             set $upstream_scheme             'http';
-            set $upstream_host               $host;
+            set $upstream_host               $http_host;
             set $upstream_upgrade            '';
             set $upstream_connection         '';
             set $upstream_uri                '';

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -480,7 +480,7 @@ _EOC_
         }
 
         set \$upstream_scheme             'http';
-        set \$upstream_host               \$host;
+        set \$upstream_host               \$http_host;
         set \$upstream_uri                '';
         set \$ctx_ref                     '';
         set \$dubbo_service_name          '';

--- a/t/node/http_host.t
+++ b/t/node/http_host.t
@@ -1,0 +1,72 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+log_level('info');
+worker_connections(256);
+no_root_location();
+no_shuffle();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: set route(id: 1)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/uri",
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: hit routes
+--- request
+GET /uri
+--- more_headers
+Host: foo.com:1984
+--- response_body
+uri: /uri
+host: foo.com:1984
+x-real-ip: 127.0.0.1
+--- no_error_log
+[error]

--- a/t/plugin/hmac-auth.t
+++ b/t/plugin/hmac-auth.t
@@ -1016,7 +1016,7 @@ GET /t
 uri: /uri
 content-length: 52
 content-type: application/x-www-form-urlencoded
-host: 127.0.0.1
+host: 127.0.0.1:1984
 x-custom-header-a: asld$%dfasf
 x-custom-header-b: 23879fmsldfk
 x-hmac-access-key: my-access-key4
@@ -1131,7 +1131,7 @@ GET /t
 uri: /uri
 content-length: 52
 content-type: application/x-www-form-urlencoded
-host: 127.0.0.1
+host: 127.0.0.1:1984
 x-custom-header-a: asld$%dfasf
 x-custom-header-b: 23879fmsldfk
 x-hmac-access-key: my-access-key4
@@ -1246,7 +1246,7 @@ GET /t
 uri: /uri
 content-length: 52
 content-type: application/x-www-form-urlencoded
-host: 127.0.0.1
+host: 127.0.0.1:1984
 x-custom-header-a: asld$%dfasf
 x-custom-header-b: 23879fmsldfk
 x-hmac-access-key: my-access-key4

--- a/t/plugin/openid-connect.t
+++ b/t/plugin/openid-connect.t
@@ -474,7 +474,7 @@ GET /t
 --- response_body_like
 uri: /uri
 cookie: .*
-host: 127.0.0.1
+host: 127.0.0.1:1984
 user-agent: .*
 x-access-token: ey.*
 x-id-token: ey.*
@@ -768,7 +768,7 @@ GET /t
 uri: /uri
 authorization: Bearer ey.*
 cookie: .*
-host: 127.0.0.1
+host: 127.0.0.1:1984
 user-agent: .*
 x-real-ip: 127.0.0.1
 --- no_error_log


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
proxy_set_header Host $host may lose port info, use http_host instead.
### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
