### PR TITLE
doc: update router variable example (#2298)

### DIFF
--- a/doc/router-radixtree.md
+++ b/doc/router-radixtree.md
@@ -78,6 +78,8 @@ $ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f
 {
     "uri": "/index.html",
     "vars": [
+        ["http_host", "==", "iresty.com"],
+        ["cookie__device_id", "==", "a66f0cdc4ba2df8c096f74c9110163a9"],
         ["arg_name", "==", "json"],
         ["arg_age", ">", "18"],
         ["arg_address", "~~", "China.*"]

--- a/doc/router-radixtree.md
+++ b/doc/router-radixtree.md
@@ -79,7 +79,7 @@ $ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f
     "uri": "/index.html",
     "vars": [
         ["http_host", "==", "iresty.com"],
-        ["cookie__device_id", "==", "a66f0cdc4ba2df8c096f74c9110163a9"],
+        ["cookie_device_id", "==", "a66f0cdc4ba2df8c096f74c9110163a9"],
         ["arg_name", "==", "json"],
         ["arg_age", ">", "18"],
         ["arg_address", "~~", "China.*"]

--- a/doc/router-radixtree.md
+++ b/doc/router-radixtree.md
@@ -78,9 +78,9 @@ $ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f
 {
     "uri": "/index.html",
     "vars": [
-        ["http_host", "iresty.com"],
-        ["cookie__device_id", "a66f0cdc4ba2df8c096f74c9110163a9"],
-        ["arg_name", "jack"]
+        ["arg_name", "==", "json"],
+        ["arg_age", ">", "18"],
+        ["arg_address", "~~", "China.*"]
     ],
     "upstream": {
         "type": "roundrobin",


### PR DESCRIPTION
### What this PR does / why we need it:
Update the `router-radixtree` document.

The former router example in this document use "==" as the default operator, which is not the current behavior.
This PR modifies the example and keeps it consistent with the `admin-api` document.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
