### PR TITLE
chore: fix kubernetes yaml not working

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -32,10 +32,8 @@
 # If the configured environment variable can't be found, an error will be thrown.
 apisix:
   admin_key:
-    -
-      name: "admin"
+    - name: "admin"
       # yamllint disable rule:comments-indentation
-      key: edd1c9f034335f136f87ad84b625c8f1  # using fixed API token has security risk, please
-                                             # update it when you deploy to production environment
+      key: edd1c9f034335f136f87ad84b625c8f1 # using fixed API token has security risk, please update it when you deploy to production environment
       # yamllint enable rule:comments-indentation
       role: admin

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-apiVersion: apps/v1 # for versions before 1.8.0 use apps/v1beta1, 1.8.0-1.9.0 use apps/v1beta2
+apiVersion: apps/v1 # for versions before 1.8.0 use apps/v1beta1, before 1.9.0 use apps/v1beta2
 kind: Deployment
 metadata:
   labels:

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-apiVersion: apps/v1beta2  # for versions before 1.8.0 use apps/v1beta1
+apiVersion: apps/v1 # for versions before 1.8.0 use apps/v1beta1, 1.8.0-1.9.0 use apps/v1beta2
 kind: Deployment
 metadata:
   labels:
@@ -35,33 +35,33 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - apisix-gw
-              topologyKey: kubernetes.io/hostname
-            weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - apisix-gw
+                topologyKey: kubernetes.io/hostname
+              weight: 100
       initContainers:
-      - command:
-        - /bin/sh
-        - -c
-        - |
-          sysctl -w net.core.somaxconn=65535
-          sysctl -w net.ipv4.ip_local_port_range="1024 65535"
-          sysctl -w net.ipv4.tcp_max_syn_backlog=8192
-          sysctl -w fs.file-max=1048576
-          sysctl -w fs.inotify.max_user_instances=16384
-          sysctl -w fs.inotify.max_user_watches=524288
-          sysctl -w fs.inotify.max_queued_events=16384
-        image: busybox:latest
-        name: init-sysctl
-        resources: {}
-        securityContext:
-          privileged: true
-          procMount: Default
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              sysctl -w net.core.somaxconn=65535
+              sysctl -w net.ipv4.ip_local_port_range="1024 65535"
+              sysctl -w net.ipv4.tcp_max_syn_backlog=8192
+              sysctl -w fs.file-max=1048576
+              sysctl -w fs.inotify.max_user_instances=16384
+              sysctl -w fs.inotify.max_user_watches=524288
+              sysctl -w fs.inotify.max_queued_events=16384
+          image: busybox:latest
+          name: init-sysctl
+          resources: {}
+          securityContext:
+            privileged: true
+            procMount: Default
       restartPolicy: Always
 
       containers:
@@ -76,16 +76,16 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-          image: 'apache/apisix:latest'
+          image: "apache/apisix:latest"
           imagePullPolicy: IfNotPresent
           name: apisix-gw-deployment
           ports:
-          - containerPort: 9080
-            name: http
-            protocol: TCP
-          - containerPort: 9443
-            name: https
-            protocol: TCP
+            - containerPort: 9080
+              name: http
+              protocol: TCP
+            - containerPort: 9443
+              name: https
+              protocol: TCP
           readinessProbe:
             failureThreshold: 6
             initialDelaySeconds: 10

--- a/kubernetes/service.yaml
+++ b/kubernetes/service.yaml
@@ -21,7 +21,7 @@ metadata:
   name: apisix-gw-lb
   # namespace: default
   labels:
-    app: apisix-gw   # useful for service discovery, for example, prometheus-operator.
+    app: apisix-gw # useful for service discovery, for example, prometheus-operator.
 spec:
   ports:
     - name: http
@@ -36,8 +36,8 @@ spec:
       #   port: 9180
       #   protocol: TCP
       #   targetPort: 9180
-      selector:
-        app: apisix-gw
-      type: NodePort
-      externalTrafficPolicy: Local
-      # sessionAffinity: None
+  selector:
+    app: apisix-gw
+  type: NodePort
+  externalTrafficPolicy: Local
+  # sessionAffinity: None


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

### What this PR does / why we need it:
#3044 imports a format error in kubernetes/service.yaml
https://github.com/apache/apisix/blob/34bcac8bf7a188edbfa9262626c4ec5347e5c495/kubernetes/service.yaml#L25-L43

What this PR does:
- fix the format error
- update default `apiVersion` of deployment
- fix more format with [YAML Language Support by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
