### PR TITLE
chore: expose more schema via control API

### DIFF
--- a/apisix/control/v1.lua
+++ b/apisix/control/v1.lua
@@ -33,6 +33,8 @@ function _M.schema()
             ssl = core.schema.ssl,
             stream_route = core.schema.stream_route,
             upstream = core.schema.upstream,
+            upstream_hash_header_schema = core.schema.upstream_hash_header_schema,
+            upstream_hash_vars_schema = core.schema.upstream_hash_vars_schema,
         },
         plugins = plugin.get_all({
             version = true,

--- a/t/control/schema.t
+++ b/t/control/schema.t
@@ -57,7 +57,9 @@ __DATA__
                         "service": {"type":"object"},
                         "ssl": {"type":"object"},
                         "stream_route": {"type":"object"},
-                        "upstream": {"type":"object"}
+                        "upstream": {"type":"object"},
+                        "upstream_hash_header_schema": {"type":"string"},
+                        "upstream_hash_vars_schema": {"type":"string"},
                     },
                     "plugins": {
                         "example-plugin": {


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Expose `upstream_hash_header_schema` and `upstream_hash_vars_schema`.
We need them to verify `hash_on` of upstream:
https://github.com/apache/apisix/blob/8983a8dd278fec89d40b3d9a14eca9ecf9a187fd/apisix/admin/upstreams.lua#L31-L49
https://github.com/apache/apisix/blob/8983a8dd278fec89d40b3d9a14eca9ecf9a187fd/apisix/admin/upstreams.lua#L82-L92


### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
