### PR TITLE
fix: bump lua-resty-etcd to 1.2

### DIFF
--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -32,7 +32,7 @@ description = {
 
 dependencies = {
     "lua-resty-template = 1.9",
-    "lua-resty-etcd = 1.1",
+    "lua-resty-etcd = 1.2",
     "lua-resty-balancer = 0.02rc5",
     "lua-resty-ngxvar = 0.5",
     "lua-resty-jit-uuid = 0.0.7",


### PR DESCRIPTION
### What this PR does / why we need it:
update lua-resty-etcd version to remove the unnecessary log in etcd v3

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
