### PR TITLE
docs: lint Markdown and remove unneeded rules

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -26,10 +26,6 @@ MD010: false
 MD011: false
 MD013: false
 MD014: false
-MD018: false
-MD019: false
-MD020: false
-MD021: false
 MD022: false
 MD023: false
 MD024: false

--- a/FAQ.md
+++ b/FAQ.md
@@ -19,11 +19,11 @@
 
 # FAQ
 
-##  Why a new API gateway?
+## Why a new API gateway?
 
 There are new requirements for API gateways in the field of microservices: higher flexibility, higher performance requirements, and cloud native.
 
-##  What are the differences between APISIX and other API gateways?
+## What are the differences between APISIX and other API gateways?
 
 APISIX is based on etcd to save and synchronize configuration, not relational databases such as Postgres or MySQL.
 


### PR DESCRIPTION
Remove rules:
MD018 - No space after hash on atx style header
MD020 - No space inside hashes on closed atx style header
MD021 - Multiple spaces inside hashes on closed atx style header

Lint for:
MD019 - Multiple spaces after hash on atx style header

### What this PR does / why we need it:
Standardizes our Markdown

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
