### PR TITLE
feat: ewma use p2c to improve performance

### DIFF
--- a/apisix/balancer/ewma.lua
+++ b/apisix/balancer/ewma.lua
@@ -187,8 +187,6 @@ local function _ewma_find(ctx, up_nodes)
 end
 
 local function _ewma_after_balance(ctx, before_retry)
-    ngx.log(ngx.WARN,"--------",core.json.encode(ctx.balancer_tried_servers), ctx.balancer_tried_servers_count)
-
     if before_retry then
         if not ctx.balancer_tried_servers then
             ctx.balancer_tried_servers = core.tablepool.fetch("balancer_tried_servers", 0, 2)

--- a/apisix/balancer/ewma.lua
+++ b/apisix/balancer/ewma.lua
@@ -140,9 +140,12 @@ end
 local function _ewma_find(ctx, up_nodes)
     local peers
 
-    if not up_nodes or nkeys(up_nodes) == 0 or
-        (ctx.balancer_tried_servers and ctx.balancer_tried_servers_count == nkeys(up_nodes)) then
+    if not up_nodes or nkeys(up_nodes) == 0 then
         return nil, 'up_nodes empty'
+    end
+
+    if ctx.balancer_tried_servers and ctx.balancer_tried_servers_count == nkeys(up_nodes) then
+        return nil, "all upstream servers tried"
     end
 
     peers = lrucache_trans_format(ctx.upstream_key, ctx.upstream_version, _trans_format, up_nodes)

--- a/apisix/balancer/ewma.lua
+++ b/apisix/balancer/ewma.lua
@@ -14,6 +14,7 @@ local ngx_shared = ngx.shared
 local ngx_now = ngx.now
 local math = math
 local pairs = pairs
+local ipairs = ipairs
 local next = next
 local error = error
 

--- a/apisix/balancer/ewma.lua
+++ b/apisix/balancer/ewma.lua
@@ -31,10 +31,8 @@ local _M = {name = "ewma"}
 
 local function lock(upstream)
     local _, err = ewma_lock:lock(upstream .. LOCK_KEY)
-    if err then
-        if err ~= "timeout" then
-            core.log.error("EWMA Balancer failed to lock: ", err)
-        end
+    if err and err ~= "timeout" then
+        core.log.error("EWMA Balancer failed to lock: ", err)
     end
 
     return err

--- a/apisix/balancer/ewma.lua
+++ b/apisix/balancer/ewma.lua
@@ -154,8 +154,8 @@ local function _ewma_find(ctx, up_nodes)
     end
 
     local filtered_peers
-    for _, peer in ipairs(peers) do
-        if ctx.balancer_tried_servers then
+    if ctx.balancer_tried_servers then
+        for _, peer in ipairs(peers) do
             if not ctx.balancer_tried_servers[get_upstream_name(peer)] then
                 if not filtered_peers then
                     filtered_peers = {}
@@ -164,10 +164,7 @@ local function _ewma_find(ctx, up_nodes)
                 table_insert(filtered_peers, peer)
             end
         end
-    end
-
-    if not filtered_peers then
-        core.log.warn("all endpoints have been retried")
+    else
         filtered_peers = peers
     end
 
@@ -190,6 +187,8 @@ local function _ewma_find(ctx, up_nodes)
 end
 
 local function _ewma_after_balance(ctx, before_retry)
+    ngx.log(ngx.WARN,"--------",core.json.encode(ctx.balancer_tried_servers), ctx.balancer_tried_servers_count)
+
     if before_retry then
         if not ctx.balancer_tried_servers then
             ctx.balancer_tried_servers = core.tablepool.fetch("balancer_tried_servers", 0, 2)

--- a/apisix/balancer/ewma.lua
+++ b/apisix/balancer/ewma.lua
@@ -79,12 +79,12 @@ local function get_or_update_ewma(upstream, rtt, update)
     local lock_err = nil
     if update then
         lock_err = lock(upstream)
+        if lock_err ~= nil then
+            return 0, lock_err
+        end
     end
 
     local ewma = shm_ewma:get(upstream) or 0
-    if lock_err ~= nil then
-        return ewma, lock_err
-    end
 
     local now = ngx_now()
     local last_touched_at = shm_last_touched_at:get(upstream) or 0

