### PR TITLE
change: default to cache DNS record according to the TTL

### DIFF
--- a/.travis/apisix_cli_test/test_validate_config.sh
+++ b/.travis/apisix_cli_test/test_validate_config.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# validate the config.yaml
+
+. ./.travis/apisix_cli_test/common.sh
+
+echo '
+apisix:
+  dns_resolver_valid: "/apisix"
+' > conf/config.yaml
+
+out=$(make init 2>&1 || true)
+if ! echo "$out" | grep 'dns_resolver_valid should be a number'; then
+    echo "failed: dns_resolver_valid should be a number"
+    exit 1
+fi
+
+echo "passed: dns_resolver_valid should be a number"

--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -65,7 +65,7 @@ stream {
 
     lua_shared_dict lrucache-lock-stream   10m;
 
-    resolver {% for _, dns_addr in ipairs(dns_resolver or {}) do %} {*dns_addr*} {% end %} valid={*dns_resolver_valid*};
+    resolver {% for _, dns_addr in ipairs(dns_resolver or {}) do %} {*dns_addr*} {% end %} {% if dns_resolver_valid then %}valid={*dns_resolver_valid*}{% end %};
     resolver_timeout {*resolver_timeout*};
 
     # stream configuration snippet starts
@@ -187,7 +187,7 @@ http {
 
     lua_socket_log_errors off;
 
-    resolver {% for _, dns_addr in ipairs(dns_resolver or {}) do %} {*dns_addr*} {% end %} valid={*dns_resolver_valid*};
+    resolver {% for _, dns_addr in ipairs(dns_resolver or {}) do %} {*dns_addr*} {% end %} {% if dns_resolver_valid then %}valid={*dns_resolver_valid*}{% end %};
     resolver_timeout {*resolver_timeout*};
 
     lua_http10_buffering off;

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -279,6 +279,12 @@ Please modify "admin_key" in conf/config.yaml .
         end
     end
 
+    if yaml_conf.apisix.dns_resolver_valid then
+        if tonumber(yaml_conf.apisix.dns_resolver_valid) == nil then
+            util.die("apisix->dns_resolver_valid should be a number")
+        end
+    end
+
     -- Using template.render
     local sys_conf = {
         use_or_1_15 = use_or_1_15,

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -106,7 +106,7 @@ apisix:
   # dns_resolver:                 # If not set, read from `/etc/resolv.conf`
   #  - 1.1.1.1
   #  - 8.8.8.8
-  dns_resolver_valid: 30          # valid time for dns result 30 seconds
+  # dns_resolver_valid: 30        # if given, override the TTL of the valid records. The unit is second.
   resolver_timeout: 5             # resolver timeout
   ssl:
     enable: true

--- a/t/coredns/db.test.local
+++ b/t/coredns/db.test.local
@@ -11,3 +11,6 @@ $ORIGIN test.local.
     3600 IN NS b.iana-servers.net.
 
 ipv6     IN AAAA  ::1
+
+ttl 300  IN A     127.0.0.1
+ttl.1s 1  IN A     127.0.0.1

--- a/t/node/upstream-node-dns.t
+++ b/t/node/upstream-node-dns.t
@@ -21,19 +21,6 @@ log_level('info');
 no_root_location();
 no_shuffle();
 
-our $yaml_config = <<_EOC_;
-apisix:
-    node_listen: 1984
-    admin_key: ~
-    dns_resolver_valid: 1
-_EOC_
-
-add_block_preprocessor(sub {
-    my ($block) = @_;
-
-    $block->set_value("yaml_config", $yaml_config);
-});
-
 run_tests();
 
 __DATA__
@@ -120,15 +107,6 @@ location /t {
         local t = require("lib.test_admin").test
         core.log.info("call /hello")
         local code, body = t('/hello', ngx.HTTP_GET)
-
-        ngx.sleep(1.1)  -- cache expired
-        core.log.info("call /hello")
-        local code, body = t('/hello', ngx.HTTP_GET)
-        local code, body = t('/hello', ngx.HTTP_GET)
-
-        ngx.sleep(1.1)  -- cache expired
-        core.log.info("call /hello")
-        local code, body = t('/hello', ngx.HTTP_GET)
     }
 }
 
@@ -140,13 +118,6 @@ qr/dns resolver domain: test.com to 127.0.0.\d|call \/hello|proxy request to 127
 call /hello
 dns resolver domain: test.com to 127.0.0.1
 proxy request to 127.0.0.1:1980
-call /hello
-dns resolver domain: test.com to 127.0.0.2
-proxy request to 127.0.0.2:1980
-proxy request to 127.0.0.2:1980
-call /hello
-dns resolver domain: test.com to 127.0.0.3
-proxy request to 127.0.0.3:1980
 
 
 
@@ -234,18 +205,6 @@ location /t {
         core.log.info("call /hello")
         local code, body = t('/hello', ngx.HTTP_GET)
         core.log.warn("code: ", code)
-
-        ngx.sleep(1.1)  -- cache expired
-        core.log.info("call /hello")
-        local code, body = t('/hello', ngx.HTTP_GET)
-        core.log.warn("code: ", code)
-        local code, body = t('/hello', ngx.HTTP_GET)
-        core.log.warn("code: ", code)
-
-        ngx.sleep(1.1)  -- cache expired
-        core.log.info("call /hello")
-        local code, body = t('/hello', ngx.HTTP_GET)
-        core.log.warn("code: ", code)
     }
 }
 
@@ -260,19 +219,6 @@ dns resolver domain: test2.com to 127.0.0.2|
 dns resolver domain: test2.com to 127.0.0.1
 dns resolver domain: test.com to 127.0.0.2)
 proxy request to 127.0.0.[12]:1980
