### PR TITLE
test: make control/discovery.t stable

### DIFF
--- a/t/control/discovery.t
+++ b/t/control/discovery.t
@@ -88,16 +88,33 @@ GET /t
             local t = require("lib.test_admin")
 
             local code, body, res = t.test('/v1/discovery/eureka/dump',
-                ngx.HTTP_GET)
-            local entity = json.decode(res)
-            ngx.say(json.encode(entity))
+                ngx.HTTP_GET, nil,
+                [[{
+                    "config": {
+                        "fetch_interval": 10,
+                        "host": [
+                            "http://127.0.0.1:8761"
+                        ],
+                        "prefix": "/eureka/",
+                        "timeout": {
+                            "connect": 1500,
+                            "read": 1500,
+                            "send": 1500
+                        },
+                        "weight": 80
+                    },
+                    "services": {}
+                }]]
+                )
+            ngx.satus = code
+            ngx.say(body)
         }
     }
 --- request
 GET /t
 --- error_code: 200
 --- response_body
-{"config":{"fetch_interval":10,"host":["http://127.0.0.1:8761"],"prefix":"/eureka/","timeout":{"connect":1500,"read":1500,"send":1500},"weight":80},"services":{}}
+passed
 
 
 


### PR DESCRIPTION
Sometimes Eureka has injected the service when the test runs.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
