### PR TITLE
fix(key-auth): 'key' is required in consumer configuration

### DIFF
--- a/apisix/plugins/key-auth.lua
+++ b/apisix/plugins/key-auth.lua
@@ -26,9 +26,17 @@ local lrucache = core.lrucache.new({
 
 local schema = {
     type = "object",
+    additionalProperties = false,
+    properties = {},
+}
+
+local consumer_schema = {
+    type = "object",
+    additionalProperties = false,
     properties = {
         key = {type = "string"},
-    }
+    },
+    required = {"key"},
 }
 
 
@@ -38,6 +46,7 @@ local _M = {
     type = 'auth',
     name = plugin_name,
     schema = schema,
+    consumer_schema = consumer_schema,
 }
 
 
@@ -50,9 +59,7 @@ do
 
         for _, consumer in ipairs(consumers.nodes) do
             core.log.info("consumer node: ", core.json.delay_encode(consumer))
-            if consumer.auth_conf.key then
-                consumer_ids[consumer.auth_conf.key] = consumer
-            end
+            consumer_ids[consumer.auth_conf.key] = consumer
         end
 
         return consumer_ids
@@ -61,8 +68,12 @@ do
 end -- do
 
 
-function _M.check_schema(conf)
-    return core.schema.check(schema, conf)
+function _M.check_schema(conf, schema_type)
+    if schema_type == core.schema.TYPE_CONSUMER then
+        return core.schema.check(consumer_schema, conf)
+    else
+        return core.schema.check(schema, conf)
+    end
 end
 
 

--- a/t/plugin/key-auth.t
+++ b/t/plugin/key-auth.t
@@ -27,8 +27,9 @@ __DATA__
 --- config
     location /t {
         content_by_lua_block {
+            local core = require("apisix.core")
             local plugin = require("apisix.plugins.key-auth")
-            local ok, err = plugin.check_schema({key = 'test-key'})
+            local ok, err = plugin.check_schema({key = 'test-key'}, core.schema.TYPE_CONSUMER)
             if not ok then
                 ngx.say(err)
             end
@@ -49,8 +50,9 @@ done
 --- config
     location /t {
         content_by_lua_block {
+            local core = require("apisix.core")
             local plugin = require("apisix.plugins.key-auth")
-            local ok, err = plugin.check_schema({key = 123})
+            local ok, err = plugin.check_schema({key = 123}, core.schema.TYPE_CONSUMER)
             if not ok then
                 ngx.say(err)
             end
@@ -247,24 +249,13 @@ apikey: auth-13
                 )
 
             ngx.status = code
-            ngx.say(body)
+            ngx.print(body)
         }
     }
 --- request
 GET /t
+--- error_code: 400
 --- response_body
-passed
---- no_error_log
-[error]
-
-
-
-=== TEST 10: valid consumer
---- request
-GET /hello
---- more_headers
-apikey: auth-one
---- response_body
-hello world
+{"error_msg":"invalid plugins configuration: failed to check the configuration of plugin key-auth err: property \"key\" is required"}
 --- no_error_log
 [error]


### PR DESCRIPTION
Close #2686.

According to the
https://github.com/apache/apisix/pull/2120#discussion_r477153261,
instead of skipping consumer without key, we should make 'key' required
only for consumer configuration.

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible?
