### PR TITLE
feat: support more customize configure in nginx.conf

### DIFF
--- a/.travis/apisix_cli_test/test_main.sh
+++ b/.travis/apisix_cli_test/test_main.sh
@@ -675,6 +675,8 @@ nginx_config:
         set $my "var";
     http_admin_configuration_snippet: |
         log_format admin "$request_time $pipe";
+    http_end_configuration_snippet: |
+        server_names_hash_bucket_size 128;
     stream_configuration_snippet: |
         tcp_nodelay off;
 ' > conf/config.yaml
@@ -702,6 +704,18 @@ fi
 grep 'log_format admin "$request_time $pipe";' -A 2 conf/nginx.conf | grep "configuration snippet ends" > /dev/null
 if [ ! $? -eq 0 ]; then
     echo "failed: can't inject admin server configuration"
+    exit 1
+fi
+
+grep 'server_names_hash_bucket_size 128;' -A 2 conf/nginx.conf | grep "configuration snippet ends" > /dev/null
+if [ ! $? -eq 0 ]; then
+    echo "failed: can't inject http end configuration"
+    exit 1
+fi
+
+grep 'server_names_hash_bucket_size 128;' -A 3 conf/nginx.conf | grep "}" > /dev/null
+if [ ! $? -eq 0 ]; then
+    echo "failed: can't inject http end configuration"
     exit 1
 fi
 

--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -26,6 +26,12 @@ worker_processes {* worker_processes *};
 worker_cpu_affinity auto;
 {% end %}
 
+# main configuration snippet starts
+{% if main_configuration_snippet then %}
+{* main_configuration_snippet *}
+{% end %}
+# main configuration snippet ends
+
 error_log {* error_log *} {* error_log_level or "warn" *};
 pid logs/nginx.pid;
 
@@ -47,12 +53,6 @@ env APISIX_PROFILE;
 env {*name*};
 {% end %}
 {% end %}
-
-# main configuration snippet starts
-{% if main_configuration_snippet then %}
-{* main_configuration_snippet *}
-{% end %}
-# main configuration snippet ends
 
 {% if stream_proxy then %}
 stream {
@@ -570,5 +570,10 @@ http {
         }
         {% end %}
     }
+    # http end configuration snippet starts
+    {% if http_end_configuration_snippet then %}
+    {* http_end_configuration_snippet *}
+    {% end %}
+    # http end configuration snippet ends
 }
 ]=]

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -152,6 +152,9 @@ nginx_config:                     # config for render the template to generate n
   http_admin_configuration_snippet: |
     # Add custom Nginx admin server configuration to nginx.conf.
     # The configuration should be well indented!
+  http_end_configuration_snippet: |
+    # Add custom Nginx http end configuration to nginx.conf.
+    # The configuration should be well indented!
   stream_configuration_snippet: |
     # Add custom Nginx stream configuration to nginx.conf.
     # The configuration should be well indented!

--- a/doc/customize-nginx-configuration.md
+++ b/doc/customize-nginx-configuration.md
@@ -53,6 +53,8 @@ nginx_config:
         set $my "var";
     http_admin_configuration_snippet: |
         log_format admin "$request_time $pipe";
+    http_end_configuration_snippet: |
+        server_names_hash_bucket_size 128;
     stream_configuration_snippet: |
         tcp_nodelay off;
 ...

--- a/doc/zh-cn/customize-nginx-configuration.md
+++ b/doc/zh-cn/customize-nginx-configuration.md
@@ -53,6 +53,8 @@ nginx_config:
         set $my "var";
     http_admin_configuration_snippet: |
         log_format admin "$request_time $pipe";
+    http_end_configuration_snippet: |
+        server_names_hash_bucket_size 128;
     stream_configuration_snippet: |
         tcp_nodelay off;
 ...


### PR DESCRIPTION
在使用apisix过程中由于要使用第三方模块，需要用到load_module和include这两个指令，目前关于nginx的自定义配置对这两个指令的支持有问题，因此这个pull request丰富了用户自定义配置的支持
具体见https://github.com/apache/apisix/issues/3203