### PR TITLE
fix: Add create_time and update_time fields for server_info

### DIFF
--- a/t/plugin/server-info.t
+++ b/t/plugin/server-info.t
@@ -69,7 +69,7 @@ location /t {
 --- request
 GET /t
 --- response_body eval
-qr/^{"boot_time":\d+,"etcd_version":"[\d\.]+","hostname":"[a-zA-Z\-0-9\.]+","id":[a-zA-Z\-0-9]+,"last_report_time":\d+,"up_time":\d+,"version":"[\d\.]+"}$/
+qr/^{"boot_time":\d+,"create_time":\d+,"etcd_version":"[\d\.]+","hostname":"[a-zA-Z\-0-9\.]+","id":[a-zA-Z\-0-9]+,"last_report_time":\d+,"up_time":\d+,"update_time":\d+,"version":"[\d\.]+"}$/
 --- no_error_log
 [error]
 --- error_log
@@ -140,6 +140,6 @@ location /t {
 --- request
 GET /t
 --- response_body eval
-qr/^{"boot_time":\d+,"etcd_version":"[\d\.]+","hostname":"[a-zA-Z\-0-9\.]+","id":[a-zA-Z\-0-9]+,"last_report_time":\d+,"up_time":\d+,"version":"[\d\.]+"}$/
+qr/^{"boot_time":\d+,"create_time":\d+,"etcd_version":"[\d\.]+","hostname":"[a-zA-Z\-0-9\.]+","id":[a-zA-Z\-0-9]+,"last_report_time":\d+,"up_time":\d+,"update_time":\d+,"version":"[\d\.]+"}$/
 --- no_error_log
 [error]


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->

As described in https://github.com/apache/apisix-dashboard/issues/1176 , currently the `create_time` and `update_time` field of `server_info` are missing in etcd. This PR is going to set there two additional fields before reporting `server_info` into etcd.

In the implementation, I assume that the `update_time` equals to `last_report_time`. Regarding to the `create_time`, it would be not reseted by hot updating APISIX.

Any feedback is welcome. Thanks.


<!--- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/apache/apisix-dashboard/issues/1176 .

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
