### PR TITLE
docs(api-breaker): the plugin docs is synchronized with the schema

### DIFF
--- a/doc/plugins/api-breaker.md
+++ b/doc/plugins/api-breaker.md
@@ -47,14 +47,14 @@ In an unhealthy state, when a request is forwarded to an upstream service and th
 
 ## Attributes
 
-| Name          | Type          | Requirement | Default | Valid      | Description                                                                 |
-| ------------- | ------------- | ----------- | ------- | ---------- | --------------------------------------------------------------------------- |
-| break_response_code           | integer | required |          | [200, ..., 600] | return error code when unhealthy |
-| max_breaker_sec | integer | optional | 300 | >=60 | Maximum breaker time(seconds) |
+| Name                    | Type          | Requirement | Default | Valid            | Description                                                                 |
+| ----------------------- | ------------- | ----------- | -------- | --------------- | --------------------------------------------------------------------------- |
+| break_response_code     | integer        | required |            | [200, ..., 599] | Return error code when unhealthy |
+| max_breaker_sec         | integer        | optional | 300        | >=60            | Maximum breaker time(seconds) |
 | unhealthy.http_statuses | array[integer] | optional | {500}      | [500, ..., 599] | Status codes when unhealthy |
-| unhealthy.failures      | integer        | optional | 1          | >=1             | Number of consecutive error requests that triggered an unhealthy state |
-| healthy.http_statuses   | array[integer] | optional | {200, 206} | [200, ..., 499] | Status codes when healthy |
-| healthy.successes | integer        | optional | 1          | >=1             | Number of consecutive normal requests that trigger health status |
+| unhealthy.failures      | integer        | optional | 3          | >=1             | Number of consecutive error requests that triggered an unhealthy state |
+| healthy.http_statuses   | array[integer] | optional | {200}      | [200, ..., 499] | Status codes when healthy |
+| healthy.successes       | integer        | optional | 3          | >=1             | Number of consecutive normal requests that trigger health status |
 
 ## How To Enable
 

--- a/doc/zh-cn/plugins/api-breaker.md
+++ b/doc/zh-cn/plugins/api-breaker.md
@@ -49,12 +49,12 @@
 
 | 名称                    | 类型           | 必选项 | 默认值     | 有效值          | 描述                             |
 | ----------------------- | -------------- | ------ | ---------- | --------------- | -------------------------------- |
-| break_response_code | integer        | 必须   | 无         | [200, ..., 600] | 不健康返回错误码                 |
-| max_breaker_sec     | integer        | 可选   | 300        | >=60            | 最大熔断持续时间                 |
+| break_response_code     | integer        | 必须   | 无         | [200, ..., 599] | 不健康返回错误码                 |
+| max_breaker_sec         | integer        | 可选   | 300        | >=60            | 最大熔断持续时间                 |
 | unhealthy.http_statuses | array[integer] | 可选   | {500}      | [500, ..., 599] | 不健康时候的状态码               |
-| unhealthy.failures      | integer        | 可选   | 1          | >=1             | 触发不健康状态的连续错误请求次数 |
-| healthy.http_statuses   | array[integer] | 可选   | {200, 206} | [200, ..., 499] | 健康时候的状态码                 |
-| healthy.successes       | integer        | 可选   | 1          | >=1             | 触发健康状态的连续正常请求次数   |
+| unhealthy.failures      | integer        | 可选   | 3          | >=1             | 触发不健康状态的连续错误请求次数 |
+| healthy.http_statuses   | array[integer] | 可选   | {200}      | [200, ..., 499] | 健康时候的状态码                 |
+| healthy.successes       | integer        | 可选   | 3          | >=1             | 触发健康状态的连续正常请求次数   |
 
 ## 启用方式
 


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The document is inconsistent with the default parameters in the plugin `schema`. 
This PR mainly solves the problem of keeping the document consistent with the default parameters of the `schema`.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
