### PR TITLE
fix: use `config_util.iterate_values` to avoid error by using invalid  data type as table

### DIFF
--- a/apisix/plugins/grpc-transcode/proto.lua
+++ b/apisix/plugins/grpc-transcode/proto.lua
@@ -17,7 +17,6 @@
 local core        = require("apisix.core")
 local config_util = require("apisix.core.config_util")
 local protoc      = require("protoc")
-local ipairs      = ipairs
 local protos
 
 

--- a/apisix/plugins/grpc-transcode/proto.lua
+++ b/apisix/plugins/grpc-transcode/proto.lua
@@ -14,9 +14,10 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 --
-local core   = require("apisix.core")
-local protoc = require("protoc")
-local ipairs = ipairs
+local core        = require("apisix.core")
+local config_util = require("apisix.core.config_util")
+local protoc      = require("protoc")
+local ipairs      = ipairs
 local protos
 
 
@@ -31,7 +32,7 @@ local function create_proto_obj(proto_id)
     end
 
     local content
-    for _, proto in ipairs(protos.values) do
+    for _, proto in config_util.iterate_values(protos.values) do
         if proto_id == proto.value.id then
             content = proto.value.content
             break

--- a/t/plugin/grpc-transcode.t
+++ b/t/plugin/grpc-transcode.t
@@ -73,7 +73,68 @@ passed
 
 
 
-=== TEST 2: set routes(id: 1)
+=== TEST 2: set proto(id: 2)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/proto/2',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "content" : "syntax = \"proto3\";
+                      package helloworld;
+                      service Greeter {
+                          rpc SayHello (HelloRequest) returns (HelloReply) {}
+                      }
+                      message HelloRequest {
+                          string name = 1;
+                      }
+                      message HelloReply {
+                          string message = 1;
+                         }"
+                   }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: delete proto(id: 2)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/proto/2',
+                 ngx.HTTP_DELETE
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: set routes(id: 1)
 --- config
     location /t {
         content_by_lua_block {
@@ -115,7 +176,7 @@ passed
 
 
 
-=== TEST 3: hit route
+=== TEST 5: hit route
 --- request
 GET /grpctest?name=world
 --- response_body eval
@@ -125,7 +186,7 @@ qr/\{"message":"Hello world"\}/
 
 
 
-=== TEST 4: hit route by post
+=== TEST 6: hit route by post
 --- request
 POST /grpctest
 name=world
@@ -136,7 +197,7 @@ qr/\{"message":"Hello world"\}/
 
 
 
-=== TEST 5: hit route by post json
+=== TEST 7: hit route by post json
 --- request
 POST /grpctest
 {"name": "world"}
@@ -149,7 +210,7 @@ qr/\{"message":"Hello world"\}/
 
 
 
-=== TEST 6: wrong service protocol
+=== TEST 8: wrong service protocol
 --- config
     location /t {
         content_by_lua_block {
@@ -190,7 +251,7 @@ GET /t
 
 
 
-=== TEST 7: wrong upstream address
+=== TEST 9: wrong upstream address
 --- config
     location /t {
         content_by_lua_block {
@@ -232,7 +293,7 @@ passed
 
 
 
-=== TEST 8: hit route (Connection refused)
+=== TEST 10: hit route (Connection refused)
 --- request
 GET /grpctest
 --- response_body eval
@@ -243,7 +304,7 @@ Connection refused) while connecting to upstream
 
 
 
-=== TEST 9: update proto(id: 1)
+=== TEST 11: update proto(id: 1)
 --- config
     location /t {
         content_by_lua_block {
@@ -290,7 +351,7 @@ passed
 
 
 
-=== TEST 10: set routes(id: 2)
+=== TEST 12: set routes(id: 2)
 --- config
     location /t {
         content_by_lua_block {
@@ -333,7 +394,7 @@ passed
 
 
 
-=== TEST 11: hit route
+=== TEST 13: hit route
 --- request
 GET /grpc_plus?a=1&b=2
 --- response_body eval
@@ -343,7 +404,7 @@ qr/\{"result":3\}/
 
 
 
-=== TEST 12: hit route
+=== TEST 14: hit route
 --- request
 GET /grpc_plus?a=1&b=2251799813685260
 --- response_body eval
@@ -353,7 +414,7 @@ qr/\{"result":"#2251799813685261"\}/
 
 
 
-=== TEST 13: set route3 deadline nodelay
+=== TEST 15: set route3 deadline nodelay
 --- config
     location /t {
         content_by_lua_block {
@@ -395,7 +456,7 @@ passed
 
 
 
-=== TEST 14: hit route
+=== TEST 16: hit route
 --- request
 GET /grpc_deadline?name=apisix
 --- response_body eval
@@ -405,7 +466,7 @@ qr/\{"message":"Hello apisix"\}/
 
 
 
-=== TEST 15: set route4 deadline delay
+=== TEST 17: set route4 deadline delay
 --- config
     location /t {
         content_by_lua_block {
@@ -447,14 +508,14 @@ passed
 
 
 
-=== TEST 16: hit route
+=== TEST 18: hit route
 --- request
 GET /grpc_delay?name=apisix
 --- error_code: 504
 
 
 
-=== TEST 17: set routes: missing method
+=== TEST 19: set routes: missing method
 --- config
     location /t {
         content_by_lua_block {
@@ -488,7 +549,7 @@ GET /t
 
 
 
-=== TEST 18: set proto(id: 1, with array parameter)
+=== TEST 20: set proto(id: 1, with array parameter)
 --- config
     location /t {
         content_by_lua_block {
@@ -527,7 +588,7 @@ passed
 
 
 
-=== TEST 19: set routes(id: 1, with array parameter)
+=== TEST 21: set routes(id: 1, with array parameter)
 --- config
     location /t {
         content_by_lua_block {
@@ -569,7 +630,7 @@ passed
 
 
 
-=== TEST 20: hit route
+=== TEST 22: hit route
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
### What this PR does / why we need it:
When watching ETCD, delete a resource item, we will set the corresponding item in `values` to false. ([refer](https://github.com/apache/apisix/blob/master/apisix/core/config_etcd.lua#L412))
When traversing the `values` of the resource, all items are directly used as `table`, which will cause errors.
Use `config_util.iterate_values` to process first to avoid this problem.

close #3166

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
