### PR TITLE
chore: remove the obsolote etcd v2 protocol error

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -320,13 +320,6 @@ local function sync_data(self)
     local res = dir_res.body.node
     local err_msg = dir_res.body.message
     if err_msg then
-        if err_msg == "The event in requested index is outdated and cleared"
-           and dir_res.body.errorCode == 401 then
-            self.need_reload = true
-            log.warn("waitdir [", self.key, "] err: ", err_msg,
-                     ", need to fully reload")
-            return false
-        end
         return false, err
     end
 


### PR DESCRIPTION
The 401 error is only for v2, so it is safe to remove it now.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
