### PR TITLE
feat: kafka-logger implemented reuse kafka producer

### DIFF
--- a/.github/workflows/centos7-ci.yml
+++ b/.github/workflows/centos7-ci.yml
@@ -75,6 +75,7 @@ jobs:
         docker run --name eureka -d -p 8761:8761 --env ENVIRONMENT=apisix --env spring.application.name=apisix-eureka --env server.port=8761 --env eureka.instance.ip-address=127.0.0.1 --env eureka.client.registerWithEureka=true --env eureka.client.fetchRegistry=false --env eureka.client.serviceUrl.defaultZone=http://127.0.0.1:8761/eureka/ bitinit/eureka
         sleep 5
         docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 1 --topic test2
+        docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 3 --topic test3
         docker run --rm --name skywalking -d -p 1234:1234 -p 11800:11800 -p 12800:12800 apache/skywalking-oap-server
 
     - name: install dependencies

--- a/.github/workflows/centos7-ci.yml
+++ b/.github/workflows/centos7-ci.yml
@@ -75,8 +75,7 @@ jobs:
         docker run --name eureka -d -p 8761:8761 --env ENVIRONMENT=apisix --env spring.application.name=apisix-eureka --env server.port=8761 --env eureka.instance.ip-address=127.0.0.1 --env eureka.client.registerWithEureka=true --env eureka.client.fetchRegistry=false --env eureka.client.serviceUrl.defaultZone=http://127.0.0.1:8761/eureka/ bitinit/eureka
         sleep 5
         docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 1 --topic test2
-        docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --topic test3 --partitions 1 --replication-factor 1
-        docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh  --alter --zookeeper zookeeper-server:2181 --topic test3 --partitions 3
+        docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --topic test3 --partitions 3 --replication-factor 1
         docker run --rm --name skywalking -d -p 1234:1234 -p 11800:11800 -p 12800:12800 apache/skywalking-oap-server
 
     - name: install dependencies

--- a/.github/workflows/centos7-ci.yml
+++ b/.github/workflows/centos7-ci.yml
@@ -75,7 +75,8 @@ jobs:
         docker run --name eureka -d -p 8761:8761 --env ENVIRONMENT=apisix --env spring.application.name=apisix-eureka --env server.port=8761 --env eureka.instance.ip-address=127.0.0.1 --env eureka.client.registerWithEureka=true --env eureka.client.fetchRegistry=false --env eureka.client.serviceUrl.defaultZone=http://127.0.0.1:8761/eureka/ bitinit/eureka
         sleep 5
         docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 1 --topic test2
-        docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 3 --topic test3
+        docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --topic test3 --partitions 1 --replication-factor 1
+        docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh  --alter --zookeeper zookeeper-server:2181 --topic test3 --partitions 3
         docker run --rm --name skywalking -d -p 1234:1234 -p 11800:11800 -p 12800:12800 apache/skywalking-oap-server
 
     - name: install dependencies

--- a/.github/workflows/centos7-ci.yml
+++ b/.github/workflows/centos7-ci.yml
@@ -75,7 +75,7 @@ jobs:
         docker run --name eureka -d -p 8761:8761 --env ENVIRONMENT=apisix --env spring.application.name=apisix-eureka --env server.port=8761 --env eureka.instance.ip-address=127.0.0.1 --env eureka.client.registerWithEureka=true --env eureka.client.fetchRegistry=false --env eureka.client.serviceUrl.defaultZone=http://127.0.0.1:8761/eureka/ bitinit/eureka
         sleep 5
         docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 1 --topic test2
-        docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --topic test3 --partitions 3 --replication-factor 1
+        docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 3 --topic test3
         docker run --rm --name skywalking -d -p 1234:1234 -p 11800:11800 -p 12800:12800 apache/skywalking-oap-server
 
     - name: install dependencies

