### PR TITLE
test: make key-auth-upstream-domain-node stable

### DIFF
--- a/t/plugin/key-auth-upstream-domain-node.t
+++ b/t/plugin/key-auth-upstream-domain-node.t
@@ -80,7 +80,7 @@ passed
 
 
 
-=== TEST 3: create route with plugin `limit-req`(upstream node contains domain)
+=== TEST 3: create route with plugin `limit-count`(upstream node contains domain)
 --- config
     location /t {
         content_by_lua_block {
@@ -89,9 +89,9 @@ passed
                 ngx.HTTP_PUT,
                 [[{
                     "plugins": {
-                        "limit-req": {
-                            "rate": 1,
-                            "burst": 0,
+                        "limit-count": {
+                            "count": 1,
+                            "time_window": 5,
                             "rejected_code": 503,
                             "key": "remote_addr"
                         }
@@ -142,6 +142,7 @@ location /t {
                 headers
             )
             ngx.say("return: ", code)
+            ngx.sleep(1)
         end
     }
 }
@@ -153,7 +154,7 @@ return: 503
 return: 503
 --- no_error_log
 [error]
---- timeout: 5
+--- timeout: 8
 
 
 
@@ -188,7 +189,7 @@ passed
 
 
 
-=== TEST 6: create route with plugin `limit-req`, and bind upstream via id
+=== TEST 6: create route with plugin `limit-count`, and bind upstream via id
 --- config
     location /t {
         content_by_lua_block {
@@ -197,9 +198,9 @@ passed
                 ngx.HTTP_PUT,
                 [[{
                     "plugins": {
-                        "limit-req": {
-                            "rate": 1,
-                            "burst": 0,
+                        "limit-count": {
+                            "count": 1,
+                            "time_window": 5,
                             "rejected_code": 503,
                             "key": "remote_addr"
                         }
@@ -255,4 +256,4 @@ return: 503
 return: 503
 --- no_error_log
 [error]
---- timeout: 5
+--- timeout: 8

--- a/t/plugin/key-auth-upstream-domain-node.t
+++ b/t/plugin/key-auth-upstream-domain-node.t
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+BEGIN {
+    $ENV{CUSTOM_DNS_SERVER} = "127.0.0.1:1053";
+}
+
 use t::APISIX 'no_plan';
 
 repeat_each(1);
@@ -98,7 +102,7 @@ passed
                     },
                     "upstream": {
                         "nodes": {
-                            "www.apiseven.com:80": 1
+                            "ttl.test.local:1980": 1
                         },
                         "pass_host": "node",
                         "type": "roundrobin"
@@ -149,12 +153,11 @@ location /t {
 --- request
 GET /t
 --- response_body
-return: 302
+return: 404
 return: 503
 return: 503
 --- no_error_log
 [error]
---- timeout: 8
 
 
 
@@ -167,7 +170,7 @@ return: 503
                 ngx.HTTP_PUT,
                 [[{
                     "nodes": {
-                        "www.apiseven.com:80": 1
+                        "ttl.test.local:1980": 1
                     },
                     "pass_host": "node",
                     "type": "roundrobin"
@@ -251,9 +254,8 @@ location /t {
 --- request
 GET /t
 --- response_body
-return: 302
+return: 404
 return: 503
 return: 503
 --- no_error_log
 [error]
---- timeout: 8


### PR DESCRIPTION
The www.apiseven.com can't be accessed as soon as the Apple's domain.

As limit-count also hit the lrucache.plugin_ctx, we can remove limit-req
with it safely.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