-call \/hello(
-dns resolver domain: test.com to 127.0.0.3
-dns resolver domain: test2.com to 127.0.0.4|
-dns resolver domain: test2.com to 127.0.0.3
-dns resolver domain: test.com to 127.0.0.4)
-proxy request to 127.0.0.[34]:1980
-proxy request to 127.0.0.[34]:1980
-call \/hello(
-dns resolver domain: test.com to 127.0.0.5
-dns resolver domain: test2.com to 127.0.0.6|
-dns resolver domain: test2.com to 127.0.0.5
-dns resolver domain: test.com to 127.0.0.6)
-proxy request to 127.0.0.[56]:1980
 /
 
 
@@ -361,15 +307,6 @@ location /t {
         local t = require("lib.test_admin").test
         core.log.info("call /hello")
         local code, body = t('/hello', ngx.HTTP_GET)
-
-        ngx.sleep(1.1)  -- cache expired
-        core.log.info("call /hello")
-        local code, body = t('/hello', ngx.HTTP_GET)
-        local code, body = t('/hello', ngx.HTTP_GET)
-
-        ngx.sleep(1.1)  -- cache expired
-        core.log.info("call /hello")
-        local code, body = t('/hello', ngx.HTTP_GET)
     }
 }
 
@@ -381,13 +318,6 @@ qr/dns resolver domain: test.com to 127.0.0.\d|call \/hello|proxy request to 127
 call /hello
 dns resolver domain: test.com to 127.0.0.1
 proxy request to 127.0.0.1:1980
-call /hello
-dns resolver domain: test.com to 127.0.0.2
-proxy request to 127.0.0.2:1980
-proxy request to 127.0.0.2:1980
-call /hello
-dns resolver domain: test.com to 127.0.0.3
-proxy request to 127.0.0.3:1980
 
 
 
@@ -448,17 +378,6 @@ location /t {
         local t = require("lib.test_admin").test
         core.log.info("call /hello")
         local code, body = t('/hello', ngx.HTTP_GET)
-
-        ngx.sleep(1.1)  -- cache expired
-        core.log.info("call /hello")
-        local code, body = t('/hello', ngx.HTTP_GET)
-        local code, body = t('/hello', ngx.HTTP_GET)
-        local code, body = t('/hello', ngx.HTTP_GET)
-        local code, body = t('/hello', ngx.HTTP_GET)
-
-        ngx.sleep(1.1)  -- cache expired
-        core.log.info("call /hello")
-        local code, body = t('/hello', ngx.HTTP_GET)
     }
 }
 
@@ -473,21 +392,6 @@ dns resolver domain: test2.com to 127.0.0.2|
 dns resolver domain: test2.com to 127.0.0.1
 dns resolver domain: test.com to 127.0.0.2)
 proxy request to 127.0.0.[12]:1980
