### PR TITLE
chore: remove spellcheck for `push`

### DIFF
--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -1,14 +1,15 @@
 name: Check Markdown links
 
-on: push
+on: pull_request
 
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
       with:
-        use-quiet-mode: 'yes'
-        use-verbose-mode: 'yes'
-        check-modified-files-only: 'yes'
+        node-version: '12.x'
+    - run: npm install -g markdown-link-check
+    - run: markdown-link-check -q -v '**/*.md'

--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -1,15 +1,14 @@
 name: Check Markdown links
 
-on: pull_request
+on: push
 
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js
-      uses: actions/setup-node@v1
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
-        node-version: '12.x'
-    - run: npm install -g markdown-link-check
-    - run: markdown-link-check -q -v '**/*.md'
+        use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'
+        check-modified-files-only: 'yes'

--- a/.github/workflows/spellchecker.yml
+++ b/.github/workflows/spellchecker.yml
@@ -1,7 +1,5 @@
 name: spellchecker
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 jobs:


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

### What this PR does / why we need it:
~The original markdown-link-check use gaurav-nelson/github-action-markdown-link-check in github actions, which is not allowed for Apache project and aborted for a while. Replace it with install node.js and npm install markdown-link-check~ duplicate of #3197, reverted from this pr

There is no need to `spellcheck` for `push`, when `pull_request` already checked and merging branches won't affect that.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
