### PR TITLE
docs: fix the example in skywalking doc

### DIFF
--- a/doc/zh-cn/plugins/skywalking.md
+++ b/doc/zh-cn/plugins/skywalking.md
@@ -65,9 +65,7 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f1
     ],
     "plugins": {
         "skywalking": {
-            "endpoint": "http://10.110.149.175:12800",
-            "sample_ratio": 1,
-            "service_name": "APISIX_SERVER"
+            "sample_ratio": 1
         }
     },
     "upstream": {


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Chinese document of skywalking is inconsistent with the English document, and the route example in the Chinese document is wrong. This PR is an example of fixing errors in Chinese documents and keeping them consistent with English documents.

Examples of errors in Chinese doc:

```shell
curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
{
    "methods": ["GET"],
    "uris": [
        "/uid/*"
    ],
    "plugins": {
        "skywalking": {
            "endpoint": "http://10.110.149.175:12800",
            "sample_ratio": 1,
            "service_name": "APISIX_SERVER"
        }
    },
    "upstream": {
        "type": "roundrobin",
        "nodes": {
            "10.110.149.175:8089": 1
        }
    }
}'
{"error_msg":"failed to check the configuration of plugin skywalking err: additional properties forbidden, found service_name"}
```

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
