### PR TITLE
fix: check decrypt key to prevent lua thread aborted

### DIFF
--- a/apisix/ssl/router/radixtree_sni.lua
+++ b/apisix/ssl/router/radixtree_sni.lua
@@ -67,12 +67,18 @@ local function decrypt_priv_pkey(iv, key)
         return key
     end
 
-    local decrypted = iv:decrypt(ngx_decode_base64(key))
-    if decrypted then
-        return decrypted
+    local decoded_key = ngx_decode_base64(key)
+    if not decoded_key then
+        core.log.error("base64 decode ssl key failed and skipped. key[", key, "] ")
+        return
     end
 
-    core.log.error("decrypt ssl key failed. key[", key, "] ")
+    local decrypted = iv:decrypt(decoded_key)
+    if not decrypted then
+        core.log.error("decrypt ssl key failed and skipped. key[", key, "] ")
+    end
+
+    return decrypted
 end
 
 

--- a/t/certs/incorrect.crt
+++ b/t/certs/incorrect.crt
@@ -1,0 +1,12 @@
+test not base64 encoded crt
+test not base64 encoded crt
+test not base64 encoded crt
+test not base64 encoded crt
+test not base64 encoded crt
+test not base64 encoded crt
+test not base64 encoded crt
+test not base64 encoded crt
+test not base64 encoded crt
+test not base64 encoded crt
+test not base64 encoded crt
+test not base64 encoded crt

--- a/t/certs/incorrect.key
+++ b/t/certs/incorrect.key
@@ -1,0 +1,12 @@
+test not base64 encoded key
+test not base64 encoded key
+test not base64 encoded key
+test not base64 encoded key
+test not base64 encoded key
+test not base64 encoded key
+test not base64 encoded key
+test not base64 encoded key
+test not base64 encoded key
+test not base64 encoded key
+test not base64 encoded key
+test not base64 encoded key


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Hi, I found that the decrypt function in `aes.lua` will cause lua thread aborted if the key is nil.

fix: #2791 

![image](https://user-images.githubusercontent.com/25628854/99897316-663e1b80-2cd3-11eb-9a5c-3c2eeb2000ba.png)

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible?
