### PR TITLE
chore: use the # operator to get the length of the Lua string

### DIFF
--- a/apisix/plugins/log-rotate.lua
+++ b/apisix/plugins/log-rotate.lua
@@ -61,7 +61,7 @@ local function get_last_index(str, key)
     local _, idx = str_find(rev, key)
     local n
     if idx then
-        n = string.len(rev) - idx + 1
+        n = #rev - idx + 1
     end
 
     return n

--- a/apisix/plugins/proxy-cache.lua
+++ b/apisix/plugins/proxy-cache.lua
@@ -194,7 +194,7 @@ local function generate_cache_filename(cache_path, cache_levels, cache_key)
     local levels = ngx_re.split(cache_levels, ":")
     local filename = ""
 
-    local index = string.len(md5sum)
+    local index = #md5sum
     for k, v in pairs(levels) do
         local length = tonumber(v)
         index = index - length


### PR DESCRIPTION
You should always use the # operator to get the length of the Lua string instead of the string.len

according to:
https://yousali.me/openresty-best-practices/lua/string_library.html

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
