### PR TITLE
fix(CI): roll our own Markdown link checker

### DIFF
--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -1,14 +1,27 @@
 name: Check Markdown links
 
-on: push
+on: [pull_request]
 
 jobs:
   markdown-link-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+        node_version:
+          - 14
+        architecture:
+          - x64
+    name: Node ${{ matrix.node_version }} - ${{ matrix.architecture }} on ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        use-quiet-mode: 'yes'
-        use-verbose-mode: 'yes'
-        check-modified-files-only: 'yes'
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node_version }}
+          architecture: ${{ matrix.architecture }}
+      - name: Install
+        run: npm install -g markdown-link-check
+      - name: Run
+        run: git ls-files . -m | xargs markdown-link-check -q -v  # modified files only, quiet mode, verbose mode


### PR DESCRIPTION
Due to the ASF's policies changing we cannot use the original GitHub Actions for linting as they are not approved.

Change Action to only rull on pull request.

### What this PR does / why we need it:

This PR fixes our Markdown link checker.

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
