### PR TITLE
chore(traffic-split): add additionalProperties field to restrict plugin configuration

### DIFF
--- a/apisix/plugins/traffic-split.lua
+++ b/apisix/plugins/traffic-split.lua
@@ -130,10 +130,12 @@ local schema = {
                 properties = {
                     match = match_schema,
                     weighted_upstreams = upstreams_schema
-                }
+                },
+                additionalProperties = false
             }
         }
-    }
+    },
+    additionalProperties = false
 }
 
 local plugin_name = "traffic-split"

--- a/t/plugin/traffic-split.t
+++ b/t/plugin/traffic-split.t
@@ -1290,3 +1290,109 @@ qr/upstream_key: roundrobin#route_1_\d/
 upstream_key: roundrobin#route_1_1
 --- no_error_log
 [error]
+
+
+
+=== TEST 38: schema validation, "additionalProperties = false" to limit the plugin configuration
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.traffic-split")
+            local ok, err = plugin.check_schema({
+                additional_properties = "hello",
+                rules = {
+                    {
+                        match = {
+                            {
+                                vars = {
+                                    {"arg_name", "==", "jack"},
+                                    {"arg_age", "!", "<", "16"}
+                                }
+                            },
+                             {
+                                vars = {
+                                    {"arg_name", "==", "rose"},
+                                    {"arg_age", "!", ">", "32"}
+                                }
+                            }
+                        },
+                        weighted_upstreams = {
+                            {
+                                upstream = {
+                                    name = "upstream_A",
+                                    type = "roundrobin",
+                                    nodes = {["127.0.0.1:1981"]=2},
+                                    timeout = {connect = 15, send = 15, read = 15}
+                                },
+                                weight = 2
+                            }
+                        }
+                    }
+                }
+            })
+            if not ok then
+                ngx.say(err)
+            end
+
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body eval
+qr/additional properties forbidden, found additional_properties/
+--- no_error_log
+[error]
+
+
+
+=== TEST 39: schema validation, "additionalProperties = false" to limit the "rules" configuration
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.traffic-split")
+            local ok, err = plugin.check_schema({
+                rules = {                    
+                    {
+                        additional_properties = "hello",
+                        match = {
+                            {
+                                vars = {
+                                    {"arg_name", "==", "jack"},
+                                    {"arg_age", "!", "<", "16"}
+                                }
+                            },
+                             {
+                                vars = {
+                                    {"arg_name", "==", "rose"},
+                                    {"arg_age", "!", ">", "32"}
+                                }
+                            }
+                        },
+                        weighted_upstreams = {
+                            {
+                                upstream = {
+                                    name = "upstream_A",
+                                    type = "roundrobin",
+                                    nodes = {["127.0.0.1:1981"]=2},
+                                    timeout = {connect = 15, send = 15, read = 15}
+                                },
+                                weight = 2
+                            }
+                        }
+                    }
+                }
+            })
+            if not ok then
+                ngx.say(err)
+            end
+
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body eval
+qr/property "rules" validation failed: failed to validate item 1: additional properties forbidden, found additional_properties/
+--- no_error_log
+[error]


### PR DESCRIPTION

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I check the schema for plugin traffic-split, it doesn't have additionalProperties = false to limit config, could we add this limit.  so that we could prompt error when config invalid.

fix https://github.com/apache/apisix-dashboard/issues/1294

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
