### PR TITLE
modify balancer.lua to solve issue that discovery Eureka cannot autom…

### DIFF
--- a/apisix/balancer.lua
+++ b/apisix/balancer.lua
@@ -19,6 +19,7 @@ local require     = require
 local discovery   = require("apisix.discovery.init").discovery
 local balancer    = require("ngx.balancer")
 local core        = require("apisix.core")
+local ngx = ngx
 local ipairs      = ipairs
 local tostring    = tostring
 local set_more_tries   = balancer.set_more_tries
@@ -218,8 +219,9 @@ local function pick_server(route, ctx)
     if checker then
         version = version .. "#" .. checker.status_ver
     end
+    local cache_key = key..ngx.md5(up_conf.nodes)
 
-    local server_picker = lrucache_server_picker(key, version,
+    local server_picker = lrucache_server_picker(cache_key, version,
                             create_server_picker, up_conf, checker)
     if not server_picker then
         return nil, "failed to fetch server picker"


### PR DESCRIPTION
…atically proxy to a new node

### What this PR does / why we need it:
to solve issue that discovery Eureka cannot automatically proxy to a new node #1838
### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
When we are getting the cached data, if we match "key" with the data"md5" of up_conf.nodes, we can find the changes of the service.
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible?
