### PR TITLE
chore: sync 'ignore stale nginx.pid'(#3416) to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,11 +99,7 @@ init: default
 ### run:              Start the apisix server
 .PHONY: run
 run: default
-ifneq ("$(wildcard logs/nginx.pid)", "")
-	@echo "APISIX is running..."
-else
 	./bin/apisix start
-endif
 
 
 ### stop:             Stop the apisix server


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

### What this PR does / why we need it:
The same and more logic has been implemented in apisix cli, but Makefile still use the original one
https://github.com/apache/apisix/blob/6415b295594767e5698b355126ebcdd5e7a37e1b/apisix/cli/ops.lua#L436-L447

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
