### PR TITLE
The old CLI invalid argument prompt is unfriendly.

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -1127,7 +1127,7 @@ end
 
 if not _M[cmd_action] then
     print("invalid argument: ", cmd_action, "\n")
-	_M.help()
+    _M.help()
     return
 end
 

--- a/bin/apisix
+++ b/bin/apisix
@@ -1127,7 +1127,7 @@ end
 
 if not _M[cmd_action] then
     print("invalid argument: ", cmd_action, "\n")
-		_M.help()
+	_M.help()
     return
 end
 

--- a/bin/apisix
+++ b/bin/apisix
@@ -1127,6 +1127,7 @@ end
 
 if not _M[cmd_action] then
     print("invalid argument: ", cmd_action, "\n")
+		_M.help()
     return
 end
 


### PR DESCRIPTION
### What this PR does / why we need it:
Because the old CLI invalid argument prompt is unfriendly. So I modify it, next look like friendly.

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?

No . maybe you can used the CLI
```shell
apisix --help
```
* [x] Have you modified the corresponding document?

I modified the invalid argument prompt. 
* [x] Is this PR backward compatible?
