### PR TITLE
fix: use openssl111 in openresty dir in precedence

### DIFF
--- a/.github/workflows/fuzzing-ci.yaml
+++ b/.github/workflows/fuzzing-ci.yaml
@@ -36,7 +36,7 @@ jobs:
         sudo apt-get -y install software-properties-common
         sudo add-apt-repository -y "deb http://openresty.org/package/ubuntu $(lsb_release -sc) main"
         sudo apt-get update
-        sudo apt-get install -y git openresty curl openresty-openssl-dev unzip make gcc
+        sudo apt-get install -y git openresty curl openresty-openssl111-dev unzip make gcc
         ./utils/linux-install-luarocks.sh
 
         make deps

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,12 @@ UNAME ?= $(shell uname)
 OR_EXEC ?= $(shell which openresty || which nginx)
 LUAROCKS_VER ?= $(shell luarocks --version | grep -E -o  "luarocks [0-9]+.")
 OR_PREFIX ?= $(shell $(OR_EXEC) -V 2>&1 | grep -Eo 'prefix=(.*)/nginx\s+' | grep -Eo '/.*/')
+OPENSSL_PREFIX ?= $(addprefix $(OR_PREFIX), openssl)
+
+# OpenResty 1.17.8 or higher version uses openssl111 as the openssl dirname.
+ifeq ($(shell test -d $(addprefix $(OR_PREFIX), openssl111) && echo -n yes), yes)
+	OPENSSL_PREFIX=$(addprefix $(OR_PREFIX), openssl111)
+endif
 
 SHELL := /bin/bash -o pipefail
 
@@ -57,18 +63,18 @@ deps: default
 ifeq ($(LUAROCKS_VER),luarocks 3.)
 	mkdir -p ~/.luarocks
 ifeq ($(shell whoami),root)
-	luarocks config variables.OPENSSL_LIBDIR $(addprefix $(OR_PREFIX), openssl/lib)
-	luarocks config variables.OPENSSL_INCDIR $(addprefix $(OR_PREFIX), openssl/include)
+	luarocks config variables.OPENSSL_LIBDIR $(addprefix $(OPENSSL_PREFIX), /lib)
+	luarocks config variables.OPENSSL_INCDIR $(addprefix $(OPENSSL_PREFIX), /include)
 else
-	luarocks config --local variables.OPENSSL_LIBDIR $(addprefix $(OR_PREFIX), openssl/lib)
-	luarocks config --local variables.OPENSSL_INCDIR $(addprefix $(OR_PREFIX), openssl/include)
+	luarocks config --local variables.OPENSSL_LIBDIR $(addprefix $(OPENSSL_PREFIX), /lib)
+	luarocks config --local variables.OPENSSL_INCDIR $(addprefix $(OPENSSL_PREFIX), /include)
 endif
 	luarocks install rockspec/apisix-master-0.rockspec --tree=deps --only-deps --local
 else
 	@echo "WARN: You're not using LuaRocks 3.x, please add the following items to your LuaRocks config file:"
 	@echo "variables = {"
-	@echo "    OPENSSL_LIBDIR=$(addprefix $(OR_PREFIX), openssl/lib)"
-	@echo "    OPENSSL_INCDIR=$(addprefix $(OR_PREFIX), openssl/include)"
+	@echo "    OPENSSL_LIBDIR=$(addprefix $(OPENSSL_PREFIX), /lib)"
+	@echo "    OPENSSL_INCDIR=$(addprefix $(OPENSSL_PREFIX), /include)"
 	@echo "}"
 	luarocks install rockspec/apisix-master-0.rockspec --tree=deps --only-deps --local
 endif

--- a/doc/install-dependencies.md
+++ b/doc/install-dependencies.md
@@ -39,6 +39,8 @@
 
 - On some platforms, installing LuaRocks via the package manager will cause Lua to be upgraded to Lua 5.3, so we recommend installing LuaRocks via source code. if you install OpenResty and its OpenSSL develop library (openresty-openssl-devel for rpm and openresty-openssl-dev for deb) via the official repository, then [we provide a script for automatic installation](../utils/linux-install-luarocks.sh). If you compile OpenResty yourself, you can refer to the above script and change the path in it. If you don't specify the OpenSSL library path when you compile, you don't need to configure the OpenSSL variables in LuaRocks, because the system's OpenSSL is used by default. If the OpenSSL library is specified at compile time, then you need to ensure that LuaRocks' OpenSSL configuration is consistent with OpenResty's.
 
