### PR TITLE
optimize: read trailing bytes only one time in stand-alone mode.

### DIFF
--- a/apisix/core/config_yaml.lua
+++ b/apisix/core/config_yaml.lua
@@ -56,8 +56,8 @@ local mt = {
 }
 
 
-    local apisix_yaml
-    local apisix_yaml_ctime
+local apisix_yaml
+local apisix_yaml_ctime
 local function read_apisix_yaml(premature, pre_mtime)
     if premature then
         return

--- a/apisix/core/config_yaml.lua
+++ b/apisix/core/config_yaml.lua
@@ -80,17 +80,10 @@ local function read_apisix_yaml(premature, pre_mtime)
         return
     end
 
-    local found_end_flag
-    for i = 1, 10 do
-        f:seek('end', -i)
-
-        local end_flag = f:read("*a")
-        -- log.info(i, " flag: ", end_flag)
-        if re_find(end_flag, [[#END\s*]], "jo") then
-            found_end_flag = true
-            break
-        end
-    end
+    f:seek('end', -10)
+    local end_flag = f:read("*a")
+    -- log.info("flag: ", end_flag)
+    local found_end_flag = re_find(end_flag, [[#END\s*$]], "jo")
 
     if not found_end_flag then
         f:close()


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
IMHO, there is no need to loop 10 times for read trailing bytes in stand-alone mode,
or maybe there is some special reason i didn't get.
If so, @membphis  would you please explain it a little? thanks.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
