### PR TITLE
chore: expose schema of `plugin_config` via control API

### DIFF
--- a/apisix/control/v1.lua
+++ b/apisix/control/v1.lua
@@ -33,6 +33,7 @@ function _M.schema()
         main = {
             consumer = core.schema.consumer,
             global_rule = core.schema.global_rule,
+            plugin_config = core.schema.plugin_config,
             plugins = core.schema.plugins,
             proto = core.schema.proto,
             route = core.schema.route,

--- a/t/control/schema.t
+++ b/t/control/schema.t
@@ -51,6 +51,7 @@ __DATA__
                     "main": {
                         "consumer": {"type":"object"},
                         "global_rule": {"type":"object"},
+                        "plugin_config": {"type":"object"},
                         "plugins": {"type":"array"},
                         "proto": {"type":"object"},
                         "route": {"type":"object"},


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

expose schema of `plugin_config` via control API,

Then, we can use the schema to verify the configuration of `plugin_config` in Dashboard.


### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
