### PR TITLE
chore: catch error while new `healthcheck` instance

### DIFF
--- a/apisix/balancer.lua
+++ b/apisix/balancer.lua
@@ -87,11 +87,16 @@ local function create_checker(upstream, healthcheck_parent)
     if healthcheck == nil then
         healthcheck = require("resty.healthcheck")
     end
-    local checker = healthcheck.new({
+    local checker, err = healthcheck.new({
         name = "upstream#" .. healthcheck_parent.key,
         shm_name = "upstream-healthcheck",
         checks = upstream.checks,
     })
+
+    if not checker then
+        core.log.error("fail to create healthcheck instance: ", err)
+        return
+    end
 
     local host = upstream.checks and upstream.checks.active and upstream.checks.active.host
     local port = upstream.checks and upstream.checks.active and upstream.checks.active.port


### PR DESCRIPTION
### What this PR does / why we need it:
catch error while new `healthcheck` instance and return the checker with nil.

the function pick_server will treat the nodes as normal  with the 'checker == nil', and get a correct one by rules.

fix #3169 
### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
