### PR TITLE
feat: Add filter on HTTP methods for consumer-restriction plugin

### DIFF
--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -19,74 +19,49 @@ local core      = require("apisix.core")
 local ngx       = ngx
 local schema = {
     type = "object",
-    oneOf = {
-        {
-            title = "blacklist",
-            properties = {
-                type = {
-                    type = "string",
-                    enum = {"consumer_name", "service_id"},
-                    default = "consumer_name"
-                },
-                blacklist = {
-                    type = "array",
-                    minItems = 1,
-                    items = {type = "string"}
-                },
-                rejected_code = {type = "integer", minimum = 200, default = 403}
-            },
-            required = {"blacklist"},
+    properties = {
+        type = {
+            type = "string",
+            enum = {"consumer_name", "service_id"},
+            default = "consumer_name"
         },
-        {
-            title = "whitelist",
-            properties = {
-                type = {
-                    type = "string",
-                    enum = {"consumer_name", "service_id"},
-                    default = "consumer_name"
-                },
-                whitelist = {
-                    type = "array",
-                    minItems = 1,
-                    items = {type = "string"}
-                },
-                rejected_code = {type = "integer", minimum = 200, default = 403}
-            },
-            required = {"whitelist"},
+        blacklist = {
+            type = "array",
+            minItems = 1,
+            items = {type = "string"}
         },
-        {
-            title = "allowed_by_methods",
-            properties = {
-                type = {
-                    type = "string",
-                    enum = {"consumer_name", "service_id"},
-                    default = "consumer_name"
-                },
-                whitelist = {
-                    type = "array",
-                    items = {
-                        type = "object",
-                        properties = {
-                            user = {
-                                type = "string"
-                            },
-                            methods = {
-                                type = "array",
-                                minItems = 1,
-                                items = {
-                                    type = "string",
-                                    enum = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD",
-                                            "OPTIONS", "CONNECT", "TRACE"},
-                                }
-                            }
+        whitelist = {
+            type = "array",
+            minItems = 1,
+            items = {type = "string"}
+        },
+        allowed_by_methods = {
+            type = "array",
+            items = {
+                type = "object",
+                properties = {
+                    user = {
+                        type = "string"
+                    },
+                    methods = {
+                        type = "array",
+                        minItems = 1,
+                        items = {
+                            type = "string",
+                            enum = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD",
+                                    "OPTIONS", "CONNECT", "TRACE"},
                         }
                     }
-                },
-                rejected_code = {type = "integer", minimum = 200, default = 403}
-            },
-            required = {"allowed_by_methods"},
-        }
-    }
+                }
+            }
+        },
+        rejected_code = {type = "integer", minimum = 200, default = 403}
+    },
+    anyOf = {
+        {required = {"blacklist"}},
+        {required = {"whitelist"}},
+        {required = {"allowed_by_methods"}}
+    },
 }
 
 local plugin_name = "consumer-restriction"
@@ -130,13 +105,14 @@ local function is_method_allowed(allowed_methods, method, user)
     return true
 end
 
+local function reject(conf)
+    return conf.rejected_code, { message = "The " .. conf.type .. " is forbidden." }
+end
+
 function _M.check_schema(conf)
     local ok, err = core.schema.check(schema, conf)
    if not ok then
         return false, err
-   end
-   if ((conf.allowed_by_methods and #conf.allowed_by_methods > 0) and not conf.whitelist ) then
-    return false, "allowed_by_methods set but no whitelist provided"
    end
    return true
 end
@@ -151,25 +127,29 @@ function _M.access(conf, ctx)
     core.log.info("value: ", value)
 
     local block = false
+    local whitelisted = false
+
     if conf.blacklist and #conf.blacklist > 0 then
         if is_include(value, conf.blacklist) then
-            block = true
+            return reject(conf)
         end
     end
 
     if conf.whitelist and #conf.whitelist > 0 then
-        if not is_include(value, conf.whitelist) then
+        whitelisted = is_include(value, conf.whitelist)
+        if not whitelisted then
             block = true
         end
-        if conf.allowed_by_methods and #conf.allowed_by_methods > 0 then
-            if not is_method_allowed(conf.allowed_by_methods, method, value) then
-                block = true
-            end
+    end
+
+    if conf.allowed_by_methods and #conf.allowed_by_methods > 0 and not whitelisted then
+        if not is_method_allowed(conf.allowed_by_methods, method, value) then
+            block = true
         end
     end
 
     if block then
-        return conf.rejected_code, { message = "The " .. conf.type .. " is forbidden." }
+        return reject(conf)
     end
 end
 

--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -173,5 +173,4 @@ function _M.access(conf, ctx)
     end
 end
 
-
 return _M

--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -119,7 +119,7 @@ end
 local function is_method_allow(allowed_methods, method, user)
     for key,value in ipairs(allowed_methods) do
         if value.user == user then
-            for k,allowed_method in pairs(value.methods) do
+            for k,allowed_method in ipairs(value.methods) do
                 if allowed_method == method then
                     return true
                 end
@@ -136,7 +136,7 @@ function _M.check_schema(conf)
         return false, err
     end
     if ((conf.allowed_methods and #conf.allowed_methods > 0) and not conf.whitelist ) then
-        return false, "allowed_methods set but no withelist provided"
+        return false, "allowed_methods set but no whitelist provided"
     end
     return true
 end

--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -132,20 +132,19 @@ end
 
 function _M.check_schema(conf)
     local ok, err = core.schema.check(schema, conf)
-   if not ok then
+    if not ok then
         return false, err
-   end
-   if ((conf.allowed_methods and #conf.allowed_methods > 0) and not conf.whitelist ) then
-    return false, "allowed_methods set but no withelist provided"
-   end
-   return true
+    end
+    if ((conf.allowed_methods and #conf.allowed_methods > 0) and not conf.whitelist ) then
+        return false, "allowed_methods set but no withelist provided"
+    end
+    return true
 end
 
 
 function _M.access(conf, ctx)
     local value = fetch_val_funcs[conf.type](ctx)
     local method = ngx.req.get_method()
-
     if not value then
         return 401, { message = "Missing authentication or identity verification."}
     end

--- a/docs/en/latest/plugins/consumer-restriction.md
+++ b/docs/en/latest/plugins/consumer-restriction.md
@@ -42,7 +42,7 @@ The `consumer-restriction` makes corresponding access restrictions based on diff
 | whitelist | array[string] | required   |               |                                 | Choose one of the two with `blacklist`, only whitelist or blacklist can be enabled separately, and the two cannot be used together. |
 | blacklist | array[string] | required   |               |                                 | Choose one of the two with `whitelist`, only whitelist or blacklist can be enabled separately, and the two cannot be used together. |
 | rejected_code | integer | optional     | 403           | [200,...]                       | The HTTP status code returned when the request is rejected.                                                                         |
-| allowed_methods | array[object] | optional     |            |                        | Set a list of allowed_methods for users declared in the whitelist section                                                                         |
+| allowed_by_methods | array[object] | optional     |            |                        | Set a list of allowed HTTP methods for users declared in the whitelist section can be `["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD",                               "OPTIONS", "CONNECT", "TRACE"]`                                                                        |
 
 For the `type` field is an enumerated type, it can be `consumer_name` or `service_id`. They stand for the following meanings:
 
@@ -117,7 +117,7 @@ HTTP/1.1 403 Forbidden
 {"message":"The consumer_name is forbidden."}
 ```
 
-### How to restrict `allowed_methods`
+### How to restrict `allowed_by_methods`
 
 This example restrict the user `jack1` to only `POST` on the resource
 
@@ -137,7 +137,7 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
             "whitelist": [
                 "jack1"
             ],
-            "allowed_methods":[{
+            "allowed_by_methods":[{
                 "user": "jack1",
                 "methods": ["POST"]
             }]
@@ -175,7 +175,7 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
             "whitelist": [
                 "jack1"
             ],
-            "allowed_methods":[{
+            "allowed_by_methods":[{
                 "user": "jack1",
                 "methods": ["POST","GET"]
             }]

--- a/docs/en/latest/plugins/consumer-restriction.md
+++ b/docs/en/latest/plugins/consumer-restriction.md
@@ -39,10 +39,10 @@ The `consumer-restriction` makes corresponding access restrictions based on diff
 |Name       |   Type      | Requirement  | Default       | Valid                           | Description                                                                                                                         |
 |-----------|-------------|--------------|---------------|---------------------------------|--------------------------------------------------------------------------------------------------------------------                 |
 | type      | string      | optional     | consumer_name | ["consumer_name", "service_id"] | According to different objects, corresponding restrictions, support `consumer_name`, `service_id`.                 |
-| whitelist | array[string] | required   |               |                                 | Choose one of the two with `blacklist`, only whitelist or blacklist can be enabled separately, and the two cannot be used together. |
-| blacklist | array[string] | required   |               |                                 | Choose one of the two with `whitelist`, only whitelist or blacklist can be enabled separately, and the two cannot be used together. |
+| whitelist | array[string] | required   |               |                                 | Grant full access to all users specified in the provided list , **has the priority over `allowed_by_methods`** |
+| blacklist | array[string] | required   |               |                                 | Reject connection to all users specified in the provided list , **has the priority over `whitelist`** |
 | rejected_code | integer | optional     | 403           | [200,...]                       | The HTTP status code returned when the request is rejected.                                                                         |
-| allowed_by_methods | array[object] | optional     |            |                        | Set a list of allowed HTTP methods for users declared in the whitelist section can be `["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD",                               "OPTIONS", "CONNECT", "TRACE"]`                                                                        |
+| allowed_by_methods | array[object] | optional     |            |                        | Set a list of allowed HTTP methods for the selected user , HTTP methods can be `["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT", "TRACE"]`                                                                        |
 
 For the `type` field is an enumerated type, it can be `consumer_name` or `service_id`. They stand for the following meanings:
 
@@ -134,9 +134,6 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
     "plugins": {
         "basic-auth": {},
         "consumer-restriction": {
-            "whitelist": [
-                "jack1"
-            ],
             "allowed_by_methods":[{
                 "user": "jack1",
                 "methods": ["POST"]
@@ -172,9 +169,6 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
     "plugins": {
         "basic-auth": {},
         "consumer-restriction": {
-            "whitelist": [
-                "jack1"
-            ],
             "allowed_by_methods":[{
                 "user": "jack1",
                 "methods": ["POST","GET"]

--- a/docs/en/latest/plugins/consumer-restriction.md
+++ b/docs/en/latest/plugins/consumer-restriction.md
@@ -42,6 +42,7 @@ The `consumer-restriction` makes corresponding access restrictions based on diff
 | whitelist | array[string] | required   |               |                                 | Choose one of the two with `blacklist`, only whitelist or blacklist can be enabled separately, and the two cannot be used together. |
 | blacklist | array[string] | required   |               |                                 | Choose one of the two with `whitelist`, only whitelist or blacklist can be enabled separately, and the two cannot be used together. |
 | rejected_code | integer | optional     | 403           | [200,...]                       | The HTTP status code returned when the request is rejected.                                                                         |
+| allowed_methods | array[object] | optional     |            |                        | Set a list of allowed_methods for users declared in the whitelist section                                                                         |
 
 For the `type` field is an enumerated type, it can be `consumer_name` or `service_id`. They stand for the following meanings:
 
@@ -114,6 +115,80 @@ curl -u jack2020:123456 http://127.0.0.1:9080/index.html -i
 HTTP/1.1 403 Forbidden
 ...
 {"message":"The consumer_name is forbidden."}
+```
+
+### How to restrict `allowed_methods`
+
+This example restrict the user `jack1` to only `POST` on the resource
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "uri": "/index.html",
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "127.0.0.1:1980": 1
+        }
+    },
+    "plugins": {
+        "basic-auth": {},
+        "consumer-restriction": {
+            "whitelist": [
+                "jack1"
+            ],
+            "allowed_methods":[{
+                "user": "jack1",
+                "methods": ["POST"]
+            }]
+        }
+    }
+}'
+```
+
+**Test Plugin**
+
+Requests from jack1:
+
+```shell
+curl -u jack2019:123456 http://127.0.0.1:9080/index.html
+HTTP/1.1 403 Forbidden
+...
+{"message":"The consumer_name is forbidden."}
+```
+
+Add the capability for `jack1` to get the resource
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "uri": "/index.html",
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "127.0.0.1:1980": 1
+        }
+    },
+    "plugins": {
+        "basic-auth": {},
+        "consumer-restriction": {
+            "whitelist": [
+                "jack1"
+            ],
+            "allowed_methods":[{
+                "user": "jack1",
+                "methods": ["POST","GET"]
+            }]
+        }
+    }
+}'
+```
+
+Requests from jack1:
+
+```shell
+curl -u jack2019:123456 http://127.0.0.1:9080/index.html
+HTTP/1.1 200 OK
 ```
 
 ## How to restrict `service_id`

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -475,7 +475,7 @@ Authorization: Basic amFjazIwMjA6MTIzNDU2
 
 
 
-=== TEST 21: set allowed_methods
+=== TEST 21: set allowed_by_methods
 --- config
     location /t {
         content_by_lua_block {
@@ -496,7 +496,7 @@ Authorization: Basic amFjazIwMjA6MTIzNDU2
                                  "whitelist": [
                                      "jack1"
                                  ],
-                                 "allowed_methods":[{
+                                 "allowed_by_methods":[{
                                     "user":"jack1",
                                     "methods":["POST"]
                                  }]
@@ -533,7 +533,7 @@ Authorization: Basic amFjazIwMTk6MTIzNDU2
 
 
 
-=== TEST 23: set allowed_methods
+=== TEST 23: set allowed_by_methods
 --- config
     location /t {
         content_by_lua_block {
@@ -554,7 +554,7 @@ Authorization: Basic amFjazIwMTk6MTIzNDU2
                                  "whitelist": [
                                      "jack1"
                                  ],
-                                 "allowed_methods":[{
+                                 "allowed_by_methods":[{
                                     "user":"jack1",
                                     "methods":["POST","GET"]
                                 }]
@@ -1345,7 +1345,7 @@ passed
 
 
 
-=== TEST 41: set wrong scheme for allowed_methods and blacklist
+=== TEST 41: set wrong scheme for allowed_by_methods and blacklist
 --- config
     location /t {
         content_by_lua_block {
@@ -1366,7 +1366,7 @@ passed
                                  "blacklist": [
                                      "jack1"
                                  ],
-                                 "allowed_methods":[{
+                                 "allowed_by_methods":[{
                                     "user":"jack1",
                                     "methods":["POST","GET"]
                                 }]
@@ -1388,7 +1388,7 @@ qr/\{"error_msg":"failed to check the configuration of plugin consumer-restricti
 
 
 
-=== TEST 42: set wrong scheme only allowed_methods
+=== TEST 42: set wrong scheme only allowed_by_methods
 --- config
     location /t {
         content_by_lua_block {
@@ -1406,7 +1406,7 @@ qr/\{"error_msg":"failed to check the configuration of plugin consumer-restricti
                         "plugins": {
                             "basic-auth": {},
                             "consumer-restriction": {
-                                 "allowed_methods":[{
+                                 "allowed_by_methods":[{
                                     "user":"jack1",
                                     "methods":["POST","GET"]
                                 }]
@@ -1422,7 +1422,7 @@ qr/\{"error_msg":"failed to check the configuration of plugin consumer-restricti
 GET /t
 --- error_code: 400
 --- response_body eval
-qr/\{"error_msg":"failed to check the configuration of plugin consumer-restriction err: allowed_methods set but no whitelist provided"}/
+qr/\{"error_msg":"failed to check the configuration of plugin consumer-restriction err: allowed_by_methods set but no whitelist provided"}/
 --- no_error_log
 [error]
 

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -207,6 +207,7 @@ passed
 [error]
 
 
+
 === TEST 6: verify unauthorized
 --- request
 GET /hello
@@ -240,6 +241,8 @@ Authorization: Basic amFjazIwMjA6MTIzNDU2
 {"message":"The consumer_name is forbidden."}
 --- no_error_log
 [error]
+
+
 
 === TEST 9: set blacklist
 --- config
@@ -470,6 +473,8 @@ Authorization: Basic amFjazIwMjA6MTIzNDU2
 --- no_error_log
 [error]
 
+
+
 === TEST 21: set allowed_methods
 --- config
     location /t {
@@ -514,6 +519,7 @@ passed
 [error]
 
 
+
 === TEST 22: verify jack1
 --- request
 GET /hello
@@ -524,6 +530,8 @@ Authorization: Basic amFjazIwMTk6MTIzNDU2
 {"message":"The consumer_name is forbidden."}
 --- no_error_log
 [error]
+
+
 
 === TEST 23: set allowed_methods
 --- config
@@ -568,6 +576,8 @@ passed
 --- no_error_log
 [error]
 
+
+
 === TEST 24: verify jack1
 --- request
 GET /hello
@@ -577,6 +587,8 @@ Authorization: Basic amFjazIwMTk6MTIzNDU2
 hello world
 --- no_error_log
 [error]
+
+
 
 === TEST 25: remove consumer-restriction
 --- config
@@ -1332,6 +1344,7 @@ passed
 [error]
 
 
+
 === TEST 41: set wrong scheme for allowed_methods and blacklist
 --- config
     location /t {
@@ -1373,6 +1386,8 @@ qr/\{"error_msg":"failed to check the configuration of plugin consumer-restricti
 --- no_error_log
 [error]
 
+
+
 === TEST 42: set wrong scheme only allowed_methods
 --- config
     location /t {
@@ -1410,6 +1425,7 @@ GET /t
 qr/\{"error_msg":"failed to check the configuration of plugin consumer-restriction err: allowed_methods set but no withelist provided"}/
 --- no_error_log
 [error]
+
 
 
 === TEST 43: delete: route (id: 1)

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -1422,7 +1422,7 @@ qr/\{"error_msg":"failed to check the configuration of plugin consumer-restricti
 GET /t
 --- error_code: 400
 --- response_body eval
-qr/\{"error_msg":"failed to check the configuration of plugin consumer-restriction err: allowed_methods set but no withelist provided"}/
+qr/\{"error_msg":"failed to check the configuration of plugin consumer-restriction err: allowed_methods set but no whitelist provided"}/
 --- no_error_log
 [error]
 

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -653,7 +653,7 @@ hello world
 
 
 
-=== TEST 28: test blacklist priority
+=== TEST 28: whitelist blacklist priority
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -207,7 +207,6 @@ passed
 [error]
 
 
-
 === TEST 6: verify unauthorized
 --- request
 GET /hello
@@ -241,8 +240,6 @@ Authorization: Basic amFjazIwMjA6MTIzNDU2
 {"message":"The consumer_name is forbidden."}
 --- no_error_log
 [error]
-
-
 
 === TEST 9: set blacklist
 --- config
@@ -473,9 +470,115 @@ Authorization: Basic amFjazIwMjA6MTIzNDU2
 --- no_error_log
 [error]
 
+=== TEST 21: set allowed_methods
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "uri": "/hello",
+                        "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                        },
+                        "plugins": {
+                            "basic-auth": {},
+                            "consumer-restriction": {
+                                 "whitelist": [
+                                     "jack1"
+                                 ],
+                                 "allowed_methods":[{
+                                    "user":"jack1",
+                                    "methods":["POST"]
+                                 }]
+                            }
+                        }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
 
 
-=== TEST 21: remove consumer-restriction
+=== TEST 22: verify jack1
+--- request
+GET /hello
+--- more_headers
+Authorization: Basic amFjazIwMTk6MTIzNDU2
+--- error_code: 403
+--- response_body
+{"message":"The consumer_name is forbidden."}
+--- no_error_log
+[error]
+
+=== TEST 23: set allowed_methods
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "uri": "/hello",
+                        "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                        },
+                        "plugins": {
+                            "basic-auth": {},
+                            "consumer-restriction": {
+                                 "whitelist": [
+                                     "jack1"
+                                 ],
+                                 "allowed_methods":[{
+                                    "user":"jack1",
+                                    "methods":["POST","GET"]
+                                }]
+                            }
+                        }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+=== TEST 24: verify jack1
+--- request
+GET /hello
+--- more_headers
+Authorization: Basic amFjazIwMTk6MTIzNDU2
+--- response_body
+hello world
+--- no_error_log
+[error]
+
+=== TEST 25: remove consumer-restriction
 --- config
     location /t {
         content_by_lua_block {
@@ -510,7 +613,7 @@ passed
 
 
 
-=== TEST 22: verify jack1
+=== TEST 26: verify jack1
 --- request
 GET /hello
 --- more_headers
@@ -522,7 +625,7 @@ hello world
 
 
 
-=== TEST 23: verify jack2
+=== TEST 27: verify jack2
 --- request
 GET /hello
 --- more_headers
@@ -534,7 +637,7 @@ hello world
 
 
 
-=== TEST 24: verify unauthorized
+=== TEST 28: verify unauthorized
 --- request
 GET /hello
 --- response_body
@@ -544,7 +647,7 @@ hello world
 
 
 
-=== TEST 25: create service (id:1)
+=== TEST 29: create service (id:1)
 --- config
     location /t {
         content_by_lua_block {
@@ -590,7 +693,7 @@ passed
 
 
 
-=== TEST 26: add consumer with plugin hmac-auth and consumer-restriction, and set whitelist
+=== TEST 30: add consumer with plugin hmac-auth and consumer-restriction, and set whitelist
 --- config
     location /t {
         content_by_lua_block {
@@ -647,7 +750,7 @@ passed
 
 
 
-=== TEST 27: Route binding `hmac-auth` plug-in and whitelist `service_id`
+=== TEST 31: Route binding `hmac-auth` plug-in and whitelist `service_id`
 --- config
     location /t {
         content_by_lua_block {
@@ -706,7 +809,7 @@ passed
 
 
 
-=== TEST 28: verify: valid whitelist `service_id`
+=== TEST 32: verify: valid whitelist `service_id`
 --- config
 location /t {
     content_by_lua_block {
@@ -766,7 +869,7 @@ passed
 
 
 
-=== TEST 29: create service (id:2)
+=== TEST 33: create service (id:2)
 --- config
     location /t {
         content_by_lua_block {
@@ -812,7 +915,7 @@ passed
 
 
 
-=== TEST 30: Route binding `hmac-auth` plug-in and invalid whitelist `service_id`
+=== TEST 34: Route binding `hmac-auth` plug-in and invalid whitelist `service_id`
 --- config
     location /t {
         content_by_lua_block {
@@ -871,7 +974,7 @@ passed
 
 
 
-=== TEST 31: verify: invalid whitelist `service_id`
+=== TEST 35: verify: invalid whitelist `service_id`
 --- config
 location /t {
     content_by_lua_block {
@@ -934,7 +1037,7 @@ qr/\{"message":"The service_id is forbidden."\}/
 
 
 
-=== TEST 32: add consumer with plugin hmac-auth and consumer-restriction, and set blacklist
+=== TEST 36: add consumer with plugin hmac-auth and consumer-restriction, and set blacklist
 --- config
     location /t {
         content_by_lua_block {
@@ -991,7 +1094,7 @@ passed
 
 
 
-=== TEST 33: Route binding `hmac-auth` plug-in and blacklist `service_id`
+=== TEST 37: Route binding `hmac-auth` plug-in and blacklist `service_id`
 --- config
     location /t {
         content_by_lua_block {
@@ -1050,7 +1153,7 @@ passed
 
 
 
-=== TEST 34: verify: valid blacklist `service_id`
+=== TEST 38: verify: valid blacklist `service_id`
 --- config
 location /t {
     content_by_lua_block {
@@ -1111,7 +1214,7 @@ qr/\{"message":"The service_id is forbidden."\}/
 
 
 
-=== TEST 35: Route binding `hmac-auth` plug-in and invalid blacklist `service_id`
+=== TEST 39: Route binding `hmac-auth` plug-in and invalid blacklist `service_id`
 --- config
     location /t {
         content_by_lua_block {
@@ -1170,7 +1273,7 @@ passed
 
 
 
-=== TEST 36: verify: invalid blacklist `service_id`
+=== TEST 40: verify: invalid blacklist `service_id`
 --- config
 location /t {
     content_by_lua_block {
@@ -1229,8 +1332,87 @@ passed
 [error]
 
 
+=== TEST 41: set wrong scheme for allowed_methods and blacklist
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "uri": "/hello",
+                        "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                        },
+                        "plugins": {
+                            "basic-auth": {},
+                            "consumer-restriction": {
+                                 "blacklist": [
+                                     "jack1"
+                                 ],
+                                 "allowed_methods":[{
+                                    "user":"jack1",
+                                    "methods":["POST","GET"]
+                                }]
+                            }
+                        }
+                }]]
+                )
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- error_code: 400
+--- response_body eval
+qr/\{"error_msg":"failed to check the configuration of plugin consumer-restriction err: value should match only one schema, but matches both schemas 1 and 3"}/
+--- no_error_log
+[error]
 
-=== TEST 37: delete: route (id: 1)
+=== TEST 42: set wrong scheme only allowed_methods
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "uri": "/hello",
+                        "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                        },
+                        "plugins": {
+                            "basic-auth": {},
+                            "consumer-restriction": {
+                                 "allowed_methods":[{
+                                    "user":"jack1",
+                                    "methods":["POST","GET"]
+                                }]
+                            }
+                        }
+                }]]
+                )
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- error_code: 400
+--- response_body eval
+qr/\{"error_msg":"failed to check the configuration of plugin consumer-restriction err: allowed_methods set but no withelist provided"}/
+--- no_error_log
+[error]
+
+
+=== TEST 43: delete: route (id: 1)
 --- config
     location /t {
         content_by_lua_block {
@@ -1250,7 +1432,7 @@ passed
 
 
 
-=== TEST 38: delete: `service_id` is 1
+=== TEST 44: delete: `service_id` is 1
 --- config
     location /t {
         content_by_lua_block {
@@ -1270,7 +1452,7 @@ passed
 
 
 
-=== TEST 39: delete: `service_id` is 2
+=== TEST 45: delete: `service_id` is 2
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
### What this PR does / why we need it:
Fix for #3635 
Add the possibility to add `allowed_methods` for a user when `whitelist` is set.
This will restrict the user to only performed the HTTP action matching the list specified in `allowed_method.methods`

This is the format : 
```
"plugins": {
        "key-auth": {},
        "consumer-restriction": {
            "whitelist": [
                "jack1"
            ],
            "allowed_methods":[{
              "user": "jack1",
              "methods": ["POST"]
            }]
        }
    }
```
I choose to add a dedicated section instead of modifying the existing `whitelist` one because i think it's more readable. 
When nothing is set , then only the whitelist is applied .
And in order to set `allowed_methods` , `whitelist` is required.

### Pre-submission checklist:
Test case updated with 2 basics tests 
1. only allow `post` on resources and try to `get` the resource -> unauthorized
2. Add `get`capability to the user and try to `get` the resource -> authorized

Add 2 test cases for testing the plugin scheme 

1. Only `allowed_methods` is set -> failed
2. `allowed_methods` is set with `blacklist` -> failed

English documentation updated , any help for the Chineese one would be appreciated.

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [X] Have you added corresponding test cases?
* [X] Have you modified the corresponding document?
* [X] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
