### PR TITLE
test: sort the output data of the plugin_proxy_rewrite_args method

### DIFF
--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -86,8 +86,15 @@ end
 function _M.plugin_proxy_rewrite_args()
     ngx.say("uri: ", ngx.var.uri)
     local args = ngx.req.get_uri_args()
-    for k,v in pairs(args) do
-        ngx.say(k, ": ", v)
+
+    local keys = {}
+    for k, _ in pairs(args) do
+        table.insert(keys, k)
+    end
+    table.sort(keys)
+
+    for _, key in ipairs(keys) do
+        ngx.say(key, ": ", args[key])
     end
 end
 

--- a/t/plugin/proxy-rewrite.t
+++ b/t/plugin/proxy-rewrite.t
@@ -515,13 +515,10 @@ passed
 === TEST 17: rewrite uri args
 --- request
 GET /hello?q=apisix&a=iresty HTTP/1.1
---- response_body_like eval
-qr/uri: \/plugin_proxy_rewrite_args(
-q: apisix
-a: iresty|
+--- response_body
+uri: /plugin_proxy_rewrite_args
 a: iresty
-q: apisix)
-/
+q: apisix
 --- no_error_log
 [error]
 


### PR DESCRIPTION

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The output data of the plugin_proxy_rewrite_args method in the `apisix/t/lib/server.lua` file is messy. There should be an orderly output.

close #3403

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
