### PR TITLE
chore: remove injected field of plugin schema from properties

### DIFF
--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -114,7 +114,7 @@ local function load_plugin(name, plugins_list, is_stream_plugin)
     local properties = plugin.schema.properties
     local plugin_injected_schema = core.schema.plugin_injected_schema
 
-    if schema['$comment'] ~= plugin_injected_schema['$comment'] then
+    if plugin.schema['$comment'] ~= plugin_injected_schema['$comment'] then
         if properties.disable then
             core.log.error("invalid plugin [", name,
                            "]: found forbidden 'disable' field in the schema")
@@ -122,7 +122,7 @@ local function load_plugin(name, plugins_list, is_stream_plugin)
         end
 
         properties.disable = plugin_injected_schema.disable
-        schema['$comment'] = plugin_injected_schema['$comment']
+        plugin.schema['$comment'] = plugin_injected_schema['$comment']
     end
 
     plugin.name = name

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -114,7 +114,7 @@ local function load_plugin(name, plugins_list, is_stream_plugin)
     local properties = plugin.schema.properties
     local plugin_injected_schema = core.schema.plugin_injected_schema
 
-    if properties['$comment'] ~= plugin_injected_schema['$comment'] then
+    if schema['$comment'] ~= plugin_injected_schema['$comment'] then
         if properties.disable then
             core.log.error("invalid plugin [", name,
                            "]: found forbidden 'disable' field in the schema")
@@ -122,7 +122,7 @@ local function load_plugin(name, plugins_list, is_stream_plugin)
         end
 
         properties.disable = plugin_injected_schema.disable
-        properties['$comment'] = plugin_injected_schema['$comment']
+        schema['$comment'] = plugin_injected_schema['$comment']
     end
 
     plugin.name = name

--- a/t/admin/plugins.t
+++ b/t/admin/plugins.t
@@ -191,7 +191,7 @@ plugins:
         }
     }
 --- response_body eval
-qr/\{"metadata_schema":\{"additionalProperties":false,"properties":\{"ikey":\{"minimum":0,"type":"number"\},"skey":\{"type":"string"\}\},"required":\["ikey","skey"\],"type":"object"\},"priority":0,"schema":\{"properties":\{"\$comment":"this is a mark for our injected plugin schema","disable":\{"type":"boolean"\},"i":\{"minimum":0,"type":"number"\},"ip":\{"type":"string"\},"port":\{"type":"integer"\},"s":\{"type":"string"\},"t":\{"minItems":1,"type":"array"\}\},"required":\["i"\],"type":"object"\},"version":0.1\}/
+qr/\{"metadata_schema":\{"additionalProperties":false,"properties":\{"ikey":\{"minimum":0,"type":"number"\},"skey":\{"type":"string"\}\},"required":\["ikey","skey"\],"type":"object"\},"priority":0,"schema":\{"\$comment":"this is a mark for our injected plugin schema","properties":\{"disable":\{"type":"boolean"\},"i":\{"minimum":0,"type":"number"\},"ip":\{"type":"string"\},"port":\{"type":"integer"\},"s":\{"type":"string"\},"t":\{"minItems":1,"type":"array"\}\},"required":\["i"\],"type":"object"\},"version":0.1\}/
 --- no_error_log
 [error]
 


### PR DESCRIPTION
### What this PR does / why we need it:

Injected `$comment` into properties will cause the schema to fail to load, so need to move it.


### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
