### PR TITLE
docs: standardize link anchors to be all lowercase

### DIFF
--- a/doc/architecture-design.md
+++ b/doc/architecture-design.md
@@ -67,7 +67,7 @@ Other default configurations can be found in the `conf/config-default.yaml` file
 
 **Note** `APISIX` will generate `conf/nginx.conf` file automatically, so please *DO NOT EDIT* `conf/nginx.conf` file too.
 
-[Back to top](#Table-of-contents)
+[Back to top](#table-of-contents)
 
 ## Route
 
@@ -111,7 +111,7 @@ When we receive a successful response, it indicates that the route was successfu
 
 For specific options of Route, please refer to [Admin API](admin-api.md#route).
 
-[Back to top](#Table-of-contents)
+[Back to top](#table-of-contents)
 
 ## Service
 
@@ -180,7 +180,7 @@ curl http://127.0.0.1:9080/apisix/admin/routes/102 -H 'X-API-KEY: edd1c9f034335f
 
 Note: When both Route and Service enable the same plugin, the Route parameter has a higher priority than Service.
 
-[Back to top](#Table-of-contents)
+[Back to top](#table-of-contents)
 
 ## Plugin
 
@@ -229,7 +229,7 @@ If a request is rejected by a plugin, there will be warn level log like `ip-rest
 
 [APISIX supported plugin list](README.md#plugins)
 
-[Back to top](#Table-of-contents)
+[Back to top](#table-of-contents)
 
 ## Script
 
@@ -449,7 +449,7 @@ The client requests with header `Content-Type`:
  curl http://127.0.0.1:9080/hash_on_header -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -H "Content-Type: application/json"
 ```
 
-[Back to top](#Table-of-contents)
+[Back to top](#table-of-contents)
 
 ## Router
 
@@ -469,7 +469,7 @@ Set the route that best suits your business needs in the local configuration `co
 * `apisix.router.ssl`: SSL loads the matching route.
     * `radixtree_sni`: (Default) Use `SNI` (Server Name Indication) as the primary index (based on the radixtree engine).
 
-[Back to top](#Table-of-contents)
+[Back to top](#table-of-contents)
 
 ## Consumer
 
@@ -577,7 +577,7 @@ HTTP/1.1 403
 
 ```
 
-[Back to top](#Table-of-contents)
+[Back to top](#table-of-contents)
 
 ## Global Rule
 
@@ -610,7 +610,7 @@ we can list all `GlobalRule` via admin api as below:
 curl https://{apisix_listen_address}/apisix/admin/global_rules
 ```
 
-[Back to top](#Table-of-contents)
+[Back to top](#table-of-contents)
 
 ## Debug mode
 
@@ -671,4 +671,4 @@ hook_phase:                     # Module Function List, Name: hook_phase
 #END
 ```
 
-[Back to top](#Table-of-contents)
+[Back to top](#table-of-contents)


### PR DESCRIPTION
Whilst the original syntax does work, it is better to standardize all anchors to lowercase like most of the codebase

### What this PR does / why we need it:

Standardizes the Markdown files.

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
