### PR TITLE
feat(http-logger): support to concat multiple log with separator.

### DIFF
--- a/apisix/plugins/http-logger.lua
+++ b/apisix/plugins/http-logger.lua
@@ -113,13 +113,6 @@ local function send_http_data(conf, log_message)
             .. "body[" .. httpc_res:read_body() .. "]"
     end
 
-    -- keep the connection alive
-    ok, err = httpc:set_keepalive(conf.keepalive)
-
-    if not ok then
-        core.log.debug("failed to keep the connection alive", err)
-    end
-
     return res, err_msg
 end
 

--- a/apisix/plugins/http-logger.lua
+++ b/apisix/plugins/http-logger.lua
@@ -23,6 +23,7 @@ local tostring = tostring
 local http = require "resty.http"
 local url = require "net.url"
 local buffers = {}
+local ipairs = ipairs
 
 local schema = {
     type = "object",

--- a/doc/plugins/http-logger.md
+++ b/doc/plugins/http-logger.md
@@ -59,7 +59,7 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
 {
       "plugins": {
             "http-logger": {
-                 "uri": "127.0.0.1:80/postendpoint?param=1",
+                "uri": "127.0.0.1:80/postendpoint?param=1",
             }
        },
       "upstream": {
@@ -91,7 +91,6 @@ APISIX plugins are hot-reloaded, therefore no need to restart APISIX.
 ```shell
 $ curl http://127.0.0.1:2379/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d value='
 {
-    "methods": ["GET"],
     "uri": "/hello",
     "plugins": {},
     "upstream": {

--- a/doc/plugins/http-logger.md
+++ b/doc/plugins/http-logger.md
@@ -20,6 +20,7 @@
 - [中文](../zh-cn/plugins/http-logger.md)
 
 # Summary
+
 - [**Name**](#name)
 - [**Attributes**](#attributes)
 - [**How To Enable**](#how-to-enable)
@@ -35,7 +36,6 @@ This will provide the ability to send Log data requests as JSON objects to Monit
 
 ## Attributes
 
-
 | Name             | Type    | Requirement | Default       | Valid   | Description                                                                              |
 | ---------------- | ------- | ----------- | ------------- | ------- | ---------------------------------------------------------------------------------------- |
 | uri              | string  | required    |               |         | URI of the server                                                                        |
@@ -48,6 +48,7 @@ This will provide the ability to send Log data requests as JSON objects to Monit
 | max_retry_count  | integer | optional    | 0             | [0,...] | Maximum number of retries before removing from the processing pipe line                  |
 | retry_delay      | integer | optional    | 1             | [0,...] | Number of seconds the process execution should be delayed if the execution fails         |
 | include_req_body | boolean | optional    | false         |         | Whether to include the request body                                                      |
+| concat_method    | string  | optional    | "json"        |         | Enum type, `json` and `new_line`. **json**: use `json.encode` for all pending logs. **new_line**: use `json.encode` for each pending log and concat them with "\n" line. |
 
 ## How To Enable
 
@@ -73,7 +74,7 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
 
 ## Test Plugin
 
-* success:
+> success:
 
 ```shell
 $ curl -i http://127.0.0.1:9080/hello

--- a/doc/zh-cn/plugins/http-logger.md
+++ b/doc/zh-cn/plugins/http-logger.md
@@ -59,7 +59,7 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
 {
       "plugins": {
             "http-logger": {
-                 "uri": "127.0.0.1:80/postendpoint?param=1"
+                "uri": "127.0.0.1:80/postendpoint?param=1"
             }
        },
       "upstream": {

--- a/doc/zh-cn/plugins/http-logger.md
+++ b/doc/zh-cn/plugins/http-logger.md
@@ -47,7 +47,6 @@
 | max_retry_count  | integer | 可选   | 0             | [0,...] | 从处理管道中移除之前的最大重试次数               |
 | retry_delay      | integer | 可选   | 1             | [0,...] | 如果执行失败，则应延迟执行流程的秒数             |
 | include_req_body | boolean | 可选   |               |         | 是否包括请求 body                                |
-| include_req_body | boolean | 可选   |               |         | 是否包括请求 body                                |
 | concat_method    | string  | 可选   | "json"        |         | 枚举类型，`json`、`new_line`。**json**: 对所有待发日志使用 `json.encode` 编码。**new_line**: 对每一条待发日志单独使用 `json.encode` 编码并使用 "\n" 连接起来。 |
 
 ## 如何开启

--- a/doc/zh-cn/plugins/http-logger.md
+++ b/doc/zh-cn/plugins/http-logger.md
@@ -47,6 +47,8 @@
 | max_retry_count  | integer | 可选   | 0             | [0,...] | 从处理管道中移除之前的最大重试次数               |
 | retry_delay      | integer | 可选   | 1             | [0,...] | 如果执行失败，则应延迟执行流程的秒数             |
 | include_req_body | boolean | 可选   |               |         | 是否包括请求 body                                |
+| include_req_body | boolean | 可选   |               |         | 是否包括请求 body                                |
+| concat_method    | string  | 可选   | "json"        |         | 枚举类型，`json`、`new_line`。**json**: 对所有待发日志使用 `json.encode` 编码。**new_line**: 对每一条待发日志单独使用 `json.encode` 编码并使用 "\n" 连接起来。 |
 
 ## 如何开启
 

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -282,4 +282,10 @@ function _M.headers()
     ngx.say("/headers")
 end
 
+function _M.log()
+    ngx.req.read_body()
+    local body = ngx.req.get_body_data()
+    ngx.log(ngx.WARN, "request log: ", body or "nil")
+end
+
 return _M

--- a/t/plugin/http-logger-new-line.t
+++ b/t/plugin/http-logger-new-line.t
@@ -152,7 +152,7 @@ location /t {
 }
 --- request
 GET /t
---- timeout: 4
+--- timeout: 10
 --- no_error_log
 [error]
 --- grep_error_log eval
@@ -179,7 +179,7 @@ location /t {
 }
 --- request
 GET /t
---- timeout: 4
+--- timeout: 10
 --- no_error_log
 [error]
 --- grep_error_log eval
@@ -210,7 +210,7 @@ location /t {
 }
 --- request
 GET /t
---- timeout: 4
+--- timeout: 10
 --- no_error_log
 [error]
 --- grep_error_log eval

--- a/t/plugin/http-logger-new-line.t
+++ b/t/plugin/http-logger-new-line.t
@@ -1,0 +1,193 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+log_level('info');
+repeat_each(1);
+no_long_string();
+no_root_location();
+run_tests;
+
+__DATA__
+
+=== TEST 1: sanity, batch_max_size=1
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "http-logger": {
+                                "uri": "http://127.0.0.1:1980/log",
+                                "batch_max_size": 1,
+                                "max_retry_count": 1,
+                                "retry_delay": 2,
+                                "buffer_duration": 2,
+                                "inactive_timeout": 2,
+                                "concat_method": "new_line"
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1982": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: hit route and report http logger
+--- request
+GET /hello
+--- response_body
+hello world
+--- wait: 0.5
+--- no_error_log
+[error]
+--- error_log
+request log: {"upstream":"127.0.0.1:1982"
+
+
+
+=== TEST 3: sanity, batch_max_size=1
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "http-logger": {
+                                "uri": "http://127.0.0.1:1980/log",
+                                "batch_max_size": 3,
+                                "max_retry_count": 3,
+                                "retry_delay": 2,
+                                "buffer_duration": 2,
+                                "inactive_timeout": 2,
+                                "concat_method": "new_line"
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1982": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: hit route, and no report log
+--- request
+GET /hello
+--- response_body
+hello world
+--- no_error_log
+[error]
+request log:
+
+
+
+=== TEST 5: hit route, and report log
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+
+        for i = 1, 6 do
+            t('/hello', ngx.HTTP_GET)
+        end
+
+        ngx.sleep(3)
+        ngx.say("done")
+    }
+}
+--- request
+GET /t
+--- timeout: 4
+--- no_error_log
+[error]
+--- grep_error_log eval
+qr/request log:/
+--- grep_error_log_out
+request log:
+request log:
+
+
+
+=== TEST 6: hit route, and report log
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+
+        for i = 1, 6 do
+            t('/hello', ngx.HTTP_GET)
+        end
+
+        ngx.sleep(3)
+        ngx.say("done")
+    }
+}
+--- request
+GET /t
+--- timeout: 4
+--- no_error_log
+[error]
+--- grep_error_log eval
+qr/"upstream":"127.0.0.1:1982"/
+--- grep_error_log_out
+"upstream":"127.0.0.1:1982"
+"upstream":"127.0.0.1:1982"
+"upstream":"127.0.0.1:1982"
+"upstream":"127.0.0.1:1982"
+"upstream":"127.0.0.1:1982"
+"upstream":"127.0.0.1:1982"

--- a/t/plugin/http-logger-new-line.t
+++ b/t/plugin/http-logger-new-line.t
@@ -96,7 +96,7 @@ request log: {"upstream":"127.0.0.1:1982"
                                 "max_retry_count": 3,
                                 "retry_delay": 2,
                                 "buffer_duration": 2,
-                                "inactive_timeout": 2,
+                                "inactive_timeout": 1,
                                 "concat_method": "new_line"
                             }
                         },
@@ -186,6 +186,36 @@ GET /t
 qr/"upstream":"127.0.0.1:1982"/
 --- grep_error_log_out
 "upstream":"127.0.0.1:1982"
+"upstream":"127.0.0.1:1982"
+"upstream":"127.0.0.1:1982"
+"upstream":"127.0.0.1:1982"
+"upstream":"127.0.0.1:1982"
+"upstream":"127.0.0.1:1982"
+
+
+
+=== TEST 7: hit route, and report log
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+
+        for i = 1, 5 do
+            t('/hello', ngx.HTTP_GET)
+        end
+
+        ngx.sleep(3)
+        ngx.say("done")
+    }
+}
+--- request
+GET /t
+--- timeout: 4
+--- no_error_log
+[error]
+--- grep_error_log eval
+qr/"upstream":"127.0.0.1:1982"/
+--- grep_error_log_out
 "upstream":"127.0.0.1:1982"
 "upstream":"127.0.0.1:1982"
 "upstream":"127.0.0.1:1982"


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

as title.

support to report log in this way:

```shell
curl http://****/log -d '
{xxxxxxxxxxxxx}
{yyyyyyyyyyyyy}
'
```

the request logs is concat by '\n' way.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
