### PR TITLE
feat: hide APISIX version from Server header.

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -117,6 +117,10 @@ function _M.http_init_worker()
     lru_resolved_domain = core.lrucache.new({
         ttl = dns_resolver_valid, count = 512, invalid_stale = true,
     })
+
+    if local_conf.apisix and local_conf.apisix.enable_server_tokens == false then
+        ver_header = "APISIX"
+    end
 end
 
 

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -39,7 +39,7 @@ apisix:
   #  enable_tcp_pp: true           # Enable the proxy protocol for tcp proxy, it works for stream_proxy.tcp option
   #  enable_tcp_pp_to_upstream: true # Enables the proxy protocol to the upstream server
 
-  enable_server_tokens: true       # Whether the APISIX version number will be showed in Server header.
+  enable_server_tokens: true       # Whether the APISIX version number should be shown in Server header.
                                    # It's enabled by default.
 
   proxy_cache:                     # Proxy Caching configuration

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -39,6 +39,9 @@ apisix:
   #  enable_tcp_pp: true           # Enable the proxy protocol for tcp proxy, it works for stream_proxy.tcp option
   #  enable_tcp_pp_to_upstream: true # Enables the proxy protocol to the upstream server
 
+  enable_server_tokens: true       # Whether the APISIX version number will be showed in Server header.
+                                   # It's enabled by default.
+
   proxy_cache:                     # Proxy Caching configuration
     cache_ttl: 10s                 # The default caching time if the upstream does not specify the cache time
     zones:                         # The parameters of a cache

--- a/t/core/utils.t
+++ b/t/core/utils.t
@@ -115,3 +115,87 @@ resolvers: ["8.8.8.8","114.114.114.114"]
 qr/"address":.+,"name":"github.com"/
 --- no_error_log
 [error]
+
+
+=== TEST 5: enable_server_tokens false
+--- yaml_config
+apisix:
+  node_listen: 1984
+  enable_server_tokens: false
+  admin_key: null
+
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body = t('/apisix/admin/routes/1',
+            ngx.HTTP_PUT,
+             [[{
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+            }]]
+            )
+
+        if code >= 300 then
+            ngx.status = code
+            ngx.say("failed")
+            return
+        end
+
+        do
+            local sock = ngx.socket.tcp()
+
+            sock:settimeout(2000)
+
+            local ok, err = sock:connect("127.0.0.1", 1984)
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            ngx.say("connected: ", ok)
+
+            local req = "GET /hello HTTP/1.0\r\nHost: www.test.com\r\nConnection: close\r\n\r\n"
+            local bytes, err = sock:send(req)
+            if not bytes then
+                ngx.say("failed to send http request: ", err)
+                return
+            end
+
+            ngx.say("sent http request: ", bytes, " bytes.")
+
+            while true do
+                local line, err = sock:receive()
+                if not line then
+                    -- ngx.say("failed to receive response status line: ", err)
+                    break
+                end
+
+                ngx.say("received: ", line)
+            end
+
+            local ok, err = sock:close()
+            ngx.say("close: ", ok, " ", err)
+        end  -- do
+    }
+}
+--- request
+GET /t
+--- response_body eval
+qr{connected: 1
+sent http request: 62 bytes.
+received: HTTP/1.1 200 OK
+received: Content-Type: text/plain
+received: Content-Length: 12
+received: Connection: close
+received: Server: APISIX
+received: Server: openresty
+received: \nreceived: hello world
+close: 1 nil}
+--- no_error_log
+[error]

--- a/t/core/utils.t
+++ b/t/core/utils.t
@@ -117,6 +117,7 @@ qr/"address":.+,"name":"github.com"/
 [error]
 
 
+
 === TEST 5: enable_server_tokens false
 --- yaml_config
 apisix:


### PR DESCRIPTION
# What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Sometimes expose version is dangerous, which can be utilized by
malicious crackers when there are some security bugs in that version.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
