### PR TITLE
feature: prometheus plugin `apisix_http_status` metric `route` tag Im…

### DIFF
--- a/apisix/http/router/radixtree_host_uri.lua
+++ b/apisix/http/router/radixtree_host_uri.lua
@@ -60,9 +60,11 @@ local function push_host_router(route, host_routes, only_uri_routes)
                        or route.value.remote_addr,
         vars = route.value.vars,
         filter_fun = filter_fun,
-        handler = function (api_ctx)
+        handler = function (api_ctx, curr_req_matched_record)
             api_ctx.matched_params = nil
             api_ctx.matched_route = route
+            --to keep the record which matches the current request and pass it to api_ctx
+            api_ctx.curr_req_matched_record = curr_req_matched_record
         end
     }
 
@@ -130,9 +132,13 @@ function _M.match(api_ctx)
     match_opts.vars = api_ctx.var
     match_opts.host = api_ctx.var.host
 
+    local curr_req_matched_record = {}
+    match_opts.matched = curr_req_matched_record
+
     if host_router then
         local host_uri = api_ctx.var.host
-        local ok = host_router:dispatch(host_uri:reverse(), match_opts, api_ctx)
+        local ok = host_router:dispatch(host_uri:reverse(), match_opts, api_ctx,
+                curr_req_matched_record)
         if ok then
             return true
         end

--- a/apisix/http/router/radixtree_uri.lua
+++ b/apisix/http/router/radixtree_uri.lua
@@ -62,9 +62,11 @@ local function create_radixtree_router(routes)
                                or route.value.remote_addr,
                 vars = route.value.vars,
                 filter_fun = filter_fun,
-                handler = function (api_ctx)
+                handler = function (api_ctx, curr_req_matched_record)
                     api_ctx.matched_params = nil
                     api_ctx.matched_route = route
+                    --to keep the record which matches the current request and pass it to api_ctx
+                    api_ctx.curr_req_matched_record = curr_req_matched_record
                 end
             })
 
@@ -95,7 +97,10 @@ function _M.match(api_ctx)
     match_opts.remote_addr = api_ctx.var.remote_addr
     match_opts.vars = api_ctx.var
 
-    local ok = uri_router:dispatch(api_ctx.var.uri, match_opts, api_ctx)
+    local curr_req_matched_record = {}
+    match_opts.matched = curr_req_matched_record
+
+    local ok = uri_router:dispatch(api_ctx.var.uri, match_opts, api_ctx, curr_req_matched_record)
     return ok
 end
 

--- a/t/plugin/prometheus.t
+++ b/t/plugin/prometheus.t
@@ -521,7 +521,7 @@ passed
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_http_status\{code="404",route="3",service="",node="127.0.0.1"\} 2/
+qr/apisix_http_status\{code="404",route="3",matched_uri="\/hello3",matched_host="",service="",node="127.0.0.1"\} 2/
 --- no_error_log
 [error]
 


### PR DESCRIPTION
…prove recognition (#1574)

fix #1574

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
Prometheus plugin `apisix_http_status` metric `route` tag Improve recognition.

Originally, the `/apisix/prometheus/metrics` endpoint only showed the `id` of the `router`.
However, if the route has `uris` or `hosts` parameters, the user does not know the number of times an element in `uris` or `hosts` has been matched, the collection of coarse granularity, and in Grafana to display the `id` of the `route` is not friendly enough.

This PR adds two elements, `matched_uri` and `matched_host`, to the `apisix_http_status` property of the `/apisix/prometheus/metrics` endpoint to show in detail the elements that are matched in the `uris` or `hosts`.
Note: I added the parameter `curr_req_matched_record` to the `api_ctx` to keep track of the `route` record for the current request match.

The `apisix_http_status` will look like this

```
apisix_http_status{code="200",route="",matched_uri="",matched_host="",service="localhost",node=""} 5
apisix_http_status{code="200",route="1",matched_uri="/hello",matched_host="",service="",node=""} 6
apisix_http_status{code="200",route="1",matched_uri="/hello",matched_host="",service="",node="127.0.0.1"} 20
apisix_http_status{code="200",route="2",matched_uri="/hello1",matched_host="",service="1",node="127.0.0.1"} 6
apisix_http_status{code="404",route="",matched_uri="",matched_host="",service="localhost",node=""} 6
apisix_http_status{code="404",route="3",matched_uri="/hello3",matched_host="",service="",node="127.0.0.1"} 2
```

[#1574](https://github.com/apache/apisix/issues/1574)

<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
