### PR TITLE
fix: authz-keycloak plugin should run in access phase and should not be designated as of type auth anymore.

### DIFF
--- a/apisix/plugins/authz-keycloak.lua
+++ b/apisix/plugins/authz-keycloak.lua
@@ -60,7 +60,6 @@ local schema = {
 local _M = {
     version = 0.1,
     priority = 2000,
-    type = 'auth',
     name = plugin_name,
     schema = schema,
 }
@@ -149,8 +148,8 @@ local function fetch_jwt_token(ctx)
 end
 
 
-function _M.rewrite(conf, ctx)
-    core.log.debug("hit keycloak-auth rewrite")
+function _M.access(conf, ctx)
+    core.log.debug("hit keycloak-auth access")
     local jwt_token, err = fetch_jwt_token(ctx)
     if not jwt_token then
         core.log.error("failed to fetch JWT token: ", err)


### PR DESCRIPTION
### What this PR does / why we need it:
The `authz-keycloak` plugin is concerned with authorization against Keycloak, not authentication. As such, it should not be designated as of type `auth`. Also, I suggest to run it in the access phase which seems more appropriate.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