--- a/.travis/linux_openresty_common_runner.sh
+++ b/.travis/linux_openresty_common_runner.sh
@@ -35,6 +35,7 @@ before_install() {
     docker run --name eureka -d -p 8761:8761 --env ENVIRONMENT=apisix --env spring.application.name=apisix-eureka --env server.port=8761 --env eureka.instance.ip-address=127.0.0.1 --env eureka.client.registerWithEureka=true --env eureka.client.fetchRegistry=false --env eureka.client.serviceUrl.defaultZone=http://127.0.0.1:8761/eureka/ bitinit/eureka
     sleep 5
     docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 1 --topic test2
+    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 3 --topic test3
 
     # start skywalking
     docker run --rm --name skywalking -d -p 1234:1234 -p 11800:11800 -p 12800:12800 apache/skywalking-oap-server

--- a/.travis/linux_openresty_common_runner.sh
+++ b/.travis/linux_openresty_common_runner.sh
@@ -35,8 +35,7 @@ before_install() {
     docker run --name eureka -d -p 8761:8761 --env ENVIRONMENT=apisix --env spring.application.name=apisix-eureka --env server.port=8761 --env eureka.instance.ip-address=127.0.0.1 --env eureka.client.registerWithEureka=true --env eureka.client.fetchRegistry=false --env eureka.client.serviceUrl.defaultZone=http://127.0.0.1:8761/eureka/ bitinit/eureka
     sleep 5
     docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 1 --topic test2
-    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --topic test3 --partitions 1 --replication-factor 1
-    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh  --alter --zookeeper zookeeper-server:2181 --topic test3 --partitions 3
+    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --topic test3 --partitions 3 --replication-factor 1
 
     # start skywalking
     docker run --rm --name skywalking -d -p 1234:1234 -p 11800:11800 -p 12800:12800 apache/skywalking-oap-server

--- a/.travis/linux_openresty_common_runner.sh
+++ b/.travis/linux_openresty_common_runner.sh
@@ -35,7 +35,8 @@ before_install() {
     docker run --name eureka -d -p 8761:8761 --env ENVIRONMENT=apisix --env spring.application.name=apisix-eureka --env server.port=8761 --env eureka.instance.ip-address=127.0.0.1 --env eureka.client.registerWithEureka=true --env eureka.client.fetchRegistry=false --env eureka.client.serviceUrl.defaultZone=http://127.0.0.1:8761/eureka/ bitinit/eureka
     sleep 5
     docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 1 --topic test2
-    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 3 --topic test3
+    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --topic test3 --partitions 1 --replication-factor 1
+    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh  --alter --zookeeper zookeeper-server:2181 --topic test3 --partitions 3
 
     # start skywalking
     docker run --rm --name skywalking -d -p 1234:1234 -p 11800:11800 -p 12800:12800 apache/skywalking-oap-server

--- a/.travis/linux_openresty_common_runner.sh
+++ b/.travis/linux_openresty_common_runner.sh
@@ -35,7 +35,7 @@ before_install() {
     docker run --name eureka -d -p 8761:8761 --env ENVIRONMENT=apisix --env spring.application.name=apisix-eureka --env server.port=8761 --env eureka.instance.ip-address=127.0.0.1 --env eureka.client.registerWithEureka=true --env eureka.client.fetchRegistry=false --env eureka.client.serviceUrl.defaultZone=http://127.0.0.1:8761/eureka/ bitinit/eureka
     sleep 5
     docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 1 --topic test2
-    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --topic test3 --partitions 3 --replication-factor 1
+    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 3 --topic test3
 
     # start skywalking
     docker run --rm --name skywalking -d -p 1234:1234 -p 11800:11800 -p 12800:12800 apache/skywalking-oap-server

--- a/.travis/linux_tengine_runner.sh
+++ b/.travis/linux_tengine_runner.sh
@@ -35,6 +35,7 @@ before_install() {
     docker run --name eureka -d -p 8761:8761 --env ENVIRONMENT=apisix --env spring.application.name=apisix-eureka --env server.port=8761 --env eureka.instance.ip-address=127.0.0.1 --env eureka.client.registerWithEureka=true --env eureka.client.fetchRegistry=false --env eureka.client.serviceUrl.defaultZone=http://127.0.0.1:8761/eureka/ bitinit/eureka
     sleep 5
     docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 1 --topic test2
+    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 3 --topic test3
 }
 
 tengine_install() {

--- a/.travis/linux_tengine_runner.sh
+++ b/.travis/linux_tengine_runner.sh
@@ -35,7 +35,7 @@ before_install() {
     docker run --name eureka -d -p 8761:8761 --env ENVIRONMENT=apisix --env spring.application.name=apisix-eureka --env server.port=8761 --env eureka.instance.ip-address=127.0.0.1 --env eureka.client.registerWithEureka=true --env eureka.client.fetchRegistry=false --env eureka.client.serviceUrl.defaultZone=http://127.0.0.1:8761/eureka/ bitinit/eureka
     sleep 5
     docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 1 --topic test2
-    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --topic test3 --partitions 3 --replication-factor 1
+    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 3 --topic test3
 }
 
 tengine_install() {

--- a/.travis/linux_tengine_runner.sh
+++ b/.travis/linux_tengine_runner.sh
@@ -35,7 +35,8 @@ before_install() {
     docker run --name eureka -d -p 8761:8761 --env ENVIRONMENT=apisix --env spring.application.name=apisix-eureka --env server.port=8761 --env eureka.instance.ip-address=127.0.0.1 --env eureka.client.registerWithEureka=true --env eureka.client.fetchRegistry=false --env eureka.client.serviceUrl.defaultZone=http://127.0.0.1:8761/eureka/ bitinit/eureka
     sleep 5
     docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 1 --topic test2
-    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 3 --topic test3
+    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --topic test3 --partitions 1 --replication-factor 1
+    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh  --alter --zookeeper zookeeper-server:2181 --topic test3 --partitions 3
 }
 
 tengine_install() {

--- a/.travis/linux_tengine_runner.sh
+++ b/.travis/linux_tengine_runner.sh
@@ -35,8 +35,7 @@ before_install() {
     docker run --name eureka -d -p 8761:8761 --env ENVIRONMENT=apisix --env spring.application.name=apisix-eureka --env server.port=8761 --env eureka.instance.ip-address=127.0.0.1 --env eureka.client.registerWithEureka=true --env eureka.client.fetchRegistry=false --env eureka.client.serviceUrl.defaultZone=http://127.0.0.1:8761/eureka/ bitinit/eureka
     sleep 5
     docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --replication-factor 1 --partitions 1 --topic test2
-    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --topic test3 --partitions 1 --replication-factor 1
-    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh  --alter --zookeeper zookeeper-server:2181 --topic test3 --partitions 3
+    docker exec -i kafka-server1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server:2181 --topic test3 --partitions 3 --replication-factor 1
 }
 
 tengine_install() {

--- a/apisix/plugins/kafka-logger.lua
+++ b/apisix/plugins/kafka-logger.lua
@@ -20,7 +20,6 @@ local producer = require ("resty.kafka.producer")
 local batch_processor = require("apisix.utils.batch-processor")
 local pairs    = pairs
 local type     = type
-local table    = table
 local ipairs   = ipairs
 local plugin_name = "kafka-logger"
 local stale_timer_running = false
@@ -116,7 +115,7 @@ end
 
 local function create_producer(broker_list, broker_config)
     core.log.info("create new kafka producer instance")
-    return producer:new(broker_list,broker_config)
+    return producer:new(broker_list, broker_config)
 end
 
 
@@ -144,17 +143,17 @@ function _M.log(conf, ctx)
     end
 
     -- reuse producer via lrucache to avoid unbalanced partitions of messages in kafka
-    local broker_list = {}
+    local broker_list = core.table.new(0, core.table.nkeys(conf.broker_list))
     local broker_config = {}
 
     for host, port in pairs(conf.broker_list) do
         if type(host) == 'string'
                 and type(port) == 'number' then
-
             local broker = {
-                host = host, port = port
+                host = host,
+                port = port
             }
-            table.insert(broker_list,broker)
+            core.table.insert(broker_list, broker)
         end
     end
 

--- a/apisix/plugins/kafka-logger.lua
+++ b/apisix/plugins/kafka-logger.lua
@@ -71,6 +71,10 @@ end
 
 
 local function partition_id(sendbuffer, topic, offset)
+    if not sendbuffer.topics[topic] then
+        core.log.info("current topic in sendbuffer has no messages")
+        return nil
+    end
     for i, message in pairs(sendbuffer.topics[topic]) do
         if message.offset == offset then
             return i

--- a/apisix/plugins/kafka-logger.lua
+++ b/apisix/plugins/kafka-logger.lua
@@ -70,13 +70,13 @@ function _M.check_schema(conf)
 end
 
 
-local function partition_id(sendbuffer, topic, offset)
+local function partition_id(sendbuffer, topic, log_message)
     if not sendbuffer.topics[topic] then
         core.log.info("current topic in sendbuffer has no message")
         return nil
     end
     for i, message in pairs(sendbuffer.topics[topic]) do
-        if message.offset == offset then
+        if log_message == message.queue[2] then
             return i
         end
     end
@@ -90,7 +90,7 @@ local function send_kafka_data(conf, log_message, prod)
 
     local ok, err = prod:send(conf.kafka_topic, conf.key, log_message)
     core.log.info("partition_id: ", partition_id(prod.sendbuffer,
-                                                 conf.kafka_topic, ok))
+                                                 conf.kafka_topic, log_message))
 
     if not ok then
         return nil, "failed to send data to Kafka topic: " .. err

--- a/apisix/plugins/kafka-logger.lua
+++ b/apisix/plugins/kafka-logger.lua
@@ -72,7 +72,7 @@ end
 
 local function partition_id(sendbuffer, topic, offset)
     if not sendbuffer.topics[topic] then
-        core.log.info("current topic in sendbuffer has no messages")
+        core.log.info("current topic in sendbuffer has no message")
         return nil
     end
     for i, message in pairs(sendbuffer.topics[topic]) do

--- a/t/plugin/kafka-logger.t
+++ b/t/plugin/kafka-logger.t
@@ -628,12 +628,16 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             t('/hello',ngx.HTTP_GET)
+            ngx.sleep(0.5)
             t('/hello',ngx.HTTP_GET)
+            ngx.sleep(0.5)
             t('/hello',ngx.HTTP_GET)
+            ngx.sleep(1)
         }
     }
 --- request
 GET /t
+--- timeout: 5
 --- ignore_response
 --- no_error_log
 [error]

--- a/t/plugin/kafka-logger.t
+++ b/t/plugin/kafka-logger.t
@@ -595,7 +595,6 @@ qr/send data to kafka: \{.*"upstream":"127.0.0.1:1980"/
                                 "kafka_topic" : "test3",
                                 "timeout" : 1,
                                 "batch_max_size": 1,
-                                "inactive_timeout": 1,
                                 "include_req_body": false
                             }
                         },
@@ -629,22 +628,16 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             t('/hello',ngx.HTTP_GET)
-            ngx.sleep(1.5)
+            ngx.sleep(0.5)
             t('/hello',ngx.HTTP_GET)
-            ngx.sleep(1.5)
+            ngx.sleep(0.5)
             t('/hello',ngx.HTTP_GET)
-            ngx.sleep(1.5)
-            t('/hello',ngx.HTTP_GET)
-            ngx.sleep(1.5)
-            t('/hello',ngx.HTTP_GET)
-            ngx.sleep(1.5)
-            t('/hello',ngx.HTTP_GET)
-            ngx.sleep(1.5)
+            ngx.sleep(0.5)
         }
     }
 --- request
 GET /t
---- timeout: 15s
+--- timeout: 5s
 --- ignore_response
 --- no_error_log
 [error]

--- a/t/plugin/kafka-logger.t
+++ b/t/plugin/kafka-logger.t
@@ -590,10 +590,10 @@ qr/send data to kafka: \{.*"upstream":"127.0.0.1:1980"/
                         "plugins": {
                             "kafka-logger": {
                                 "broker_list" : {
-                                    "127.0.0.1":9092
+                                    "127.0.0.1": 9092
                                 },
                                 "kafka_topic" : "test3",
-                                "timeout" : 1,
+                                "timeout" : 2,
                                 "batch_max_size": 1,
                                 "include_req_body": false
                             }
@@ -628,16 +628,17 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             t('/hello',ngx.HTTP_GET)
-            ngx.sleep(0.5)
             t('/hello',ngx.HTTP_GET)
-            ngx.sleep(0.5)
             t('/hello',ngx.HTTP_GET)
-            ngx.sleep(1)
+            t('/hello',ngx.HTTP_GET)
+            t('/hello',ngx.HTTP_GET)
+            t('/hello',ngx.HTTP_GET)
+            ngx.sleep(6)
         }
     }
 --- request
 GET /t
---- timeout: 5
+--- timeout: 10s
 --- ignore_response
 --- no_error_log
 [error]

--- a/t/plugin/kafka-logger.t
+++ b/t/plugin/kafka-logger.t
@@ -595,6 +595,7 @@ qr/send data to kafka: \{.*"upstream":"127.0.0.1:1980"/
                                 "kafka_topic" : "test3",
                                 "timeout" : 1,
                                 "batch_max_size": 1,
+                                "inactive_timeout": 1,
                                 "include_req_body": false
                             }
                         },
