### PR TITLE
fix: plugins should not exit by itself

### DIFF
--- a/.travis/linux_openresty_runner.sh
+++ b/.travis/linux_openresty_runner.sh
@@ -167,6 +167,8 @@ script() {
     ./bin/apisix stop
     sleep 1
 
+    sudo sh ./utils/check-plugins-code.sh
+
     make lint && make license-check || exit 1
     APISIX_ENABLE_LUACOV=1 PERL5LIB=.:$PERL5LIB prove -Itest-nginx/lib -r t
 }

--- a/apisix/plugins/fault-injection.lua
+++ b/apisix/plugins/fault-injection.lua
@@ -66,7 +66,7 @@ function _M.rewrite(conf, ctx)
     end
 
     if conf.abort and conf.abort.http_status ~= nil then
-        core.response.exit(conf.abort.http_status, conf.abort.body)
+        return conf.abort.http_status, conf.abort.body
     end
 end
 

--- a/apisix/plugins/redirect.lua
+++ b/apisix/plugins/redirect.lua
@@ -141,11 +141,11 @@ function _M.rewrite(conf, ctx)
         if not new_uri then
             core.log.error("failed to generate new uri by: ", uri, " error: ",
                            err)
-            core.response.exit(500)
+            return 500
         end
 
         core.response.set_header("Location", new_uri)
-        core.response.exit(ret_code)
+        return ret_code
     end
 end
 

--- a/apisix/plugins/request-validation.lua
+++ b/apisix/plugins/request-validation.lua
@@ -72,7 +72,7 @@ function _M.rewrite(conf)
         local ok, err = core.schema.check(conf.header_schema, headers)
         if not ok then
             core.log.error("req schema validation failed", err)
-            core.response.exit(400, err)
+            return 400, err
         end
     end
 
@@ -84,11 +84,11 @@ function _M.rewrite(conf)
         if not body then
             local filename = ngx.req.get_body_file()
             if not filename then
-                return core.response.exit(500)
+                return 500
             end
             local fd = io.open(filename, 'rb')
             if not fd then
-                return core.response.exit(500)
+                return 500
             end
             body = fd:read('*a')
         end
@@ -101,13 +101,13 @@ function _M.rewrite(conf)
 
         if not req_body then
           core.log.error('failed to decode the req body', error)
-          return core.response.exit(400, error)
+          return 400, error
         end
 
         local ok, err = core.schema.check(conf.body_schema, req_body)
         if not ok then
           core.log.error("req schema validation failed", err)
-          return core.response.exit(400, err)
+          return 400, err
         end
     end
 end

--- a/apisix/plugins/uri-blocker.lua
+++ b/apisix/plugins/uri-blocker.lua
@@ -86,7 +86,7 @@ function _M.rewrite(conf, ctx)
 
     local from = re_find(ctx.var.request_uri, conf.block_rules_concat, "jo")
     if from then
-        core.response.exit(conf.rejected_code)
+        return conf.rejected_code
     end
 end
 

