### PR TITLE
fix: ctx being contaminated due to a new feature of openresty 1.19

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -185,6 +185,7 @@ function _M.http_ssl_phase()
         end
         ngx_exit(-1)
     end
+    ngx.ctx = nil
 end
 
 
@@ -334,12 +335,8 @@ end
 
 function _M.http_access_phase()
     local ngx_ctx = ngx.ctx
-    local api_ctx = ngx_ctx.api_ctx
-
-    if not api_ctx then
-        api_ctx = core.tablepool.fetch("api_ctx", 0, 32)
-        ngx_ctx.api_ctx = api_ctx
-    end
+    local api_ctx = core.tablepool.fetch("api_ctx", 0, 32)
+    ngx_ctx.api_ctx = api_ctx
 
     core.ctx.set_vars_meta(api_ctx)
 

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -185,6 +185,8 @@ function _M.http_ssl_phase()
         end
         ngx_exit(-1)
     end
+
+    -- clear the ctx of the ssl phase, avoid affecting other phases
     ngx.ctx = nil
 end
 
@@ -335,6 +337,7 @@ end
 
 function _M.http_access_phase()
     local ngx_ctx = ngx.ctx
+    -- always fetch table from the table pool, we don't need a reused api_ctx
     local api_ctx = core.tablepool.fetch("api_ctx", 0, 32)
     ngx_ctx.api_ctx = api_ctx
 

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -184,7 +184,7 @@ function _M.http_ssl_phase()
             core.log.error("failed to fetch ssl config: ", err)
         end
         -- clear the ctx of the ssl phase, avoid affecting other phases
-        ngx.ctx = nil       
+        ngx.ctx = nil
         ngx_exit(-1)
     end
 

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -183,6 +183,8 @@ function _M.http_ssl_phase()
         if err then
             core.log.error("failed to fetch ssl config: ", err)
         end
+        -- clear the ctx of the ssl phase, avoid affecting other phases
+        ngx.ctx = nil       
         ngx_exit(-1)
     end
 


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->

A new feature has been added in OpenResty 1.19.3.1:
`Shared ngx.ctx among SSL_* phases and the following phases.`

In the ssl phase, ctx is created but not cleared. 

In the access phase, it is judged that if ctx already exists, it will not be created. 

This causes a same client to access an `https` service and then access another `http` service, it will be reused the previous ctx, resulting in this bug.


<!--- If it fixes an open issue, please link to the issue here. -->
fix #3079

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
       we could add test cases later for quick fix. we could track it by #3103  
* [ ] Have you modified the corresponding document?
       we don't need to modify docs for this change.
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
