### PR TITLE
refactor: the parent of upstream should point to its original src

### DIFF
--- a/apisix/core/table.lua
+++ b/apisix/core/table.lua
@@ -96,24 +96,43 @@ function _M.setmt__gc(t, mt)
 end
 
 
-local function deepcopy(orig)
-    local orig_type = type(orig)
-    if orig_type ~= 'table' then
-        return orig
+local deepcopy
+do
+    local function _deepcopy(orig, copied)
+        -- prevent infinite loop when a field refers its parent
+        copied[orig] = true
+        -- If the array-like table contains nil in the middle,
+        -- the len might be smaller than the expected.
+        -- But it doesn't affect the correctness.
+        local len = #orig
+        local copy = new_tab(len, nkeys(orig) - len)
+        for orig_key, orig_value in pairs(orig) do
+            if type(orig_value) == "table" and not copied[orig_value] then
+                copy[orig_key] = _deepcopy(orig_value, copied)
+            else
+                copy[orig_key] = orig_value
+            end
+        end
+
+        return copy
     end
 
-    -- If the array-like table contains nil in the middle,
-    -- the len might be smaller than the expected.
-    -- But it doesn't affect the correctness.
-    local len = #orig
-    local copy = new_tab(len, nkeys(orig) - len)
-    for orig_key, orig_value in pairs(orig) do
-        copy[orig_key] = deepcopy(orig_value)
-    end
 
-    return copy
+    local copied_recorder = {}
+
+    function deepcopy(orig)
+        local orig_type = type(orig)
+        if orig_type ~= 'table' then
+            return orig
+        end
+
+        local res = _deepcopy(orig, copied_recorder)
+        _M.clear(copied_recorder)
+        return res
+    end
 end
 _M.deepcopy = deepcopy
+
 
 local ngx_null = ngx.null
 local function merge(origin, extend)

--- a/apisix/http/service.lua
+++ b/apisix/http/service.lua
@@ -79,6 +79,7 @@ local function filter(service)
         service.value.upstream.nodes = new_nodes
     end
 
+    service.value.upstream.parent = service
     core.log.info("filter service: ", core.json.delay_encode(service))
 end
 

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -401,11 +401,8 @@ local function merge_service_route(service_conf, route_conf)
     local route_upstream = route_conf.value.upstream
     if route_upstream then
         new_conf.value.upstream = route_upstream
-
-        if route_upstream.checks then
-            route_upstream.parent = route_conf
-        end
-
+        -- when route's upstream override service's upstream,
+        -- the upstream.parent still point to the route
         new_conf.value.upstream_id = nil
         new_conf.has_domain = route_conf.has_domain
     end

--- a/apisix/plugins/example-plugin.lua
+++ b/apisix/plugins/example-plugin.lua
@@ -99,7 +99,7 @@ function _M.access(conf, ctx)
 
     local matched_route = ctx.matched_route
     upstream.set(ctx, up_conf.type .. "#route_" .. matched_route.value.id,
-                 ctx.conf_version, up_conf, matched_route)
+                 ctx.conf_version, up_conf)
     return
 end
 

--- a/apisix/plugins/traffic-split.lua
+++ b/apisix/plugins/traffic-split.lua
@@ -238,14 +238,16 @@ local function set_upstream(upstream_info, ctx)
 
     local ok, err = upstream.check_schema(up_conf)
     if not ok then
+        core.log.error("failed to validate generated upstream: ", err)
         return 500, err
     end
 
     local matched_route = ctx.matched_route
+    up_conf.parent = matched_route
     local upstream_key = up_conf.type .. "#route_" ..
                          matched_route.value.id .. "_" ..upstream_info.vid
     core.log.info("upstream_key: ", upstream_key)
-    upstream.set(ctx, upstream_key, ctx.conf_version, up_conf, matched_route)
+    upstream.set(ctx, upstream_key, ctx.conf_version, up_conf)
 
     return
 end

--- a/apisix/router.lua
+++ b/apisix/router.lua
@@ -64,6 +64,7 @@ local function filter(route)
         route.value.upstream.nodes = new_nodes
     end
 
+    route.value.upstream.parent = route
     core.log.info("filter route: ", core.json.delay_encode(route))
 end
 

--- a/apisix/stream/plugins/mqtt-proxy.lua
+++ b/apisix/stream/plugins/mqtt-proxy.lua
@@ -173,7 +173,7 @@ function _M.preread(conf, ctx)
 
     local matched_route = ctx.matched_route
     upstream.set(ctx, up_conf.type .. "#route_" .. matched_route.value.id,
-                 ctx.conf_version, up_conf, matched_route)
+                 ctx.conf_version, up_conf)
     return
 end
 

--- a/t/node/healthcheck2.t
+++ b/t/node/healthcheck2.t
@@ -19,8 +19,10 @@ use t::APISIX 'no_plan';
 
 master_on();
 repeat_each(1);
+log_level('info');
 no_root_location();
 no_shuffle();