--- a/doc/plugin-develop.md
+++ b/doc/plugin-develop.md
@@ -154,6 +154,8 @@ function _M.log(conf)
 end
 ```
 
+**Note : we can't invoke `ngx.exit` or `core.respond.exit` in rewrite phase and access phase. if need to exit, just return the status and body, the plugin engine will make the exit happen with the returned status and body. [example](https://github.com/apache/apisix/blob/master/apisix/plugins/limit-count.lua#L132)**
+
 ## implement the logic
 
 Write the logic of the plugin in the corresponding phase.

--- a/doc/zh-cn/plugin-develop.md
+++ b/doc/zh-cn/plugin-develop.md
@@ -139,6 +139,8 @@ $(INSTALL) apisix/plugins/skywalking/*.lua $(INST_LUADIR)/apisix/plugins/skywalk
 该插件在 rewrite 、access 阶段执行都可以，项目中是用 rewrite 阶段执行认证逻辑，一般 IP 准入、接口权限是在 access 阶段
 完成的。
 
+**注意：我们不能在 rewrite 和 access 阶段调用 `ngx.exit` 或者 `core.respond.exit`。如果确实需要退出，只需要 return 状态码和正文，插件引擎将使用返回的状态码和正文进行退出。**
+
 ## 编写执行逻辑
 
 在对应的阶段方法里编写功能的逻辑代码。

--- a/t/fake-plugin-exit.lua
+++ b/t/fake-plugin-exit.lua
@@ -1,0 +1,46 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+local core = require("apisix.core")
+
+local schema = {
+    type = "object",
+    properties = {
+    }
+}
+
+
+local plugin_name = "uri-blocker"
+
+local _M = {
+    version = 0.1,
+    priority = 2900,
+    name = plugin_name,
+    schema = schema,
+}
+
+
+function _M.check_schema(conf)
+    return true
+end
+
+
+function _M.rewrite(conf, ctx)
+    core.respond.exit(400)
+end
+
+
+return _M

--- a/utils/check-plugins-code.sh
+++ b/utils/check-plugins-code.sh
@@ -18,7 +18,7 @@
 #
 
 
-function checkfunc(){
+function checkfunc {
     funccontent=$1
     [[ $funccontent =~ "core.response.exit" ]] && echo "can't exit in rewrite or access phase !" && exit 1
     [[ $funccontent =~ "ngx.exit" ]] && echo "can't exit in rewrite or access phase !" && exit 1
@@ -26,7 +26,7 @@ function checkfunc(){
 }
 
 
-function filtercode(){
+function filtercode {
     content=$1
 
     rcontent=${content##*_M.rewrite}

--- a/utils/check-plugins-code.sh
+++ b/utils/check-plugins-code.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
@@ -41,9 +41,8 @@ filtercode () {
 
 for file in apisix/plugins/*.lua
 do
-    if test -f $file
+    if test -f $file 
     then
-        arr=(${arr[*]} $file)
         echo $file
         content=$(cat $file)
         filtercode "$content"

--- a/utils/check-plugins-code.sh
+++ b/utils/check-plugins-code.sh
@@ -17,12 +17,14 @@
 # limitations under the License.
 #
 
+
 function checkfunc(){
     funccontent=$1
     [[ $funccontent =~ "core.response.exit" ]] && echo "can't exit in rewrite or access phase !" && exit 1
     [[ $funccontent =~ "ngx.exit" ]] && echo "can't exit in rewrite or access phase !" && exit 1
     echo "passed."
 }
+
 
 function filtercode(){
     content=$1
@@ -44,7 +46,12 @@ do
         arr=(${arr[*]} $file)
         echo $file
         content=$(cat $file)
-        filtercode "$content";
+        filtercode "$content"
     fi
 done
 
+# test case for check
+content=$(cat t/fake-plugin-exit.lua)
+filtercode "$content" > test.log 2>&1 || (cat test.log && exit 1)
+
+echo "done."

--- a/utils/check-plugins-code.sh
+++ b/utils/check-plugins-code.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+function checkfunc(){
+    funccontent=$1
+    [[ $funccontent =~ "core.response.exit" ]] && echo "can't exit in rewrite or access phase !" && exit 1
+    [[ $funccontent =~ "ngx.exit" ]] && echo "can't exit in rewrite or access phase !" && exit 1
+    echo "passed."
+}
+
+function filtercode(){
+    content=$1
+
+    rcontent=${content##*_M.rewrite}
+    rewritefunc=${rcontent%%function*}
+    checkfunc "$rewritefunc"
+
+    rcontent=${content##*_M.access}
+    accessfunc=${rcontent%%function*}
+    checkfunc "$accessfunc"
+}
+
+
+for file in apisix/plugins/*.lua
+do
+    if test -f $file
+    then
+        arr=(${arr[*]} $file)
+        echo $file
+        content=$(cat $file)
+        filtercode "$content";
+    fi
+done
+

--- a/utils/check-plugins-code.sh
+++ b/utils/check-plugins-code.sh
@@ -41,7 +41,7 @@ filtercode () {
 
 for file in apisix/plugins/*.lua
 do
-    if test -f $file 
+    if test -f $file
     then
         echo $file
         content=$(cat $file)

--- a/utils/check-plugins-code.sh
+++ b/utils/check-plugins-code.sh
@@ -18,7 +18,7 @@
 #
 
 
-function checkfunc {
+checkfunc () {
     funccontent=$1
     [[ $funccontent =~ "core.response.exit" ]] && echo "can't exit in rewrite or access phase !" && exit 1
     [[ $funccontent =~ "ngx.exit" ]] && echo "can't exit in rewrite or access phase !" && exit 1
@@ -26,7 +26,7 @@ function checkfunc {
 }
 
 
-function filtercode {
+filtercode () {
     content=$1
 
     rcontent=${content##*_M.rewrite}


### PR DESCRIPTION
### What this PR does / why we need it:
plugins should not exit by itself in access and rewrite phase, it can't be reuse in script, and the plugin engine has already covered:

https://github.com/apache/apisix/blob/master/apisix/init.lua#L134

#2111 

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