@@ -628,12 +629,22 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             t('/hello',ngx.HTTP_GET)
+            ngx.sleep(1.5)
             t('/hello',ngx.HTTP_GET)
+            ngx.sleep(1.5)
             t('/hello',ngx.HTTP_GET)
+            ngx.sleep(1.5)
+            t('/hello',ngx.HTTP_GET)
+            ngx.sleep(1.5)
+            t('/hello',ngx.HTTP_GET)
+            ngx.sleep(1.5)
+            t('/hello',ngx.HTTP_GET)
+            ngx.sleep(1.5)
         }
     }
 --- request
 GET /t
+--- timeout: 15s
 --- ignore_response
 --- no_error_log
 [error]

--- a/t/plugin/kafka-logger.t
+++ b/t/plugin/kafka-logger.t
@@ -593,7 +593,7 @@ qr/send data to kafka: \{.*"upstream":"127.0.0.1:1980"/
                                     "127.0.0.1": 9092
                                 },
                                 "kafka_topic" : "test3",
-                                "timeout" : 2,
+                                "timeout" : 1,
                                 "batch_max_size": 1,
                                 "include_req_body": false
                             }
@@ -630,19 +630,14 @@ passed
             t('/hello',ngx.HTTP_GET)
             t('/hello',ngx.HTTP_GET)
             t('/hello',ngx.HTTP_GET)
