### PR TITLE
feat: detect whether etcd gRPC gateway is enabled in command line

### DIFF
--- a/apisix/cli/etcd.lua
+++ b/apisix/cli/etcd.lua
@@ -199,6 +199,11 @@ function _M.init(env, show_output)
                         .. " --max-time " .. timeout * 2 .. " --retry 1 2>&1"
 
             local res = util.execute_cmd(cmd)
+            if res:find("404 page not found", 1, true) then
+                util.die("gRPC gateway is not enabled in your etcd cluster, ",
+                         "which is required by Apache APISIX.", "\n")
+            end
+
             if res:find("error", 1, true) then
                 is_success = false
                 if (index == host_count) then


### PR DESCRIPTION
Signed-off-by: Alex Zhang <zchao1995@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

etcd gRPC gateway is required by APISIX, we should detect it when calling `bin/apisix init_etcd`, or errors will occur in the runtime, which harms the service availability.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
