### PR TITLE
[doc]to correct some typo and incorrect examples in getting-started.md and syslog.md

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -237,7 +237,7 @@ curl http://127.0.0.1:9080/apisix/admin/routes/5 -H 'X-API-KEY: edd1c9f034335f13
 Now you can invoke the route with the following command:
 
 ```bash
-curl -i -X GET http://127.0.0.1:9080/samplePrefix/get?param1=foo&param2=bar -H 'apikey: superSecretAPIKey'
+curl -i -X GET "http://127.0.0.1:9080/samplePrefix/get?param1=foo&param2=bar" -H 'apikey: superSecretAPIKey'
 ```
 
 ## APISIX Dashboard

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -237,7 +237,7 @@ curl http://127.0.0.1:9080/apisix/admin/routes/5 -H 'X-API-KEY: edd1c9f034335f13
 Now you can invoke the route with the following command:
 
 ```bash
-curl -i -X GET "http://127.0.0.1:9080/samplePrefix/get?param1=foo&param2=bar" -H 'apikey: superSecretAPIKey'
+curl -i -X GET 'http://127.0.0.1:9080/samplePrefix/get?param1=foo&param2=bar' -H 'apikey: superSecretAPIKey'
 ```
 
 ## APISIX Dashboard

--- a/doc/plugins/syslog.md
+++ b/doc/plugins/syslog.md
@@ -57,25 +57,22 @@ This will provide the ability to send Log data requests as JSON objects.
 The following is an example on how to enable the sys-logger for a specific route.
 
 ```shell
-curl http://127.0.0.1:9080/apisix/admin/consumers -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
-    "username": "foo",
     "plugins": {
-          "plugins": {
-                "syslog": {
-                     "host" : "127.0.0.1",
-                     "port" : 5044,
-                     "flush_limit" : 1
-                  }
-           },
-          "upstream": {
-               "type": "roundrobin",
-               "nodes": {
-                   "127.0.0.1:1980": 1
-               }
-          },
-          "uri": "/hello"
-    }
+        "syslog": {
+                "host" : "127.0.0.1",
+                "port" : 5044,
+                "flush_limit" : 1
+            }
+    },
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "127.0.0.1:1980": 1
+        }
+    },
+    "uri": "/hello"
 }'
 ```
 
@@ -96,7 +93,7 @@ Remove the corresponding json configuration in the plugin configuration to disab
 APISIX plugins are hot-reloaded, therefore no need to restart APISIX.
 
 ```shell
-$ curl http://127.0.0.1:2379/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d value='
+$ curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d value='
 {
     "methods": ["GET"],
     "uri": "/hello",

--- a/doc/plugins/syslog.md
+++ b/doc/plugins/syslog.md
@@ -93,7 +93,7 @@ Remove the corresponding json configuration in the plugin configuration to disab
 APISIX plugins are hot-reloaded, therefore no need to restart APISIX.
 
 ```shell
-$ curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d value='
+$ curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "methods": ["GET"],
     "uri": "/hello",

--- a/doc/zh-cn/getting-started.md
+++ b/doc/zh-cn/getting-started.md
@@ -232,7 +232,7 @@ curl http://127.0.0.1:9080/apisix/admin/routes/5 -H 'X-API-KEY: edd1c9f034335f13
 现在可以使用以下命令调用路由：
 
 ```bash
-curl -i -X GET "http://127.0.0.1:9080/samplePrefix/get?param1=foo&param2=bar" -H 'apikey: superSecretAPIKey'
+curl -i -X GET 'http://127.0.0.1:9080/samplePrefix/get?param1=foo&param2=bar' -H 'apikey: superSecretAPIKey'
 ```
 
 ## Apache APISIX 控制台

--- a/doc/zh-cn/getting-started.md
+++ b/doc/zh-cn/getting-started.md
@@ -232,7 +232,7 @@ curl http://127.0.0.1:9080/apisix/admin/routes/5 -H 'X-API-KEY: edd1c9f034335f13
 现在可以使用以下命令调用路由：
 
 ```bash
-curl -i -X GET http://127.0.0.1:9080/samplePrefix/get?param1=foo&param2=bar -H 'apikey: superSecretAPIKey'
+curl -i -X GET "http://127.0.0.1:9080/samplePrefix/get?param1=foo&param2=bar" -H 'apikey: superSecretAPIKey'
 ```
 
 ## Apache APISIX 控制台

--- a/doc/zh-cn/plugins/syslog.md
+++ b/doc/zh-cn/plugins/syslog.md
@@ -93,7 +93,7 @@ hello, world
 想要禁用“sys-logger”插件，是非常简单的，将对应的插件配置从json配置删除，就会立即生效，不需要重新启动服务：
 
 ```shell
-$ curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d value='
+$ curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "methods": ["GET"],
     "uri": "/hello",

--- a/doc/zh-cn/plugins/syslog.md
+++ b/doc/zh-cn/plugins/syslog.md
@@ -57,25 +57,22 @@
 1. 下面例子展示了如何为指定路由开启 `sys-logger` 插件的。
 
 ```shell
-curl http://127.0.0.1:9080/apisix/admin/consumers -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
-    "username": "foo",
     "plugins": {
-          "plugins": {
-              "syslog": {
-                   "host" : "127.0.0.1",
-                   "port" : 5044,
-                   "flush_limit" : 1
-                }
-           },
-          "upstream": {
-               "type": "roundrobin",
-               "nodes": {
-                   "127.0.0.1:1980": 1
-               }
-          },
-          "uri": "/hello"
-    }
+        "syslog": {
+            "host" : "127.0.0.1",
+            "port" : 5044,
+            "flush_limit" : 1
+        }
+    },
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "127.0.0.1:1980": 1
+        }
+    },
+    "uri": "/hello"
 }'
 ```
 
@@ -96,7 +93,7 @@ hello, world
 想要禁用“sys-logger”插件，是非常简单的，将对应的插件配置从json配置删除，就会立即生效，不需要重新启动服务：
 
 ```shell
-$ curl http://127.0.0.1:2379/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d value='
+$ curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d value='
 {
     "methods": ["GET"],
     "uri": "/hello",


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
fix #2457 
### Pre-submission checklist:
https://github.com/apache/apisix/blob/master/doc/getting-started.md#add-a-prefix-to-the-route Line 240
should be replaced with
curl -i -X GET "http://127.0.0.1:9080/samplePrefix/get?param1=foo&param2=bar" -H 'apikey: superSecretAPIKey'

the example in  https://github.com/apache/apisix/blob/master/doc/plugins/syslog.md#how-to-enable should be for route not consumers and the value is wrong.