### PR TITLE
chore: remove stale access to modifiedIndex_org

### DIFF
--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -207,7 +207,7 @@ local function set_modify_index(key, items, items_ver, global_max_index)
     if items_ver and items then
         for _, item in ipairs(items) do
             if type(item) == "table" then
-                local modify_index = item.modifiedIndex_org or item.modifiedIndex
+                local modify_index = item.modifiedIndex
                 if modify_index > max_idx then
                     max_idx = modify_index
                 end


### PR DESCRIPTION
Since c5dcced1cf90e2ffa5b73583784fc9bd34706aac,
modifiedIndex_org is only accessed in this place without any assignment.

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible?
