### PR TITLE
chore: restrict the apisix/admin routers

### DIFF
--- a/apisix/admin/init.lua
+++ b/apisix/admin/init.lua
@@ -267,13 +267,13 @@ local uri_route = {
         handler = run,
     },
     {
-        paths = [[/apisix/admin/stream_routes*]],
+        paths = [[/apisix/admin/stream_routes/*]],
         methods = {"GET", "PUT", "POST", "DELETE", "PATCH"},
         handler = run_stream,
     },
     {
         paths = [[/apisix/admin/plugins/list]],
-        methods = {"GET", "PUT", "POST", "DELETE"},
+        methods = {"GET"},
         handler = get_plugins_list,
     },
     {


### PR DESCRIPTION
1. /stream_routes needs to be ended with '/'
2. /list only needs GET method

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible?