--- a/apisix/balancer/ewma.lua
+++ b/apisix/balancer/ewma.lua
@@ -153,7 +153,7 @@ local function _ewma_find(ctx, up_nodes)
         return nil, 'up_nodes trans error'
     end
 
-    local endpoint, backendpoint = peers[1], nil
+    local endpoint = peers[1]
 
     if #peers > 1 then
         local a, b = math.random(1, #peers), math.random(1, #peers - 1)
@@ -161,9 +161,10 @@ local function _ewma_find(ctx, up_nodes)
             b = b + 1
         end
 
+        local backendpoint
         endpoint, backendpoint = peers[a], peers[b]
         if score(endpoint) > score(backendpoint) then
-            endpoint, backendpoint = backendpoint, endpoint
+            endpoint = backendpoint
         end
     end
 

--- a/apisix/balancer/ewma.lua
+++ b/apisix/balancer/ewma.lua
@@ -59,7 +59,7 @@ end
 local function store_stats(upstream, ewma, now)
     local success, err, forcible = shm_last_touched_at:set(upstream, now)
     if not success then
-        core.log.warn("shm_last_touched_at:set failed: ", err)
+        core.log.error("shm_last_touched_at:set failed: ", err)
     end
     if forcible then
         core.log.warn("shm_last_touched_at:set valid items forcibly overwritten")
@@ -67,7 +67,7 @@ local function store_stats(upstream, ewma, now)
 
     success, err, forcible = shm_ewma:set(upstream, ewma)
     if not success then
-        core.log.warn("shm_ewma:set failed: ", err)
+        core.log.error("shm_ewma:set failed: ", err)
     end
     if forcible then
         core.log.warn("shm_ewma:set valid items forcibly overwritten")

--- a/apisix/balancer/ewma.lua
+++ b/apisix/balancer/ewma.lua
@@ -76,9 +76,8 @@ local function store_stats(upstream, ewma, now)
 end
 
 local function get_or_update_ewma(upstream, rtt, update)
-    local lock_err = nil
     if update then
-        lock_err = lock(upstream)
+        local lock_err = lock(upstream)
         if lock_err ~= nil then
             return 0, lock_err
         end

--- a/apisix/balancer/ewma.lua
+++ b/apisix/balancer/ewma.lua
@@ -4,9 +4,9 @@
 -- https://github.com/twitter/finagle/blob/1bc837c4feafc0096e43c0e98516a8e1c50c4421
 --   /finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/PeakEwma.scala
 local core = require("apisix.core")
-local nkeys = require("core.table").nkeys
 local resty_lock = require("resty.lock")
 
+local nkeys = core.table.nkeys
 local ngx = ngx
 local ngx_shared = ngx.shared
 local ngx_now = ngx.now

--- a/apisix/balancer/ewma.lua
+++ b/apisix/balancer/ewma.lua
@@ -51,7 +51,7 @@ end
 
 local function decay_ewma(ewma, last_touched_at, rtt, now)
     local td = now - last_touched_at
-    td = (td > 0) and td or 0
+    td = math.max(td, 0)
     local weight = math.exp(-td / DECAY_TIME)
 
     ewma = ewma * weight + rtt * (1.0 - weight)
@@ -64,8 +64,7 @@ local function store_stats(upstream, ewma, now)
         core.log.warn("shm_last_touched_at:set failed: ", err)
     end
     if forcible then
-        core.log
-            .warn("shm_last_touched_at:set valid items forcibly overwritten")
+        core.log.warn("shm_last_touched_at:set valid items forcibly overwritten")
     end
 
     success, err, forcible = shm_ewma:set(upstream, ewma)

--- a/apisix/balancer/ewma.lua
+++ b/apisix/balancer/ewma.lua
@@ -4,7 +4,7 @@
 -- https://github.com/twitter/finagle/blob/1bc837c4feafc0096e43c0e98516a8e1c50c4421
 --   /finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/PeakEwma.scala
 local core = require("apisix.core")
-local nkeys = require("core.table.nkeys")
+local nkeys = require("core.table").nkeys
 local resty_lock = require("resty.lock")
 
 local ngx = ngx

--- a/apisix/balancer/ewma.lua
+++ b/apisix/balancer/ewma.lua
@@ -13,6 +13,7 @@ local ngx_now = ngx.now
 local math = math
 local pairs = pairs
 local next = next
+local error = error
 
 local DECAY_TIME = 10 -- this value is in seconds
 local LOCK_KEY = ":ewma_key"

--- a/apisix/balancer/ewma.lua
+++ b/apisix/balancer/ewma.lua
@@ -11,6 +11,7 @@ local ngx_shared = ngx.shared
 local ngx_now = ngx.now
 local math = math
 local pairs = pairs
+local next = next
 
 local DECAY_TIME = 10 -- this value is in seconds
 local LOCK_KEY = ":ewma_key"

--- a/apisix/balancer/ewma.lua
+++ b/apisix/balancer/ewma.lua
@@ -8,7 +8,6 @@ local resty_lock = require("resty.lock")
 
 local nkeys = core.table.nkeys
 local table_insert = core.table.insert
-local table_deepcopy = core.table.deepcopy
 local ngx = ngx
 local ngx_shared = ngx.shared
 local ngx_now = ngx.now

--- a/t/node/ewma.t
+++ b/t/node/ewma.t
@@ -217,6 +217,7 @@ GET /t
 [error]
 
 
+
 === TEST 4: about filter tried servers
 --- timeout: 5
 --- config
@@ -284,5 +285,3 @@ GET /t
 --- error_code: 200
 --- no_error_log
 [error]
-
-

--- a/t/node/ewma.t
+++ b/t/node/ewma.t
@@ -215,3 +215,74 @@ GET /t
 --- error_code: 200
 --- no_error_log
 [error]
+
+
+=== TEST 4: about filter tried servers
+--- timeout: 5
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+
+            --remove the 1981 node,
+            --add the 1984 node (invalid node)
+            --keep two nodes for triggering ewma logic in server_picker function of balancer phase
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 100,
+                                "127.0.0.1:1984": 100
+                            },
+                            "type": "ewma"
+                        },
+                        "uri": "/ewma"
+                }]]
+                )
+
+            if code ~= 200 then
+                ngx.say("update route failed")
+                return
+            end
+
+            local http = require "resty.http"
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port
+                        .. "/ewma"
+
+            local ports_count = {}
+            for i = 1, 12 do
+                local httpc = http.new()
+                httpc:set_timeout(1000)
+                local res, err = httpc:request_uri(uri, {method = "GET", keepalive = false})
+                if not res then
+                    ngx.say(err)
+                    return
+                end
+
+                ports_count[res.body] = (ports_count[res.body] or 0) + 1
+            end
+
+            local ports_arr = {}
+            for port, count in pairs(ports_count) do
+                table.insert(ports_arr, {port = port, count = count})
+            end
+
+            local function cmd(a, b)
+                return a.port > b.port
+            end
+            table.sort(ports_arr, cmd)
+
+            ngx.say(require("toolkit.json").encode(ports_arr))
+            ngx.exit(200)
+        }
+    }
+--- request
+GET /t
+--- response_body
+[{"count":12,"port":"1980"}]
+--- error_code: 200
+--- no_error_log
+[error]
+
+

