### PR TITLE
fix: fix on setting server info to etcd

### DIFF
--- a/apisix/plugins/server-info.lua
+++ b/apisix/plugins/server-info.lua
@@ -127,16 +127,16 @@ local function report(premature, report_ttl)
 
     server_info.last_report_time = ngx_time()
 
-    local data, err = core.json.encode(server_info)
-    if not data then
-        core.log.error("failed to encode server_info: ", err)
+    local key = "/data_plane/server_info/" .. server_info.id
+    local ok, err = core.etcd.set(key, server_info, report_ttl)
+    if not ok then
+        core.log.error("failed to report server info to etcd: ", err)
         return
     end
 
-    local key = "/data_plane/server_info/" .. server_info.id
-    local ok, err = core.etcd.set(key, data, report_ttl)
-    if not ok then
-        core.log.error("failed to report server info to etcd: ", err)
+    local data, err = core.json.encode(server_info)
+    if not data then
+        core.log.error("failed to encode server_info: ", err)
         return
     end
 

--- a/t/plugin/server-info.t
+++ b/t/plugin/server-info.t
@@ -52,7 +52,6 @@ plugin_attr:
 location /t {
     content_by_lua_block {
         ngx.sleep(2)
-        local json_decode = require("cjson.safe").decode
         local core = require("apisix.core")
         local key = "/data_plane/server_info/" .. core.id.get()
         local res, err = core.etcd.get(key)
@@ -63,8 +62,7 @@ location /t {
         end
 
         local keys = {}
-        local body = json_decode(res.body.node.value)
-        for k in pairs(body) do
+        for k in pairs(value) do
             keys[#keys + 1] = k
         end
 
@@ -104,7 +102,6 @@ plugin_attr:
 --- config
 location /t {
     content_by_lua_block {
-        local json_decode = require("cjson.safe").decode
         local core = require("apisix.core")
         local key = "/data_plane/server_info/" .. core.id.get()
         local res, err = core.etcd.get(key)
@@ -115,8 +112,8 @@ location /t {
         end
 
         local keys = {}
-        local body = json_decode(res.body.node.value)
-        for k in pairs(body) do
+        local value = res.body.node.value
+        for k in pairs(value) do
             keys[#keys + 1] = k
         end
 

--- a/t/plugin/server-info.t
+++ b/t/plugin/server-info.t
@@ -62,13 +62,14 @@ location /t {
         end
 
         local keys = {}
+        local value = res.body.node.value
         for k in pairs(value) do
             keys[#keys + 1] = k
         end
 
         table.sort(keys)
         for i = 1, #keys do
-            ngx.say(keys[i], ": ", body[keys[i]])
+            ngx.say(keys[i], ": ", value[keys[i]])
         end
     }
 }
@@ -117,7 +118,7 @@ location /t {
             keys[#keys + 1] = k
         end
 
-        if body.up_time >= 2 then
+        if value.up_time >= 2 then
             ngx.say("integral")
         else
             ngx.say("reset")


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**

I think there is no need to encode the object that calls `etcd.set`.Because the `lua-resty-etcd` will serialize it.

