### PR TITLE
fix: APISIX runs in the `/root` directory and reports errors

### DIFF
--- a/.travis/apisix_cli_test/test_main.sh
+++ b/.travis/apisix_cli_test/test_main.sh
@@ -1003,9 +1003,9 @@ cd /root/apisix
 make init
 
 out=$(make run 2>&1 || true)
-if echo "$out" | grep "Error: It is forbidden to run APISIX in the /root directory"; then
-    echo "failed: APISIX cannot be run under the /root folder."
+if ! echo "$out" | grep "Error: It is forbidden to run APISIX in the /root directory"; then
+    echo "failed: should echo It is forbidden to run APISIX in the /root directory."
     exit 1
 fi
 
-echo "APISIX started successfully."
+echo "pass: successfully prohibit APISIX from running in the /root directory."

--- a/.travis/apisix_cli_test/test_main.sh
+++ b/.travis/apisix_cli_test/test_main.sh
@@ -880,6 +880,10 @@ fi
 
 echo "pass: successfully prohibit APISIX from running in the /root directory"
 
+rm -rf /root/apisix
+#restore directory
+cd -
+
 # check etcd while enable auth
 git checkout conf/config.yaml
 

--- a/.travis/apisix_cli_test/test_main.sh
+++ b/.travis/apisix_cli_test/test_main.sh
@@ -880,9 +880,8 @@ fi
 
 echo "pass: successfully prohibit APISIX from running in the /root directory"
 
-rm -rf /root/apisix
-#restore directory
 cd -
+rm -rf /root/apisix
 
 # check etcd while enable auth
 git checkout conf/config.yaml

--- a/.travis/apisix_cli_test/test_main.sh
+++ b/.travis/apisix_cli_test/test_main.sh
@@ -878,9 +878,10 @@ if ! echo "$out" | grep "Error: It is forbidden to run APISIX in the /root direc
     exit 1
 fi
 
-echo "pass: successfully prohibit APISIX from running in the /root directory"
-
 cd -
+
+echo "passed: successfully prohibit APISIX from running in the /root directory"
+
 rm -rf /root/apisix
 
 # check etcd while enable auth

--- a/.travis/apisix_cli_test/test_main.sh
+++ b/.travis/apisix_cli_test/test_main.sh
@@ -994,18 +994,16 @@ etcdctl --endpoints=127.0.0.1:2379 role delete root
 etcdctl --endpoints=127.0.0.1:2379 user delete root
 
 # It is forbidden to run apisix under the "/root" folder.
-git checkout conf/config.yaml
-
 mkdir /root/apisix
