### PR TITLE
fix(CI): roll our own linter for YAML

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -9,7 +9,6 @@ assignees: ''
 
 ### Issue description
 
-
 ### Environment
 
 * apisix version (cmd: `apisix version`):
@@ -17,12 +16,11 @@ assignees: ''
 * OpenResty / Nginx version: (cmd: `nginx -V` or `openresty -V`)
 
 ### Minimal test code / Steps to reproduce the issue
+
 1.
 2.
 3.
 
 ### What's the actual result? (including assertion message & call stack if applicable)
-
-
 
 ### What's the expected result?

--- a/.github/ISSUE_TEMPLATE/request-help.md
+++ b/.github/ISSUE_TEMPLATE/request-help.md
@@ -9,7 +9,6 @@ assignees: ''
 
 ### Issue description
 
-
 ### Environment
 
 * apisix version (cmd: `apisix version`):

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,5 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'  # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          architecture: 'x64'  # optional x64 or x86. Defaults to x64 if not specified
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install yamllint
       - name: 🧹 YAML Lint
-        uses: ibiqlik/action-yamllint@v3
+        run: |
+          yamllint .

--- a/doc/plugins/openid-connect.md
+++ b/doc/plugins/openid-connect.md
@@ -80,7 +80,6 @@ will be rejected without redirecting to the ID provider to obtain a valid token.
 The method used to authenticate a request also affects the headers that can be enforced on the request before
 sending it to upstream. The headers that can be enforced are mentioned below in each relevant section.
 
-
 ### Token Introspection
 
 Token introspection helps to validate a request by verifying the token against an Oauth 2 authorization server.


### PR DESCRIPTION
Due to the ASF's policies changing we cannot use the original GitHub Actions for linting as they are not approved

Lint Markdown for rules:
- MD012/no-multiple-blanks
- MD032/blanks-around-lists

refs #3178 

### What this PR does / why we need it:

Fixes the YAML linter so we can continue to have standardized YAML.

Standardizes our Markdown.

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
