### PR TITLE
feature: support injecting lua_ssl_trusted_certificate.

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -389,6 +389,10 @@ http {
         ssl_session_cache    shared:SSL:20m;
         ssl_session_timeout 10m;
 
+        {% if ssl.ssl_trusted_certificate ~= nil then %}
+        lua_ssl_trusted_certificate {* ssl.ssl_trusted_certificate *};
+        {% end %}
+
         ssl_protocols {* ssl.ssl_protocols *};
         ssl_ciphers {* ssl.ssl_ciphers *};
         ssl_prefer_server_ciphers on;
@@ -587,6 +591,17 @@ local function read_file(file_path)
     local data = file:read("*all")
     file:close()
     return data
+end
+
+
+local function is_file_exist(file_path)
+    local file, err = io.open(file_path)
+    if not file then
+        return false, "failed to open file: " .. file_path .. ", error info: " .. err
+    end
+
+    file:close()
+    return true
 end
 
 
@@ -902,6 +917,14 @@ Please modify "admin_key" in conf/config.yaml .
     if type(yaml_conf.apisix.ssl.listen_port) == "number" then
         local listen_port = {yaml_conf.apisix.ssl.listen_port}
         yaml_conf.apisix.ssl.listen_port = listen_port
+    end
+
+    if yaml_conf.apisix.ssl.ssl_trusted_certificate ~= nil then
+        local ok, err = is_file_exist(yaml_conf.apisix.ssl.ssl_trusted_certificate)
+        if not ok then
+            io.stderr:write(err, "\n")
+            os.exit(1)
+        end
     end
 
 

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -101,6 +101,9 @@ apisix:
     enable: true
     enable_http2: true
     listen_port: 9443
+    # ssl_trusted_certificate: /path/to/ca-cert # Specifies a file path with trusted CA certificates in the PEM format
+                                                # used to verify the certificate when APISIX needs to do SSL/TLS handshaking
+                                                # with external services (e.g. etcd)
     ssl_protocols: "TLSv1.2 TLSv1.3"
     ssl_ciphers: "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"
     key_encrypt_salt: "edd1c9f0985e76a2"    #  If not set, will save origin ssl key into etcd.


### PR DESCRIPTION
### What this PR does / why we need it:

Support to configure `lua_ssl_trusted_certificate` in configuration, so that one can use the certs signed by their own CA as an external dependency of APISIX, like ETCD.

This PR is necessary for the subsequent TLS for ETCD connection feature.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