-            t('/hello',ngx.HTTP_GET)
-            t('/hello',ngx.HTTP_GET)
-            t('/hello',ngx.HTTP_GET)
-            ngx.sleep(5)
         }
     }
 --- request
 GET /t
---- timeout: 10s
 --- ignore_response
 --- no_error_log
 [error]
 --- error_log eval
 [qr/partition_id: 1/,
-qr/partition_id: 2/,
-qr/partition_id: 0/]
+qr/partition_id: 0/,
+qr/partition_id: 2/]

--- a/t/plugin/kafka-logger.t
+++ b/t/plugin/kafka-logger.t
@@ -633,7 +633,7 @@ passed
             t('/hello',ngx.HTTP_GET)
             t('/hello',ngx.HTTP_GET)
             t('/hello',ngx.HTTP_GET)
-            ngx.sleep(6)
+            ngx.sleep(5)
         }
     }
 --- request

--- a/t/plugin/kafka-logger.t
+++ b/t/plugin/kafka-logger.t
@@ -576,3 +576,68 @@ hello world
 --- error_log_like eval
 qr/send data to kafka: \{.*"upstream":"127.0.0.1:1980"/
 --- wait: 2
+
+
+
+=== TEST 17: use the topic with 3 partitions
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "kafka-logger": {
+                                "broker_list" : {
+                                    "127.0.0.1":9092
+                                },
+                                "kafka_topic" : "test3",
+                                "timeout" : 1,
+                                "batch_max_size": 1,
+                                "include_req_body": false
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 18: report log to kafka by different partitions
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            t('/hello',ngx.HTTP_GET)
+            t('/hello',ngx.HTTP_GET)
+            t('/hello',ngx.HTTP_GET)
+        }
+    }
+--- request
+GET /t
+--- ignore_response
+--- no_error_log
+[error]
+--- error_log eval
+[qr/partition_id: 1/,
+qr/partition_id: 2/,
+qr/partition_id: 0/]


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
When a topic has multiple partitions, the kafka-logger plugin creates a new producer instance to connect to kafka every time it pushes a message, which causes kafka to reallocate the partition each time, and all messages are placed in the same partition.

This PR reuse producer via lrucache to solve above problem.
<!--- If it fixes an open issue, please link to the issue here. -->
fix #3384
### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**