--- a/t/node/ewma.t
+++ b/t/node/ewma.t
@@ -226,7 +226,7 @@ GET /t
             local t = require("lib.test_admin").test
 
             --remove the 1981 node,
-            --add the 0 node (invalid node)
+            --add the 9527 node (invalid node)
             --keep two nodes for triggering ewma logic in server_picker function of balancer phase
             local code, body = t('/apisix/admin/routes/1',
                  ngx.HTTP_PUT,
@@ -234,7 +234,7 @@ GET /t
                         "upstream": {
                             "nodes": {
                                 "127.0.0.1:1980": 1,
-                                "127.0.0.1:0": 1
+                                "127.0.0.1:9527": 1
                             },
                             "type": "ewma",
                             "timeout": {
@@ -308,7 +308,7 @@ Connection refused) while connecting to upstream
             local t = require("lib.test_admin").test
 
             --add the 9527 node (invalid node)
-            --remove the 1980 node
+            --add the 9528 node (invalid node)
             --keep two nodes for triggering ewma logic in server_picker function of balancer phase
             local code, body = t('/apisix/admin/routes/1',
                  ngx.HTTP_PUT,
@@ -316,7 +316,7 @@ Connection refused) while connecting to upstream
                         "upstream": {
                             "nodes": {
                                 "127.0.0.1:9527": 1,
-                                "127.0.0.1:0": 1
+                                "127.0.0.1:9528": 1
                             },
                             "type": "ewma",
                             "timeout": {

--- a/t/node/ewma.t
+++ b/t/node/ewma.t
@@ -251,6 +251,7 @@ GET /t
             local uri = "http://127.0.0.1:" .. ngx.var.server_port
                         .. "/ewma"
 
+            --should select the 1984 node, because it is invalid
             local ports_count = {}
             for i = 1, 12 do
                 local httpc = http.new()

--- a/t/node/ewma.t
+++ b/t/node/ewma.t
@@ -290,4 +290,4 @@ GET /t
 [{"count":12,"port":"1980"}]
 --- error_code: 200
 --- error_log
-timed out) while reading response header from upstream
+upstream timed out

--- a/t/node/ewma.t
+++ b/t/node/ewma.t
@@ -338,7 +338,7 @@ Connection refused) while connecting to upstream
             local uri = "http://127.0.0.1:" .. ngx.var.server_port
                         .. "/ewma"
 
-            --should always select the 1980 node, because 0 is invalid
+            --should always return 502, because both 9527 and 9528 are invalid
             local t = {}
             local ports_count = {}
             for i = 1, 12 do

--- a/t/node/ewma.t
+++ b/t/node/ewma.t
@@ -219,7 +219,7 @@ GET /t
 
 
 === TEST 4: about filter tried servers
---- timeout: 5
+--- timeout: 10
 --- config
     location /t {
         content_by_lua_block {
@@ -233,10 +233,15 @@ GET /t
                  [[{
                         "upstream": {
                             "nodes": {
-                                "127.0.0.1:1980": 100,
-                                "127.0.0.1:1984": 100
+                                "127.0.0.1:1980": 1,
+                                "127.0.0.1:1984": 1
                             },
-                            "type": "ewma"
+                            "type": "ewma",
+                            "timeout": {
+                                "connect": 0.5,
+                                "send": 0.5,
+                                "read": 0.5
+                            }
                         },
                         "uri": "/ewma"
                 }]]
@@ -251,11 +256,11 @@ GET /t
             local uri = "http://127.0.0.1:" .. ngx.var.server_port
                         .. "/ewma"
 
-            --should select the 1984 node, because it is invalid
+            --should select the 1980 node, because 1984 is invalid
             local ports_count = {}
             for i = 1, 12 do
                 local httpc = http.new()
-                httpc:set_timeout(1000)
+                httpc:set_timeout(2000)
                 local res, err = httpc:request_uri(uri, {method = "GET", keepalive = false})
                 if not res then
                     ngx.say(err)
@@ -284,5 +289,5 @@ GET /t
 --- response_body
 [{"count":12,"port":"1980"}]
 --- error_code: 200
---- no_error_log
-[error]
+--- error_log
+timed out) while reading response header from upstream

--- a/t/node/ewma.t
+++ b/t/node/ewma.t
@@ -257,17 +257,23 @@ GET /t
                         .. "/ewma"
 
             --should always select the 1980 node, because 8888 is invalid
+            local t = {}
             local ports_count = {}
             for i = 1, 12 do
-                local httpc = http.new()
-                httpc:set_timeout(2000)
-                local res, err = httpc:request_uri(uri, {method = "GET", keepalive = false})
-                if not res then
-                    ngx.say(err)
-                    return
-                end
-
-                ports_count[res.body] = (ports_count[res.body] or 0) + 1
+                local th = assert(ngx.thread.spawn(function(i)
+                    local httpc = http.new()
+                    httpc:set_timeout(2000)
+                    local res, err = httpc:request_uri(uri, {method = "GET", keepalive = false})
+                    if not res then
+                        ngx.say(err)
+                        return
+                    end
+                    ports_count[res.body] = (ports_count[res.body] or 0) + 1
+                end, i))
+                table.insert(t, th)
+            end
+            for i, th in ipairs(t) do
+                ngx.thread.wait(th)
             end
 
             local ports_arr = {}
@@ -288,6 +294,88 @@ GET /t
 GET /t
 --- response_body
 [{"count":12,"port":"1980"}]
+--- error_code: 200
+--- error_log
+Connection refused) while connecting to upstream
+
+
+
+=== TEST 5: about all endpoints have been retried
+--- timeout: 10
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+
+            --add the 9527 node (invalid node)
+            --remove the 1980 node
+            --keep two nodes for triggering ewma logic in server_picker function of balancer phase
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:9527": 1,
+                                "127.0.0.1:8888": 1
+                            },
+                            "type": "ewma",
+                            "timeout": {
+                                "connect": 0.1,
+                                "send": 0.5,
+                                "read": 0.5
+                            }
+                        },
+                        "uri": "/ewma"
+                }]]
+                )
+
+            if code ~= 200 then
+                ngx.say("update route failed")
+                return
+            end
+
+            local http = require "resty.http"
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port
+                        .. "/ewma"
+
+            --should always select the 1980 node, because 8888 is invalid
+            local t = {}
+            local ports_count = {}
+            for i = 1, 12 do
+                local th = assert(ngx.thread.spawn(function(i)
+                    local httpc = http.new()
+                    httpc:set_timeout(2000)
+                    local res, err = httpc:request_uri(uri, {method = "GET", keepalive = false})
+                    if not res then
+                        ngx.say(err)
+                        return
+                    end
+                    ports_count[res.status] = (ports_count[res.status] or 0) + 1
+                end, i))
+                table.insert(t, th)
+            end
+            for i, th in ipairs(t) do
+                ngx.thread.wait(th)
+            end
+
+            local ports_arr = {}
+            for port, count in pairs(ports_count) do
+                table.insert(ports_arr, {port = port, count = count})
+            end
+
+            local function cmd(a, b)
+                return a.port > b.port
+            end
+            table.sort(ports_arr, cmd)
+
+            ngx.say(require("toolkit.json").encode(ports_arr))
+            ngx.exit(200)
+        }
+    }
+--- request
+GET /t
+--- response_body
+[{"count":12,"port":502}]
 --- error_code: 200
 --- error_log
 Connection refused) while connecting to upstream

