### PR TITLE
feat: Add create_time and update_time in global_rule schema

### DIFF
--- a/apisix/admin/global_rules.lua
+++ b/apisix/admin/global_rules.lua
@@ -15,6 +15,7 @@
 -- limitations under the License.
 --
 local core = require("apisix.core")
+local utils = require("apisix.admin.utils")
 local schema_plugin = require("apisix.admin.plugins").check_schema
 local type = type
 local tostring = tostring
@@ -68,6 +69,12 @@ function _M.put(id, conf)
     end
 
     local key = "/global_rules/" .. id
+
+    local ok, err = utils.inject_conf_with_prev_conf("route", key, conf)
+    if not ok then
+        return 500, {error_msg = err}
+    end
+
     local res, err = core.etcd.set(key, conf)
     if not res then
         core.log.error("failed to put global rule[", key, "]: ", err)
@@ -148,6 +155,8 @@ function _M.patch(id, conf, sub_path)
     end
 
     core.log.info("new conf: ", core.json.delay_encode(node_value, true))
+
+    utils.inject_timestamp(node_value, nil, conf)
 
     local ok, err = check_conf(id, node_value, true)
     if not ok then

--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -688,7 +688,9 @@ _M.global_rule = {
     type = "object",
     properties = {
         id = id_schema,
-        plugins = plugins_schema
+        plugins = plugins_schema,
+        create_time = timestamp_def,
+        update_time = timestamp_def
     },
     required = {"plugins"},
     additionalProperties = false,

--- a/t/admin/global-rules.t
+++ b/t/admin/global-rules.t
@@ -448,3 +448,139 @@ GET /t
 passed
 --- no_error_log
 [error]
+
+
+
+=== TEST 12: not unwanted data, PUT
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local t = require("lib.test_admin").test
+            local code, message, res = t('/apisix/admin/global_rules/1',
+                 ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "proxy-rewrite": {
+                            "uri": "/"
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(message)
+                return
+            end
+
+            res = json.decode(res)
+            res.node.value.create_time = nil
+            res.node.value.update_time = nil
+            ngx.say(json.encode(res))
+        }
+    }
+--- response_body
+{"action":"set","node":{"key":"/apisix/global_rules/1","value":{"id":"1","plugins":{"proxy-rewrite":{"uri":"/"}}}}}
+--- request
+GET /t
+--- no_error_log
+[error]
+
+
+
+=== TEST 13: not unwanted data, PATCH
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local t = require("lib.test_admin").test
+            local code, message, res = t('/apisix/admin/global_rules/1',
+                 ngx.HTTP_PATCH,
+                [[{
+                    "plugins": {
+                        "proxy-rewrite": {
+                            "uri": "/"
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(message)
+                return
+            end
+
+            res = json.decode(res)
+            res.node.value.create_time = nil
+            res.node.value.update_time = nil
+            ngx.say(json.encode(res))
+        }
+    }
+--- response_body
+{"action":"compareAndSwap","node":{"key":"/apisix/global_rules/1","value":{"id":"1","plugins":{"proxy-rewrite":{"uri":"/"}}}}}
+--- request
+GET /t
+--- no_error_log
+[error]
+
+
+
+=== TEST 14: not unwanted data, GET
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local t = require("lib.test_admin").test
+            local code, message, res = t('/apisix/admin/global_rules/1',
+                 ngx.HTTP_GET
+                )
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(message)
+                return
+            end
+
+            res = json.decode(res)
+            res.node.value.create_time = nil
+            res.node.value.update_time = nil
+            ngx.say(json.encode(res))
+        }
+    }
+--- response_body
+{"action":"get","count":"1","node":{"key":"/apisix/global_rules/1","value":{"id":"1","plugins":{"proxy-rewrite":{"uri":"/"}}}}}
+--- request
+GET /t
+--- no_error_log
+[error]
+
+
+
+=== TEST 15: not unwanted data, DELETE
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local t = require("lib.test_admin").test
+            local code, message, res = t('/apisix/admin/global_rules/1',
+                 ngx.HTTP_DELETE
+                )
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(message)
+                return
+            end
+
+            res = json.decode(res)
+            ngx.say(json.encode(res))
+        }
+    }
+--- response_body
+{"action":"delete","deleted":"1","key":"/apisix/global_rules/1","node":{}}
+--- request
+GET /t
+--- no_error_log
+[error]

--- a/t/admin/global-rules.t
+++ b/t/admin/global-rules.t
@@ -31,6 +31,7 @@ __DATA__
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
+            local etcd = require("apisix.core.etcd")
             local code, body = t('/apisix/admin/global_rules/1',
                 ngx.HTTP_PUT,
                 [[{
@@ -63,6 +64,12 @@ __DATA__
 
             ngx.status = code
             ngx.say(body)
+
+            local res = assert(etcd.get('/global_rules/1'))
+            local create_time = res.body.node.value.create_time
+            assert(create_time ~= nil, "create_time is nil")
+            local update_time = res.body.node.value.update_time
+            assert(update_time ~= nil, "update_time is nil")
         }
     }
 --- request
@@ -164,6 +171,14 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
+            local etcd = require("apisix.core.etcd")
+            local res = assert(etcd.get('/global_rules/1'))
+            local prev_create_time = res.body.node.value.create_time
+            assert(prev_create_time ~= nil, "create_time is nil")
+            local prev_update_time = res.body.node.value.update_time
+            assert(prev_update_time ~= nil, "update_time is nil")
+            ngx.sleep(1)
+
             local code, body = t('/apisix/admin/global_rules/1',
                 ngx.HTTP_PATCH,
                 [[{
@@ -195,6 +210,13 @@ passed
 
             ngx.status = code
             ngx.say(body)
+
+            local res = assert(etcd.get('/global_rules/1'))
+            local create_time = res.body.node.value.create_time
+            assert(prev_create_time == create_time, "create_time mismatched")
+            local update_time = res.body.node.value.update_time
+            assert(update_time ~= nil, "update_time is nil")
+            assert(prev_update_time ~= update_time, "update_time should be changed")
         }
     }
 --- request
@@ -211,6 +233,14 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
+            local etcd = require("apisix.core.etcd")
+            local res = assert(etcd.get('/global_rules/1'))
+            local prev_create_time = res.body.node.value.create_time
+            assert(prev_create_time ~= nil, "create_time is nil")
+            local prev_update_time = res.body.node.value.update_time
+            assert(prev_update_time ~= nil, "update_time is nil")
+            ngx.sleep(1)
+
             local code, body = t('/apisix/admin/global_rules/1/plugins',
                 ngx.HTTP_PATCH,
                 [[{
@@ -241,6 +271,13 @@ passed
 
             ngx.status = code
             ngx.say(body)
+
+            local res = assert(etcd.get('/global_rules/1'))
+            local create_time = res.body.node.value.create_time
+            assert(prev_create_time == create_time, "create_time mismatched")
+            local update_time = res.body.node.value.update_time
+            assert(update_time ~= nil, "update_time is nil")
+            assert(prev_update_time ~= update_time, "update_time should be changed")
         }
     }
 --- request
@@ -409,141 +446,5 @@ passed
 GET /t
 --- response_body
 passed
---- no_error_log
-[error]
-
-
-
-=== TEST 12: not unwanted data, PUT
---- config
-    location /t {
-        content_by_lua_block {
-            local json = require("toolkit.json")
-            local t = require("lib.test_admin").test
-            local code, message, res = t('/apisix/admin/global_rules/1',
-                 ngx.HTTP_PUT,
-                [[{
-                    "plugins": {
-                        "proxy-rewrite": {
-                            "uri": "/"
-                        }
-                    }
-                }]]
-                )
-
-            if code >= 300 then
-                ngx.status = code
-                ngx.say(message)
-                return
-            end
-
-            res = json.decode(res)
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
-            ngx.say(json.encode(res))
-        }
-    }
---- response_body
-{"action":"set","node":{"key":"/apisix/global_rules/1","value":{"id":"1","plugins":{"proxy-rewrite":{"uri":"/"}}}}}
---- request
-GET /t
---- no_error_log
-[error]
-
-
-
-=== TEST 13: not unwanted data, PATCH
---- config
-    location /t {
-        content_by_lua_block {
-            local json = require("toolkit.json")
-            local t = require("lib.test_admin").test
-            local code, message, res = t('/apisix/admin/global_rules/1',
-                 ngx.HTTP_PATCH,
-                [[{
-                    "plugins": {
-                        "proxy-rewrite": {
-                            "uri": "/"
-                        }
-                    }
-                }]]
-                )
-
-            if code >= 300 then
-                ngx.status = code
-                ngx.say(message)
-                return
-            end
-
-            res = json.decode(res)
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
-            ngx.say(json.encode(res))
-        }
-    }
---- response_body
-{"action":"compareAndSwap","node":{"key":"/apisix/global_rules/1","value":{"id":"1","plugins":{"proxy-rewrite":{"uri":"/"}}}}}
---- request
-GET /t
---- no_error_log
-[error]
-
-
-
-=== TEST 14: not unwanted data, GET
---- config
-    location /t {
-        content_by_lua_block {
-            local json = require("toolkit.json")
-            local t = require("lib.test_admin").test
-            local code, message, res = t('/apisix/admin/global_rules/1',
-                 ngx.HTTP_GET
-                )
-
-            if code >= 300 then
-                ngx.status = code
-                ngx.say(message)
-                return
-            end
-
-            res = json.decode(res)
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
-            ngx.say(json.encode(res))
-        }
-    }
---- response_body
-{"action":"get","count":"1","node":{"key":"/apisix/global_rules/1","value":{"id":"1","plugins":{"proxy-rewrite":{"uri":"/"}}}}}
---- request
-GET /t
---- no_error_log
-[error]
-
-
-
-=== TEST 15: not unwanted data, DELETE
---- config
-    location /t {
-        content_by_lua_block {
-            local json = require("toolkit.json")
-            local t = require("lib.test_admin").test
-            local code, message, res = t('/apisix/admin/global_rules/1',
-                 ngx.HTTP_DELETE
-                )
-
-            if code >= 300 then
-                ngx.status = code
-                ngx.say(message)
-                return
-            end
-
-            res = json.decode(res)
-            ngx.say(json.encode(res))
-        }
-    }
---- response_body
-{"action":"delete","deleted":"1","key":"/apisix/global_rules/1","node":{}}
---- request
-GET /t
 --- no_error_log
 [error]

--- a/t/admin/schema.t
+++ b/t/admin/schema.t
@@ -281,3 +281,13 @@ GET /apisix/admin/schema/plugins/node-status
 qr/"disable":\{"type":"boolean"\}/
 --- no_error_log
 [error]
+
+
+
+=== TEST 15: get global_rule schema to check if it contains `create_time` and `update_time`
+--- request
+GET /apisix/admin/schema/global_rule
+--- response_body eval
+qr/("update_time":\{"type":"integer"\}.*"create_time":\{"type":"integer"\}|"create_time":\{"type":"integer"\}.*"update_time":\{"type":"integer"\})/
+--- no_error_log
+[error]


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->

As https://github.com/apache/apisix-dashboard/issues/1143 comes to a conclusion that `create_time` and `update_time` are needed for `global_rule` entity. This PR is going to  add the two fields and relevant test cases. 

<!--- If it fixes an open issue, please link to the issue here. -->

Related to https://github.com/apache/apisix-dashboard/issues/1143  , taking charge of the APISIX part.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
