### PR TITLE
feat: Implement traffic splitting plugin.

### DIFF
--- a/apisix/plugins/traffic-split.lua
+++ b/apisix/plugins/traffic-split.lua
@@ -1,0 +1,311 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+local core       = require("apisix.core")
+local upstream   = require("apisix.upstream")
+local schema_def = require("apisix.schema_def")
+local roundrobin = require("resty.roundrobin")
+local ipmatcher  = require("resty.ipmatcher")
+local expr       = require("resty.expr.v1")
+local pairs      = pairs
+local ipairs     = ipairs
+local table_insert = table.insert
+
+local lrucache = core.lrucache.new({
+    ttl = 0, count = 512
+})
+
+
+local vars_schema = {
+    type = "array",
+    items = {
+        type = "array",
+        items = {
+            {
+                type = "string",
+                minLength = 1,
+                maxLength = 100
+            },
+            {
+                type = "string",
+                minLength = 1,
+                maxLength = 2
+            }
+        },
+        additionalItems = {
+            anyOf = {
+                {type = "string"},
+                {type = "number"},
+                {type = "boolean"},
+                {
+                    type = "array",
+                    items = {
+                        anyOf = {
+                            {
+                            type = "string",
+                            minLength = 1, maxLength = 100
+                            },
+                            {
+                                type = "number"
+                            },
+                            {
+                                type = "boolean"
+                            }
+                        }
+                    },
+                    uniqueItems = true
+                }
+            }
+        },
+        minItems = 0,
+        maxItems = 10
+    }
+}
+
+
+local match_schema = {
+    type = "array",
+    items = {
+        type = "object",
+        properties = {
+            vars = vars_schema
+        }
+    },
+    -- When there is no `match` rule, the default rule passes.
+    -- Perform upstream logic of plugin configuration.
+    default = {{ vars = {{"server_port", ">", 0}}}}
+}
+
+
+local upstreams_schema = {
+    type = "array",
+    items = {
+        type = "object",
+        properties = {
+            upstream_id = schema_def.id_schema,    -- todo: support upstream_id method
+            upstream = schema_def.upstream,
+            weight = {
+                description = "used to split traffic between different" ..
+                               "upstreams for plugin configuration",
+                type = "integer",
+                default = 1,
+                minimum = 0
+            }
+        }
+    },
+    -- When the upstream configuration of the plugin is missing,
+    -- the upstream of `route` is used by default.
+    default = {
+        {
+            weight = 1
+        }
+    },
+    minItems = 1,
+    maxItems = 20
+}
+
+
+local schema = {
+    type = "object",
+    properties = {
+        rules = {
+            type = "array",
+            items = {
+                type = "object",
+                properties = {
+                    match = match_schema,
+                    upstreams = upstreams_schema
+                }
+            }
+        }
+    }
+}
+
+local plugin_name = "traffic-split"
+
+local _M = {
+    version = 0.1,
+    priority = 966,
+    name = plugin_name,
+    schema = schema
+}
+
+function _M.check_schema(conf)
+    local ok, err = core.schema.check(schema, conf)
+
+    if not ok then
+        return false, err
+    end
+
+    return true
+end
+
+
+local function parse_domain(host)
+    local ip_info, err = core.utils.dns_parse(host)
+    if not ip_info then
+        core.log.error("failed to parse domain: ", host, ", error: ",err)
+        return nil, err
+    end
+
+    core.log.info("parse addr: ", core.json.delay_encode(ip_info))
+    core.log.info("host: ", host)
+    if not ip_info.address then
+        return nil, "failed to parse domain"
+    end
+
+    core.log.info("dns resolver domain: ", host, " to ", ip_info.address)
+    return ip_info.address
+end
+
+
+local function parse_domain_for_node(node)
+    if not ipmatcher.parse_ipv4(node) and not ipmatcher.parse_ipv6(node) then
+        local ip, err = parse_domain(node)
+        if ip then
+            return ip
+        end
+
+        if err then
+            return nil, err
+        end
+    end
+
+    return node
+end
+
+
+local function set_upstream(upstream_info, ctx)
+    local nodes = upstream_info.nodes
+    local new_nodes = {}
+    for addr, weight in pairs(nodes) do
+        local node = {}
+        local ip, port, host
+        host, port = core.utils.parse_addr(addr)
+        ip = parse_domain_for_node(host)
+        node.host = ip
+        node.port = port
+        node.weight = weight
+        table_insert(new_nodes, node)
+
+        -- Currently only supports a single upstream of the domain name.
+        -- When the upstream is `IP`, do not do any `pass_host` operation.
+        if not core.utils.parse_ipv4(host) and not core.utils.parse_ipv6(host) then
+            local pass_host = upstream_info.pass_host or "pass"
+            if pass_host == "pass" then
+                ctx.var.upstream_host = ctx.var.host
+                break
+            end
+
+            if pass_host == "rewrite" then
+                ctx.var.upstream_host = upstream_info.upstream_host
+                break
+            end
+
+            ctx.var.upstream_host = host
+            break
+        end
+    end
+    core.log.info("upstream_host: ", ctx.var.upstream_host)
+
+    local up_conf = {
+        name = upstream_info.name,
+        type = upstream_info.type,
+        nodes = new_nodes,
+        timeout = {
+            send = upstream_info.timeout and upstream_info.timeout.send or 15,
+            read = upstream_info.timeout and upstream_info.timeout.read or 15,
+            connect = upstream_info.timeout and upstream_info.timeout.connect or 15
+        }
+    }
+
+    local ok, err = upstream.check_schema(up_conf)
+    if not ok then
+        return 500, err
+    end
+
+    local matched_route = ctx.matched_route
+    upstream.set(ctx, up_conf.type .. "#route_" .. matched_route.value.id,
+                ctx.conf_version, up_conf, matched_route)
+    return
+end
+
+
+local function new_rr_obj(upstreams)
+    local server_list = {}
+    for _, upstream_obj in ipairs(upstreams) do
+        if not upstream_obj.upstream then
+            -- If the `upstream` object has only the `weight` value, it means that
+            -- the `upstream` weight value on the default `route` has been reached.
+            -- Need to set an identifier to mark the empty upstream.
+            upstream_obj.upstream = "empty_upstream"
+        end
+        server_list[upstream_obj.upstream] = upstream_obj.weight
+    end
+
+    return roundrobin:new(server_list)
+end
+
+
+function _M.access(conf, ctx)
+    if not conf or not conf.rules then
+        return
+    end
+
+    local upstreams, match_flag
+    for _, rule in pairs(conf.rules) do
+        match_flag = true
+        for _, single_match in pairs(rule.match) do
+            local expr, err = expr.new(single_match.vars)
+            if err then
+                return 500, err
+            end
+
+            match_flag = expr:eval()
+            if match_flag then
+                break
+            end
+        end
+
+        if match_flag then
+            upstreams = rule.upstreams
+            break
+        end
+    end
+
+    core.log.info("match_flag: ", match_flag)
+
+    if not match_flag then
+        return
+    end
+
+    local rr_up, err = lrucache(upstreams, nil, new_rr_obj, upstreams)
+    if not rr_up then
+        core.log.error("lrucache roundrobin failed: ", err)
+        return 500
+    end
+
+    local upstream = rr_up:find()
+    if upstream and upstream ~= "empty_upstream" then
+        core.log.info("upstream: ", core.json.encode(upstream))
+        return set_upstream(upstream, ctx)
+    end
+
+    return
+end
+
+
+return _M

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -238,6 +238,7 @@ plugins:                          # plugin list (sorted in alphabetical order)
   - uri-blocker
   - wolf-rbac
   - zipkin
