### PR TITLE
chore: change test case to keep stable

### DIFF
--- a/t/plugin/batch-requests.t
+++ b/t/plugin/batch-requests.t
@@ -991,3 +991,29 @@ GET /t
 qr/\{"error_msg":"invalid configuration: property \\"max_body_size\\" validation failed: expected 0 to be sctrictly greater than 0"\}/
 --- no_error_log
 [error]
+
+
+
+=== TEST 23: keep environment clean
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/plugin_metadata/batch-requests',
+                ngx.HTTP_PUT,
+                [[{
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]

--- a/t/plugin/udp-logger.t
+++ b/t/plugin/udp-logger.t
@@ -228,4 +228,4 @@ GET /t
 --- error_log
 failed to connect to UDP server: host[312.0.0.1] port[2000]
 [error]
---- wait: 2
+--- wait: 5


### PR DESCRIPTION
Two fixes:
- Delete the test configuration to keep the environment clean, otherwise the next run will fail。
- The wait time of udp-logger test case is too short, it will failed sometime.Increase it to 5 secs keep stable.