### PR TITLE
feature: `consumer` provides access to a collection of `service` 

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -403,10 +403,12 @@ function _M.http_access_phase()
         api_ctx.conf_type = "route&service"
         api_ctx.conf_version = route.modifiedIndex .. "&" .. service.modifiedIndex
         api_ctx.conf_id = route.value.id .. "&" .. service.value.id
+        api_ctx.service_id = service.value.id
     else
         api_ctx.conf_type = "route"
         api_ctx.conf_version = route.modifiedIndex
         api_ctx.conf_id = route.value.id
+        api_ctx.route_id = route.value.id
     end
 
     local enable_websocket

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -408,8 +408,8 @@ function _M.http_access_phase()
         api_ctx.conf_type = "route"
         api_ctx.conf_version = route.modifiedIndex
         api_ctx.conf_id = route.value.id
-        api_ctx.route_id = route.value.id
     end
+    api_ctx.route_id = route.value.id
 
     local enable_websocket
     local up_id = route.value.upstream_id

--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -16,6 +16,7 @@
 --
 local ipairs    = ipairs
 local core      = require("apisix.core")
+local ngx_re    = require("ngx.re")
 
 local schema = {
     type = "object",
@@ -54,7 +55,10 @@ local _M = {
 
 local fetch_val_funcs = {
     ["service_id"] = function(ctx)
-        return ctx.service.service_id
+        local conf_data = ngx_re.split(ctx.conf_id, "&")
+        core.log.info("conf_data: ", core.json.encode(conf_data))
+        -- get service_id
+        return conf_data[2]
     end,
     ["consumer_name"] = function(ctx)
         return ctx.consumer.username
@@ -91,7 +95,7 @@ function _M.access(conf, ctx)
     if not value then
         return 401, { message = "Failed to fetch value by value type: " .. conf.type }
     end
-    core.log.info("value: ", value)
+    core.log.warn("value: ", value)
 
     local block = false
     if conf.blacklist and #conf.blacklist > 0 then

--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -35,7 +35,7 @@ local schema = {
             items = {type = "string"},
             minItems = 1
         },
-        rejected_code = {type = "integer", minimum = 200, default = 401}
+        rejected_code = {type = "integer", minimum = 200, default = 403}
     },
     oneOf = {
         {required = {"whitelist"}},
@@ -107,7 +107,7 @@ function _M.access(conf, ctx)
     end
 
     if block then
-        return conf.rejected_code, { message = "The" .. conf.type .. "is not allowed" }
+        return conf.rejected_code, { message = "The " .. conf.type .. " is not allowed" }
     end
 end
 

--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -53,6 +53,15 @@ local _M = {
     schema = schema,
 }
 
+local type_funcs = {
+    ["serviec"] = function(ctx)
+        return ctx.service.service_id
+    end,
+    ["consumer"] = function(ctx)
+        return ctx.consumer.username
+    end
+}
+
 local function is_include(value, tab)
     for k,v in ipairs(tab) do
         if v == value then
@@ -74,39 +83,30 @@ function _M.check_schema(conf)
 end
 
 
-local type_funcs = {
-    ["serviec"] = function()
-        return ctx.service.service_id
-    end,
-    ["consumer"] = function()
-        return ctx.consumer.username
-    end
-}
-
 function _M.access(conf, ctx)
     local types_of = conf.types_of
     if not types_of then
         return 401, { message = "Missing authentication or identity verification." }
     end
 
-    local type_name = type_funcs[types_of]()
-    core.log.warn("type_name: ", type_name)
+    local type_id = type_funcs[types_of](ctx)
+    core.log.warn("type_id: ", type_id)
 
     local block = false
     if conf.blacklist and #conf.blacklist > 0 then
-        if is_include(type_name, conf.blacklist) then
+        if is_include(type_id, conf.blacklist) then
             block = true
         end
     end
 
     if conf.whitelist and #conf.whitelist > 0 then
-        if not is_include(type_name, conf.whitelist) then
+        if not is_include(type_id, conf.whitelist) then
             block = true
         end
     end
 
     if block then
-        return conf.rejected_code, { message = "The consumer is not allowed" }
+        return conf.rejected_code, { message = "The" .. types_of .. "is not allowed" }
     end
 end
 

--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -55,10 +55,7 @@ local _M = {
 
 local fetch_val_funcs = {
     ["service_id"] = function(ctx)
-        local conf_data = ngx_re.split(ctx.conf_id, "&")
-        core.log.info("conf_data: ", core.json.encode(conf_data))
-        -- get service_id
-        return conf_data[2]
+        return ctx.service_id
     end,
     ["consumer_name"] = function(ctx)
         return ctx.consumer.username

--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -16,7 +16,6 @@
 --
 local ipairs    = ipairs
 local core      = require("apisix.core")
-local ngx_re    = require("ngx.re")
 
 local schema = {
     type = "object",

--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -57,7 +57,7 @@ local fetch_val_funcs = {
         return ctx.service_id
     end,
     ["consumer_name"] = function(ctx)
-        return ctx.consumer.username
+        return ctx.consumer_id
     end
 }
 
@@ -85,7 +85,7 @@ end
 function _M.access(conf, ctx)
     local value = fetch_val_funcs[conf.type](ctx)
     if not value then
-        return 401, { message = "Failed to fetch value by value type: " .. conf.type }
+        return 401, { message = "Missing authentication or identity verification."}
     end
     core.log.info("value: ", value)
 

--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -57,7 +57,7 @@ local fetch_val_funcs = {
         return ctx.service_id
     end,
     ["consumer_name"] = function(ctx)
-        return ctx.consumer_id
+        return ctx.consumer.username
     end
 }
 
@@ -83,13 +83,9 @@ end
 
 
 function _M.access(conf, ctx)
-    if not conf.type then
-        return 401, { message = "Missing authentication or identity verification." }
-    end
-
     local value = fetch_val_funcs[conf.type](ctx)
     if not value then
-        return 401, { message = "Missing authentication or identity verification."}
+        return 401, { message = "Failed to fetch value by value type: " .. conf.type }
     end
     core.log.info("value: ", value)
 
@@ -107,7 +103,7 @@ function _M.access(conf, ctx)
     end
 
     if block then
-        return conf.rejected_code, { message = "The " .. conf.type .. " is not allowed" }
+        return conf.rejected_code, { message = "The " .. conf.type .. " is forbidden." }
     end
 end
 

--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -57,7 +57,7 @@ local fetch_val_funcs = {
         return ctx.service_id
     end,
     ["consumer_name"] = function(ctx)
-        return ctx.consumer.username
+        return ctx.consumer_id
     end
 }
 
@@ -89,7 +89,7 @@ function _M.access(conf, ctx)
 
     local value = fetch_val_funcs[conf.type](ctx)
     if not value then
-        return 401, { message = "Failed to fetch value by value type: " .. conf.type }
+        return 401, { message = "Missing authentication or identity verification."}
     end
     core.log.info("value: ", value)
 

--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -52,7 +52,7 @@ local _M = {
     schema = schema,
 }
 
-local type_funcs = {
+local fetch_val_funcs = {
     ["service_id"] = function(ctx)
         return ctx.service.service_id
     end,
@@ -87,21 +87,21 @@ function _M.access(conf, ctx)
         return 401, { message = "Missing authentication or identity verification." }
     end
 
-    local type_value = type_funcs[conf.type](ctx)
-    if not type_value then
-        return 401, { message = "Missing `type` value." }
+    local value = fetch_val_funcs[conf.type](ctx)
+    if not value then
+        return 401, { message = "Failed to fetch value by value type: " .. conf.type }
     end
-    core.log.info("type_value: ", type_value)
+    core.log.info("value: ", value)
 
     local block = false
     if conf.blacklist and #conf.blacklist > 0 then
-        if is_include(type_value, conf.blacklist) then
+        if is_include(value, conf.blacklist) then
             block = true
         end
     end
 
     if conf.whitelist and #conf.whitelist > 0 then
-        if not is_include(type_value, conf.whitelist) then
+        if not is_include(value, conf.whitelist) then
             block = true
         end
     end

--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -91,7 +91,7 @@ function _M.access(conf, ctx)
     if not value then
         return 401, { message = "Failed to fetch value by value type: " .. conf.type }
     end
-    core.log.warn("value: ", value)
+    core.log.info("value: ", value)
 
     local block = false
     if conf.blacklist and #conf.blacklist > 0 then

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -337,6 +337,7 @@ hello world
                         },
                         "plugins": {
                             "consumer-restriction": {
+                                "type": "consumer_name",
                                  "whitelist": [
                                      "jack1"
                                  ]
@@ -632,6 +633,7 @@ GET /t
 passed
 --- no_error_log
 [error]
+
 
 
 
@@ -1158,7 +1160,7 @@ location /t {
 --- request
 GET /t
 --- error_code: 200
---- response_body eval
+--- response_body
 passed
 --- no_error_log
 [error]

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -337,7 +337,6 @@ hello world
                         },
                         "plugins": {
                             "consumer-restriction": {
-                                "type": "consumer_name",
                                  "whitelist": [
                                      "jack1"
                                  ]

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -636,7 +636,6 @@ passed
 
 
 
-
 === TEST 27: add consumer with plugin hmac-auth and consumer-restriction, and set whitelist
 --- config
     location /t {

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -718,8 +718,11 @@ location /t {
         local secret_key = "my-secret-key"
         local timestamp = ngx_time()
         local access_key = "my-access-key"
+        local custom_header_a = "asld$%dfasf"
+        local custom_header_b = "23879fmsldfk"
+
         local signing_string = "GET" .. "/hello" ..  "" ..
-        "" .. access_key .. timestamp .. secret_key
+            access_key .. timestamp .. custom_header_a .. custom_header_b
 
         local signature = hmac:new(secret_key, hmac.ALGOS.SHA256):final(signing_string)
         core.log.info("signature:", ngx_encode_base64(signature))
@@ -728,6 +731,9 @@ location /t {
         headers["X-HMAC-ALGORITHM"] = "hmac-sha256"
         headers["X-HMAC-TIMESTAMP"] = timestamp
         headers["X-HMAC-ACCESS-KEY"] = access_key
+        headers["X-HMAC-SIGNED-HEADERS"] = "x-custom-header-a;x-custom-header-b"
+        headers["x-custom-header-a"] = custom_header_a
+        headers["x-custom-header-b"] = custom_header_b
 
         local code, body = t.test('/hello',
             ngx.HTTP_GET,
@@ -742,7 +748,6 @@ location /t {
 }
 --- request
 GET /t
---- error_code: 200
 --- response_body
 passed
 --- no_error_log
@@ -868,8 +873,11 @@ location /t {
         local secret_key = "my-secret-key"
         local timestamp = ngx_time()
         local access_key = "my-access-key"
+        local custom_header_a = "asld$%dfasf"
+        local custom_header_b = "23879fmsldfk"
+
         local signing_string = "GET" .. "/hello" ..  "" ..
-        "" .. access_key .. timestamp .. secret_key
+            access_key .. timestamp .. custom_header_a .. custom_header_b
 
         local signature = hmac:new(secret_key, hmac.ALGOS.SHA256):final(signing_string)
         core.log.info("signature:", ngx_encode_base64(signature))
@@ -878,6 +886,9 @@ location /t {
         headers["X-HMAC-ALGORITHM"] = "hmac-sha256"
         headers["X-HMAC-TIMESTAMP"] = timestamp
         headers["X-HMAC-ACCESS-KEY"] = access_key
+        headers["X-HMAC-SIGNED-HEADERS"] = "x-custom-header-a;x-custom-header-b"
+        headers["x-custom-header-a"] = custom_header_a
+        headers["x-custom-header-b"] = custom_header_b
 
         local code, body = t.test('/hello',
             ngx.HTTP_GET,
@@ -885,8 +896,10 @@ location /t {
             nil,
             headers
         )
-
-        ngx.status = code
+        if code >= 300 then
+            ngx.status = code
+        end
+        
         ngx.say(body)
     }
 }
@@ -894,7 +907,7 @@ location /t {
 GET /t
 --- error_code: 401
 --- response_body eval
-qr/{"message":"The service_id is forbidden."}/
+qr/\{"message":"The service_id is forbidden."\}/
 --- no_error_log
 [error]
 
@@ -1029,8 +1042,11 @@ location /t {
         local secret_key = "my-secret-key"
         local timestamp = ngx_time()
         local access_key = "my-access-key"
+        local custom_header_a = "asld$%dfasf"
+        local custom_header_b = "23879fmsldfk"
+
         local signing_string = "GET" .. "/hello" ..  "" ..
-        "" .. access_key .. timestamp .. secret_key
+            access_key .. timestamp .. custom_header_a .. custom_header_b
 
         local signature = hmac:new(secret_key, hmac.ALGOS.SHA256):final(signing_string)
         core.log.info("signature:", ngx_encode_base64(signature))
@@ -1039,6 +1055,9 @@ location /t {
         headers["X-HMAC-ALGORITHM"] = "hmac-sha256"
         headers["X-HMAC-TIMESTAMP"] = timestamp
         headers["X-HMAC-ACCESS-KEY"] = access_key
+        headers["X-HMAC-SIGNED-HEADERS"] = "x-custom-header-a;x-custom-header-b"
+        headers["x-custom-header-a"] = custom_header_a
+        headers["x-custom-header-b"] = custom_header_b
 
         local code, body = t.test('/hello',
             ngx.HTTP_GET,
@@ -1055,10 +1074,9 @@ location /t {
 GET /t
 --- error_code: 401
 --- response_body eval
-qr/{"message":"The service_id is forbidden."}/
+qr/\{"message":"The service_id is forbidden."\}/
 --- no_error_log
 [error]
-
 
 
 === TEST 35: Route binding `hmac-auth` plug-in and invalid blacklist `service_id`
@@ -1133,8 +1151,11 @@ location /t {
         local secret_key = "my-secret-key"
         local timestamp = ngx_time()
         local access_key = "my-access-key"
+        local custom_header_a = "asld$%dfasf"
+        local custom_header_b = "23879fmsldfk"
+
         local signing_string = "GET" .. "/hello" ..  "" ..
-        "" .. access_key .. timestamp .. secret_key
+            access_key .. timestamp .. custom_header_a .. custom_header_b
 
         local signature = hmac:new(secret_key, hmac.ALGOS.SHA256):final(signing_string)
         core.log.info("signature:", ngx_encode_base64(signature))
@@ -1143,6 +1164,9 @@ location /t {
         headers["X-HMAC-ALGORITHM"] = "hmac-sha256"
         headers["X-HMAC-TIMESTAMP"] = timestamp
         headers["X-HMAC-ACCESS-KEY"] = access_key
+        headers["X-HMAC-SIGNED-HEADERS"] = "x-custom-header-a;x-custom-header-b"
+        headers["x-custom-header-a"] = custom_header_a
+        headers["x-custom-header-b"] = custom_header_b
 
         local code, body = t.test('/hello',
             ngx.HTTP_GET,
@@ -1157,7 +1181,6 @@ location /t {
 }
 --- request
 GET /t
---- error_code: 200
 --- response_body
 passed
 --- no_error_log

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -692,7 +692,111 @@ passed
 
 
 
-=== TEST 28: Route binding `hmac-auth` plug-in and `service_id`
+=== TEST 28: Route binding `hmac-auth` plug-in and whitelist `service_id`
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "methods": ["GET"],
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "service_id": 1,
+                    "uri": "/hello",
+                    "plugins": {
+                        "hmac-auth": {}
+                    }
+
+                }]],
+                [[{
+                    "node": {
+                        "value": {
+                            "methods": [
+                                "GET"
+                            ],
+                            "uri": "/hello",
+                            "upstream": {
+                                "nodes": {
+                                    "127.0.0.1:1980": 1
+                                },
+                                "type": "roundrobin"
+                            },
+                            "service_id": 1,
+                            "plugins": {
+                                "hmac-auth": {}
+                            }
+                        },
+                        "key": "/apisix/routes/1"
+                    },
+                    "action": "set"
+                }]]
+                )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 29: verify: valid whitelist `service_id`
+--- config
+location /t {
+    content_by_lua_block {
+        local ngx_time   = ngx.time
+        local core = require("apisix.core")
+        local t = require("lib.test_admin")
+        local hmac = require("resty.hmac")
+        local ngx_encode_base64 = ngx.encode_base64
+
+        local secret_key = "my-secret-key"
+        local timestamp = ngx_time()
+        local access_key = "my-access-key"
+        local signing_string = "GET" .. "/hello" ..  "" ..
+        "" .. access_key .. timestamp .. secret_key
+
+        local signature = hmac:new(secret_key, hmac.ALGOS.SHA256):final(signing_string)
+        core.log.info("signature:", ngx_encode_base64(signature))
+        local headers = {}
+        headers["X-HMAC-SIGNATURE"] = ngx_encode_base64(signature)
+        headers["X-HMAC-ALGORITHM"] = "hmac-sha256"
+        headers["X-HMAC-TIMESTAMP"] = timestamp
+        headers["X-HMAC-ACCESS-KEY"] = access_key
+
+        local code, body = t.test('/hello',
+            ngx.HTTP_GET,
+            "",
+            nil,
+            headers
+        )
+
+        ngx.status = code
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- error_code: 200
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 30: Route binding `hmac-auth` plug-in and invalid whitelist `service_id`
 --- config
     location /t {
         content_by_lua_block {
@@ -751,7 +855,7 @@ passed
 
 
 
-=== TEST 29: verify: ok
+=== TEST 31: verify: invalid whitelist `service_id`
 --- config
 location /t {
     content_by_lua_block {
@@ -783,13 +887,318 @@ location /t {
         )
 
         ngx.status = code
-        ngx.print(body)
+        ngx.say(body)
     }
 }
 --- request
 GET /t
 --- error_code: 401
+--- response_body eval
+qr/{"message":"The service_id is not allowed"}/
+--- no_error_log
+[error]
+
+
+
+=== TEST 32: add consumer with plugin hmac-auth and consumer-restriction, and set blacklist
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack",
+                    "plugins": {
+                        "hmac-auth": {
+                            "access_key": "my-access-key",
+                            "secret_key": "my-secret-key"
+                        },
+                        "consumer-restriction": {
+                            "type": "service_id",
+                            "blacklist": [ "1" ],
+                            "rejected_code": 401
+                        }
+                    }
+                }]],
+                [[{
+                    "node": {
+                        "value": {
+                            "username": "jack",
+                            "plugins": {
+                                "hmac-auth": {
+                                    "access_key": "my-access-key",
+                                    "secret_key": "my-secret-key",
+                                    "algorithm": "hmac-sha256",
+                                    "clock_skew": 300
+                                },
+                                "consumer-restriction": {
+                                    "type": "service_id",
+                                    "blacklist": [ "1" ],
+                                    "rejected_code": 401
+                                }
+                            }
+                        }
+                    },
+                    "action": "set"
+                }]]
+                )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
 --- response_body
-{"message":"The service_id is not allowed"}
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 33: Route binding `hmac-auth` plug-in and blacklist `service_id`
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "methods": ["GET"],
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "service_id": 1,
+                    "uri": "/hello",
+                    "plugins": {
+                        "hmac-auth": {}
+                    }
+
+                }]],
+                [[{
+                    "node": {
+                        "value": {
+                            "methods": [
+                                "GET"
+                            ],
+                            "uri": "/hello",
+                            "upstream": {
+                                "nodes": {
+                                    "127.0.0.1:1980": 1
+                                },
+                                "type": "roundrobin"
+                            },
+                            "service_id": 1,
+                            "plugins": {
+                                "hmac-auth": {}
+                            }
+                        },
+                        "key": "/apisix/routes/1"
+                    },
+                    "action": "set"
+                }]]
+                )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 34: verify: valid blacklist `service_id`
+--- config
+location /t {
+    content_by_lua_block {
+        local ngx_time   = ngx.time
+        local core = require("apisix.core")
+        local t = require("lib.test_admin")
+        local hmac = require("resty.hmac")
+        local ngx_encode_base64 = ngx.encode_base64
+
+        local secret_key = "my-secret-key"
+        local timestamp = ngx_time()
+        local access_key = "my-access-key"
+        local signing_string = "GET" .. "/hello" ..  "" ..
+        "" .. access_key .. timestamp .. secret_key
+
+        local signature = hmac:new(secret_key, hmac.ALGOS.SHA256):final(signing_string)
+        core.log.info("signature:", ngx_encode_base64(signature))
+        local headers = {}
+        headers["X-HMAC-SIGNATURE"] = ngx_encode_base64(signature)
+        headers["X-HMAC-ALGORITHM"] = "hmac-sha256"
+        headers["X-HMAC-TIMESTAMP"] = timestamp
+        headers["X-HMAC-ACCESS-KEY"] = access_key
+
+        local code, body = t.test('/hello',
+            ngx.HTTP_GET,
+            "",
+            nil,
+            headers
+        )
+
+        ngx.status = code
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- error_code: 401
+--- response_body eval
+qr/{"message":"The service_id is not allowed"}/
+--- no_error_log
+[error]
+
+
+
+=== TEST 35: Route binding `hmac-auth` plug-in and invalid blacklist `service_id`
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "methods": ["GET"],
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "service_id": 2,
+                    "uri": "/hello",
+                    "plugins": {
+                        "hmac-auth": {}
+                    }
+
+                }]],
+                [[{
+                    "node": {
+                        "value": {
+                            "methods": [
+                                "GET"
+                            ],
+                            "uri": "/hello",
+                            "upstream": {
+                                "nodes": {
+                                    "127.0.0.1:1980": 1
+                                },
+                                "type": "roundrobin"
+                            },
+                            "service_id": 2,
+                            "plugins": {
+                                "hmac-auth": {}
+                            }
+                        },
+                        "key": "/apisix/routes/1"
+                    },
+                    "action": "set"
+                }]]
+                )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 36: verify: invalid blacklist `service_id`
+--- config
+location /t {
+    content_by_lua_block {
+        local ngx_time   = ngx.time
+        local core = require("apisix.core")
+        local t = require("lib.test_admin")
+        local hmac = require("resty.hmac")
+        local ngx_encode_base64 = ngx.encode_base64
+
+        local secret_key = "my-secret-key"
+        local timestamp = ngx_time()
+        local access_key = "my-access-key"
+        local signing_string = "GET" .. "/hello" ..  "" ..
+        "" .. access_key .. timestamp .. secret_key
+
+        local signature = hmac:new(secret_key, hmac.ALGOS.SHA256):final(signing_string)
+        core.log.info("signature:", ngx_encode_base64(signature))
+        local headers = {}
+        headers["X-HMAC-SIGNATURE"] = ngx_encode_base64(signature)
+        headers["X-HMAC-ALGORITHM"] = "hmac-sha256"
+        headers["X-HMAC-TIMESTAMP"] = timestamp
+        headers["X-HMAC-ACCESS-KEY"] = access_key
+
+        local code, body = t.test('/hello',
+            ngx.HTTP_GET,
+            "",
+            nil,
+            headers
+        )
+
+        ngx.status = code
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- error_code: 200
+--- response_body eval
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 37: delete: `service_id` is 1
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t( '/apisix/admin/services/1', ngx.HTTP_DELETE )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 38: delete: `service_id` is 2
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t( '/apisix/admin/services/2', ngx.HTTP_DELETE )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
 --- no_error_log
 [error]

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -1165,7 +1165,27 @@ passed
 
 
 
-=== TEST 37: delete: `service_id` is 1
+=== TEST 37: delete: route (id: 1)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t( '/apisix/admin/routes/1', ngx.HTTP_DELETE )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 38: delete: `service_id` is 1
 --- config
     location /t {
         content_by_lua_block {
@@ -1185,7 +1205,7 @@ passed
 
 
 
-=== TEST 38: delete: `service_id` is 2
+=== TEST 39: delete: `service_id` is 2
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -237,7 +237,7 @@ GET /hello
 Authorization: Basic amFjazIwMjA6MTIzNDU2
 --- error_code: 403
 --- response_body
-{"message":"The consumer_name is not allowed"}
+{"message":"The consumer_name is forbidden."}
 --- no_error_log
 [error]
 
@@ -302,7 +302,7 @@ GET /hello
 Authorization: Basic amFjazIwMTk6MTIzNDU2
 --- error_code: 403
 --- response_body
-{"message":"The consumer_name is not allowed"}
+{"message":"The consumer_name is forbidden."}
 --- no_error_log
 [error]
 
@@ -590,54 +590,7 @@ passed
 
 
 
-=== TEST 26: create service (id:2)
---- config
-    location /t {
-        content_by_lua_block {
-            local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/services/2',
-                 ngx.HTTP_PUT,
-                 [[{
-                    "upstream": {
-                        "nodes": {
-                            "127.0.0.1:1980": 1
-                        },
-                        "type": "roundrobin"
-                    },
-                    "desc": "new service 002"
-                }]],
-                [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:1980": 1
-                                },
-                                "type": "roundrobin"
-                            },
-                            "desc": "new service 002"
-                        },
-                        "key": "/apisix/services/2"
-                    },
-                    "action": "set"
-                }]]
-                )
-
-            ngx.status = code
-            ngx.say(body)
-        }
-    }
---- request
-GET /t
---- response_body
-passed
---- no_error_log
-[error]
-
-
-
-
-=== TEST 27: add consumer with plugin hmac-auth and consumer-restriction, and set whitelist
+=== TEST 26: add consumer with plugin hmac-auth and consumer-restriction, and set whitelist
 --- config
     location /t {
         content_by_lua_block {
@@ -694,7 +647,7 @@ passed
 
 
 
-=== TEST 28: Route binding `hmac-auth` plug-in and whitelist `service_id`
+=== TEST 27: Route binding `hmac-auth` plug-in and whitelist `service_id`
 --- config
     location /t {
         content_by_lua_block {
@@ -753,7 +706,7 @@ passed
 
 
 
-=== TEST 29: verify: valid whitelist `service_id`
+=== TEST 28: verify: valid whitelist `service_id`
 --- config
 location /t {
     content_by_lua_block {
@@ -791,6 +744,52 @@ location /t {
 --- request
 GET /t
 --- error_code: 200
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 29: create service (id:2)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/services/2',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "desc": "new service 002"
+                }]],
+                [[{
+                    "node": {
+                        "value": {
+                            "upstream": {
+                                "nodes": {
+                                    "127.0.0.1:1980": 1
+                                },
+                                "type": "roundrobin"
+                            },
+                            "desc": "new service 002"
+                        },
+                        "key": "/apisix/services/2"
+                    },
+                    "action": "set"
+                }]]
+                )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
 --- response_body
 passed
 --- no_error_log
@@ -896,7 +895,7 @@ location /t {
 GET /t
 --- error_code: 401
 --- response_body eval
-qr/{"message":"The service_id is not allowed"}/
+qr/{"message":"The service_id is forbidden."}/
 --- no_error_log
 [error]
 
@@ -1057,7 +1056,7 @@ location /t {
 GET /t
 --- error_code: 401
 --- response_body eval
-qr/{"message":"The service_id is not allowed"}/
+qr/{"message":"The service_id is forbidden."}/
 --- no_error_log
 [error]
 

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -237,7 +237,7 @@ GET /hello
 Authorization: Basic amFjazIwMjA6MTIzNDU2
 --- error_code: 403
 --- response_body
-{"message":"The jack2 is not allowed"}
+{"message":"The consumer_name is not allowed"}
 --- no_error_log
 [error]
 
@@ -302,7 +302,7 @@ GET /hello
 Authorization: Basic amFjazIwMTk6MTIzNDU2
 --- error_code: 403
 --- response_body
-{"message":"The jack1 is not allowed"}
+{"message":"The consumer_name is not allowed"}
 --- no_error_log
 [error]
 

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -47,7 +47,7 @@ __DATA__
 --- request
 GET /t
 --- response_body
-{"whitelist":["jack1","jack2"]}
+{"rejected_code":403,"type":"consumer_name","whitelist":["jack1","jack2"]}
 --- no_error_log
 [error]
 
@@ -237,7 +237,7 @@ GET /hello
 Authorization: Basic amFjazIwMjA6MTIzNDU2
 --- error_code: 403
 --- response_body
-{"message":"The consumer is not allowed"}
+{"message":"The consumer_name is not allowed"}
 --- no_error_log
 [error]
 
@@ -302,7 +302,7 @@ GET /hello
 Authorization: Basic amFjazIwMTk6MTIzNDU2
 --- error_code: 403
 --- response_body
-{"message":"The consumer is not allowed"}
+{"message":"The consumer_name is not allowed"}
 --- no_error_log
 [error]
 
@@ -540,3 +540,5 @@ GET /hello
 hello world
 --- no_error_log
 [error]
+
+

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -237,7 +237,7 @@ GET /hello
 Authorization: Basic amFjazIwMjA6MTIzNDU2
 --- error_code: 403
 --- response_body
-{"message":"The consumer_name is not allowed"}
+{"message":"The jack2 is not allowed"}
 --- no_error_log
 [error]
 
@@ -302,7 +302,7 @@ GET /hello
 Authorization: Basic amFjazIwMTk6MTIzNDU2
 --- error_code: 403
 --- response_body
-{"message":"The consumer_name is not allowed"}
+{"message":"The jack1 is not allowed"}
 --- no_error_log
 [error]
 
@@ -337,6 +337,7 @@ hello world
                         },
                         "plugins": {
                             "consumer-restriction": {
+                                "type": "consumer_name",
                                  "whitelist": [
                                      "jack1"
                                  ]


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `consumer` provides access to the `service` collection . Put it in the "consumer-restriction" plug-in to achieve, by adding the "schema" field of this plug-in, to control the access of "consumer" and "service".
### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
