### PR TITLE
fix: the traffic-split plugin is invalid to bind upstream via upstream_id

### DIFF
--- a/apisix/plugins/traffic-split.lua
+++ b/apisix/plugins/traffic-split.lua
@@ -314,7 +314,8 @@ function _M.access(conf, ctx)
         return
     end
 
-    local rr_up, err = lrucache(weighted_upstreams, nil, new_rr_obj, weighted_upstreams, ctx.matched_route.value.upstream_id)
+    local rr_up, err = lrucache(weighted_upstreams, nil, new_rr_obj, weighted_upstreams,
+                                ctx.matched_route.value.upstream_id)
     if not rr_up then
         core.log.error("lrucache roundrobin failed: ", err)
         return 500

--- a/apisix/plugins/traffic-split.lua
+++ b/apisix/plugins/traffic-split.lua
@@ -306,8 +306,8 @@ function _M.access(conf, ctx)
     core.log.info("match_flag: ", match_flag)
 
     if not match_flag then
-        if ctx.matched_route.value["original_uid"] then
-            ctx.matched_route.value.upstream_id = ctx.matched_route.value["original_uid"]
+        if ctx.matched_route.value.original_upstream_id then
+            ctx.matched_route.value.upstream_id = ctx.matched_route.value.original_upstream_id
             core.log.info("original_uid: ", ctx.matched_route.value.upstream_id)
         end
         return
@@ -324,7 +324,7 @@ function _M.access(conf, ctx)
         core.log.info("upstream: ", core.json.encode(upstream))
         return set_upstream(upstream, ctx)
     elseif upstream and upstream ~= "plugin#upstream#is#empty" then
-        ctx.matched_route.value["original_uid"] = ctx.matched_route.value.upstream_id
+        ctx.matched_route.value.original_upstream_id = ctx.matched_route.value.upstream_id
         ctx.matched_route.value.upstream_id = upstream
         core.log.info("upstream_id: ", upstream)
         return

--- a/apisix/plugins/traffic-split.lua
+++ b/apisix/plugins/traffic-split.lua
@@ -306,6 +306,10 @@ function _M.access(conf, ctx)
     core.log.info("match_flag: ", match_flag)
 
     if not match_flag then
+        if ctx.matched_route.value["original_uid"] then
+            ctx.matched_route.value.upstream_id = ctx.matched_route.value["original_uid"]
+            core.log.info("original_uid: ", ctx.matched_route.value.upstream_id)
+        end
         return
     end
 
@@ -320,6 +324,7 @@ function _M.access(conf, ctx)
         core.log.info("upstream: ", core.json.encode(upstream))
         return set_upstream(upstream, ctx)
     elseif upstream and upstream ~= "plugin#upstream#is#empty" then
+        ctx.matched_route.value["original_uid"] = ctx.matched_route.value.upstream_id
         ctx.matched_route.value.upstream_id = upstream
         core.log.info("upstream_id: ", upstream)
         return

--- a/apisix/plugins/traffic-split.lua
+++ b/apisix/plugins/traffic-split.lua
@@ -314,8 +314,9 @@ function _M.access(conf, ctx)
         return
     end
 
+    local route_upstream_id = ctx.matched_route.value.upstream_id
     local rr_up, err = lrucache(weighted_upstreams, nil, new_rr_obj, weighted_upstreams,
-                                ctx.matched_route.value.upstream_id)
+                                route_upstream_id)
     if not rr_up then
         core.log.error("lrucache roundrobin failed: ", err)
         return 500

--- a/apisix/plugins/traffic-split.lua
+++ b/apisix/plugins/traffic-split.lua
@@ -315,8 +315,8 @@ function _M.access(conf, ctx)
     end
 
     local route_upstream_id = ctx.matched_route.value.upstream_id
-    local rr_up, err = lrucache(weighted_upstreams, nil, new_rr_obj, weighted_upstreams,
-                                route_upstream_id)
+    local rr_up, err = core.lrucache.plugin_ctx(lrucache, ctx, nil, new_rr_obj,
+                                                weighted_upstreams,route_upstream_id)
     if not rr_up then
         core.log.error("lrucache roundrobin failed: ", err)
         return 500

--- a/t/plugin/traffic-split.t
+++ b/t/plugin/traffic-split.t
@@ -1664,13 +1664,8 @@ passed
 ["GET /hello", "GET /hello1", "GET /hello", "GET /hello1", "GET /hello", "GET /hello1"]
 --- response_body eval
 ["hello world\n", "hello1 world\n", "hello world\n", "hello1 world\n", "hello world\n", "hello1 world\n"]
---- grep_error_log_out eval
-[
-"match_flag: true",
-"upstream_id: 2",
-"match_flag: false",
-"original_uid: 1"
-]
+--- no_error_log
+[error]
 
 
 

--- a/t/plugin/traffic-split.t
+++ b/t/plugin/traffic-split.t
@@ -1724,9 +1724,8 @@ location /t {
     content_by_lua_block {
         local t = require("lib.test_admin").test
         local bodys = {}
-        local headers = {}
         for i = 1, 6 do
-            local _, _, body = t('/server_port', ngx.HTTP_GET, "", nil, headers)
+            local _, _, body = t('/server_port', ngx.HTTP_GET)
             bodys[i] = body
         end
         table.sort(bodys)


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix: #3740 
### Pre-submission checklist:
the cause of the bug reference: https://github.com/apache/apisix/issues/3740#issuecomment-789852741
~~this change temporarily stores the route's `upstream_id` in the `matched_route` table. If the current request `match` fails and the temporarily stored `upstream_id` exists in the `matched_route` table, the route's `upstream_id` is restored to the temporarily stored `upstream_id`.~~
when the `route` is configured with an `upstream_id`, the `upstream_id` is passed into the `server_list`.
* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
