### PR TITLE
fix: validate plugins configuration of `plugin_config` via incremental sync

### DIFF
--- a/apisix/plugin_config.lua
+++ b/apisix/plugin_config.lua
@@ -31,6 +31,7 @@ function _M.init_worker()
     local err
     plugin_configs, err = core.config.new("/plugin_configs", {
         automatic = true,
+        item_schema = core.schema.plugin_config,
         checker = plugin_checker,
     })
     if not plugin_configs then

--- a/t/node/plugin-configs.t
+++ b/t/node/plugin-configs.t
@@ -123,3 +123,38 @@ qr/conf_version: \d+#\d/
 qr/conf_version: \d+#1
 conf_version: \d+#2
 /
+
+
+
+=== TEST 2: validated plugins configuration via incremental sync
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local core = require("apisix.core")
+
+            assert(core.etcd.set("/plugin_configs/1",
+                {id = 1, plugins = { ["uri-blocker"] = { block_rules =  {"root.exe","root.m+"} }}}
+            ))
+            -- wait for sync
+            ngx.sleep(0.6)
+
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port
+                        .. "/hello?x=root.exe"
+
+            local httpc = http.new()
+            local res, err = httpc:request_uri(uri, {method = "GET"})
+            if not res then
+                ngx.say(err)
+                return
+            end
+
+            ngx.status = res.status
+            ngx.say(uri)
+            ngx.say(res.body)
+
+        }
+    }
+--- request
+GET /t
+--- error_code: 403

--- a/t/node/plugin-configs.t
+++ b/t/node/plugin-configs.t
@@ -158,3 +158,24 @@ conf_version: \d+#2
 --- request
 GET /t
 --- error_code: 403
+
+
+
+=== TEST 3: validated plugins configuration via incremental sync (malformed data)
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local core = require("apisix.core")
+
+            assert(core.etcd.set("/plugin_configs/1",
+                {id = 1, plugins = { ["uri-blocker"] = { block_rules =  1 }}}
+            ))
+            -- wait for sync
+            ngx.sleep(0.6)
+        }
+    }
+--- request
+GET /t
+--- error_log
+property "block_rules" validation failed


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

close #3674

Currently, the `item_schema` is not set for `plugin_config`, 
which causes the plugin configuration to not be validated when incrementally updated from ETCD (see: https://github.com/apache/apisix/blob/master/apisix/core/config_etcd.lua#L347), 
resulting in the default value of the plugin configuration not being set.


### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
