### PR TITLE
ci: use httpbin deployed in kubernetes to avoid unstability

### DIFF
--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -40,6 +40,8 @@ jobs:
           kubectl apply -f ./kubernetes/deployment.yaml
           kubectl apply -f ./kubernetes/service.yaml
           bash ./t/chaos/setup_chaos_utils.sh ensure_pods_ready apisix-gw "True" 30
+          kubectl apply -f https://raw.githubusercontent.com/istio/istio/master/samples/httpbin/httpbin.yaml
+          bash ./t/chaos/setup_chaos_utils.sh ensure_pods_ready httpbin "True" 30
           nohup kubectl port-forward svc/apisix-gw-lb 9080:9080 >/dev/null 2>&1 &
 
       - name: Deploy Chaos mesh

--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Deploy Chaos mesh
         run: |
           curl -sSL https://mirrors.chaos-mesh.org/v1.1.1/install.sh | bash
+          ps -ef | grep port-forward
 
       - name: run test
         working-directory: ./t/chaos

--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Deploy Chaos mesh
         run: |
           curl -sSL https://mirrors.chaos-mesh.org/v1.1.1/install.sh | bash
-          ps -ef | grep port-forward
 
       - name: run test
         working-directory: ./t/chaos

--- a/t/chaos/kill-etcd_test.go
+++ b/t/chaos/kill-etcd_test.go
@@ -68,9 +68,10 @@ func TestGetSuccessWhenEtcdKilled(t *testing.T) {
 
 	// check if everything works
 	setRoute(e, http.StatusCreated)
+	getRouteList(e, http.StatusOK)
 
 	// to avoid route haven't been set yet
-	time.Sleep(3 * time.Second)
+	time.Sleep(10 * time.Second)
 	getRoute(e, http.StatusOK)
 	testPrometheusEtcdMetric(e, 1)
 
@@ -82,8 +83,8 @@ func TestGetSuccessWhenEtcdKilled(t *testing.T) {
 		}
 	}()
 
-	// wait 3 seconds to let first route access returns
-	time.Sleep(3 * time.Second)
+	// wait 1 seconds to let first route access returns
+	time.Sleep(1 * time.Second)
 	bandwidthBefore, durationBefore := getIngressBandwidthPerSecond(e, g)
 	bpsBefore := bandwidthBefore / durationBefore
 	g.Expect(bpsBefore).NotTo(BeZero())

