### PR TITLE
chore: minor change in bin/apisix

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -68,7 +68,6 @@ local function get_openresty_version()
     end
 
     str = "nginx version: nginx/"
-    ret = util.execute_cmd("openresty -v 2>&1")
     pos = string.find(ret, str)
     if pos then
         return string.sub(ret, pos + string.len(str))

--- a/bin/apisix
+++ b/bin/apisix
@@ -62,7 +62,7 @@ end
 local function get_openresty_version()
     local str = "nginx version: openresty/"
     local ret = util.execute_cmd("openresty -v 2>&1")
-    local pos = string.find(ret,str)
+    local pos = string.find(ret, str)
     if pos then
         return string.sub(ret, pos + string.len(str))
     end


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
* We don't need to execute `openresty -v 2>&1` twice to get correct version.
* One line code style correction.
