### PR TITLE
fix(traffic-split): the header set in vars cannot have a horizontal line

### DIFF
--- a/apisix/plugins/traffic-split.lua
+++ b/apisix/plugins/traffic-split.lua
@@ -291,7 +291,7 @@ function _M.access(conf, ctx)
                 return 500, err
             end
 
-            match_flag = expr:eval()
+            match_flag = expr:eval(ctx.var)
             if match_flag then
                 break
             end

--- a/t/plugin/traffic-split.t
+++ b/t/plugin/traffic-split.t
@@ -1396,3 +1396,151 @@ GET /t
 qr/property "rules" validation failed: failed to validate item 1: additional properties forbidden, found additional_properties/
 --- no_error_log
 [error]
+
+
+
+=== TEST 40: the request header contains horizontal lines("-")
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [=[{
+                    "uri": "/server_port",
+                    "plugins": {
+                        "traffic-split": {
+                            "rules": [
+                                {
+                                    "match": [
+                                        {
+                                            "vars": [["http_x-api-appkey", "==", "api-key"]]
+                                        }
+                                    ],
+                                    "weighted_upstreams": [
+                                        {"upstream": {"name": "upstream_A", "type": "roundrobin", "nodes": [{"host":"127.0.0.1", "port":1981, "weight": 2}, {"host":"127.0.0.1", "port":1982, "weight": 2}]}, "weight": 4},
+                                        {"weight": 1}
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                    }
+                }]=]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 41: `match` rule passed
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local bodys = {}
+        local headers = {}
+        headers["x-api-appkey"] = "api-key"
+        for i = 1, 5 do
+            local _, _, body = t('/server_port', ngx.HTTP_GET, nil, "", headers)
+            bodys[i] = body
+        end
+        table.sort(bodys)
+        ngx.say(table.concat(bodys, ", "))
+    }
+}
+--- request
+GET /t
+--- response_body
+1980, 1981, 1981, 1982, 1982
+--- no_error_log
+[error]
+
+
+
+=== TEST 42: request args and request headers contain horizontal lines("-")
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [=[{
+                    "uri": "/server_port",
+                    "plugins": {
+                        "traffic-split": {
+                            "rules": [
+                                {
+                                    "match": [
+                                        {
+                                            "vars": [["arg_x-api-name", "==", "jack"], ["arg_x-api-age", ">", "23"],["http_x-api-appkey", "~~", "[a-z]{1,5}"]]
+                                        }
+                                    ],
+                                    "weighted_upstreams": [
+                                        {"upstream": {"name": "upstream_A", "type": "roundrobin", "nodes": [{"host":"127.0.0.1", "port":1981, "weight": 2}, {"host":"127.0.0.1", "port":1982, "weight": 2}]}, "weight": 4},
+                                        {"weight": 1}
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                    }
+                }]=]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 43: `match` rule passed
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local bodys = {}
+        local headers = {}
+        headers["x-api-appkey"] = "hello"
+        for i = 1, 5 do
+            local _, _, body = t('/server_port?x-api-name=jack&x-api-age=36', ngx.HTTP_GET, "", nil, headers)
+            bodys[i] = body
+        end
+        table.sort(bodys)
+        ngx.say(table.concat(bodys, ", "))
+    }
+}
+--- request
+GET /t
+--- response_body
+1980, 1981, 1981, 1982, 1982
+--- no_error_log
+[error]

--- a/t/plugin/traffic-split.t
+++ b/t/plugin/traffic-split.t
@@ -908,8 +908,10 @@ location /t {
     content_by_lua_block {
         local t = require("lib.test_admin").test
         local bodys = {}
+        local headers = {}
+        headers["appkey"] = "api-key"
         for i = 1, 5 do
-            local _, _, body = t('/server_port?name=jack&age=36', ngx.HTTP_GET)
+            local _, _, body = t('/server_port?name=jack&age=36', ngx.HTTP_GET, "", nil, headers)
             bodys[i] = body
         end
         table.sort(bodys)
@@ -1057,8 +1059,10 @@ location /t {
     content_by_lua_block {
         local t = require("lib.test_admin").test
         local bodys = {}
+        local headers = {}
+        headers["appkey"] = "api-key"
         for i = 1, 5 do
-            local _, _, body = t('/server_port?name=jack&age=36', ngx.HTTP_GET)
+            local _, _, body = t('/server_port?name=jack&age=36', ngx.HTTP_GET, "", nil, headers)
             bodys[i] = body
         end
         table.sort(bodys)
@@ -1130,8 +1134,10 @@ location /t {
     content_by_lua_block {
         local t = require("lib.test_admin").test
         local bodys = {}
+        local headers = {}
+        headers["appkey"] = "api-key"
         for i = 1, 5 do
-            local _, _, body = t('/server_port?name=jack&age=36', ngx.HTTP_GET)
+            local _, _, body = t('/server_port?name=jack&age=36', ngx.HTTP_GET, "", nil, headers)
             bodys[i] = body
         end
         table.sort(bodys)
@@ -1457,7 +1463,7 @@ location /t {
         local headers = {}
         headers["x-api-appkey"] = "api-key"
         for i = 1, 5 do
-            local _, _, body = t('/server_port', ngx.HTTP_GET, nil, "", headers)
+            local _, _, body = t('/server_port', ngx.HTTP_GET, "", nil, headers)
             bodys[i] = body
         end
         table.sort(bodys)


### PR DESCRIPTION

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fix #3306
Currently, the vars of the traffic-split plug-in cannot have a horizontal line ("-") when setting the header. This PR is used to allow request parameters and request headers to have a horizontal line ("-").
### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
