### PR TITLE
if the last server doesn't work well, we can use next in chash.

### DIFF
--- a/apisix/balancer/chash.lua
+++ b/apisix/balancer/chash.lua
@@ -68,8 +68,15 @@ function _M.new(up_nodes, upstream)
     return {
         upstream = upstream,
         get = function (ctx)
-            local chash_key = fetch_chash_hash_key(ctx, upstream)
-            local id = picker:find(chash_key)
+            local id, index
+            local last_index = ctx.chash_last_server_index
+            if ctx.chash_last_server_index then
+                id, index = picker:next(last_index)
+            else
+                local chash_key = fetch_chash_hash_key(ctx, upstream)
+                id, index = picker:find(chash_key)
+            end
+            ctx.chash_last_server_index = index
             -- core.log.warn("chash id: ", id, " val: ", servers[id])
             return servers[id]
         end

--- a/apisix/balancer/chash.lua
+++ b/apisix/balancer/chash.lua
@@ -70,7 +70,7 @@ function _M.new(up_nodes, upstream)
         get = function (ctx)
             local id, index
             local last_index = ctx.chash_last_server_index
-            if ctx.chash_last_server_index then
+            if last_index then
                 id, index = picker:next(last_index)
             else
                 local chash_key = fetch_chash_hash_key(ctx, upstream)


### PR DESCRIPTION
Fix that if the last server doesn't work well and the upstream.type is chash, apisix won't use another server.


### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