-
 cp -r ./*  /root/apisix
 cd /root/apisix
+
 make init
 
 out=$(make run 2>&1 || true)
 if ! echo "$out" | grep "Error: It is forbidden to run APISIX in the /root directory"; then
-    echo "failed: should echo It is forbidden to run APISIX in the /root directory."
+    echo "failed: should echo It is forbidden to run APISIX in the /root directory"
     exit 1
 fi
 
-echo "pass: successfully prohibit APISIX from running in the /root directory."
+echo "pass: successfully prohibit APISIX from running in the /root directory"

--- a/.travis/apisix_cli_test/test_main.sh
+++ b/.travis/apisix_cli_test/test_main.sh
@@ -993,3 +993,19 @@ etcdctl --endpoints=127.0.0.1:2379 --user=root:apache-api6 auth disable
 etcdctl --endpoints=127.0.0.1:2379 role delete root
 etcdctl --endpoints=127.0.0.1:2379 user delete root
 
+# It is forbidden to run apisix under the "/root" folder.
+git checkout conf/config.yaml
+
+mkdir /root/apisix
+
+cp -r ./*  /root/apisix
+cd /root/apisix
+make init
+
+out=$(make run 2>&1 || true)
+if echo "$out" | grep "Error: It is forbidden to run APISIX in the /root directory"; then
+    echo "failed: APISIX cannot be run under the /root folder."
+    exit 1
+fi
+
+echo "APISIX started successfully."

--- a/.travis/apisix_cli_test/test_main.sh
+++ b/.travis/apisix_cli_test/test_main.sh
@@ -863,6 +863,23 @@ fi
 
 echo "pass: uninitialized variable not found during writing access log (port_admin set)"
 
+# It is forbidden to run apisix under the "/root" directory.
+git checkout conf/config.yaml
+
+mkdir /root/apisix
+
+cp -r ./*  /root/apisix
+cd /root/apisix
+make init
+
+out=$(make run 2>&1 || true)
+if ! echo "$out" | grep "Error: It is forbidden to run APISIX in the /root directory"; then
+    echo "failed: should echo It is forbidden to run APISIX in the /root directory"
+    exit 1
+fi
+
+echo "pass: successfully prohibit APISIX from running in the /root directory"
+
 # check etcd while enable auth
 git checkout conf/config.yaml
 
@@ -992,18 +1009,3 @@ echo "passed: show password error successfully"
 etcdctl --endpoints=127.0.0.1:2379 --user=root:apache-api6 auth disable
 etcdctl --endpoints=127.0.0.1:2379 role delete root
 etcdctl --endpoints=127.0.0.1:2379 user delete root
-
-# It is forbidden to run apisix under the "/root" folder.
-mkdir /root/apisix
-cp -r ./*  /root/apisix
-cd /root/apisix
-
-make init
-
-out=$(make run 2>&1 || true)
-if ! echo "$out" | grep "Error: It is forbidden to run APISIX in the /root directory"; then
-    echo "failed: should echo It is forbidden to run APISIX in the /root directory"
-    exit 1
-fi
-
-echo "pass: successfully prohibit APISIX from running in the /root directory"

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,9 @@ init: default
 ### run:              Start the apisix server
 .PHONY: run
 run: default
-ifeq ("$(wildcard logs/nginx.pid)", "")
+ifeq ("$(findstring /root, ${PWD})", "/root")
+	@echo "Warning! It is forbidden to run APISIX in the /root directory."
+else ifeq ("$(wildcard logs/nginx.pid)", "")
 	mkdir -p logs
 	$(OR_EXEC) -p $$PWD/ -c $$PWD/conf/nginx.conf
 else

--- a/Makefile
+++ b/Makefile
@@ -83,14 +83,10 @@ init: default
 ### run:              Start the apisix server
 .PHONY: run
 run: default
-ifeq ("$(findstring /root, ${PWD})", "/root")
-	@echo "Error: It is forbidden to run APISIX in the /root directory."
-	@exit 1
-else ifeq ("$(wildcard logs/nginx.pid)", "")
-	mkdir -p logs
-	$(OR_EXEC) -p $$PWD/ -c $$PWD/conf/nginx.conf
-else
+ifneq ("$(wildcard logs/nginx.pid)", "")
 	@echo "APISIX is running..."
+else
+	./bin/apisix start
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,8 @@ init: default
 .PHONY: run
 run: default
 ifeq ("$(findstring /root, ${PWD})", "/root")
-	@echo "Warning! It is forbidden to run APISIX in the /root directory."
+	@echo "Non-zero exit status: 1"
+	@echo "Error, It is forbidden to run APISIX in the /root directory."
 else ifeq ("$(wildcard logs/nginx.pid)", "")
 	mkdir -p logs
 	$(OR_EXEC) -p $$PWD/ -c $$PWD/conf/nginx.conf

--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,8 @@ init: default
 .PHONY: run
 run: default
 ifeq ("$(findstring /root, ${PWD})", "/root")
-	@echo "Non-zero exit status: 1"
-	@echo "Error, It is forbidden to run APISIX in the /root directory."
+	@echo "Error: It is forbidden to run APISIX in the /root directory."
+	@exit 1
 else ifeq ("$(wildcard logs/nginx.pid)", "")
 	mkdir -p logs
 	$(OR_EXEC) -p $$PWD/ -c $$PWD/conf/nginx.conf

--- a/apisix/cli/env.lua
+++ b/apisix/cli/env.lua
@@ -37,6 +37,8 @@ return function (apisix_home, pkg_cpath_org, pkg_path_org)
             error("failed to fetch current path")
         end
 
+        -- determine whether the current path is under the "/root" folder.
+        -- "/root/" is the root folder flag.
         if str_find(apisix_home .. "/", '/root/', nil, true) == 1 then
             is_root_path = true
         end

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -375,6 +375,10 @@ end
 
 
 local function start(env, ...)
+    if env.is_root_path then
+        util.die("Error: It is forbidden to run APISIX in the /root directory.\n")
+    end
+
     local cmd_logs = "mkdir -p " .. env.apisix_home .. "/logs"
     util.execute_cmd(cmd_logs)
 

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -375,6 +375,9 @@ end
 
 
 local function start(env, ...)
+    -- Because the worker process started by apisix has "nobody" permission,
+    -- it cannot access the `/root` directory. Therefore, it is necessary to
+    -- prohibit APISIX from running in the /root directory.
     if env.is_root_path then
         util.die("Error: It is forbidden to run APISIX in the /root directory.\n")
     end

--- a/t/cli/cli.t
+++ b/t/cli/cli.t
@@ -58,3 +58,21 @@ nameserver 172.27.0.1
 nameserver fe80::215:5dff:fec5:8e1d
 --- response_body
 ["172.27.0.1","fe80::215:5dff:fec5:8e1d"]
+
+
+
+=== TEST 2: It is forbidden to run APISIX under the /root directory(is_root_path is true).
+--- config
+    location /t {
+        content_by_lua_block {
+            local ops = require("apisix.cli.ops")
+            local env = {is_root_path = true}
+            local arg = {"start"}
+            ops.execute(env, arg)
+        }
+    }
+--- request
+GET /t
+--- error_code:
+--- error_log
+Error: It is forbidden to run APISIX in the /root directory.

--- a/t/cli/cli.t
+++ b/t/cli/cli.t
@@ -58,21 +58,3 @@ nameserver 172.27.0.1
 nameserver fe80::215:5dff:fec5:8e1d
 --- response_body
 ["172.27.0.1","fe80::215:5dff:fec5:8e1d"]
-
-
-
-=== TEST 2: It is forbidden to run APISIX under the /root directory(is_root_path is true).
---- config
-    location /t {
-        content_by_lua_block {
-            local ops = require("apisix.cli.ops")
-            local env = {is_root_path = true}
-            local arg = {"start"}
-            ops.execute(env, arg)
-        }
-    }
---- request
-GET /t
---- error_code:
---- error_log
-Error: It is forbidden to run APISIX in the /root directory.


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Cause of the bug: After APISIX is started, the `worker process` has the authority of nobody ordinary user. When APISIX is in the /root directory, ordinary users do not have the authority to access the `/root` directory. Therefore, when APISIX is started, the error log `error.log` will show the following error message:

```
init_worker_by_lua error: /root/apisix-2.1/apisix/init.lua:89: module 'resty.worker.events' not found:
        no field package.preload['resty.worker.events']
        no file '/root/apisix-2.1//deps/share/lua/5.1/resty/worker/events.lua'
        no file '/root/apisix-2.1//deps/share/lua/5.1/resty/worker/events/init.lua'
        no file '/root/apisix-2.1/resty/worker/events.lua'
        no file '/root/apisix-2.1/resty/worker/events/init.lua'
```

The solution: it is forbidden to execute make run in the /root directory to run apisix.

close #3207
### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
