### PR TITLE
feat: In dns parse, when the parameter `resolvers` is empty, the local dns is used as `resolvers` by default 

### DIFF
--- a/apisix/core/utils.lua
+++ b/apisix/core/utils.lua
@@ -69,7 +69,7 @@ function _M.split_uri(uri)
 end
 
 
-local function dns_parse(resolvers, domain)
+local function dns_parse(domain, resolvers)
     resolvers = resolvers or _M.resolvers
     local r, err = resolver:new{
         nameservers = table.clone(resolvers),
@@ -101,7 +101,7 @@ local function dns_parse(resolvers, domain)
         return nil, "unsupport DNS answer"
     end
 
-    return dns_parse(resolvers, answer.cname)
+    return dns_parse(answer.cname, resolvers)
 end
 _M.dns_parse = dns_parse
 

--- a/apisix/core/utils.lua
+++ b/apisix/core/utils.lua
@@ -70,6 +70,7 @@ end
 
 
 local function dns_parse(resolvers, domain)
+    resolvers = resolvers or _M.resolvers
     local r, err = resolver:new{
         nameservers = table.clone(resolvers),
         retrans = 5,  -- 5 retransmissions on receive timeout
@@ -103,6 +104,11 @@ local function dns_parse(resolvers, domain)
     return dns_parse(resolvers, answer.cname)
 end
 _M.dns_parse = dns_parse
+
+
+function _M.set_resolver(resolvers)
+    _M.resolvers = resolvers
+end
 
 
 local function rfind_char(s, ch, idx)

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -178,7 +178,7 @@ end
 
 
 local function parse_domain(host)
-    local ip_info, err = core.utils.dns_parse(dns_resolver, host)
+    local ip_info, err = core.utils.dns_parse(host, dns_resolver)
     if not ip_info then
         core.log.error("failed to parse domain: ", host, ", error: ",err)
         return nil, err

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -178,7 +178,7 @@ end
 
 
 local function parse_domain(host)
-    local ip_info, err = core.utils.dns_parse(host, dns_resolver)
+    local ip_info, err = core.utils.dns_parse(host)
     if not ip_info then
         core.log.error("failed to parse domain: ", host, ", error: ",err)
         return nil, err

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -45,6 +45,7 @@ local ver_header    = "APISIX/" .. core.version.VERSION
 
 local function parse_args(args)
     dns_resolver = args and args["dns_resolver"]
+    core.utils.set_resolver(dns_resolver)
     core.log.info("dns resolver", core.json.delay_encode(dns_resolver, true))
 end
 
@@ -218,6 +219,7 @@ local function parse_domain_for_nodes(nodes)
     end
     return new_nodes
 end
+
 
 local function compare_upstream_node(old_t, new_t)
     if type(old_t) ~= "table" then

--- a/t/core/utils.t
+++ b/t/core/utils.t
@@ -88,10 +88,10 @@ GET /t
 --- request
 GET /t
 --- response_body eval
-qr/"name":"baidu.com"/
+qr/"address":.+,"name":"baidu.com"/
 --- no_error_log
 [error]
-
+--- LAST
 
 
 === TEST 4: resolvers is empty
@@ -112,6 +112,6 @@ GET /t
 --- response_body
 resolvers: ["8.8.8.8","114.114.114.114"]
 --- error_log eval
-qr/"name":"baidu.com"/
+qr/"address":.+,"name":"baidu.com"/
 --- no_error_log
 [error]

--- a/t/core/utils.t
+++ b/t/core/utils.t
@@ -91,7 +91,7 @@ GET /t
 qr/"address":.+,"name":"baidu.com"/
 --- no_error_log
 [error]
---- LAST
+
 
 
 === TEST 4: resolvers is empty

--- a/t/core/utils.t
+++ b/t/core/utils.t
@@ -68,3 +68,19 @@ qr/random seed \d+\ntwice: false/
 GET /t
 --- no_error_log
 [error]
+
+
+=== TEST 2: allow resolvers is empty
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            ngx.say("resolvers: ", core.json.encode(core.utils.resolvers))
+        }
+    }
+--- request
+GET /t
+--- response_body
+resolvers: ["8.8.8.8","114.114.114.114"]
+--- no_error_log
+[error]

--- a/t/core/utils.t
+++ b/t/core/utils.t
@@ -70,17 +70,20 @@ GET /t
 [error]
 
 
+
 === TEST 2: allow resolvers is empty
 --- config
     location /t {
         content_by_lua_block {
             local core = require("apisix.core")
+            local resolvers
+            core.utils.set_resolver(resolvers)
             ngx.say("resolvers: ", core.json.encode(core.utils.resolvers))
         }
     }
 --- request
 GET /t
 --- response_body
-resolvers: ["8.8.8.8","114.114.114.114"]
+resolvers: null
 --- no_error_log
 [error]

