### PR TITLE
use next() method pick next id.

### DIFF
--- a/apisix/balancer/chash.lua
+++ b/apisix/balancer/chash.lua
@@ -55,6 +55,7 @@ end
 
 function _M.new(up_nodes, upstream)
     local str_null = str_char(0)
+    local last_server_index
 
     local servers, nodes = {}, {}
     for serv, weight in pairs(up_nodes) do
@@ -68,8 +69,12 @@ function _M.new(up_nodes, upstream)
     return {
         upstream = upstream,
         get = function (ctx)
-            local chash_key = fetch_chash_hash_key(ctx, upstream)
-            local id = picker:find(chash_key)
+            local id
+            if ctx.balancer_try_count > 1 then
+                id, last_server_index = picker:next(last_server_index)
+            else
+                local chash_key = fetch_chash_hash_key(ctx, upstream)
+                id, last_server_index = picker:find(chash_key)
             -- core.log.warn("chash id: ", id, " val: ", servers[id])
             return servers[id]
         end


### PR DESCRIPTION
when last server doesn't work and upstream type is chash, should not use the same server, use next() method pick next id.


### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
