### PR TITLE
test: use the same buffer size across different platforms

### DIFF
--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -380,6 +380,7 @@ _EOC_
 
     underscores_in_headers on;
     lua_socket_log_errors off;
+    client_body_buffer_size 8k;
 
     upstream apisix_backend {
         server 0.0.0.1;


### PR DESCRIPTION
The buffer size in x86 is 8k while the one in arm64 is 16k.
Fix #3355

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
