### PR TITLE
bugfix: check every etcd version, rather than only check the first one

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -1012,8 +1012,6 @@ local function init_etcd(show_output)
                             ", please upgrade your etcd cluster\n")
             os.exit(1)
         end
-
-        break
     end
 
     local etcd_ok = false


### PR DESCRIPTION
### What this PR does / why we need it:

IMHO, the operation of "check the etcd cluster version" should check every etcd version in the yaml_conf.etcd.host list.
But the `break` make it only check the first one.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