+  - traffic-split
 
 stream_plugins:
   - mqtt-proxy

--- a/doc/plugins/traffic-split.md
+++ b/doc/plugins/traffic-split.md
@@ -1,0 +1,308 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+- [中文](../zh-cn/plugins/traffic-split.md)
+
+# Summary
+- [**Name**](#name)
+- [**Attributes**](#attributes)
+- [**How To Enable**](#how-to-enable)
+  - [**Grayscale Release**](#grayscale-release)
+  - [**Blue-green Release**](#blue-green-release)
+  - [**Custom Release**](#custom-release)
+- [**Test Plugin**](#test-plugin)
+  - [**Grayscale Test**](#grayscale-test)
+  - [**Blue-green Test**](#blue-green-test)
+  - [**Custom Test**](#custom-test)
+- [**Disable Plugin**](#disable-plugin)
+
+## Name
+
+The traffic splitting plug-in divides the request traffic according to a specified ratio and diverts it to the corresponding upstream. The plug-in can realize the functions of gray release, blue-green release and custom release.
+
+## Attributes
+
+| Name             | Type    | Requirement | Default | Valid   | Description                                                                              |
+| ---------------- | ------- | ----------- | ------- | ------- | ---------------------------------------------------------------------------------------- |
+| rules.match      | array[object]  | optional    |         |  | List of matching rules.                                                                    |
+| rules.match.vars | array[array] | optional    |     |  | A list consisting of one or more {var, operator, val} elements, like this: {{var, operator, val}, {var, operator, val}, ...}}. For example: {"arg_name", "==", "json"}, which means that the current request parameter name is json. The var here is consistent with the naming of Nginx internal variables, so request_uri, host, etc. can also be used; for the operator part, the currently supported operators are ==, ~=, ~~, >, <, in, has and !. For the specific usage of operators, please see the section `Operator List` below. |
+| rules.upstreams  | array[object] | optional    |    |         | List of upstream configuration rules.                                                   |
+| rules.upstreams.upstream_id  | string or integer | optional    |         |         | The upstream id is bound to the corresponding upstream.            |
+| rules.upstreams.upstream   | object | optional    |     |      | Upstream configuration information.                                                    |
+| rules.upstreams.upstream.type | enum | optional    | roundrobin  | [roundrobin, chash] | roundrobin supports weighted load, chash consistent hashing, the two are alternatives.   |
+| rules.upstreams.upstream.nodes  | object | optional    |       |  | In the hash table, the key of the internal element is the list of upstream machine addresses, in the format of address + Port, where the address part can be an IP or a domain name, such as 192.168.1.100:80, foo.com:80, etc. value is the weight of the node. In particular, when the weight value is 0, it has special meaning, which usually means that the upstream node is invalid and never wants to be selected. |
+| rules.upstreams.upstream.timeout  | object | optional    |        |   | Set the timeout period for connecting, sending and receiving messages.  |
+| rules.upstreams.upstream.enable_websocket      | boolean | optional    |        |   | Whether to enable websocket, it is not enabled by default.  |
+| rules.upstreams.upstream.pass_host | enum | optional    | "pass"  | ["pass", "node", "rewrite"]  | pass: pass the host requested by the client, node: pass the host requested by the client; use the host configured with the upstream node, rewrite: rewrite the host with the value configured by the upstream_host. |
+| rules.upstreams.upstream.name      | string | optional    |        |   | Identify the upstream service name, usage scenario, etc.  |
+| rules.upstreams.upstream.upstream_host | string | optional    |    |   | Only valid when pass_host is configured as rewrite.    |
+| rules.upstreams.weight | integer | optional    | weight = 1   |  | According to the weight value to do traffic segmentation. The roundrobin algorithm is used by default, and currently only the roundrobin algorithm is supported.    |
+
+### Operator List
+
+|operator|         description             |      example                        |
+|--------|---------------------------------|-------------------------------------|
+|==      |equal                            |{"arg_name", "==", "json"}           |
+|~=      |not equal                        |{"arg_name", "~=", "json"}           |
+|>       |greater than                     | {"arg_age", ">", 24}                |
+|<       |less than                        |{"arg_age", "<", 24}                 |
+|~~      |Regular match                    |{"arg_name", "~~", "[a-z]+"}         |
+|~*      |Case insensitive regular match   |{"arg_name", "~*", "[a-z]+"}         |
+|in      |find in array                    |{"arg_name", "in", {"1","2"}}        |
+|has     |left value array has value in the right |{"graphql_root_fields", "has", "repo"}|
+|!       |reverse the result               |{"arg_name", "!", "~~", "[a-z]+"}    |
+
+## How To Enable
+
+### Grayscale Release
+
+Traffic is split according to the weight value configured by upstreams in the plugin (the rule of `match` is not configured, and `match` is passed by default). The request traffic is divided into 4:2, 2/3 of the traffic reaches the upstream of the `1981` port in the plugin, and 1/3 of the traffic reaches the upstream of the default `1980` port on the route.
+
+```json
+{
+    "weight": 2
+}
+```
+
+There is only a `weight` value in the plugin upstreams, which represents the weight value of the upstream traffic arriving on the route.
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "uri": "/index.html",
+    "plugins": {
+        "traffic-split": {
+            "rules": [
+                {
+                    "upstreams": [
+                        {
+                            "upstream": {
+                                "name": "upstream_A",
+                                "type": "roundrobin",
+                                "nodes": {
+                                    "127.0.0.1:1981":10
+                                },
+                                "timeout": {
+                                    "connect": 15,
+                                    "send": 15,
+                                    "read": 15
+                                }
+                            },
+                            "weight": 4
+                        },
+                        {
+                            "weight": 2
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "upstream": {
+            "type": "roundrobin",
+            "nodes": {
+                "127.0.0.1:1980": 1
+            }
+    }
+}'
+```
+
+### Blue-green Release
+
+Get the blue and green conditions through the request header (you can also get through the request parameters or NGINX variables). After the `match` rule is matched, it means that all requests hit the upstream configured by the plugin, otherwise the request only hits the configuration on the route upstream.
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "uri": "/index.html",
+    "plugins": {
+        "traffic-split": {
+            "rules": [
+                {
+                    "match": [
+                        {
+                            "vars": [
+                                ["http_new-release","==","blue"]
+                            ]
+                        }
+                    ],
+                    "upstreams": [
+                        {
+                            "upstream": {
+                                "name": "upstream_A",
+                                "type": "roundrobin",
+                                "nodes": {
+                                    "127.0.0.1:1981":10
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "upstream": {
+            "type": "roundrobin",
+            "nodes": {
+                "127.0.0.1:1980": 1
+            }
+    }
+}'
+```
+
+### Custom Release
+
+Multiple matching rules can be set in `match` (multiple conditions in `vars` are the relationship of `add`, and the relationship between multiple `vars` rules is the relationship of `or`; as long as one of the vars rules passes, it means `match` passed), only one is configured here, and the traffic is divided into 4:2 according to the value of `weight`. Among them, only the `weight` part represents the proportion of upstream on the route. When `match` fails to match, all traffic will only hit upstream on the route.
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "uri": "/index.html",
+    "plugins": {
+        "traffic-split": {
+            "rules": [
+                {
+                    "match": [
+                        {
+                            "vars": [
+                                ["arg_name","==","jack"],
+                                ["http_user-id",">","23"],
+                                ["http_apisix-key","~~","[a-z]+"]
+                            ]
+                        }
+                    ],
+                    "upstreams": [
+                        {
+                            "upstream": {
+                                "name": "upstream_A",
+                                "type": "roundrobin",
+                                "nodes": {
+                                    "127.0.0.1:1981":10
+                                }
+                            },
+                            "weight": 4
+                        },
+                        {
+                            "weight": 2
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "upstream": {
+            "type": "roundrobin",
+            "nodes": {
+                "127.0.0.1:1980": 1
+            }
+    }
+}'
+```
+
+The plug-in sets the request matching rules and sets the port to upstream with `1981`, and the route has upstream with port `1980`.
+
+## Test Plugin
+
+### Grayscale Test
+
+**2/3 of the requests hit the upstream on port 1981, and 1/3 of the traffic hit the upstream on port 1980.**
+
+```shell
+$ curl http://127.0.0.1:9080/index.html -i
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+......
+
+hello 1980
+
+$ curl http://127.0.0.1:9080/index.html -i
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+......
+
+world 1981
+```
+
+### Blue-green Test
+
+```shell
+$ curl http://127.0.0.1:9080/index.html?name=jack -H 'new-release: blue' -i
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+......
+
+world 1981
+```
+
+When the match is passed, all requests will hit the upstream configured by the plugin, otherwise hit the upstream configured on the route.
+
+### Custom Test
+
+**After the verification of the `match` rule passed, 2/3 of the requests hit the upstream of port 1981, and 1/3 hit the upstream of port 1980.**
+
+```shell
+$ curl http://127.0.0.1:9080/index.html?name=jack -H 'user-id:30' -H 'apisix-key: hello' -i
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+......
+
+hello 1980
+```
+
+The match check succeeds, but it hits the upstream of the default port of `1980`.
+
+```shell
+$ curl http://127.0.0.1:9080/index.html?name=jack -H 'user-id:30' -H 'apisix-key: hello' -i
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+......
+
+world 1981
+```
+
+The match check succeeds and it hits the upstream port of `1981`.
+
+**The `match` rule verification failed (missing request header `apisix-key`), the response is the default upstream data `hello 1980`**
+
+```shell
+$ curl http://127.0.0.1:9080/index.html?name=jack -H 'user-id:30' -i
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+......
+
+hello 1980
+```
+
+## Disable Plugin
+
+When you want to remove the traffic-split plug-in, it's very simple, just delete the corresponding json configuration in the plug-in configuration, no need to restart the service, it will take effect immediately:
+
+```shell
+$ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "uri": "/index.html",
+    "plugins": {},
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "127.0.0.1:1980": 1
+        }
+    }
+}'
+```

--- a/doc/zh-cn/plugins/traffic-split.md
+++ b/doc/zh-cn/plugins/traffic-split.md
@@ -1,0 +1,310 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+- [English](../../plugins/traffic-split.md)
+
+# 目录
+
+- [名字](#名字)
+- [属性](#属性)
+- [如何启用](#如何启用)
+  - [灰度发布](#灰度发布)
+  - [蓝绿发布](#蓝绿发布)
+  - [自定义发布](#自定义发布)
+- [测试插件](#测试插件)
+  - [灰度测试](#灰度测试)
+  - [蓝绿测试](#蓝绿测试)
+  - [自定义测试](#自定义测试)
+- [禁用插件](#禁用插件)
+
+
+## 名字
+
+流量分割插件，对请求流量按指定的比例划分，并将其分流到对应的 upstream。通过该插件可以实现 灰度发布、蓝绿发布和自定义发布功能。
+
+## 属性
+
+| 参数名        | 类型          | 可选项 | 默认值 | 有效值 | 描述                 |
+| ------------ | ------------- | ------ | ------ | ------ | -------------------- |
+| rules.match | array[object] | 可选  |        |        | 匹配规则列表  |
+| rules.match.vars | array[array]   | 可选   |        |        | 由一个或多个{var, operator, val}元素组成的列表，类似这样：{{var, operator, val}, {var, operator, val}, ...}}。例如：{"arg_name", "==", "json"}，表示当前请求参数 name 是 json。这里的 var 与 Nginx 内部自身变量命名是保持一致，所以也可以使用 request_uri、host 等；对于 operator 部分，目前已支持的运算符有 ==、~=、~~、>、<、in、has 和 ! 。操作符的具体用法请看下文的 `运算符列表` 部分。 |
+| rules.upstreams    | array[object] | 可选   |        |        | 上游配置规则列表。 |
+| rules.upstreams.upstream_id  | string or integer | 可选   |        |        | 通过上游 id 绑定对应上游。 |
+| rules.upstreams.upstream     | object | 可选   |        |        | 上游配置信息。 |
+| rules.upstreams.upstream.type | enum | 可选   |   roundrobin |  [roundrobin, chash]      | roundrobin 支持权重的负载，chash 一致性哈希，两者是二选一的。 |
+| rules.upstreams.upstream.nodes | object | 可选   |        |        | 哈希表，内部元素的 key 是上游机器地址 列表，格式为地址 + Port，其中地址部 分可以是 IP 也可以是域名，⽐如 192.168.1.100:80、foo.com:80等。 value 则是节点的权重，特别的，当权重 值为 0 有特殊含义，通常代表该上游节点 失效，永远不希望被选中。 |
+| rules.upstreams.upstream.timeout | object | 可选   |        |        | 设置连接、发送消息、接收消息的超时时间 |
+| rules.upstreams.upstream.enable_websocket | boolean | 可选   |        |        | 是否启用 websocket，默认不启用。 |
+| rules.upstreams.upstream.pass_host  | enum | 可选   | "pass"   | ["pass", "node", "rewrite"]  | pass: 透传客户端请求的 host, node: 不透传客户端请求的 host; 使用 upstream node 配置的 host, rewrite: 使用 upstream_host 配置的值重写 host 。 |
+| rules.upstreams.upstream.name  | string | 可选   |        |  | 标识上游服务名称、使⽤场景等。 |
+| rules.upstreams.upstream.upstream_host | string | 可选   |        |        | 只在 pass_host 配置为 rewrite 时有效。 |
+| rules.upstreams.weight       | integer | 可选   |   weight = 1     |        | 根据 weight 值来做流量切分。默认使用 roundrobin 算法，且目前只支持 roundrobin 算法。|
+
+### 运算符列表
+
+| 运算符 |  描述       |                        示例                                  |
+|-------|------------|--------------------------------------------------------------|
+| ==    | 相等        | {"arg_name", "==", "json"}                                   |
+| ~=    | 不等        | {"arg_name", "~=", "json"}                                   |
+| ~~    |  正则匹配    | {"arg_name", "~~", "[a-z]+"}                                |
+| ~*    |  不区分大小写的正则匹配 | {"arg_name", "~*", "[a-z]+"}                       |
+| <     | 小于        | {"arg_age", "<", 24}                                         |
+| >     | 大于        | {"arg_age", ">", 24}                                         |
+| in    | 在数组中查找 |  {"arg_name", "in",{"1","2"}}                                |
+| has   | 在左边的数组值中有右边的值 | {"graphql_root_fields", "has", "repo"}           |
+| !     | 结果值取反   | {"arg_name", "!", "~~", "[a-z]+"}                            |
+
+## 如何启用
+
+### 灰度发布
+
+根据插件中 upstreams 配置的 weight 值做流量分流（不配置 `match` 的规则，已经默认 `match` 通过）。将请求流量按 4:2 划分，2/3 的流量到达插件中的 `1981` 端口上游， 1/3 的流量到达 route 上默认的 `1980` 端口上游。
+
+```json
+{
+    "weight": 2
+}
+```
+
+在插件 upstreams 中只有 `weight` 值，表示到达 route 上的 upstream 流量权重值。
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "uri": "/index.html",
+    "plugins": {
+        "traffic-split": {
+            "rules": [
+                {
+                    "upstreams": [
+                        {
+                            "upstream": {
+                                "name": "upstream_A",
+                                "type": "roundrobin",
+                                "nodes": {
+                                    "127.0.0.1:1981":10
+                                },
+                                "timeout": {
+                                    "connect": 15,
+                                    "send": 15,
+                                    "read": 15
+                                }
+                            },
+                            "weight": 4
+                        },
+                        {
+                            "weight": 2
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "upstream": {
+            "type": "roundrobin",
+            "nodes": {
+                "127.0.0.1:1980": 1
+            }
+    }
+}'
+```
+
+### 蓝绿发布
+
+通过请求头获取蓝绿条件(也可以通过请求参数获取或NGINX变量)，在 `match` 规则匹配通过后，表示所有请求都命中到插件配置的 upstream ，否则所以请求只命中 `route` 上配置的 upstream 。
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "uri": "/index.html",
+    "plugins": {
+        "traffic-split": {
+            "rules": [
+                {
+                    "match": [
+                        {
+                            "vars": [
+                                ["http_new-release","==","blue"]
+                            ]
+                        }
+                    ],
+                    "upstreams": [
+                        {
+                            "upstream": {
+                                "name": "upstream_A",
+                                "type": "roundrobin",
+                                "nodes": {
+                                    "127.0.0.1:1981":10
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "upstream": {
+            "type": "roundrobin",
+            "nodes": {
+                "127.0.0.1:1980": 1
+            }
+    }
+}'
+```
+
+### 自定义发布
+
+`match` 中可以设置多个匹配规则(`vars` 中的多个条件是 `add` 的关系， 多个 `vars` 规则之间是 `or` 的关系；只要其中一个 vars 规则通过，则表示 `match` 通过), 这里就只配置了一个， 根据 `weight` 值将流量按 4:2 划分。其中只有 `weight` 部分表示 route 上的 upstream 所占的比例。 当 `match` 匹配不通过时，所有的流量只会命中 route 上的 upstream 。
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "uri": "/index.html",
+    "plugins": {
+        "traffic-split": {
+            "rules": [
+                {
+                    "match": [
+                        {
+                            "vars": [
+                                ["arg_name","==","jack"],
+                                ["http_user-id",">","23"],
+                                ["http_apisix-key","~~","[a-z]+"]
+                            ]
+                        }
+                    ],
+                    "upstreams": [
+                        {
+                            "upstream": {
+                                "name": "upstream_A",
+                                "type": "roundrobin",
+                                "nodes": {
+                                    "127.0.0.1:1981":10
+                                }
+                            },
+                            "weight": 4
+                        },
+                        {
+                            "weight": 2
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "upstream": {
+            "type": "roundrobin",
+            "nodes": {
+                "127.0.0.1:1980": 1
+            }
+    }
+}'
+```
+
+插件设置了请求的匹配规则并设置端口为`1981`的 upstream，route 上具有端口为`1980`的upstream。
+
+## 测试插件
+
+### 灰度测试
+
+**2/3 的请求命中到1981端口的upstream, 1/3 的流量命中到1980端口的upstream。**
+
+```shell
+$ curl http://127.0.0.1:9080/index.html -i
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+......
+
+hello 1980
+
+$ curl http://127.0.0.1:9080/index.html -i
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+......
+
+world 1981
+```
+
+### 蓝绿测试
+
+```shell
+$ curl http://127.0.0.1:9080/index.html?name=jack -H 'new-release: blue' -i
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+......
+
+world 1981
+```
+
+当 `match` 匹配通过后，所有请求都命中到插件配置的 `upstream`，否则命中 `route` 上配置的 upstream 。
+
+### 自定义测试
+
+**在`match` 规则校验通过后, 2/3 的请求命中到1981端口的upstream, 1/3 命中到1980端口的upstream。**
+
+```shell
+$ curl http://127.0.0.1:9080/index.html?name=jack -H 'user-id:30' -H 'apisix-key: hello' -i
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+......
+
+hello 1980
+```
+
+match 校验成功，但是命中默认端口为`1980`的 upstream。
+
+```shell
+$ curl http://127.0.0.1:9080/index.html?name=jack -H 'user-id:30' -H 'apisix-key: hello' -i
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+......
+
+world 1981
+```
+
+match 校验成功， 命中端口为`1981`的 upstream。
+
+**`match` 规则校验失败(缺少请求头 `apisix-key` ), 响应都为默认 upstream 的数据 `hello 1980`**
+
+```shell
+$ curl http://127.0.0.1:9080/index.html?name=jack -H 'user-id:30' -i
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+......
+
+hello 1980
+```
+
+## 禁用插件
+
+当你想去掉 traffic-split 插件的时候，很简单，在插件的配置中把对应的 json 配置删除即可，无须重启服务，即刻生效：
+
+```shell
+$ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "uri": "/index.html",
+    "plugins": {},
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "127.0.0.1:1980": 1
+        }
+    }
+}'
+```

--- a/t/admin/plugins.t
+++ b/t/admin/plugins.t
@@ -40,7 +40,7 @@ __DATA__
 --- request
 GET /apisix/admin/plugins/list
 --- response_body_like eval
-qr/\["zipkin","request-id","fault-injection","serverless-pre-function","batch-requests","cors","ip-restriction","referer-restriction","uri-blocker","request-validation","openid-connect","wolf-rbac","hmac-auth","basic-auth","jwt-auth","key-auth","consumer-restriction","authz-keycloak","proxy-mirror","proxy-cache","proxy-rewrite","api-breaker","limit-conn","limit-count","limit-req","redirect","response-rewrite","grpc-transcode","prometheus","echo","http-logger","sls-logger","tcp-logger","kafka-logger","syslog","udp-logger","example-plugin","serverless-post-function"\]/
+qr/\["zipkin","request-id","fault-injection","serverless-pre-function","batch-requests","cors","ip-restriction","referer-restriction","uri-blocker","request-validation","openid-connect","wolf-rbac","hmac-auth","basic-auth","jwt-auth","key-auth","consumer-restriction","authz-keycloak","proxy-mirror","proxy-cache","proxy-rewrite","api-breaker","limit-conn","limit-count","limit-req","traffic-split","redirect","response-rewrite","grpc-transcode","prometheus","echo","http-logger","sls-logger","tcp-logger","kafka-logger","syslog","udp-logger","example-plugin","serverless-post-function"\]/
 --- no_error_log
 [error]
 

--- a/t/debug/debug-mode.t
+++ b/t/debug/debug-mode.t
@@ -71,6 +71,7 @@ loaded plugin and sort by priority: 1005 name: api-breaker
 loaded plugin and sort by priority: 1003 name: limit-conn
 loaded plugin and sort by priority: 1002 name: limit-count
 loaded plugin and sort by priority: 1001 name: limit-req
+loaded plugin and sort by priority: 966 name: traffic-split
 loaded plugin and sort by priority: 900 name: redirect
 loaded plugin and sort by priority: 899 name: response-rewrite
 loaded plugin and sort by priority: 506 name: grpc-transcode

--- a/t/plugin/traffic-split.t
+++ b/t/plugin/traffic-split.t
@@ -1,0 +1,964 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+log_level("info");
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: schema validation passed
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.traffic-split")
+            local ok, err = plugin.check_schema({
+                rules = {
+                    {
+                        match = {
+                            {
+                                vars = {
+                                    {"arg_name", "==", "jack"},
+                                    {"arg_age", "!", "<", "16"}
+                                }
+                            },
+                             {
+                                vars = {
+                                    {"arg_name", "==", "rose"},
+                                    {"arg_age", "!", ">", "32"}
+                                }
+                            }
+                        },
+                        upstreams = {
+                            {
+                                upstream = {
+                                    name = "upstream_A",
+                                    type = "roundrobin",
+                                    nodes = {["127.0.0.1:1981"]=2},
+                                    timeout = {connect = 15, send = 15, read = 15}
+                                },
+                                weight = 2
+                            },
+                            {
+                                upstream = {
+                                    name = "upstream_B",
+                                    type = "roundrobin",
+                                    nodes = {["127.0.0.1:1982"]=2},
+                                    timeout = {connect = 15, send = 15, read = 15}
+                                },
+                                weight = 2
+                            },
+                            {
+                                weight = 1
+                            }
+                        }
+                    }
+                }
+            })
+            if not ok then
+                ngx.say(err)
+            end
+
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: schema validation passed, and `match` configuration is missing
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.traffic-split")
+            local ok, err = plugin.check_schema({
+                rules = {
+                    {
+                        upstreams = {
+                            {
+                                upstream = {
+                                    name = "upstream_A",
+                                    type = "roundrobin",
+                                    nodes = {["127.0.0.1:1981"]=2},
+                                    timeout = {connect = 15, send = 15, read = 15}
+                                },
+                                weight = 2
+                            },
+                            {
+                                weight = 1
+                            }
+                        }
+                    }
+                }
+            })
+            if not ok then
+                ngx.say(err)
+            end
+
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: schema validation failed, `vars` expression operator type is wrong
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.traffic-split")
+            local ok, err = plugin.check_schema({
+                rules = {
+                    {
+                        match = {
+                            {
+                                vars = {
+                                    {"arg_name", 123, "jack"}
+                                }
+                            }
+                        },
+                        upstreams = {
+                            {
+                                upstream = {
+                                    name = "upstream_A",
+                                    type = "roundrobin",
+                                    nodes = {["127.0.0.1:1981"]=2},
+                                    timeout = {connect = 15, send = 15, read = 15}
+                                },
+                                weight = 2
+                            },
+                            {
+                                weight = 1
+                            }
+                        }
+                    }
+                }
+            })
+            if not ok then
+                ngx.say(err)
+            end
+
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body eval
+qr/property "rules" validation failed:.* failed to validate item 2: wrong type: expected string, got number/
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: missing `rules` configuration, the upstream of the default `route` takes effect
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/server_port",
+                    "plugins": {
+                        "traffic-split": {}
+                    },
+                    "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: the upstream of the default `route` takes effect
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local bodys = {}
+        for i = 1, 6 do
+            local _, _, body = t('/server_port', ngx.HTTP_GET)
+            bodys[i] = body
+        end
+        table.sort(bodys)
+        ngx.say(table.concat(bodys, ", "))
+    }
+}
+--- request
+GET /t
+--- response_body
+1980, 1980, 1980, 1980, 1980, 1980
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: when `upstreams` is empty, the upstream of `route` is used by default
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/server_port",
+                    "plugins": {
+                        "traffic-split": {
+                             "rules": [
+                                {
+                                    "upstreams": [{}]
+                                }
+                            ]
+                        }
+                    },
+                    "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 7: the upstream of the default `route` takes effect
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local bodys = {}
+        for i = 1, 6 do
+            local _, _, body = t('/server_port', ngx.HTTP_GET)
+            bodys[i] = body
+        end
+        table.sort(bodys)
+        ngx.say(table.concat(bodys, ", "))
+    }
+}
+--- request
+GET /t
+--- response_body
+1980, 1980, 1980, 1980, 1980, 1980
+--- no_error_log
+[error]
+
+
+
+=== TEST 8: single `vars` expression and single plugin `upstream`, and the upstream traffic on `route` accounts for 1/3
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/server_port",
+                    "plugins": {
+                        "traffic-split": {
+                            "rules": [
+                                {
+                                    "match": [
+                                        {
+                                            "vars": [
+                                                ["arg_name", "==", "jack"],
+                                                ["arg_age", "!","<", "16"]
+                                            ]
+                                        }
+                                    ],
+                                    "upstreams": [
+                                        {
+                                           "upstream": {"name": "upstream_A", "type": "roundrobin", "nodes": {"127.0.0.1:1981":2}, "timeout": {"connect": 15, "send": 15, "read": 15}},
+                                            "weight": 2
+                                        },
+                                        {
+                                            "weight": 1
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 9: expression validation failed, return to the default `route` upstream port `1980`
+--- request
+GET /server_port?name=jack&age=14
+--- response_body eval
+1980
+--- no_error_log
+[error]
+
+
+
+=== TEST 10: the expression passes and initiated multiple requests, the upstream traffic of `route` accounts for 1/3, and the upstream traffic of plugins accounts for 2/3
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local bodys = {}
+        for i = 1, 6 do
+            local _, _, body = t('/server_port?name=jack&age=16', ngx.HTTP_GET)
+            bodys[i] = body
+        end
+        table.sort(bodys)
+        ngx.say(table.concat(bodys, ", "))
+    }
+}
+--- request
+GET /t
+--- response_body
+1980, 1980, 1981, 1981, 1981, 1981
+--- no_error_log
+[error]
+
+
+
+=== TEST 11: Multiple vars rules and multiple plugin upstream
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [=[{
+                    "uri": "/server_port",
+                    "plugins": {
+                        "traffic-split": {
+                            "rules": [
+                                {
+                                    "match": [
+                                        {
+                                            "vars": [["arg_name", "==", "jack"], ["arg_age", "~~", "^[1-9]{1,2}"]]
+                                        },
+                                        {
+                                            "vars": [["arg_name2", "in", ["jack", "rose"]], ["arg_age2", "!", "<", 18]]
+                                        }
+                                    ],
+                                    "upstreams": [
+                                        {"upstream": {"name": "upstream_A", "type": "roundrobin", "nodes": {"127.0.0.1:1981":20}, "timeout": {"connect": 15, "send": 15, "read": 15}}, "weight": 2},
+                                        {"upstream": {"name": "upstream_B", "type": "roundrobin", "nodes": {"127.0.0.1:1982":10}, "timeout": {"connect": 15, "send": 15, "read": 15}}, "weight": 2},
+                                        {"weight": 1}
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                    }
+                }]=]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 12: expression validation failed, return to the default `route` upstream port `1980`
+--- request
+GET /server_port?name=jack&age=0
+--- response_body eval
+1980
+--- no_error_log
+[error]
+
+
+
+=== TEST 13: the expression passes and initiated multiple requests, the upstream traffic of `route` accounts for 1/5, and the upstream traffic of plugins accounts for 4/5
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local bodys = {}
+        for i = 1, 5 do
+            local _, _, body = t('/server_port?name=jack&age=22', ngx.HTTP_GET)
+            bodys[i] = body
+        end
+        table.sort(bodys)
+        ngx.say(table.concat(bodys, ", "))
+    }
+}
+--- request
+GET /t
+--- response_body
+1980, 1981, 1981, 1982, 1982
+--- no_error_log
+[error]
+
+
+
+=== TEST 14: Multiple vars rules and multiple plugin upstream, do not split traffic to the upstream of `route`
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [=[{
+                    "uri": "/server_port",
+                    "plugins": {
+                        "traffic-split": {
+                            "rules": [
+                                {
+                                    "match": [
+                                        {
+                                            "vars": [["arg_name", "==", "jack"], ["arg_age", "~~", "^[1-9]{1,2}"]]
+                                        },
+                                        {
+                                            "vars": [["arg_name2", "in", ["jack", "rose"]], ["arg_age2", "!", "<", 18]]
+                                        }
+                                    ],
+                                    "upstreams": [
+                                        {"upstream": {"name": "upstream_A", "type": "roundrobin", "nodes": {"127.0.0.1:1981":20}, "timeout": {"connect": 15, "send": 15, "read": 15}}, "weight": 2},
+                                        {"upstream": {"name": "upstream_B", "type": "roundrobin", "nodes": {"127.0.0.1:1982":10}, "timeout": {"connect": 15, "send": 15, "read": 15}}, "weight": 2}
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                    }
+                }]=]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 15: the expression passes and initiated multiple requests, do not split traffic to the upstream of `route`
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local bodys = {}
+        for i = 1, 6 do
+            local _, _, body = t('/server_port?name=jack&age=22', ngx.HTTP_GET)
+            bodys[i] = body
+        end
+        table.sort(bodys)
+        ngx.say(table.concat(bodys, ", "))
+    }
+}
+--- request
+GET /t
+--- response_body
+1981, 1981, 1981, 1982, 1982, 1982
+--- no_error_log
+[error]
+
+
+
+=== TEST 16: support multiple ip configuration of `nodes`, and missing upstream configuration on `route`
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [=[{
+                    "uri": "/server_port",
+                    "plugins": {
+                        "traffic-split": {
+                            "rules": [
+                                {
+                                    "match": [
+                                        {
+                                            "vars": [["arg_name", "==", "jack"], ["arg_age", "~~", "^[1-9]{1,2}"]]
+                                        }
+                                    ],
+                                    "upstreams": [
+                                        {"upstream": {"name": "upstream_A", "type": "roundrobin", "nodes": {"127.0.0.1:1980":1, "127.0.0.1:1981":2, "127.0.0.1:1982":2}, "timeout": {"connect": 15, "send": 15, "read": 15}}, "weight": 1}
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }]=]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 17: the expression passes and initiated multiple requests, roundrobin the ip of nodes
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local bodys = {}
+        for i = 1, 5 do
+            local _, _, body = t('/server_port?name=jack&age=22', ngx.HTTP_GET)
+            bodys[i] = body
+        end
+        table.sort(bodys)
+        ngx.say(table.concat(bodys, ", "))
+    }
+}
+--- request
+GET /t
+--- response_body
+1980, 1981, 1981, 1982, 1982
+--- no_error_log
+
+
+
+=== TEST 18: host is domain name
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/server_port",
+                    "plugins": {
+                        "traffic-split": {
+                            "rules": [
+                                {
+                                    "upstreams": [
+                                        {
+                                            "upstream": {
+                                                "name": "upstream_A",
+                                                "type": "roundrobin",
+                                                "nodes": {
+                                                    "foo.com:80": 0
+                                                }
+                                            },
+                                            "weight": 2
+                                        },
+                                        {
+                                            "weight": 1
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 19: domain name resolved successfully
+--- request
+GET /server_port
+--- error_code: 502
+--- error_log eval
+qr/dns resolver domain: foo.com to \d+.\d+.\d+.\d+/
+
+
+
+=== TEST 20: mock Grayscale Release
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/server_port",
+                    "plugins": {
+                        "traffic-split": {
+                            "rules": [
+                                {
+                                    "upstreams": [
+                                        {
+                                            "upstream": {
+                                                "name": "upstream_A",
+                                                "type": "roundrobin",
+                                                "nodes": {
+                                                    "127.0.0.1:1981":1
+                                                }
+                                            },
+                                            "weight": 2
+                                        },
+                                        {
+                                            "weight": 1
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 21: 2/3 request traffic hits the upstream of the plugin, 1/3 request traffic hits the upstream of `route`
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local bodys = {}
+        for i = 1, 6 do
+            local _, _, body = t('/server_port', ngx.HTTP_GET)
+            bodys[i] = body
+        end
+        table.sort(bodys)
+        ngx.say(table.concat(bodys, ", "))
+    }
+}
+--- request
+GET /t
+--- response_body
+1980, 1980, 1981, 1981, 1981, 1981
+--- no_error_log
+[error]
+
+
+
+=== TEST 22: mock Blue-green Release
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/server_port",
+                    "plugins": {
+                        "traffic-split": {
+                            "rules": [
+                                {
+                                    "match": [
+                                        {
+                                            "vars": [
+                                                [ "http_release","==","blue" ]
+                                            ]
+                                        }
+                                    ],
+                                    "upstreams": [
+                                        {
+                                            "upstream": {
+                                                "name": "upstream_A",
+                                                "type": "roundrobin",
+                                                "nodes": {
+                                                    "127.0.0.1:1981":1
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 23: release is equal to `blue`
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local bodys = {}
+        local headers = {}
+        headers["release"] = "blue"
+        for i = 1, 6 do
+            local _, _, body = t('/server_port', ngx.HTTP_GET, "", nil, headers)
+            bodys[i] = body
+        end
+        table.sort(bodys)
+        ngx.say(table.concat(bodys, ", "))
+    }
+}
+--- request
+GET /t
+--- response_body
+1981, 1981, 1981, 1981, 1981, 1981
+--- no_error_log
+[error]
+
+
+
+=== TEST 24: release is equal to `green` 
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local bodys = {}
+        local headers = {}
+        headers["release"] = "green"
+        for i = 1, 6 do
+            local _, _, body = t('/server_port', ngx.HTTP_GET, "", nil, headers)
+            bodys[i] = body
+        end
+        table.sort(bodys)
+        ngx.say(table.concat(bodys, ", "))
+    }
+}
+--- request
+GET /t
+--- response_body
+1980, 1980, 1980, 1980, 1980, 1980
+--- no_error_log
+[error]
+
+
+
+=== TEST 25: mock Custom Release
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [=[{
+                    "uri": "/server_port",
+                    "plugins": {
+                        "traffic-split": {
+                            "rules": [
+                                {
+                                    "match": [
+                                        {
+                                            "vars": [["arg_name", "==", "jack"], ["arg_age", ">", "23"],["http_appkey", "~~", "[a-z]{1,5}"]]
+                                        }
+                                    ],
+                                    "upstreams": [
+                                        {"upstream": {"name": "upstream_A", "type": "roundrobin", "nodes": {"127.0.0.1:1981":20}, "timeout": {"connect": 15, "send": 15, "read": 15}}, "weight": 2},
+                                        {"upstream": {"name": "upstream_B", "type": "roundrobin", "nodes": {"127.0.0.1:1982":10}, "timeout": {"connect": 15, "send": 15, "read": 15}}, "weight": 2},
+                                        {"weight": 1}
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                    }
+                }]=]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 23: `match` rule passed
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local bodys = {}
+        local headers = {}
+        headers["appkey"] = "hello"
+        for i = 1, 5 do
+            local _, _, body = t('/server_port?name=jack&age=36', ngx.HTTP_GET, "", nil, headers)
+            bodys[i] = body
+        end
+        table.sort(bodys)
+        ngx.say(table.concat(bodys, ", "))
+    }
+}
+--- request
+GET /t
+--- response_body
+1980, 1981, 1981, 1982, 1982
+--- no_error_log
+[error]
+
+
+
+=== TEST 24: `match` rule failed, `age` condition did not match 
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local bodys = {}
+        local headers = {}
+        headers["release"] = "green"
+        for i = 1, 6 do
+            local _, _, body = t('/server_port?name=jack&age=16', ngx.HTTP_GET, "", nil, headers)
+            bodys[i] = body
+        end
+        table.sort(bodys)
+        ngx.say(table.concat(bodys, ", "))
+    }
+}
+--- request
+GET /t
+--- response_body
+1980, 1980, 1980, 1980, 1980, 1980
+--- no_error_log
+[error]


### PR DESCRIPTION
close #2303 close #2603

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Implement a traffic splitting plugin, the plugin is named `traffic-split`. The main function of the plug-in is to divide the request traffic according to the specified ratio and divert it to the corresponding "upstream". The functions of `Gray release`, `Blue-green release` and `Custom release` can be realized through this plugin.

Related issue：
[https://github.com/apache/apisix/issues/2303 ](https://github.com/apache/apisix/issues/2303)

[https://github.com/apache/apisix/issues/2603 ](https://github.com/apache/apisix/issues/2603)

Mailing list discussion address:
https://lists.apache.org/thread.html/rf02dc53a4af5d98d2513d89256b47466934d129af06d0bdcdb49cc8e%40%3Cdev.apisix.apache.org%3E 

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
