### PR TITLE
fix: log `index` function should use `self` instead of `m` or `_M` 

### DIFF
--- a/apisix/core/log.lua
+++ b/apisix/core/log.lua
@@ -59,7 +59,7 @@ function _M.new(prefix)
 
         -- cache the lazily generated method in our
         -- module table
-        m[cmd] = method
+        self[cmd] = method
         return method
     end})
 
@@ -82,7 +82,7 @@ setmetatable(_M, {__index = function(self, cmd)
 
     -- cache the lazily generated method in our
     -- module table
-    _M[cmd] = method
+    self[cmd] = method
     return method
 end})
 


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

 It is more reasonable to use `self` variables than to use `_M` or `m` directly.
### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
