### PR TITLE
change: allow users to see warnings by default

### DIFF
--- a/.travis/apisix_cli_test.sh
+++ b/.travis/apisix_cli_test.sh
@@ -35,8 +35,17 @@ fi
 
 echo "passed: 'Server: APISIX' not in nginx.conf"
 
+#make init <- no need to re-run since we don't change the config yet.
+
+# check the error_log directive uses warn level by default.
+if ! grep "error_log logs/error.log warn;" conf/nginx.conf > /dev/null; then
+    echo "failed: error_log directive doesn't use warn level by default"
+    exit 1
+fi
+
+echo "passed: error_log directive uses warn level by default"
+
 # check whether the 'reuseport' is in nginx.conf .
-make init
 
 grep -E "listen 9080.*reuseport" conf/nginx.conf > /dev/null
 if [ ! $? -eq 0 ]; then

--- a/bin/apisix
+++ b/bin/apisix
@@ -94,7 +94,7 @@ worker_processes {* worker_processes *};
 worker_cpu_affinity auto;
 {% end %}
 
-error_log {* error_log *} {* error_log_level or "error" *};
+error_log {* error_log *} {* error_log_level or "warn" *};
 pid logs/nginx.pid;
 
 worker_rlimit_nofile {* worker_rlimit_nofile *};


### PR DESCRIPTION
Previously, with the default configure, people don't have the chance to
ignore the warning message.

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
