### PR TITLE
fix: Use correct name when accessing Authorization header in auth-keycloak plugin.

### DIFF
--- a/apisix/plugins/authz-keycloak.lua
+++ b/apisix/plugins/authz-keycloak.lua
@@ -136,7 +136,7 @@ end
 
 
 local function fetch_jwt_token(ctx)
-    local token = core.request.header(ctx, "authorization")
+    local token = core.request.header(ctx, "Authorization")
     if not token then
         return nil, "authorization header not available"
     end


### PR DESCRIPTION
### What this PR does / why we need it:
The `auth-keycloak` plugin expects to find a bearer token in the standard `Authorization` header. However, it tries to obtain a token from a header called `authorization`, i.e. not properly capitalized. This PR fixes the capitalization so the correct header is used; cf. https://en.wikipedia.org/wiki/List_of_HTTP_header_fields.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
