### PR TITLE
fix: remove stale checker before adding new one

### DIFF
--- a/apisix/upstream.lua
+++ b/apisix/upstream.lua
@@ -88,6 +88,13 @@ local function create_checker(upstream)
         return nil
     end
 
+    if healthcheck_parent.checker then
+        core.config_util.cancel_clean_handler(healthcheck_parent,
+                                              healthcheck_parent.checker_idx, true)
+    end
+
+    core.log.info("create new checker: ", tostring(checker))
+
     local host = upstream.checks and upstream.checks.active and upstream.checks.active.host
     local port = upstream.checks and upstream.checks.active and upstream.checks.active.port
     for _, node in ipairs(upstream.nodes) do
@@ -97,13 +104,6 @@ local function create_checker(upstream)
                     port or node.port, " err: ", err)
         end
     end
-
-    if healthcheck_parent.checker then
-        core.config_util.cancel_clean_handler(healthcheck_parent,
-                                              healthcheck_parent.checker_idx, true)
-    end
-
-    core.log.info("create new checker: ", tostring(checker))
 
     healthcheck_parent.checker = checker
     healthcheck_parent.checker_upstream = upstream

--- a/t/node/healthcheck-discovery.t
+++ b/t/node/healthcheck-discovery.t
@@ -156,6 +156,8 @@ qr/(create new checker|try to release checker): table/
 create new checker: table
 try to release checker: table
 create new checker: table
+--- no_error_log
+all upstream nodes is unhealthy, use default
 
 
 


### PR DESCRIPTION
lua-resty-healthcheck remove target according to the `ip, port,
hostname` tuple. If the newly added target has the same tuple, it will
be removed accidently.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
