### PR TITLE
ci: run chaos test on HEAD of PR

### DIFF
--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           bash ./t/chaos/setup_chaos_utils.sh start_minikube
           wget https://raw.githubusercontent.com/apache/apisix-docker/master/alpine-local/Dockerfile
-          docker build -t apisix:alpine-local --build-arg APISIX_PATH=. -f Dockerfile .
+          docker build -t apache/apisix:alpine-local --build-arg APISIX_PATH=. -f Dockerfile .
           minikube cache add apache/apisix:alpine-local -v 7 --alsologtostderr
 
       - name: Print cluster information

--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -16,6 +16,7 @@ jobs:
         run: |
           bash ./t/chaos/setup_chaos_utils.sh start_minikube
           wget https://raw.githubusercontent.com/apache/apisix-docker/master/alpine-local/Dockerfile
+          mkdir logs
           docker build -t apache/apisix:alpine-local --build-arg APISIX_PATH=. -f Dockerfile .
           minikube cache add apache/apisix:alpine-local -v 7 --alsologtostderr
 

--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           bash ./t/chaos/setup_chaos_utils.sh start_minikube
           wget https://raw.githubusercontent.com/apache/apisix-docker/master/alpine-local/Dockerfile
-          docker build -t apisix:alpine-local --build-arg APISIX_PATH=. -f Dockerfile alpine
+          docker build -t apisix:alpine-local --build-arg APISIX_PATH=. -f Dockerfile .
           minikube cache add apache/apisix:alpine-local -v 7 --alsologtostderr
 
       - name: Print cluster information

--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Creating minikube cluster
         run: |
           bash ./t/chaos/setup_chaos_utils.sh start_minikube
+          wget https://raw.githubusercontent.com/apache/apisix-docker/master/alpine-local/Dockerfile
+          docker build -t apisix:alpine-local --build-arg APISIX_PATH=. -f Dockerfile alpine
+          minikube cache add apache/apisix:alpine-local -v 7 --alsologtostderr
 
       - name: Print cluster information
         run: |

--- a/t/chaos/setup_chaos_utils.sh
+++ b/t/chaos/setup_chaos_utils.sh
@@ -36,6 +36,7 @@ modify_config() {
 etcd:
   host:
     - \"http://etcd-cluster-client.default.svc.cluster.local:2379\" " > ./conf/config.yaml
+    sed -i -e 's/apisix:latest/apisix:alpine-local/g' kubernetes/deployment.yaml
 }
 
 ensure_pods_ready() {


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

### What this PR does / why we need it:
fix #3625
Currently, chaos test use lastest docker image as apisix, so it's actually always runs on lastest release.
Since we could build docker from local code after https://github.com/apache/apisix-docker/pull/137 got merged, changed to run chaos on current change in PR.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
