### PR TITLE
fix bug of attempt to compare number with string

### DIFF
--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -178,8 +178,13 @@ local function set_modify_index(key, items, items_ver, global_max_index)
     local max_idx = 0
     if items_ver and items then
         for _, item in ipairs(items) do
-            if type(item) == "table" and item.modifiedIndex > max_idx then
-                max_idx = item.modifiedIndex
+            if type(item) == "table" then
+                if type(item.modifiedIndex) == 'string' then
+                  item.modifiedIndex = tonumber(item.modifiedIndex)
+                end
+                if item.modifiedIndex > max_idx then
+                  max_idx = item.modifiedIndex
+                end
             end
         end
     end


### PR DESCRIPTION

### What this PR does / why we need it:
   found a bug of compare number with string.

2020/11/1 11:14:47 [error] 20511#20511: *12449485 lua entry thread aborted: runtime error: /usr/local/apisix/apisix/plugins/prometheus/exporter.lua:181: attempt to compare number with string
stack traceback:
coroutine 0:
	/usr/local/apisix/apisix/plugins/prometheus/exporter.lua: in function 'set_modify_index'
	/usr/local/apisix/apisix/plugins/prometheus/exporter.lua:203: in function 'etcd_modify_index'
	/usr/local/apisix/apisix/plugins/prometheus/exporter.lua:262: in function 'handler'
	/usr/local/apisix/apisix/plugin.lua:209: in function 'handler'
	/usr/local/apisix//deps/share/lua/5.1/resty/radixtree.lua:739: in function 'dispatch'
	/usr/local/apisix/apisix/http/router/radixtree_uri.lua:110: in function 'match'
	/usr/local/apisix/apisix/init.lua:336: in function 'http_access_phase'

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible?
