### PR TITLE
fix: Openid connect plugin should run in rewrite phase.

### DIFF
--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -139,7 +139,7 @@ local function add_user_header(user)
 end
 
 
-function _M.access(plugin_conf, ctx)
+function _M.rewrite(plugin_conf, ctx)
     local conf = core.table.clone(plugin_conf)
     if not conf.redirect_uri then
         conf.redirect_uri = ctx.var.request_uri


### PR DESCRIPTION
### What this PR does / why we need it:
The `openid-connect` plugin is an authentication plugin. As such, it should run in the rewrite phase, not the access phase. The current version runs in the access phase, this PR changes the phase to rewrite.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
