### PR TITLE
docs: Missing plugins doc of apisix shown in website

### DIFF
--- a/docs/en/latest/config.json
+++ b/docs/en/latest/config.json
@@ -23,7 +23,9 @@
           "items": [
             "plugins/batch-requests",
             "plugins/serverless",
-            "plugins/redirect"
+            "plugins/redirect",
+            "plugins/echo",
+            "plugins/server-info"
           ]
         },
         {
@@ -45,7 +47,8 @@
             "plugins/basic-auth",
             "plugins/authz-keycloak",
             "plugins/wolf-rbac",
-            "plugins/openid-connect"
+            "plugins/openid-connect",
+            "plugins/hmac-auth"
           ]
         },
         {
@@ -55,7 +58,8 @@
             "plugins/cors",
             "plugins/uri-blocker",
             "plugins/ip-restriction",
-            "plugins/referer-restriction"
+            "plugins/referer-restriction",
+            "plugins/consumer-restriction"
           ]
         },
         {
@@ -69,7 +73,8 @@
             "plugins/request-validation",
             "plugins/proxy-mirror",
             "plugins/api-breaker",
-            "plugins/traffic-split"
+            "plugins/traffic-split",
+            "plugins/request-id"
           ]
         },
         {
@@ -78,7 +83,8 @@
           "items": [
             "plugins/prometheus",
             "plugins/zipkin",
-            "plugins/skywalking"
+            "plugins/skywalking",
+            "plugins/node-status"
           ]
         },
         {
@@ -90,7 +96,17 @@
             "plugins/kafka-logger",
             "plugins/udp-logger",
             "plugins/syslog",
-            "plugins/log-rotate"
+            "plugins/log-rotate",
+            "plugins/error-log-logger",
+            "plugins/sls-logger"
+          ]
+        },
+        {
+          "type": "category",
+          "label": "Other Protocols",
+          "items": [
+            "plugins/dubbo-proxy",
+            "plugins/mqtt-proxy"
           ]
         }
       ]

--- a/docs/zh/latest/config.json
+++ b/docs/zh/latest/config.json
@@ -99,7 +99,7 @@
         },
         {
           "type": "category",
-          "label": "Other Protocols",
+          "label": "其它",
           "items": [
             "plugins/dubbo-proxy",
             "plugins/mqtt-proxy"

--- a/docs/zh/latest/config.json
+++ b/docs/zh/latest/config.json
@@ -19,7 +19,9 @@
           "items": [
             "plugins/batch-requests",
             "plugins/serverless",
-            "plugins/redirect"
+            "plugins/redirect",
+            "plugins/echo",
+            "plugins/server-info"
           ]
         },
         {
@@ -41,7 +43,8 @@
             "plugins/key-auth",
             "plugins/jwt-auth",
             "plugins/basic-auth",
-            "plugins/openid-connect"
+            "plugins/openid-connect",
+            "plugins/hmac-auth"
           ]
         },
         {
@@ -51,7 +54,8 @@
             "plugins/cors",
             "plugins/uri-blocker",
             "plugins/ip-restriction",
-            "plugins/referer-restriction"
+            "plugins/referer-restriction",
+            "plugins/consumer-restriction"
           ]
         },
         {
@@ -65,7 +69,8 @@
             "plugins/request-validation",
             "plugins/proxy-mirror",
             "plugins/api-breaker",
-            "plugins/traffic-split"
+            "plugins/traffic-split",
+            "plugins/request-id"
           ]
         },
         {
@@ -74,7 +79,8 @@
           "items": [
             "plugins/prometheus",
             "plugins/zipkin",
-            "plugins/skywalking"
+            "plugins/skywalking",
+            "plugins/node-status"
           ]
         },
         {
@@ -86,7 +92,17 @@
             "plugins/kafka-logger",
             "plugins/udp-logger",
             "plugins/syslog",
-            "plugins/log-rotate"
+            "plugins/log-rotate",
+            "plugins/error-log-logger",
+            "plugins/sls-logger"
+          ]
+        },
+        {
+          "type": "category",
+          "label": "Other Protocols",
+          "items": [
+            "plugins/dubbo-proxy",
+            "plugins/mqtt-proxy"
           ]
         }
       ]


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
There are some missing docs plugins of apisix on the website.

We could find the missing plugins in the doc folder of the apisix repo, but they are not present on the website, because they are not added in the "config.json" file.
So this PR fixes the above issue, as all the missing plugins are added in the "docs/en/latest/config.json" and "docs/zh/latest/config.json" file.

<!--- If it fixes an open issue, please link to the issue here. -->
Fix: https://github.com/apache/apisix-website/issues/236

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