--- a/t/core/utils.t
+++ b/t/core/utils.t
@@ -71,14 +71,14 @@ GET /t
 
 
 
-=== TEST 3: resolvers is not empty
+=== TEST 3: specify resolvers
 --- config
     location /t {
         content_by_lua_block {
             local core = require("apisix.core")
             local resolvers = {"8.8.8.8"}
             core.utils.set_resolver(resolvers)
-            local ip_info, err = core.utils.dns_parse("baidu.com", resolvers)
+            local ip_info, err = core.utils.dns_parse("github.com", resolvers)
             if not ip_info then
                 core.log.error("failed to parse domain: ", host, ", error: ",err)
             end
@@ -88,18 +88,18 @@ GET /t
 --- request
 GET /t
 --- response_body eval
-qr/"address":.+,"name":"baidu.com"/
+qr/"address":.+,"name":"github.com"/
 --- no_error_log
 [error]
 
 
 
-=== TEST 4: resolvers is empty
+=== TEST 4: default resolvers
 --- config
     location /t {
         content_by_lua_block {
             local core = require("apisix.core")
-            local ip_info, err = core.utils.dns_parse("baidu.com")
+            local ip_info, err = core.utils.dns_parse("github.com")
             if not ip_info then
                 core.log.error("failed to parse domain: ", host, ", error: ",err)
             end
@@ -112,6 +112,6 @@ GET /t
 --- response_body
 resolvers: ["8.8.8.8","114.114.114.114"]
 --- error_log eval
-qr/"address":.+,"name":"baidu.com"/
+qr/"address":.+,"name":"github.com"/
 --- no_error_log
 [error]

--- a/t/node/upstream-node-dns.t
+++ b/t/node/upstream-node-dns.t
@@ -79,7 +79,7 @@ passed
     apisix.http_init()
 
     local utils = require("apisix.core.utils")
-    utils.dns_parse = function (resolvers, domain)  -- mock: DNS parser
+    utils.dns_parse = function (domain, resolvers)  -- mock: DNS parser
         if domain == "test.com" then
             return {address = "127.0.0.2"}
         end
@@ -104,7 +104,7 @@ hello world
 
     local utils = require("apisix.core.utils")
     local count = 0
-    utils.dns_parse = function (resolvers, domain)  -- mock: DNS parser
+    utils.dns_parse = function (domain, resolvers)  -- mock: DNS parser
         count = count + 1
 
         if domain == "test.com" then
@@ -192,7 +192,7 @@ passed
     apisix.http_init()
 
     local utils = require("apisix.core.utils")
-    utils.dns_parse = function (resolvers, domain)  -- mock: DNS parser
+    utils.dns_parse = function (domain, resolvers)  -- mock: DNS parser
         if domain == "test.com" or domain == "test2.com" then
             return {address = "127.0.0.2"}
         end
@@ -217,7 +217,7 @@ hello world
 
     local utils = require("apisix.core.utils")
     local count = 0
-    utils.dns_parse = function (resolvers, domain)  -- mock: DNS parser
+    utils.dns_parse = function (domain, resolvers)  -- mock: DNS parser
         count = count + 1
 
         if domain == "test.com" or domain == "test2.com" then
@@ -338,7 +338,7 @@ passed
 
     local utils = require("apisix.core.utils")
     local count = 0
-    utils.dns_parse = function (resolvers, domain)  -- mock: DNS parser
+    utils.dns_parse = function (domain, resolvers)  -- mock: DNS parser
         count = count + 1
 
         if domain == "test.com" then
@@ -425,7 +425,7 @@ passed
 
     local utils = require("apisix.core.utils")
     local count = 0
-    utils.dns_parse = function (resolvers, domain)  -- mock: DNS parser
+    utils.dns_parse = function (domain, resolvers)  -- mock: DNS parser
         count = count + 1
 
         if domain == "test.com" or domain == "test2.com" then
@@ -487,7 +487,7 @@ proxy request to 127.0.0.5:1980
 
     local utils = require("apisix.core.utils")
     local count = 1
-    utils.dns_parse = function (resolvers, domain)  -- mock: DNS parser
+    utils.dns_parse = function (domain, resolvers)  -- mock: DNS parser
         if domain == "test.com" or domain == "test2.com" then
             return {address = "127.0.0.1"}
         end
@@ -579,7 +579,7 @@ passed
 
     local utils = require("apisix.core.utils")
     local count = 0
-    utils.dns_parse = function (resolvers, domain)  -- mock: DNS parser
+    utils.dns_parse = function (domain, resolvers)  -- mock: DNS parser
         count = count + 1
         if domain == "test.com" or domain == "test2.com" then
             return {address = "127.0.0." .. count}


### PR DESCRIPTION
fix #2422

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
