### PR TITLE
fix: min_etcd_version is a nil value when etcd version less than min_etcd_version

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -597,7 +597,7 @@ local function init_etcd(show_output)
 
         if compare_semantic_version(cluster_version, env.min_etcd_version) then
             io.stderr:write("etcd cluster version ".. cluster_version ..
-                            " is less than the required version ".. min_etcd_version ..
+                            " is less than the required version ".. env.min_etcd_version ..
                             ", please upgrade your etcd cluster\n")
             os.exit(1)
         end


### PR DESCRIPTION
Signed-off-by: liuhong <liuhong_yewu@cmss.chinamobile.com>

### What this PR does / why we need it:
Executing apisix init_etcd,it will report min_etcd_version is a nil value when etcd version is less than min_etcd_version

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible?
