### PR TITLE
chore: update lua-resty-expr to v1.1.0

### DIFF
--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -58,7 +58,7 @@ dependencies = {
     "binaryheap = 0.4",
     "dkjson = 2.5-2",
     "resty-redis-cluster = 1.02-4",
-    "lua-resty-expr = 1.0.0",
+    "lua-resty-expr = 1.1.0",
     "graphql = 0.0.2",
     "luasocket = 3.0rc1-2",
 }


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

lua-resty-expr has released the latest version, you need to update lua-resty-expr to v1.1.0

See here:
https://github.com/api7/lua-resty-expr/issues/24
https://github.com/api7/lua-resty-expr/issues/20

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
