### PR TITLE
refactor: disable node-status by default

### DIFF
--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -179,7 +179,7 @@ plugins:                          # plugin list
   - key-auth
   - basic-auth
   - prometheus
-  - node-status
+  #- node-status
   - jwt-auth
   - zipkin
   - ip-restriction


### PR DESCRIPTION
To avoid leaking the APISIX uid.
The route can be protected via the plugin interceptors.

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible?