--- a/t/node/ewma.t
+++ b/t/node/ewma.t
@@ -226,7 +226,7 @@ GET /t
             local t = require("lib.test_admin").test
 
             --remove the 1981 node,
-            --add the 8888 node (invalid node)
+            --add the 0 node (invalid node)
             --keep two nodes for triggering ewma logic in server_picker function of balancer phase
             local code, body = t('/apisix/admin/routes/1',
                  ngx.HTTP_PUT,
@@ -234,7 +234,7 @@ GET /t
                         "upstream": {
                             "nodes": {
                                 "127.0.0.1:1980": 1,
-                                "127.0.0.1:8888": 1
+                                "127.0.0.1:0": 1
                             },
                             "type": "ewma",
                             "timeout": {
@@ -256,7 +256,7 @@ GET /t
             local uri = "http://127.0.0.1:" .. ngx.var.server_port
                         .. "/ewma"
 
-            --should always select the 1980 node, because 8888 is invalid
+            --should always select the 1980 node, because 0 is invalid
             local t = {}
             local ports_count = {}
             for i = 1, 12 do
@@ -316,7 +316,7 @@ Connection refused) while connecting to upstream
                         "upstream": {
                             "nodes": {
                                 "127.0.0.1:9527": 1,
-                                "127.0.0.1:8888": 1
+                                "127.0.0.1:0": 1
                             },
                             "type": "ewma",
                             "timeout": {
@@ -338,7 +338,7 @@ Connection refused) while connecting to upstream
             local uri = "http://127.0.0.1:" .. ngx.var.server_port
                         .. "/ewma"
 
-            --should always select the 1980 node, because 8888 is invalid
+            --should always select the 1980 node, because 0 is invalid
             local t = {}
             local ports_count = {}
             for i = 1, 12 do

--- a/t/node/ewma.t
+++ b/t/node/ewma.t
@@ -166,7 +166,7 @@ GET /t
                 return
             end
 
-            ngx.sleep(20)
+            ngx.sleep(11)
             --keep the node 1980 hot
             for i = 1, 12 do
                 local httpc = http.new()
@@ -226,7 +226,7 @@ GET /t
             local t = require("lib.test_admin").test
 
             --remove the 1981 node,
-            --add the 1984 node (invalid node)
+            --add the 8888 node (invalid node)
             --keep two nodes for triggering ewma logic in server_picker function of balancer phase
             local code, body = t('/apisix/admin/routes/1',
                  ngx.HTTP_PUT,
@@ -234,11 +234,11 @@ GET /t
                         "upstream": {
                             "nodes": {
                                 "127.0.0.1:1980": 1,
-                                "127.0.0.1:1984": 1
+                                "127.0.0.1:8888": 1
                             },
                             "type": "ewma",
                             "timeout": {
-                                "connect": 0.5,
+                                "connect": 0.1,
                                 "send": 0.5,
                                 "read": 0.5
                             }
@@ -256,7 +256,7 @@ GET /t
             local uri = "http://127.0.0.1:" .. ngx.var.server_port
                         .. "/ewma"
 
-            --should select the 1980 node, because 1984 is invalid
+            --should always select the 1980 node, because 8888 is invalid
             local ports_count = {}
             for i = 1, 12 do
                 local httpc = http.new()
@@ -290,4 +290,4 @@ GET /t
 [{"count":12,"port":"1980"}]
 --- error_code: 200
 --- error_log
-upstream timed out
+Connection refused) while connecting to upstream


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Details can be found in #3211 

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [] Have you added corresponding test cases?
* [] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**

Before
===
apisix: 1 worker + 200 upstream + no plugin
---
```
+ wrk -d 5 -c 16 http://127.0.0.1:9080/hello
Running 5s test @ http://127.0.0.1:9080/hello
  2 threads and 16 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.65ms    1.53ms  32.40ms   97.65%
    Req/Sec     5.26k   663.77     8.41k    79.21%
  52974 requests in 5.11s, 211.22MB read
Requests/sec:  10369.65
Transfer/sec:     41.35MB
+ sleep 1
+ wrk -d 5 -c 16 http://127.0.0.1:9080/hello
Running 5s test @ http://127.0.0.1:9080/hello
  2 threads and 16 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.82ms    1.99ms  30.06ms   96.26%
    Req/Sec     5.10k   845.05     6.21k    81.00%
  50759 requests in 5.00s, 202.39MB read
Requests/sec:  10149.88
Transfer/sec:     40.47MB
```

apisix: 1 worker + 200 upstream + no plugin + ewma
---

```
+ wrk -d 5 -c 16 http://127.0.0.1:9080/hello
Running 5s test @ http://127.0.0.1:9080/hello
  2 threads and 16 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.95ms    1.55ms  27.52ms   93.33%
    Req/Sec     2.84k   490.54     6.22k    88.12%
  28488 requests in 5.10s, 113.60MB read
Requests/sec:   5585.89
Transfer/sec:     22.27MB
+ sleep 1
+ wrk -d 5 -c 16 http://127.0.0.1:9080/hello
Running 5s test @ http://127.0.0.1:9080/hello
  2 threads and 16 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.01ms    0.86ms  23.33ms   85.91%
    Req/Sec     2.68k   228.62     3.11k    68.00%
  26713 requests in 5.00s, 106.52MB read
Requests/sec:   5338.53
Transfer/sec:     21.29MB
```
After
===

apisix: 1 worker + 200 upstream + no plugin + ewma
---
```
+ wrk -d 5 -c 16 http://127.0.0.1:9080/hello
Running 5s test @ http://127.0.0.1:9080/hello
  2 threads and 16 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.85ms    0.88ms  21.68ms   94.33%
    Req/Sec     4.48k   562.97     5.48k    68.00%
  44599 requests in 5.00s, 177.83MB read
Requests/sec:   8912.87
Transfer/sec:     35.54MB
+ sleep 1
+ wrk -d 5 -c 16 http://127.0.0.1:9080/hello
Running 5s test @ http://127.0.0.1:9080/hello
  2 threads and 16 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.73ms  693.40us  16.92ms   95.53%
    Req/Sec     4.73k   434.96     5.49k    74.51%
  48052 requests in 5.09s, 191.60MB read
Requests/sec:   9440.28
Transfer/sec:     37.64MB
```
