### PR TITLE
chore: git ignore openwhisk to smoothly check license locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ t/lib/dubbo-backend/dubbo-backend-provider/target/
 \.*
 !.github/
 !.travis/
+.travis/openwhisk-utilities/
 !.gitmodules
 !.markdownlint.yml
 !.yamllint


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

### What this PR does / why we need it:
Currently when check license (`sudo make license-check`) locally, it would pull openwhisk-utilities. While since it is not ignored, we need to remove it whenever make commits.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