-call \/hello(
-dns resolver domain: test.com to 127.0.0.3
-dns resolver domain: test2.com to 127.0.0.4|
-dns resolver domain: test2.com to 127.0.0.3
-dns resolver domain: test.com to 127.0.0.4)
-proxy request to 127.0.0.[34]:1980
-proxy request to 127.0.0.[34]:1980
-proxy request to 127.0.0.[34]:1980
-proxy request to 127.0.0.[34]:1980
-call \/hello(
-dns resolver domain: test2.com to 127.0.0.5
-dns resolver domain: test.com to 127.0.0.6|
-dns resolver domain: test.com to 127.0.0.5
-dns resolver domain: test2.com to 127.0.0.6)
-proxy request to 127.0.0.[56]:1980
 /
 
 
@@ -515,17 +419,6 @@ location /t {
         local t = require("lib.test_admin").test
         core.log.info("call /hello")
         local code, body = t('/hello', ngx.HTTP_GET)
-
-        ngx.sleep(1.1)  -- cache expired
-        core.log.info("call /hello")
-        local code, body = t('/hello', ngx.HTTP_GET)
-        local code, body = t('/hello', ngx.HTTP_GET)
-        local code, body = t('/hello', ngx.HTTP_GET)
-        local code, body = t('/hello', ngx.HTTP_GET)
-
-        ngx.sleep(1.1)  -- cache expired
-        core.log.info("call /hello")
-        local code, body = t('/hello', ngx.HTTP_GET)
     }
 }
 
@@ -535,21 +428,6 @@ GET /t
 qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy request to 127.0.0.\d:1980/
 --- grep_error_log_out eval
 qr/call \/hello(
-dns resolver domain: test.com to 127.0.0.1
-dns resolver domain: test2.com to 127.0.0.1|
-dns resolver domain: test2.com to 127.0.0.1
-dns resolver domain: test.com to 127.0.0.1)
-proxy request to 127.0.0.1:1980
-call \/hello(
-dns resolver domain: test.com to 127.0.0.1
-dns resolver domain: test2.com to 127.0.0.1|
-dns resolver domain: test2.com to 127.0.0.1
-dns resolver domain: test.com to 127.0.0.1)
-proxy request to 127.0.0.1:1980
-proxy request to 127.0.0.1:1980
-proxy request to 127.0.0.1:1980
-proxy request to 127.0.0.1:1980
-call \/hello(
 dns resolver domain: test.com to 127.0.0.1
 dns resolver domain: test2.com to 127.0.0.1|
 dns resolver domain: test2.com to 127.0.0.1
@@ -615,17 +493,6 @@ location /t {
         local t = require("lib.test_admin").test
         core.log.info("call /hello")
         local code, body = t('/hello', ngx.HTTP_GET)
-
-        ngx.sleep(1.1)  -- cache expired
-        core.log.info("call /hello")
-        local code, body = t('/hello', ngx.HTTP_GET)
-        local code, body = t('/hello', ngx.HTTP_GET)
-        local code, body = t('/hello', ngx.HTTP_GET)
-        local code, body = t('/hello', ngx.HTTP_GET)
-
-        ngx.sleep(1.1)  -- cache expired
-        core.log.info("call /hello")
-        local code, body = t('/hello', ngx.HTTP_GET)
     }
 }
 
@@ -637,13 +504,4 @@ qr/dns resolver domain: \w+.com to 127.0.0.\d|call \/hello|proxy request to 127.
 qr/call \/hello
 dns resolver domain: test.com to 127.0.0.1
 proxy request to 127.0.0.(1:1980|5:1981)
-call \/hello
-dns resolver domain: test.com to 127.0.0.2
-proxy request to 127.0.0.(2:1980|5:1981)
-proxy request to 127.0.0.(2:1980|5:1981)
-proxy request to 127.0.0.(2:1980|5:1981)
-proxy request to 127.0.0.(2:1980|5:1981)
-call \/hello
-dns resolver domain: test.com to 127.0.0.3
-proxy request to 127.0.0.(3:1980|5:1981)
 /


### PR DESCRIPTION
Since lua-resty-dns-client provides an internal cache, we don't need to
cache it twice.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
