### PR TITLE
test: move test requires root privilege to ci_only group

### DIFF
--- a/.travis/apisix_cli_test/test_ci_only.sh
+++ b/.travis/apisix_cli_test/test_ci_only.sh
@@ -39,3 +39,24 @@ if ! echo "$out" | grep 'etcd cluster version 3.3.0 is less than the required ve
 fi
 
 echo "passed: properly handle the error when connecting to old etcd"
+
+# It is forbidden to run apisix under the "/root" directory.
+git checkout conf/config.yaml
+
+mkdir /root/apisix
+
+cp -r ./*  /root/apisix
+cd /root/apisix
+make init
+
+out=$(make run 2>&1 || true)
+if ! echo "$out" | grep "Error: It is forbidden to run APISIX in the /root directory"; then
+    echo "failed: should echo It is forbidden to run APISIX in the /root directory"
+    exit 1
+fi
+
+cd -
+
+echo "passed: successfully prohibit APISIX from running in the /root directory"
+
+rm -rf /root/apisix

--- a/.travis/apisix_cli_test/test_main.sh
+++ b/.travis/apisix_cli_test/test_main.sh
@@ -863,27 +863,6 @@ fi
 
 echo "pass: uninitialized variable not found during writing access log (port_admin set)"
 
-# It is forbidden to run apisix under the "/root" directory.
-git checkout conf/config.yaml
-
-mkdir /root/apisix
-
-cp -r ./*  /root/apisix
-cd /root/apisix
-make init
-
-out=$(make run 2>&1 || true)
-if ! echo "$out" | grep "Error: It is forbidden to run APISIX in the /root directory"; then
-    echo "failed: should echo It is forbidden to run APISIX in the /root directory"
-    exit 1
-fi
-
-cd -
-
-echo "passed: successfully prohibit APISIX from running in the /root directory"
-
-rm -rf /root/apisix
-
 # check etcd while enable auth
 git checkout conf/config.yaml
 


### PR DESCRIPTION
This test can't be run if we don't use root privilege.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
