### PR TITLE
fix: Use luajit by default when run APISIX CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,10 @@ RELEASE_SRC = apache-apisix-${VERSION}-src
 default:
 ifeq ($(OR_EXEC), )
 ifeq ("$(wildcard /usr/local/openresty-debug/bin/openresty)", "")
-	@echo "ERROR: OpenResty not found. You have to install OpenResty and add the binary file to PATH before install Apache APISIX."
+	@echo "WARNING: OpenResty not found. You have to install OpenResty and add the binary file to PATH before install Apache APISIX."
 	exit 1
+else
+	OR_EXEC=/usr/local/openresty-debug/bin/openresty
 endif
 endif
 

--- a/apisix/cli/apisix.lua
+++ b/apisix/cli/apisix.lua
@@ -1,0 +1,37 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+local pkg_cpath_org = package.cpath
+local pkg_path_org = package.path
+
+local apisix_home = "/usr/local/apisix"
+local pkg_cpath = apisix_home .. "/deps/lib64/lua/5.1/?.so;"
+                  .. apisix_home .. "/deps/lib/lua/5.1/?.so;"
+                  .. "/usr/lib64/lua/5.1/?.so;"
+                  .. "/usr/lib/lua/5.1/?.so;;"
+local pkg_path = apisix_home .. "/deps/share/lua/5.1/?.lua;"
+                  .. "/usr/share/lua/5.1/?.lua;;"
+
+-- modify the load path to load our dependencies
+package.cpath = pkg_cpath .. pkg_cpath_org
+package.path  = pkg_path .. pkg_path_org
+
+-- pass path to construct the final result
+local env = require("apisix.cli.env")(apisix_home, pkg_cpath_org, pkg_path_org)
+local ops = require("apisix.cli.ops")
+
+ops.execute(env, arg)

