### PR TITLE
fix(standalone): require consumer's id to be the same as username

### DIFF
--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -97,13 +97,29 @@ local function check_consumer(consumer)
 end
 
 
+local function filter(consumer)
+    if not consumer.value then
+        return
+    end
+
+    -- We expect the id is the same as username. Fix up it here if it isn't.
+    consumer.value.id = consumer.value.username
+end
+
+
 function _M.init_worker()
     local err
-    consumers, err = core.config.new("/consumers", {
-            automatic = true,
-            item_schema = core.schema.consumer,
-            checker = check_consumer,
-        })
+    local config = core.config.new()
+    local cfg = {
+        automatic = true,
+        item_schema = core.schema.consumer,
+        checker = check_consumer,
+    }
+    if config.type ~= "etcd" then
+        cfg.filter = filter
+    end
+
+    consumers, err = core.config.new("/consumers", cfg)
     if not consumers then
         error("failed to create etcd instance for fetching consumers: " .. err)
         return

--- a/t/config-center-yaml/consumer.t
+++ b/t/config-center-yaml/consumer.t
@@ -98,3 +98,32 @@ consumers:
 --- request
 GET /apisix/plugin/jwt/sign?key=user-key
 --- error_code: 200
+
+
+
+=== TEST 4: consummer restriction
+--- apisix_yaml
+consumers:
+  - username: jack
+    plugins:
+        key-auth:
+            key: user-key
+routes:
+    - id: 1
+      methods:
+          - POST
+      uri: "/hello"
+      plugins:
+          key-auth:
+          consumer-restriction:
+              whitelist:
+                  - jack
+      upstream:
+          type: roundrobin
+          nodes:
+              "127.0.0.1:1980": 1
+#END
+--- more_headers
+apikey: user-key
+--- request
+POST /hello


### PR DESCRIPTION
We already did the same thing with the configuration from etcd.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