+worker_connections(256);
 
 add_block_preprocessor(sub {
     my ($block) = @_;
@@ -37,11 +39,7 @@ _EOC_
     }
 
     if (!$block->request) {
-        $block->set_value("request", "GET /hello");
-    }
-
-    if ((!defined $block->error_log) && (!defined $block->no_error_log)) {
-        $block->set_value("no_error_log", "[error]");
+        $block->set_value("request", "GET /t");
     }
 });
 
@@ -66,4 +64,171 @@ upstreams:
 #END
 --- error_log
 value should match only one schema, but matches both schemas 1 and 2
+--- request
+GET /hello
 --- error_code: 502
+
+
+
+=== TEST 2: route + service
+--- apisix_yaml
+services:
+    - id: 1
+      upstream:
+          type: roundrobin
+          nodes:
+              "127.0.0.1:1980": 1
+              "127.0.0.1:1970": 1
+          checks:
+              active:
+                  http_path: /status
+                  host: foo.com
+                  healthy:
+                      interval: 1
+                      successes: 1
+                  unhealthy:
+                      interval: 1
+                      http_failures: 2
+routes:
+    -
+    service_id: 1
+    uri: /server_port
+#END
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port
+                        .. "/server_port"
+
+            do
+                local httpc = http.new()
+                local res, err = httpc:request_uri(uri, {method = "GET", keepalive = false})
+            end
+
+            ngx.sleep(2.5)
+
+            local ports_count = {}
+            for i = 1, 12 do
+                local httpc = http.new()
+                local res, err = httpc:request_uri(uri, {method = "GET", keepalive = false})
+                if not res then
+                    ngx.say(err)
+                    return
+                end
+
+                ports_count[res.body] = (ports_count[res.body] or 0) + 1
+            end
+
+            local ports_arr = {}
+            for port, count in pairs(ports_count) do
+                table.insert(ports_arr, {port = port, count = count})
+            end
+
+            local function cmd(a, b)
+                return a.port > b.port
+            end
+            table.sort(ports_arr, cmd)
+
+            ngx.say(require("toolkit.json").encode(ports_arr))
+            ngx.exit(200)
+        }
+    }
+--- response_body
+[{"count":12,"port":"1980"}]
+--- grep_error_log eval
+qr/\([^)]+\) unhealthy .* for '.*'/
+--- grep_error_log_out
+(upstream#/services/1) unhealthy TCP increment (1/2) for 'foo.com(127.0.0.1:1970)'
+(upstream#/services/1) unhealthy TCP increment (2/2) for 'foo.com(127.0.0.1:1970)'
+--- timeout: 10
+
+
+
+=== TEST 3: route override service
+--- apisix_yaml
+services:
+    - id: 1
+      upstream:
+          type: roundrobin
+          nodes:
+              "127.0.0.2:1980": 1
+              "127.0.0.2:1970": 1
+          checks:
+              active:
+                  http_path: /status
+                  host: foo.com
+                  healthy:
+                      interval: 1
+                      successes: 1
+                  unhealthy:
+                      interval: 1
+                      http_failures: 2
+routes:
+    -
+    service_id: 1
+    uri: /server_port
+    upstream:
+        type: roundrobin
+        nodes:
+            "127.0.0.1:1980": 1
+            "127.0.0.1:1970": 1
+        checks:
+            active:
+                http_path: /status
+                host: foo.com
+                healthy:
+                    interval: 1
+                    successes: 1
+                unhealthy:
+                    interval: 1
+                    http_failures: 2
+#END
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port
+                        .. "/server_port"
+
+            do
+                local httpc = http.new()
+                local res, err = httpc:request_uri(uri, {method = "GET", keepalive = false})
+            end
+
+            ngx.sleep(2.5)
+
+            local ports_count = {}
+            for i = 1, 12 do
+                local httpc = http.new()
+                local res, err = httpc:request_uri(uri, {method = "GET", keepalive = false})
+                if not res then
+                    ngx.say(err)
+                    return
+                end
+
+                ports_count[res.body] = (ports_count[res.body] or 0) + 1
+            end
+
+            local ports_arr = {}
+            for port, count in pairs(ports_count) do
+                table.insert(ports_arr, {port = port, count = count})
+            end
+
+            local function cmd(a, b)
+                return a.port > b.port
+            end
+            table.sort(ports_arr, cmd)
+
+            ngx.say(require("toolkit.json").encode(ports_arr))
+            ngx.exit(200)
+        }
+    }
+--- response_body
+[{"count":12,"port":"1980"}]
+--- grep_error_log eval
+qr/\([^)]+\) unhealthy .* for '.*'/
+--- grep_error_log_out
+(upstream#/routes/arr_1) unhealthy TCP increment (1/2) for 'foo.com(127.0.0.1:1970)'
+(upstream#/routes/arr_1) unhealthy TCP increment (2/2) for 'foo.com(127.0.0.1:1970)'
+--- timeout: 10


### PR DESCRIPTION
Previously, the parent of up_conf is always a `route` even if it comes from upstream or service.
As the key of the parent will be used as health checker's key, when multiple routes shares the same upstream, the health checker will be bound with one of the route instead of the upstream.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
