### PR TITLE
refactor: add the spell checker to the lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,18 @@ jobs:
           node-version: '12.x'
       - run: npm install -g markdownlint-cli@0.25.0
       - run: markdownlint '**/*.md'
+  spelling:
+    name: Spell checker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Install
+        run: |
+          wget -O - -q https://git.io/misspell | sh -s -- -b .
+      - name: Misspell
+        run: |
+          find *.md apisix doc bin t -not -path "README_ES.md" -not -path "t/toolkit/*.lua" -type f | xargs ./misspell -error
   yamllint:
     name: 🍺 YAML
     runs-on: ubuntu-latest

--- a/.github/workflows/misc-checker.yml
+++ b/.github/workflows/misc-checker.yml
@@ -9,12 +9,6 @@ jobs:
     steps:
       - name: Check out code.
         uses: actions/checkout@v1
-      - name: Install
-        run: |
-          wget -O - -q https://git.io/misspell | sh -s -- -b .
-      - name: Misspell
-        run: |
-          find *.md apisix doc bin t -not -path "README_ES.md" -not -path "t/toolkit/*.lua" -type f | xargs ./misspell -error
       - name: Merge conflict
         run: |
           grep "^<<<<<<< HEAD" $(git ls-files | grep -v "t/toolkit" | xargs) && exit 1 || true


### PR DESCRIPTION
The spell checker only needs to run on pull request.

This also gives separate steps for each test on the pull request page instead of having `misspell` and the `merge conflict` tests as one step.  Makes it easier and quicker to see which test is failing.

### What this PR does / why we need it:

Clearer to see which steps fail quicker.

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
