### PR TITLE
docs: update the error-log-logger plugin docs

### DIFF
--- a/doc/plugins/error-log-logger.md
+++ b/doc/plugins/error-log-logger.md
@@ -92,7 +92,7 @@ plugins:                          # plugin list
 Step: update the attributes of the plugin
 
 ```shell
-curl http://127.0.0.1:9080//apisix/admin/plugin_metadata/error-log-logger -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+curl http://127.0.0.1:9080/apisix/admin/plugin_metadata/error-log-logger -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
   "host": "127.0.0.1",
   "port": 1999,

--- a/doc/zh-cn/plugins/error-log-logger.md
+++ b/doc/zh-cn/plugins/error-log-logger.md
@@ -90,7 +90,7 @@ plugins:                          # plugin list
 步骤：更新插件属性
 
 ```shell
-curl http://127.0.0.1:9080//apisix/admin/plugin_metadata/error-log-logger -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+curl http://127.0.0.1:9080/apisix/admin/plugin_metadata/error-log-logger -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
   "host": "127.0.0.1",
   "port": 1999,


### PR DESCRIPTION
### What this PR does / why we need it:
Fixes an extra '/' typo that was apart of the error-log-logger plugin docs 
Issue [#3473](https://github.com/apache/apisix/issues/3473)

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [X] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
