### PR TITLE
chore: use api7/etcd-operator in chaos CI

### DIFF
--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -24,10 +24,9 @@ jobs:
           kubectl get pods -n kube-system
           kubectl version
 
-      # TODO: should not use personal repo, while it's hard to modify a lot in an archived repo. Could we use api7's repo?
       - name: Deploy Etcd Operator
         run: |
-          git clone https://github.com/yiyiyimu/etcd-operator.git --depth 1
+          git clone https://github.com/api7/etcd-operator.git --depth 1
           bash etcd-operator/example/rbac/create_role.sh
           kubectl create -f etcd-operator/example/deployment.yaml
           bash ./t/chaos/utils.sh ensure_pods_ready etcd-operator "True" 30


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

### What this PR does / why we need it:
Originally chaos CI use personal repo. Now change it to api7's.

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
