### PR TITLE
Add apisix configmaps yaml file.

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -30,6 +30,8 @@ There are some yaml files for deploying apisix in Kubernetes.
 if you do not need to change any config, and use default config in `../conf/config.yaml`
 ```
 $ kubectl create configmap apisix-gw-config.yaml --from-file=../conf/config.yaml
+# or
+$ kubectl apply -f apisix/kubernetes/apisix-configmaps.yaml
 ```
 
 #### when using etcd-operator

--- a/kubernetes/apisix-configmaps.yaml
+++ b/kubernetes/apisix-configmaps.yaml
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: apisix-gw-config.yaml
+data:
+  config.yaml: |
+    # Licensed to the Apache Software Foundation (ASF) under one or more
+    # contributor license agreements.  See the NOTICE file distributed with
+    # this work for additional information regarding copyright ownership.
+    # The ASF licenses this file to You under the Apache License, Version 2.0
+    # (the "License"); you may not use this file except in compliance with
+    # the License.  You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+    #
+    # If you want to set the specified configuration value, you can set the new
+    # in this file. For example if you want to specify the etcd address:
+    #
+    etcd:
+      host:
+        - "http://192.168.1.1:2379"
+    #
+    # To configure via environment variables, you can use `${{VAR}}` syntax. For instance:
+    #
+    # etcd:
+    #     host:
+    #       - "http://${{ETCD_HOST}}:2379"
+    #
+    # If the configured environment variable can't be found, an error will be thrown.
+    apisix:
+      admin_key:
+        -
+          name: "admin"
+          key: edd1c9f034335f136f87ad84b625c8f1 
+    # using fixed API token has security risk, please
+    # update it when you deploy to production environment
+          role: admin


### PR DESCRIPTION
### What this PR does / why we need it:
Add apisix configmaps yaml file. We no longer need to find configuration files from the apisix package