--- a/t/chaos/kill-etcd_test.go
+++ b/t/chaos/kill-etcd_test.go
@@ -70,7 +70,7 @@ func TestGetSuccessWhenEtcdKilled(t *testing.T) {
 	setRoute(e, http.StatusCreated)
 
 	// to avoid route haven't been set yet
-	time.Sleep(1 * time.Second)
+	time.Sleep(3 * time.Second)
 	getRoute(e, http.StatusOK)
 	testPrometheusEtcdMetric(e, 1)
 
@@ -78,12 +78,12 @@ func TestGetSuccessWhenEtcdKilled(t *testing.T) {
 	go func() {
 		for {
 			go getRoute(eSilent, http.StatusOK)
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(500 * time.Millisecond)
 		}
 	}()
 
 	// wait 5 second to let first route access returns
-	time.Sleep(5 * time.Second)
+	time.Sleep(3 * time.Second)
 	bandwidthBefore, durationBefore := getIngressBandwidthPerSecond(e, g)
 	bpsBefore := bandwidthBefore / durationBefore
 	g.Expect(bpsBefore).NotTo(BeZero())

--- a/t/chaos/kill-etcd_test.go
+++ b/t/chaos/kill-etcd_test.go
@@ -68,6 +68,9 @@ func TestGetSuccessWhenEtcdKilled(t *testing.T) {
 
 	// check if everything works
 	setRoute(e, http.StatusCreated)
+
+	// to avoid route haven't been set yet
+	time.Sleep(1 * time.Second)
 	getRoute(e, http.StatusOK)
 	testPrometheusEtcdMetric(e, 1)
 

--- a/t/chaos/kill-etcd_test.go
+++ b/t/chaos/kill-etcd_test.go
@@ -78,7 +78,7 @@ func TestGetSuccessWhenEtcdKilled(t *testing.T) {
 	go func() {
 		for {
 			go getRoute(eSilent, http.StatusOK)
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 		}
 	}()
 

--- a/t/chaos/kill-etcd_test.go
+++ b/t/chaos/kill-etcd_test.go
@@ -82,7 +82,7 @@ func TestGetSuccessWhenEtcdKilled(t *testing.T) {
 		}
 	}()
 
-	// wait 5 second to let first route access returns
+	// wait 3 seconds to let first route access returns
 	time.Sleep(3 * time.Second)
 	bandwidthBefore, durationBefore := getIngressBandwidthPerSecond(e, g)
 	bpsBefore := bandwidthBefore / durationBefore

--- a/t/chaos/utils.go
+++ b/t/chaos/utils.go
@@ -85,13 +85,12 @@ func setRoute(e *httpexpect.Expect, expectStatus int) {
 		Headers: map[string]string{"X-API-KEY": token},
 		Body: `{
 			 "uri": "/get",
-			 "host": "httpbin.org",
 			 "plugins": {
 				 "prometheus": {}
 			 },
 			 "upstream": {
 				 "nodes": {
-					 "httpbin.org:80": 1
+					 "http://httpbin.default.svc.cluster.local:8000": 1
 				 },
 				 "type": "roundrobin"
 			 }
@@ -105,7 +104,7 @@ func getRoute(e *httpexpect.Expect, expectStatus int) {
 		E:            e,
 		Method:       http.MethodGet,
 		Path:         "/get",
-		Headers:      map[string]string{"Host": "httpbin.org"},
+		Headers:      map[string]string{"Host": "http://httpbin.default.svc.cluster.local"},
 		ExpectStatus: expectStatus,
 	})
 }

--- a/t/chaos/utils.go
+++ b/t/chaos/utils.go
@@ -156,7 +156,7 @@ func getIngressBandwidthPerSecond(e *httpexpect.Expect, g *WithT) (float64, floa
 	// so need to calculate the duration
 	timeStart := time.Now()
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(5 * time.Second)
 	bandWidthString = getPrometheusMetric(e, g, key)
 	bandWidthEnd, err := strconv.ParseFloat(bandWidthString, 64)
 	g.Expect(err).To(BeNil())

--- a/t/chaos/utils.go
+++ b/t/chaos/utils.go
@@ -156,7 +156,7 @@ func getIngressBandwidthPerSecond(e *httpexpect.Expect, g *WithT) (float64, floa
 	// so need to calculate the duration
 	timeStart := time.Now()
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 	bandWidthString = getPrometheusMetric(e, g, key)
 	bandWidthEnd, err := strconv.ParseFloat(bandWidthString, 64)
 	g.Expect(err).To(BeNil())

--- a/t/chaos/utils.go
+++ b/t/chaos/utils.go
@@ -104,7 +104,6 @@ func getRoute(e *httpexpect.Expect, expectStatus int) {
 		E:            e,
 		Method:       http.MethodGet,
 		Path:         "/get",
-		Headers:      map[string]string{"Host": "http://httpbin.default.svc.cluster.local"},
 		ExpectStatus: expectStatus,
 	})
 }

--- a/t/chaos/utils.go
+++ b/t/chaos/utils.go
@@ -108,6 +108,17 @@ func getRoute(e *httpexpect.Expect, expectStatus int) {
 	})
 }
 
+func getRouteList(e *httpexpect.Expect, expectStatus int) {
+	caseCheck(httpTestCase{
+		E:            e,
+		Method:       http.MethodGet,
+		Path:         "/apisix/admin/routes",
+		Headers:      map[string]string{"X-API-KEY": token},
+		ExpectStatus: expectStatus,
+		ExpectBody:   "httpbin.default.svc.cluster.local",
+	})
+}
+
 func deleteRoute(e *httpexpect.Expect, expectStatus int) {
 	caseCheck(httpTestCase{
 		E:            e,

--- a/t/chaos/utils.go
+++ b/t/chaos/utils.go
@@ -90,7 +90,7 @@ func setRoute(e *httpexpect.Expect, expectStatus int) {
 			 },
 			 "upstream": {
 				 "nodes": {
-					 "http://httpbin.default.svc.cluster.local:8000": 1
+					 "httpbin.default.svc.cluster.local:8000": 1
 				 },
 				 "type": "roundrobin"
 			 }


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

### What this PR does / why we need it:
After #3614 got merged, chaos test is using `httpbin.org` as upstream, which could be unstable. Struggled some time with #3613 and suddenly found apisix inside kubernetes could not directly access localhost openresty...

So changed to deploy httpbin inside kubernetes, to make it stable

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