+- If you are using OpenResty/1.17.8 or higher version, please installing openresty-openssl111-devel instead of openresty-openssl-devel.
+
 # CentOS 7
 
 ```shell
@@ -52,7 +54,6 @@ tar -xvf etcd-v3.4.13-linux-amd64.tar.gz && \
 sudo yum install yum-utils
 sudo yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
 
-# install OpenResty and some compilation tools
 sudo yum install -y openresty curl git gcc openresty-openssl-devel unzip
 
 # install LuaRocks

--- a/doc/install-dependencies.md
+++ b/doc/install-dependencies.md
@@ -54,6 +54,7 @@ tar -xvf etcd-v3.4.13-linux-amd64.tar.gz && \
 sudo yum install yum-utils
 sudo yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
 
+# install OpenResty and some compilation tools
 sudo yum install -y openresty curl git gcc openresty-openssl-devel unzip
 
 # install LuaRocks

--- a/doc/install-dependencies.md
+++ b/doc/install-dependencies.md
@@ -37,9 +37,9 @@
 
 - If it is OpenResty 1.19, APISIX will use OpenResty's built-in LuaJIT to run `bin/apisix`; otherwise it will use Lua 5.1. If you encounter `luajit: lj_asm_x86.h:2819: asm_loop_ fixup: Assertion '((intptr_t)target & 15) == 0' failed`, this is a problem with the low version of OpenResty's built-in LuaJIT under certain compilation conditions.
 
-- On some platforms, installing LuaRocks via the package manager will cause Lua to be upgraded to Lua 5.3, so we recommend installing LuaRocks via source code. if you install OpenResty and its OpenSSL develop library (openresty-openssl-devel for rpm and openresty-openssl-dev for deb) via the official repository, then [we provide a script for automatic installation](../utils/linux-install-luarocks.sh). If you compile OpenResty yourself, you can refer to the above script and change the path in it. If you don't specify the OpenSSL library path when you compile, you don't need to configure the OpenSSL variables in LuaRocks, because the system's OpenSSL is used by default. If the OpenSSL library is specified at compile time, then you need to ensure that LuaRocks' OpenSSL configuration is consistent with OpenResty's.
+- On some platforms, installing LuaRocks via the package manager will cause Lua to be upgraded to Lua 5.3, so we recommend installing LuaRocks via source code. if you install OpenResty and its OpenSSL develop library (openresty-openssl111-devel for rpm and openresty-openssl111-dev for deb) via the official repository, then [we provide a script for automatic installation](../utils/linux-install-luarocks.sh). If you compile OpenResty yourself, you can refer to the above script and change the path in it. If you don't specify the OpenSSL library path when you compile, you don't need to configure the OpenSSL variables in LuaRocks, because the system's OpenSSL is used by default. If the OpenSSL library is specified at compile time, then you need to ensure that LuaRocks' OpenSSL configuration is consistent with OpenResty's.
 
-- If you are using OpenResty/1.17.8 or higher version, please installing openresty-openssl111-devel instead of openresty-openssl-devel.
+- WARNING: If you are using OpenResty which is older than `1.17.8`, please installing openresty-openss-devel instead of openresty-openssl111-devel.
 
 # CentOS 7
 
@@ -55,7 +55,7 @@ sudo yum install yum-utils
 sudo yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
 
 # install OpenResty and some compilation tools
-sudo yum install -y openresty curl git gcc openresty-openssl-devel unzip
+sudo yum install -y openresty curl git gcc openresty-openssl111-devel unzip
 
 # install LuaRocks
 curl https://raw.githubusercontent.com/apache/apisix/master/utils/linux-install-luarocks.sh -sL | bash -
@@ -78,7 +78,7 @@ tar -xvf etcd-v3.4.13-linux-amd64.tar.gz && \
     sudo cp -a etcd etcdctl /usr/bin/
 
 # install OpenResty and some compilation tools
-sudo yum install -y openresty curl git gcc openresty-openssl-devel
+sudo yum install -y openresty curl git gcc openresty-openssl111-devel
 
 # install LuaRocks
 curl https://raw.githubusercontent.com/apache/apisix/master/utils/linux-install-luarocks.sh -sL | bash -
@@ -104,7 +104,7 @@ tar -xvf etcd-v3.4.13-linux-amd64.tar.gz && \
     sudo cp -a etcd etcdctl /usr/bin/
 
 # install OpenResty and some compilation tools
-sudo apt-get install -y git openresty curl openresty-openssl-dev
+sudo apt-get install -y git openresty curl openresty-openssl111-dev
 
 # install LuaRocks
 curl https://raw.githubusercontent.com/apache/apisix/master/utils/linux-install-luarocks.sh -sL | bash -
@@ -135,7 +135,7 @@ tar -xvf etcd-v3.4.13-linux-amd64.tar.gz && \
     sudo cp -a etcd etcdctl /usr/bin/
 
 # install OpenResty and some compilation tools
-sudo apt-get install -y git openresty curl make openresty-openssl-dev
+sudo apt-get install -y git openresty curl make openresty-openssl111-dev
 
 # install LuaRocks
 curl https://raw.githubusercontent.com/apache/apisix/master/utils/linux-install-luarocks.sh -sL | bash -

--- a/doc/zh-cn/install-dependencies.md
+++ b/doc/zh-cn/install-dependencies.md
@@ -36,7 +36,9 @@
 
 - 如果是 OpenResty 1.19，APISIX 会使用 OpenResty 内置的 LuaJIT 来运行 `bin/apisix`；否则会使用 Lua 5.1。如果运行过程中遇到 `luajit: lj_asm_x86.h:2819: asm_loop_fixup: Assertion '((intptr_t)target & 15) == 0' failed`，这是低版本 OpenResty 内置的 LuaJIT 在特定编译条件下的问题。
 
-- 在某些平台上，通过包管理器安装 LuaRocks 会导致 Lua 被升级为 Lua 5.3，所以我们建议通过源代码的方式安装 LuaRocks。如果你通过官方仓库安装 OpenResty 和 OpenResty 的 OpenSSL 开发库（rpm 版本：openresty-openssl-devel，deb 版本：openresty-openssl-dev），那么 [我们提供了自动安装的脚本](../../utils/linux-install-luarocks.sh)。如果你是自己编译的 OpenResty，可以参考上述脚本并修改里面的路径。如果编译时没有指定 OpenSSL 库的路径，那么无需配置 LuaRocks 内跟 OpenSSL 相关的变量，因为默认都是用的系统自带的 OpenSSL。如果编译时指定了 OpenSSL 库，那么需要保证 LuaRocks 的 OpenSSL 配置跟 OpenResty 的相一致。
+- 在某些平台上，通过包管理器安装 LuaRocks 会导致 Lua 被升级为 Lua 5.3，所以我们建议通过源代码的方式安装 LuaRocks。如果你通过官方仓库安装 OpenResty 和 OpenResty 的 OpenSSL 开发库（rpm 版本：openresty-openssl111-devel，deb 版本：openresty-openssl111-dev），那么 [我们提供了自动安装的脚本](../../utils/linux-install-luarocks.sh)。如果你是自己编译的 OpenResty，可以参考上述脚本并修改里面的路径。如果编译时没有指定 OpenSSL 库的路径，那么无需配置 LuaRocks 内跟 OpenSSL 相关的变量，因为默认都是用的系统自带的 OpenSSL。如果编译时指定了 OpenSSL 库，那么需要保证 LuaRocks 的 OpenSSL 配置跟 OpenResty 的相一致。
+
+- 警告：如果你正在使用低于 `1.17.8` 的 OpenResty 版本，请安装 openresty-openssl-devel，而不是 openresty-openssl111-devel。
 
 # CentOS 7
 
@@ -52,7 +54,7 @@ sudo yum install yum-utils
 sudo yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
 
 # 安装 OpenResty 和 编译工具
-sudo yum install -y openresty curl git gcc openresty-openssl-devel unzip
+sudo yum install -y openresty curl git gcc openresty-openssl111-devel unzip
 
 # 安装 LuaRocks
 curl https://raw.githubusercontent.com/apache/apisix/master/utils/linux-install-luarocks.sh -sL | bash -
@@ -75,7 +77,7 @@ tar -xvf etcd-v3.4.13-linux-amd64.tar.gz && \
     sudo cp -a etcd etcdctl /usr/bin/
 
 # 安装 OpenResty 和 编译工具
-sudo yum install -y openresty curl git gcc openresty-openssl-devel
+sudo yum install -y openresty curl git gcc openresty-openssl111-devel
 
 # 安装 LuaRocks
 curl https://raw.githubusercontent.com/apache/apisix/master/utils/linux-install-luarocks.sh -sL | bash -
@@ -101,7 +103,7 @@ tar -xvf etcd-v3.4.13-linux-amd64.tar.gz && \
     sudo cp -a etcd etcdctl /usr/bin/
 
 # 安装 OpenResty 和 编译工具
-sudo apt-get install -y git openresty curl openresty-openssl-dev
+sudo apt-get install -y git openresty curl openresty-openssl111-dev
 
 # 安装 LuaRocks
 curl https://raw.githubusercontent.com/apache/apisix/master/utils/linux-install-luarocks.sh -sL | bash -
@@ -132,7 +134,7 @@ tar -xvf etcd-v3.4.13-linux-amd64.tar.gz && \
     sudo cp -a etcd etcdctl /usr/bin/
 
 # 安装 OpenResty 和 编译工具
-sudo apt-get install -y git openresty curl make openresty-openssl-dev
+sudo apt-get install -y git openresty curl make openresty-openssl111-dev
 
 # 安装 LuaRocks
 curl https://raw.githubusercontent.com/apache/apisix/master/utils/linux-install-luarocks.sh -sL | bash -

--- a/utils/centos7-ci.sh
+++ b/utils/centos7-ci.sh
@@ -27,7 +27,7 @@ install_dependencies() {
 
     # install openresty
     yum install -y yum-utils && yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
-    yum install -y openresty-debug openresty-openssl-debug-devel
+    yum install -y openresty-debug openresty-openssl111-debug-devel
 
     # install luarocks
     ./utils/linux-install-luarocks.sh

--- a/utils/linux-install-luarocks.sh
+++ b/utils/linux-install-luarocks.sh
@@ -43,5 +43,12 @@ cd .. || exit
 rm -rf luarocks-3.4.0
 
 mkdir ~/.luarocks || true
-luarocks config variables.OPENSSL_LIBDIR ${OPENRESTY_PREFIX}/openssl/lib
-luarocks config variables.OPENSSL_INCDIR ${OPENRESTY_PREFIX}/openssl/include
+
+# OpenResty 1.17.8 or higher version uses openssl111 as the openssl dirname.
+OPENSSL_PREFIX=${OPENRESTY_PREFIX}/openssl
+if [ -d ${OPENRESTY_PREFIX}/openssl111 ]; then
+    OPENSSL_PREFIX=${OPENRESTY_PREFIX}/openssl111
+fi
+
+luarocks config variables.OPENSSL_LIBDIR ${OPENSSL_PREFIX}/lib
+luarocks config variables.OPENSSL_INCDIR ${OPENSSL_PREFIX}/include

--- a/utils/linux-install-openresty.sh
+++ b/utils/linux-install-openresty.sh
@@ -88,15 +88,22 @@ verlt() {
     [ "$1" = "$2" ] && return 1 || verlte $1 $2
 }
 
+echo "before install openresty"
+
 sudo apt-get install "$openresty" lua5.1 liblua5.1-0-dev
 
+echo "after install openresty"
+
 if [ $OPENRESTY_VERSION == "default" ]; then
+    echo "install openresty-openssl111 default"
     sudo apt-get install openresty-openssl111-debug-dev
 else
     verlt $OPENRESTY_VERSION 1.17.8.1
     if [ $? -eq 0 ]; then
+        echo "install openresty-openssl"
         sudo apt-get install openresty-openssl-debug-dev
     else
+        echo "install openresty-openssl111-debug"
         sudo apt-get install openresty-openssl111-debug-dev
     fi
 fi

--- a/utils/linux-install-openresty.sh
+++ b/utils/linux-install-openresty.sh
@@ -15,8 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# set -euo pipefail
-set -uo pipefail
+set -euo pipefail
 
 wget -qO - https://openresty.org/package/pubkey.gpg | sudo apt-key add -
 sudo apt-get -y update --fix-missing
@@ -81,23 +80,10 @@ else
     openresty="openresty-debug=$OPENRESTY_VERSION*"
 fi
 
-verlte() {
-    [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
-}
-
-verlt() {
-    [ "$1" = "$2" ] && return 1 || verlte $1 $2
-}
-
 sudo apt-get install "$openresty" lua5.1 liblua5.1-0-dev
 
-if [ "$OPENRESTY_VERSION" == "default" ]; then
-    sudo apt-get install openresty-openssl111-debug-dev
+if [ "$OPENRESTY_VERSION" == "1.15.8.2" ]; then
+    sudo apt-get install openresty-openssl-debug-dev
 else
-    verlt $OPENRESTY_VERSION 1.17.8.1
-    if [ $? -eq 0 ]; then
-        sudo apt-get install openresty-openssl-debug-dev
-    else
-        sudo apt-get install openresty-openssl111-debug-dev
-    fi
+    sudo apt-get install openresty-openssl111-debug-dev
 fi

--- a/utils/linux-install-openresty.sh
+++ b/utils/linux-install-openresty.sh
@@ -88,22 +88,15 @@ verlt() {
     [ "$1" = "$2" ] && return 1 || verlte $1 $2
 }
 
-echo "before install openresty"
-
 sudo apt-get install "$openresty" lua5.1 liblua5.1-0-dev
 
-echo "after install openresty"
-
-if [ $OPENRESTY_VERSION == "default" ]; then
-    echo "install openresty-openssl111 default"
+if [ "$OPENRESTY_VERSION" == "default" ]; then
     sudo apt-get install openresty-openssl111-debug-dev
 else
     verlt $OPENRESTY_VERSION 1.17.8.1
     if [ $? -eq 0 ]; then
-        echo "install openresty-openssl"
         sudo apt-get install openresty-openssl-debug-dev
     else
-        echo "install openresty-openssl111-debug"
         sudo apt-get install openresty-openssl111-debug-dev
     fi
 fi

--- a/utils/linux-install-openresty.sh
+++ b/utils/linux-install-openresty.sh
@@ -93,7 +93,7 @@ sudo apt-get install "$openresty" lua5.1 liblua5.1-0-dev
 if [ $OPENRESTY_VERSION == "default" ]; then
     sudo apt-get install openresty-openssl111-debug-dev
 else
-    verlt $OPENRESTY_VERSION 1.17.8
+    verlt $OPENRESTY_VERSION 1.17.8.1
     if [ $? -eq 0 ]; then
         sudo apt-get install openresty-openssl-debug-dev
     else

--- a/utils/linux-install-openresty.sh
+++ b/utils/linux-install-openresty.sh
@@ -15,7 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-set -euo pipefail
+# set -euo pipefail
+set -uo pipefail
 
 wget -qO - https://openresty.org/package/pubkey.gpg | sudo apt-key add -
 sudo apt-get -y update --fix-missing

--- a/utils/linux-install-openresty.sh
+++ b/utils/linux-install-openresty.sh
@@ -88,6 +88,7 @@ verlt() {
     [ "$1" = "$2" ] && return 1 || verlte $1 $2
 }
 
+echo "OR: $openresty"
 sudo apt-get install "$openresty" lua5.1 liblua5.1-0-dev
 
 if [ "$OPENRESTY_VERSION" == "default" ]; then

--- a/utils/linux-install-openresty.sh
+++ b/utils/linux-install-openresty.sh
@@ -70,7 +70,7 @@ if [ "$OPENRESTY_VERSION" == "source" ]; then
     make
     sudo make install
 
-    sudo apt-get install openresty-openssl-debug-dev
+    sudo apt-get install openresty-openssl111-debug-dev
     exit 0
 fi
 
@@ -80,4 +80,23 @@ else
     openresty="openresty-debug=$OPENRESTY_VERSION*"
 fi
 
-sudo apt-get install "$openresty" lua5.1 liblua5.1-0-dev openresty-openssl-debug-dev
+verlte() {
+    [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
+}
+
+verlt() {
+    [ "$1" = "$2" ] && return 1 || verlte $1 $2
+}
+
+sudo apt-get install "$openresty" lua5.1 liblua5.1-0-dev
+
+if [ $OPENRESTY_VERSION == "default" ]; then
+    sudo apt-get install openresty-openssl111-debug-dev
+else
+    verlt $OPENRESTY_VERSION 1.17.8
+    if [ $? -eq 0 ]; then
+        sudo apt-get install openresty-openssl-debug-dev
+    else
+        sudo apt-get install openresty-openssl111-debug-dev
+    fi
+fi

--- a/utils/linux-install-openresty.sh
+++ b/utils/linux-install-openresty.sh
@@ -89,7 +89,6 @@ verlt() {
     [ "$1" = "$2" ] && return 1 || verlte $1 $2
 }
 
-echo "OR: $openresty"
 sudo apt-get install "$openresty" lua5.1 liblua5.1-0-dev
 
 if [ "$OPENRESTY_VERSION" == "default" ]; then


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We use luasec since 5399a31b, however, it uses the openssl libs and headers to compile itself, currently, we set two variables `$OPENSSL_LIBDIR` (e.g. `/usr/local/openresty/openssl/lib`) and `$OPENSSL_INCDIR` (e.g. `/usr/local/openresty/openssl/include`).

However, OpenResty 1.17.8 or higher version actually uses `openssl111` as the dir name of openssl. So in this PR, we detect the existence of dir `openssl111` and use it in precedence.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
