### PR TITLE
fix: remove upstream 'Server' header info. fix #2714

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -403,7 +403,6 @@ http {
             proxy_set_header   Upgrade           $upstream_upgrade;
             proxy_set_header   Connection        $upstream_connection;
             proxy_set_header   X-Real-IP         $remote_addr;
-            proxy_pass_header  Server;
             proxy_pass_header  Date;
 
             ### the following x-forwarded-* headers is to send to upstream server

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -622,7 +622,7 @@ end
 
 function _M.http_header_filter_phase()
     core.response.set_header("Server", ver_header)
-    
+
     common_phase("header_filter")
 end
 

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -338,8 +338,6 @@ function _M.http_access_phase()
 
     core.ctx.set_vars_meta(api_ctx)
 
-    core.response.set_header("Server", ver_header)
-
     -- load and run global rule
     if router.global_rules and router.global_rules.values
        and #router.global_rules.values > 0 then
@@ -623,6 +621,8 @@ end
 
 
 function _M.http_header_filter_phase()
+    core.response.set_header("Server", ver_header)
+    
     common_phase("header_filter")
 end
 

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -399,7 +399,6 @@ _EOC_
             proxy_set_header   Upgrade           \$upstream_upgrade;
             proxy_set_header   Connection        \$upstream_connection;
             proxy_set_header   X-Real-IP         \$remote_addr;
-            proxy_pass_header  Server;
             proxy_pass_header  Date;
             proxy_pass         \$upstream_scheme://apisix_backend\$upstream_uri;
             mirror             /proxy_mirror;

--- a/t/core/utils.t
+++ b/t/core/utils.t
@@ -195,7 +195,6 @@ received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
 received: Server: APISIX
-received: Server: openresty
 received: \nreceived: hello world
 close: 1 nil}
 --- no_error_log

--- a/t/node/remote-addr-ipv6.t
+++ b/t/node/remote-addr-ipv6.t
@@ -116,7 +116,6 @@ received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
 received: Server: APISIX/\d\.\d+(\.\d+)?
-received: Server: \w+
 received: 
 received: hello world
 failed to receive a line: closed \[\]

--- a/t/plugin/redirect.t
+++ b/t/plugin/redirect.t
@@ -671,7 +671,6 @@ received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
 received: Server: APISIX/\d\.\d+(\.\d+)?
-received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}
 --- no_error_log

--- a/t/router/multi-ssl-certs.t
+++ b/t/router/multi-ssl-certs.t
@@ -162,7 +162,6 @@ received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
 received: Server: APISIX/\d\.\d+(\.\d+)?
-received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}
 --- error_log

--- a/t/router/radixtree-sni.t
+++ b/t/router/radixtree-sni.t
@@ -162,7 +162,6 @@ received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
 received: Server: APISIX/\d\.\d+(\.\d+)?
-received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}
 --- error_log
@@ -317,7 +316,6 @@ received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
 received: Server: APISIX/\d\.\d+(\.\d+)?
-received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}
 --- error_log
@@ -432,7 +430,6 @@ received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
 received: Server: APISIX/\d\.\d+(\.\d+)?
-received: Server: \w+
 received: \nreceived: hello world
 close: 1 nil}
 --- error_log


### PR DESCRIPTION
### What this PR does / why we need it:
I think it's better to just leave `Server: APISIX/2.0` and override the other `server` header field!

demo：
```

$ curl  http://127.0.0.1:9080/test_core -i
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
Transfer-Encoding: chunked
Connection: keep-alive
Server: APISIX/2.0
Date: Thu, 12 Nov 2020 04:31:03 GMT

tested by python
```

ref:
https://github.com/apache/apisix/issues/2714

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible?
