### PR TITLE
fix: set `ngx.ctx` to nil will corrupt the inner ngx_lua_ctx_tables

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -183,13 +183,8 @@ function _M.http_ssl_phase()
         if err then
             core.log.error("failed to fetch ssl config: ", err)
         end
-        -- clear the ctx of the ssl phase, avoid affecting other phases
-        ngx.ctx = nil
         ngx_exit(-1)
     end
-
-    -- clear the ctx of the ssl phase, avoid affecting other phases
-    ngx.ctx = nil
 end
 
 


### PR DESCRIPTION
And it doesn't free the reference which is actually controlled in C
land.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