--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -57,9 +57,12 @@ env {*name*};
 {% if stream_proxy then %}
 stream {
     lua_package_path  "{*extra_lua_path*}$prefix/deps/share/lua/5.1/?.lua;$prefix/deps/share/lua/5.1/?/init.lua;]=]
+                      .. [=[/usr/share/lua/5.1/?.lua;/usr/share/lua/5.1/?/init.lua;]=]
                       .. [=[{*apisix_lua_home*}/?.lua;{*apisix_lua_home*}/?/init.lua;;{*lua_path*};";
     lua_package_cpath "{*extra_lua_cpath*}$prefix/deps/lib64/lua/5.1/?.so;]=]
                       .. [=[$prefix/deps/lib/lua/5.1/?.so;;]=]
+                      .. [=[/usr/lib64/lua/5.1/?.so;]=]
+                      .. [=[/usr/lib/lua/5.1/?.so;]=]
                       .. [=[{*lua_cpath*};";
     lua_socket_log_errors off;
 
@@ -120,9 +123,12 @@ http {
     # put extra_lua_path in front of the builtin path
     # so user can override the source code
     lua_package_path  "{*extra_lua_path*}$prefix/deps/share/lua/5.1/?.lua;$prefix/deps/share/lua/5.1/?/init.lua;]=]
+                       .. [=[/usr/share/lua/5.1/?.lua;/usr/share/lua/5.1/?/init.lua;]=]
                        .. [=[{*apisix_lua_home*}/?.lua;{*apisix_lua_home*}/?/init.lua;;{*lua_path*};";
     lua_package_cpath "{*extra_lua_cpath*}$prefix/deps/lib64/lua/5.1/?.so;]=]
                       .. [=[$prefix/deps/lib/lua/5.1/?.so;;]=]
+                      .. [=[/usr/lib64/lua/5.1/?.so;]=]
+                      .. [=[/usr/lib/lua/5.1/?.so;]=]
                       .. [=[{*lua_cpath*};";
 
     lua_shared_dict internal_status      10m;

--- a/bin/apisix
+++ b/bin/apisix
@@ -1,36 +1,46 @@
-#!/usr/bin/env lua
+#!/bin/bash
 
---
--- Licensed to the Apache Software Foundation (ASF) under one or more
--- contributor license agreements.  See the NOTICE file distributed with
--- this work for additional information regarding copyright ownership.
--- The ASF licenses this file to You under the Apache License, Version 2.0
--- (the "License"); you may not use this file except in compliance with
--- the License.  You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
---
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-local pkg_cpath_org = package.cpath
-local pkg_path_org = package.path
+if [ -s './apisix/cli/apisix.lua' ]; then
+    APISIX_LUA=./apisix/cli/apisix.lua
+elif [ -s '/usr/share/lua/5.1/apisix/cli/apisix.lua' ]; then
+    APISIX_LUA=/usr/share/lua/5.1/apisix/cli/apisix.lua
+else
+    APISIX_LUA=/usr/local/apisix/apisix/cli/apisix.lua
+fi
 
-local apisix_home = "/usr/local/apisix"
-local pkg_cpath = apisix_home .. "/deps/lib64/lua/5.1/?.so;"
-                  .. apisix_home .. "/deps/lib/lua/5.1/?.so;;"
-local pkg_path = apisix_home .. "/deps/share/lua/5.1/?.lua;;"
+# find the openresty
+OR_BIN=$(which openresty)
+OR_EXEC=${OR_BIN:-'/usr/local/openresty-debug/bin/openresty'}
+OR_VER=$(openresty -v 2>&1 | awk -F '/' '{print $2}' | awk -F '.' '{print $1"."$2}')
+LUA_VERSION=$(lua -v 2>&1| grep -E -o  "Lua [0-9]+.[0-9]+")
 
--- modify the load path to load our dependencies
-package.cpath = pkg_cpath .. pkg_cpath_org
-package.path  = pkg_path .. pkg_path_org
+if [[ -e $OR_EXEC && "$OR_VER" =~ "1.19" ]]; then
+    # OpenResty version is 1.19, use luajit by default
+    # find the luajit binary of openresty
+    LUAJIT_BIN=$(${OR_EXEC} -V 2>&1 | grep prefix | grep -Eo 'prefix=(.*)/nginx\s+--' | grep -Eo '/.*/')luajit/bin/luajit
 
--- pass path to construct the final result
-local env = require("apisix.cli.env")(apisix_home, pkg_cpath_org, pkg_path_org)
-local ops = require("apisix.cli.ops")
-
-ops.execute(env, arg)
+    # use the luajit of openresty
+    $LUAJIT_BIN $APISIX_LUA $*
+elif [[ "$LUA_VERSION" =~ "Lua 5.1" ]]; then
+    # OpenResty version is not 1.19, use Lua 5.1 by default
+    lua $APISIX_LUA $*
+else
+    echo "ERROR: Please check the version of OpenResty and Lua, OpenResty 1.19 and Lua 5.1 are recommended before install Apache APISIX."
+fi

--- a/doc/install-dependencies.md
+++ b/doc/install-dependencies.md
@@ -35,6 +35,8 @@
 
 - If you want use Tengine instead of OpenResty, please take a look at this installation step script [Install Tengine at Ubuntu](../.travis/linux_tengine_runner.sh).
 
+- By default Apache APISIX runs with LuaJIT of OpenResty 1.19 (priority) or Lua 5.1. If you run in to an issue `luajit: lj_asm_x86.h:2819: asm_loop_fixup: Assertion '((intptr_t)target & 15) == 0' failed`, it is caused by to the compatibility of OpenResty version. OpenResty 1.19 is recommended, please take a look at this installation step script [linux-install-openresty](../utils/linux-install-openresty.sh).
+
 # CentOS 7
 
 ```shell

--- a/doc/zh-cn/install-dependencies.md
+++ b/doc/zh-cn/install-dependencies.md
@@ -34,6 +34,8 @@
 
 - 如果你要想使用 Tengine 替代 OpenResty，请参考 [Install Tengine at Ubuntu](../../.travis/linux_tengine_runner.sh)。
 
+- Apache APISIX 运行默认使用 OpenResty 1.19 内置的 LuaJIT（优先推荐）或 Lua 5.1。若运行过程中出现问题 `luajit: lj_asm_x86.h:2819: asm_loop_fixup: Assertion '((intptr_t)target & 15) == 0' failed`，是因 OpenResty 版本兼容性问题，建议更换 OpenResty 版本为 1.19，请参考 [linux-install-openresty](../../utils/linux-install-openresty.sh)。
+
 # CentOS 7
 
 ```shell


### PR DESCRIPTION
Signed-off-by: fukiki <one.fhh@163.com>

### What this PR does / why we need it:

When run APISIX, use LuaJIT or Lua 5.1 by default. 

If the local lua version is not 5.1, use openresty-luajit as default.

Fix : #3281 

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
