### PR TITLE
fix: the jwt plugin does not handle the case where `exp` is empty. (#…

### DIFF
--- a/apisix/plugins/jwt-auth.lua
+++ b/apisix/plugins/jwt-auth.lua
@@ -53,7 +53,7 @@ local consumer_schema = {
             enum = {"HS256", "HS512", "RS256"},
             default = "HS256"
         },
-        exp = {type = "integer", minimum = 1},
+        exp = {type = "integer", minimum = 1, default = 86400},
         base64_secret = {
             type = "boolean",
             default = false
@@ -121,10 +121,6 @@ function _M.check_schema(conf, schema_type)
             if not conf.private_key then
                 return false, "missing valid private key"
             end
-        end
-
-        if not conf.exp then
-            conf.exp = 60 * 60 * 24
         end
     end
 

--- a/t/plugin/jwt-auth.t
+++ b/t/plugin/jwt-auth.t
@@ -526,7 +526,7 @@ GET /t
 --- request
 GET /apisix/admin/schema/plugins/jwt-auth?schema_type=consumer
 --- response_body
-{"required":["key"],"properties":{"exp":{"minimum":1,"type":"integer"},"private_key":{"type":"string"},"public_key":{"type":"string"},"algorithm":{"type":"string","default":"HS256","enum":["HS256","HS512","RS256"]},"base64_secret":{"default":false,"type":"boolean"},"secret":{"type":"string"},"key":{"type":"string"}},"additionalProperties":false,"type":"object"}
+{"required":["key"],"properties":{"exp":{"type":"integer","default":86400,"minimum":1},"private_key":{"type":"string"},"public_key":{"type":"string"},"algorithm":{"type":"string","default":"HS256","enum":["HS256","HS512","RS256"]},"base64_secret":{"default":false,"type":"boolean"},"secret":{"type":"string"},"key":{"type":"string"}},"additionalProperties":false,"type":"object"}
 --- no_error_log
 [error]
 

--- a/t/plugin/jwt-auth.t
+++ b/t/plugin/jwt-auth.t
@@ -1194,7 +1194,7 @@ qr/"exp":86400/
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body, res_data = t('/apisix/plugin/jwt/sign?key=exp-not-set',
-                ngx.HTTP_GET, nil, nil)
+                ngx.HTTP_GET)
 
             local jwt = require("resty.jwt")
             local jwt_obj = jwt:load_jwt(res_data)

--- a/t/plugin/jwt-auth.t
+++ b/t/plugin/jwt-auth.t
@@ -1140,3 +1140,48 @@ base64_secret required but the secret is not in base64 format
 [error]
 --- request
 GET /t
+
+
+
+=== TEST 50: when the exp value is not set,make sure the default value(86400) works
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body, res_data = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "kerouac",
+                    "plugins": {
+                        "jwt-auth": {
+                            "key": "user-key",
+                            "secret": "my-secret-key"
+                        }
+                    }
+                }]],
+                [[{
+                    "node": {
+                        "value": {
+                            "username": "kerouac",
+                            "plugins": {
+                                "jwt-auth": {
+                                    "key": "user-key",
+                                    "secret": "my-secret-key"
+                                }
+                            }
+                        }
+                    },
+                    "action": "set"
+                }]]
+                )
+
+            ngx.status = code
+            ngx.say(require("cjson").encode(res_data))
+        }
+    }
+--- request
+GET /t
+--- response_body_like eval
+qr/"exp":86400/
+--- no_error_log
+[error]


### PR DESCRIPTION
…2649)

fix #2649

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
