### PR TITLE
fix: should assign value to `api_ctx.global_rules` before running global rules

### DIFF
--- a/apisix/api_router.lua
+++ b/apisix/api_router.lua
@@ -125,7 +125,6 @@ function fetch_api_router()
                             if not skip_global_rule then
                                 plugin_mod.run_global_rules(api_ctx,
                                     apisix_router.global_rules, "access")
-                                api_ctx.global_rules = apisix_router.global_rules
                             end
 
                             code, body = route.handler(api_ctx)

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -297,7 +297,6 @@ function _M.http_access_phase()
     router.router_http.match(api_ctx)
 
     -- run global rule
-    api_ctx.global_rules = router.global_rules
     plugin.run_global_rules(api_ctx, router.global_rules, "access")
 
     local route = api_ctx.matched_route

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -297,8 +297,8 @@ function _M.http_access_phase()
     router.router_http.match(api_ctx)
 
     -- run global rule
-    plugin.run_global_rules(api_ctx, router.global_rules, "access")
     api_ctx.global_rules = router.global_rules
+    plugin.run_global_rules(api_ctx, router.global_rules, "access")
 
     local route = api_ctx.matched_route
     if not route then

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -689,6 +689,10 @@ function _M.run_global_rules(api_ctx, global_rules, phase_name)
         local orig_conf_version = api_ctx.conf_version
         local orig_conf_id = api_ctx.conf_id
 
+        if phase_name == "access" then
+            api_ctx.global_rules = global_rules
+        end
+
         local plugins = core.tablepool.fetch("plugins", 32, 0)
         local values = global_rules.values
         for _, global_rule in config_util.iterate_values(values) do

--- a/t/node/global-rule.t
+++ b/t/node/global-rule.t
@@ -262,7 +262,7 @@ apisix:
 plugins:
   - response-rewrite
   - uri-blocker
-  - node-status  
+  - node-status
 --- request
 GET /apisix/status?name=;union%20select%20
 --- error_code: 403

--- a/t/node/global-rule.t
+++ b/t/node/global-rule.t
@@ -210,18 +210,71 @@ passed
 
 
 
-=== TEST 11: hit block rule
+=== TEST 11: set one more global rule
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/global_rules/2',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "response-rewrite": {
+                            "headers": {
+                                "X-TEST":"test"
+                            }
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
 --- request
-GET /hello?name=;union%20select%20
---- error_code: 403
---- response_headers
-X-VERSION: 1.0
+GET /t
+--- response_body
+passed
 --- no_error_log
 [error]
 
 
 
-=== TEST 12: delete global rule
+=== TEST 12: hit global rules
+--- request
+GET /hello?name=;union%20select%20
+--- error_code: 403
+--- response_headers
+X-VERSION: 1.0
+X-TEST: test
+--- no_error_log
+[error]
+
+
+
+=== TEST 13: hit global rules by internal api
+--- yaml_config
+apisix:
+  global_rule_skip_internal_api: false
+plugins:
+  - response-rewrite
+  - uri-blocker
+  - node-status  
+--- request
+GET /apisix/status?name=;union%20select%20
+--- error_code: 403
+--- response_headers
+X-VERSION: 1.0
+X-TEST: test
+--- no_error_log
+[error]
+
+
+
+=== TEST 14: delete global rules
 --- config
     location /t {
         content_by_lua_block {
@@ -232,6 +285,12 @@ X-VERSION: 1.0
                 ngx.status = code
             end
             ngx.say(body)
+
+            local code, body = t('/apisix/admin/global_rules/2', ngx.HTTP_DELETE)
+
+            if code >= 300 then
+                ngx.status = code
+            end
 
             local code, body = t('/not_found', ngx.HTTP_GET)
             ngx.say(code)


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

this bug introduced by #3396.

should assign value to `api_ctx.global_rules` before running global rules, otherwise if a plugin exits in the access phase, global rules will not be able to run in the subsequent phases.


### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
