### PR TITLE
bugfix: add compatible for ETCD missing some special keys lead to watch failure

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -241,7 +241,11 @@ local function sync_data(self)
 
         else
             if not dir_res.nodes then
-                dir_res.nodes = {}
+                if dir_res.key then
+                    dir_res.nodes = { clone_tab(dir_res) }
+                else
+                    dir_res.nodes = {}
+                end
             end
 
             self.values = new_tab(#dir_res.nodes, 0)


### PR DESCRIPTION
### What this PR does / why we need it:

In some case,  the ETCD maybe missing some special keys, such as `/apisix/services`, then the APISIX will fail in init existing etcd data.

Just fix the discuss: #3362.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
