### PR TITLE
feat: Allow to inject custom TLS root CA certificates store.

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -167,6 +167,9 @@ http {
     {% end %}
 
     lua_ssl_verify_depth 5;
+    {% if http.lua_ssl_trusted_certificate then %}
+    lua_ssl_trusted_certificate {* http.lua_ssl_trusted_certificate *};
+    {% end %}
     ssl_session_timeout 86400;
 
     {% if http.underscores_in_headers then %}

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -168,6 +168,7 @@ nginx_config:                     # config for render the template to genarate n
     real_ip_from:                  # http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from
       - 127.0.0.1
       - 'unix:'
+    #lua_ssl_trusted_certificate: "</etc/ssl/certs/ca-certificates.crt"    # Path to TLS root CA certificates store, e.g. when using custom root certificates.
     #lua_shared_dicts:              # add custom shared cache to nginx.conf
     #  ipc_shared_dict: 100m        # custom shared cache, format: `cache-key: cache-size`
 


### PR DESCRIPTION
### What this PR does / why we need it:
This change allows to inject a path to a custom TLS root CA certificates store through the configuration file. Needed in cases where custom root CA certificates are used and they are not contained in the default bundle used.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
