### PR TITLE
fix: it does'nt make sence to compare etcd_version, since it's nil.

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -984,7 +984,6 @@ local function init_etcd(show_output)
         yaml_conf.etcd.host = {yaml_conf.etcd.host}
     end
 
-    local cluster_version
     local host_count = #(yaml_conf.etcd.host)
     local dkjson = require("dkjson")
 
@@ -1032,7 +1031,7 @@ local function init_etcd(show_output)
                         .. " --max-time " .. timeout * 2 .. " --retry 1 2>&1"
 
             local res = execute_cmd(cmd)
-            if (etcd_version == "v3" and not res:find("OK", 1, true)) then
+            if res:find("OK", 1, true) then
                 is_success = false
                 if (index == host_count) then
                     error(cmd .. "\n" .. res)


### PR DESCRIPTION
### What this PR does / why we need it:

1. the result below will always be false ,since etcd_version is nil:

```lua
if (etcd_version == "v3" and not res:find("OK", 1, true)) then
                is_success = false
                if (index == host_count) then
                    error(cmd .. "\n" .. res)
                end

                break
            end
``` 
and since etcd_version has been checked before, I think maybe there is no need to check it again here.

2. cluster_version has been defined previously, no need to define a new local one.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?

