### PR TITLE
fix: make set_more_retries() work when upstream_type is chash

### DIFF
--- a/apisix/balancer/chash.lua
+++ b/apisix/balancer/chash.lua
@@ -69,11 +69,11 @@ function _M.new(up_nodes, upstream)
         upstream = upstream,
         get = function (ctx)
             local id
-            if ctx.balancer_try_count > 1 and ctx.last_server_index then
-                id, ctx.last_server_index = picker:next(ctx.last_server_index)
+            if ctx.balancer_try_count > 1 and ctx.chash_last_server_index then
+                id, ctx.chash_last_server_index = picker:next(ctx.chash_last_server_index)
             else
                 local chash_key = fetch_chash_hash_key(ctx, upstream)
-                id, ctx.last_server_index = picker:find(chash_key)
+                id, ctx.chash_last_server_index = picker:find(chash_key)
             end
             -- core.log.warn("chash id: ", id, " val: ", servers[id])
             return servers[id]

--- a/apisix/balancer/chash.lua
+++ b/apisix/balancer/chash.lua
@@ -55,7 +55,6 @@ end
 
 function _M.new(up_nodes, upstream)
     local str_null = str_char(0)
-    local last_server_index
 
     local servers, nodes = {}, {}
     for serv, weight in pairs(up_nodes) do
@@ -70,11 +69,11 @@ function _M.new(up_nodes, upstream)
         upstream = upstream,
         get = function (ctx)
             local id
-            if ctx.balancer_try_count > 1 then
-                id, last_server_index = picker:next(last_server_index)
+            if ctx.balancer_try_count > 1 and ctx.last_server_index then
+                id, ctx.last_server_index = picker:next(ctx.last_server_index)
             else
                 local chash_key = fetch_chash_hash_key(ctx, upstream)
-                id, last_server_index = picker:find(chash_key)
+                id, ctx.last_server_index = picker:find(chash_key)
             end
             -- core.log.warn("chash id: ", id, " val: ", servers[id])
             return servers[id]

--- a/apisix/balancer/chash.lua
+++ b/apisix/balancer/chash.lua
@@ -55,6 +55,7 @@ end
 
 function _M.new(up_nodes, upstream)
     local str_null = str_char(0)
+    local last_server_index
 
     local servers, nodes = {}, {}
     for serv, weight in pairs(up_nodes) do
@@ -68,8 +69,13 @@ function _M.new(up_nodes, upstream)
     return {
         upstream = upstream,
         get = function (ctx)
-            local chash_key = fetch_chash_hash_key(ctx, upstream)
-            local id = picker:find(chash_key)
+            local id
+            if ctx.balancer_try_count > 1 then
+                id, last_server_index = picker:next(last_server_index)
+            else
+                local chash_key = fetch_chash_hash_key(ctx, upstream)
+                id, last_server_index = picker:find(chash_key)
+            end
             -- core.log.warn("chash id: ", id, " val: ", servers[id])
             return servers[id]
         end

--- a/t/admin/balancer.t
+++ b/t/admin/balancer.t
@@ -33,6 +33,7 @@ add_block_preprocessor(sub {
         local balancer = require("apisix.balancer")
         local res = {}
         for i = 1, count or 12 do
+            ctx.balancer_try_count = 0
             local server, err = balancer.pick_server(route, ctx)
             if err then
                 ngx.say("failed: ", err)

--- a/t/node/healthcheck.t
+++ b/t/node/healthcheck.t
@@ -484,10 +484,10 @@ res: 502 err: nil
 qr{\[error\].*while connecting to upstream.*}
 --- grep_error_log_out eval
 qr{.*http://127.0.0.1:1960/server_port.*
-.*http://127.0.0.1:1960/server_port.*
 .*http://127.0.0.1:1961/server_port.*
 .*http://127.0.0.1:1961/server_port.*
-.*http://127.0.0.1:1961/server_port.*}
+.*http://127.0.0.1:1961/server_port.*
+.*http://127.0.0.1:1960/server_port.*}
 --- timeout: 10
 
 

--- a/t/node/healthcheck.t
+++ b/t/node/healthcheck.t
@@ -484,10 +484,10 @@ res: 502 err: nil
 qr{\[error\].*while connecting to upstream.*}
 --- grep_error_log_out eval
 qr{.*http://127.0.0.1:1960/server_port.*
+.*http://127.0.0.1:1960/server_port.*
 .*http://127.0.0.1:1961/server_port.*
 .*http://127.0.0.1:1961/server_port.*
-.*http://127.0.0.1:1961/server_port.*
-.*http://127.0.0.1:1960/server_port.*}
+.*http://127.0.0.1:1961/server_port.*}
 --- timeout: 10
 
 


### PR DESCRIPTION
chash will pick next if last doesn't work to enable set_more_retries().

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
