### PR TITLE
docs: fix case of GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Using AWS's 8 core server, APISIX's QPS reach to 140,000 with a latency of only 
 | :-------------------------------------------------------------- | :------------------------------------------------ | :---------------------- |
 | Belongs to                                                      | Apache Software Foundation                        | Kong Inc.               |
 | Tech Architecture                                               | Nginx + etcd                                      | Nginx + postgres        |
-| Communication channels                                          | Mail list, Wechat group, QQ group, Github, meetup | Github, freenode, forum |
+| Communication channels                                          | Mail list, Wechat group, QQ group, GitHub, meetup | GitHub, freenode, forum |
 | Single-core CPU, QPS(enable limit-count and prometheus plugins) | 18000                                             | 1700                    |
 | Latency                                                         | 0.2 ms                                            | 2 ms                    |
 | Dubbo                                                           | Yes                                               | No                      |

--- a/README_CN.md
+++ b/README_CN.md
@@ -272,7 +272,7 @@ CentOS 7, Ubuntu 16.04, Ubuntu 18.04, Debian 9, Debian 10, macOS, **ARM64** Ubun
 | :------------------------------------ | :-------------------------------------- | :--------------------- |
 | 项目归属                              | Apache 软件基金会                       | Kong Inc.              |
 | 技术架构                              | Nginx + etcd                            | Nginx + postgres       |
-| 交流渠道                              | 微信群、QQ 群、邮件列表、Github、meetup | Github、论坛、freenode |
+| 交流渠道                              | 微信群、QQ 群、邮件列表、GitHub、meetup | GitHub、论坛、freenode |
 | 单核 QPS (开启限流和 prometheus 插件) | 18000                                   | 1700                   |
 | 平均延迟                              | 0.2 毫秒                                | 2 毫秒                 |
 | 支持 Dubbo 代理                       | 是                                      | 否                     |


### PR DESCRIPTION
Changed `Github` to `GitHub`

### What this PR does / why we need it:
Standardizes the way we spell `GitHub`.  Makes our docs look better.

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
