### PR TITLE
feat: add dump for consul_kv

### DIFF
--- a/apisix/control/router.lua
+++ b/apisix/control/router.lua
@@ -46,7 +46,7 @@ local function format_dismod_uri(mod_name, uri)
 end
 
 -- we do not hardcode the discovery module's control api uri
-local function format_dismod_controlapi_uris(mod_name, api_route)
+local function format_dismod_control_api_uris(mod_name, api_route)
     if not api_route or #api_route == 0 then
         return api_route
     end
@@ -113,7 +113,7 @@ function fetch_control_api_router()
             local api_fun = dis_mod.control_api
             if api_fun then
                 local api_route = api_fun()
-                local format_route = format_dismod_controlapi_uris(key, api_route)
+                local format_route = format_dismod_control_api_uris(key, api_route)
                 register_api_routes(routes, format_route)
             end
 

--- a/apisix/control/router.lua
+++ b/apisix/control/router.lua
@@ -31,6 +31,41 @@ local get_method = ngx.req.get_method
 local _M = {}
 
 
+local function format_dismod_uri(mod_name, uri)
+    if core.string.has_prefix(uri, "/v1/") then
+        return uri
+    end
+
+    local tmp = {"/v1/discovery/", mod_name}
+    if not core.string.has_prefix(uri, "/") then
+        core.table.insert(tmp, "/")
+    end
+    core.table.insert(tmp, uri)
+
+    return core.table.concat(tmp, "")
+end
+
+-- we do not hardcode the discovery module's control api uri
+local function format_dismod_controlapi_uris(mod_name, api_route)
+    if not api_route or #api_route == 0 then
+        return api_route
+    end
+
+    local clone_route = core.table.clone(api_route)
+    for _, v in ipairs(clone_route) do
+        local uris = v.uris
+        local target_uris = core.table.new(#uris, 0)
+        for _, uri in ipairs(uris) do
+            local target_uri = format_dismod_uri(mod_name, uri)
+            core.table.insert(target_uris, target_uri)
+        end
+        v.uris = target_uris
+    end
+
+    return clone_route
+end
+
+
 local fetch_control_api_router
 do
     local function register_api_routes(routes, api_routes)
@@ -78,14 +113,16 @@ function fetch_control_api_router()
             local api_fun = dis_mod.control_api
             if api_fun then
                 local api_route = api_fun()
-                register_api_routes(routes, api_route)
+                local format_route = format_dismod_controlapi_uris(key, api_route)
+                register_api_routes(routes, format_route)
             end
 
             local dump_data = dis_mod.dump_data
             if dump_data then
+                local target_uri = format_dismod_uri(key, "/dump")
                 local item = {
                     methods = {"GET"},
-                    uris = {"/v1/discovery/" .. key .. "/dump"},
+                    uris = {target_uri},
                     handler = function()
                         return 200, dump_data()
                     end

--- a/apisix/discovery/consul_kv.lua
+++ b/apisix/discovery/consul_kv.lua
@@ -262,7 +262,7 @@ local function read_dump_srvs()
     end
 
     if not entity.services or not entity.last_update then
-        log.error("decoded dump data miss fields, file content: ", data)
+        log.warn("decoded dump data miss fields, file content: ", data)
         return
     end
 
@@ -270,9 +270,8 @@ local function read_dump_srvs()
     log.info("dump file last_update: ", entity.last_update, ", dump_params.expire: ",
         dump_params.expire, ", now_time: ", now_time)
     if dump_params.expire ~= 0  and (entity.last_update + dump_params.expire) < now_time then
-       log.warn("dump file: ", dump_params.path,
-         " had expired, ignored it")
-        return
+       log.warn("dump file: ", dump_params.path, " had expired, ignored it")
+       return
     end
 
     applications = entity.services

--- a/apisix/discovery/consul_kv.lua
+++ b/apisix/discovery/consul_kv.lua
@@ -266,7 +266,10 @@ local function read_dump_srvs()
         return
     end
 
-    if dump_params.expire ~= 0  and (entity.last_update + dump_params.expire) < ngx.time() then
+    local now_time = ngx.time()
+    core.log.info("dump file last_update: ", entity.last_update, ", dump_params.expire: ",
+        dump_params.expire, ", now_time: ", now_time)
+    if dump_params.expire ~= 0  and (entity.last_update + dump_params.expire) < now_time then
        core.log.warn("dump file: ", dump_params.path,
          " had expired, ignored it")
         return

--- a/apisix/discovery/consul_kv.lua
+++ b/apisix/discovery/consul_kv.lua
@@ -301,7 +301,7 @@ local function show_dump_file()
 
     local data, err = util.read_file(dump_params.path)
     if not data then
-        return 500, err
+        return 503, err
     end
 
     return 200, data

--- a/apisix/discovery/consul_kv.lua
+++ b/apisix/discovery/consul_kv.lua
@@ -248,35 +248,35 @@ local function read_dump_srvs()
         return
     end
 
-    core.log.info("read dump file: ", data)
+    log.info("read dump file: ", data)
     data = util.trim(data)
     if #data == 0 then
-        core.log.error("dump file is empty")
+        log.error("dump file is empty")
         return
     end
 
     local entity, err  = core.json.decode(data)
     if err then
-        core.log.error("decoded dump data got error: ", err, ", file content: ", data)
+        log.error("decoded dump data got error: ", err, ", file content: ", data)
         return
     end
 
     if not entity.services or not entity.last_update then
-        core.log.error("decoded dump data miss fields, file content: ", data)
+        log.error("decoded dump data miss fields, file content: ", data)
         return
     end
 
     local now_time = ngx.time()
-    core.log.info("dump file last_update: ", entity.last_update, ", dump_params.expire: ",
+    log.info("dump file last_update: ", entity.last_update, ", dump_params.expire: ",
         dump_params.expire, ", now_time: ", now_time)
     if dump_params.expire ~= 0  and (entity.last_update + dump_params.expire) < now_time then
-       core.log.warn("dump file: ", dump_params.path,
+       log.warn("dump file: ", dump_params.path,
          " had expired, ignored it")
         return
     end
 
     applications = entity.services
-    core.log.info("load dump file into memory success")
+    log.info("load dump file into memory success")
 end
 
 
@@ -289,7 +289,7 @@ local function write_dump_srvs()
     local data = core.json.encode(entity)
     local succ, err =  util.write_file(dump_params.path, data)
     if not succ then
-        core.log.error("write dump into file got error: ", err)
+        log.error("write dump into file got error: ", err)
     end
 end
 

--- a/apisix/discovery/consul_kv.lua
+++ b/apisix/discovery/consul_kv.lua
@@ -296,7 +296,7 @@ end
 
 local function show_dump_file()
     if not dump_params then
-        return 500, "dump params is nil"
+        return 503, "dump params is nil"
     end
 
     local data, err = util.read_file(dump_params.path)

--- a/apisix/discovery/consul_kv.lua
+++ b/apisix/discovery/consul_kv.lua
@@ -440,12 +440,7 @@ function _M.init_worker()
 
     if consul_conf.dump then
       local dump = consul_conf.dump
-      if not dump.path or #dump.path == 0 then
-          error("invalid consul_kv dump path")
-          return
-      end
-
-      dump_params = consul_conf.dump
+      dump_params = dump
 
       if dump.load_on_init then
           read_dump_srvs()

--- a/apisix/discovery/consul_kv.lua
+++ b/apisix/discovery/consul_kv.lua
@@ -244,7 +244,7 @@ end
 local function read_dump_srvs()
     local data, err = util.read_file(dump_params.path)
     if not data then
-        log.warn("read dump file get error: ", err)
+        log.notice("read dump file get error: ", err)
         return
     end
 

--- a/apisix/discovery/consul_kv.lua
+++ b/apisix/discovery/consul_kv.lua
@@ -87,10 +87,11 @@ local schema = {
         dump = {
             type = "object",
             properties = {
-                path = {type = "string"},
+                path = {type = "string", minLength = 1},
                 load_on_init = {type = "boolean", default = true},
                 expire = {type = "integer", default = 0},
-            }
+            },
+            required = {"path"},
         },
         default_service = {
             type = "object",
@@ -292,12 +293,12 @@ end
 
 local function show_dump_file()
     if not dump_params then
-        return 200, "dump params is nil"
+        return 500, "dump params is nil"
     end
 
     local data, err = util.read_file(dump_params.path)
     if not data then
-        return 200, err
+        return 500, err
     end
 
     return 200, data
@@ -397,7 +398,7 @@ local function format_consul_params(consul_conf)
         if scheme ~= "http" then
             return nil, "only support consul http schema address, eg: http://address:port"
         elseif path ~= "/" or core.string.has_suffix(v, '/') then
-            return nil, "invald consul server address, the valid format: http://address:port"
+            return nil, "invalid consul server address, the valid format: http://address:port"
         end
 
         core.table.insert(consul_server_list, {

--- a/docs/en/latest/discovery/consul_kv.md
+++ b/docs/en/latest/discovery/consul_kv.md
@@ -94,11 +94,12 @@ The `dump` has three optional values now:
     - make sure the dump file's parent path exist
     - make sure the `apisix` has the dump file's read-write access permission,eg: `chown  www:root conf/upstream.d/`
 - `load_on_init`, default value is `true`
-    - if `true`, load the data from dump file before load data from consul
+    - if `true`, will try load the data from dump file before load data from consul
     - if `false`, ignore load data
+    - and anyhow, we don't need to prepare a dump file for apisix at anytime
 - `expire`, unit sec, avoiding load expired dump data when load
     - default `0`, it is unexpired forever
-    - recommend 2592000, which is 30 days(3600 * 24 * 30)
+    - recommend 2592000, which is 30 days(equals 3600 \* 24 \* 30)
 
 ### Register Http API Services
 

--- a/docs/en/latest/discovery/consul_kv.md
+++ b/docs/en/latest/discovery/consul_kv.md
@@ -57,6 +57,9 @@ discovery:
         fail_timeout: 1           # default 1 ms
         weight: 1                 # default 1
         max_fails: 1              # default 1
+    dump:                         # if you need, when registered nodes updated can dump into file
+       path: "logs/consul_kv.dump"
+       expire: 2592000      # unit sec, here is 30 day
 ```
 
 And you can config it in short by default value:
@@ -72,6 +75,30 @@ The `keepalive` has two optional values:
 
 - `true`, default and recommend value, use the long pull way to query consul servers
 - `false`, not recommend, it would use the short pull way to query consul servers, then you can set the `fetch_interval` for fetch interval
+
+#### Dump Data
+
+When we need reload `apisix` online, as the `consul_kv` module maybe loads data from CONSUL slower than load routes from ETCD, and would get the log at the moment before load successfully from consul:
+
+```
+ http_access_phase(): failed to set upstream: no valid upstream node
+```
+
+So, we import the `dump` function for `consul_kv` module. When reload, would load the dump file before from consul; when the registered nodes in consul been updated, would dump the upstream nodes into file automatically.
+
+The `dump` has three optional values now:
+
+- `path`, the dump file save path
+    - support relative path, eg: `logs/consul_kv.dump`
+    - support absolute path, eg: `/tmp/consul_kv.bin`
+    - make sure the dump file's parent path exist
+    - make sure the `apisix` has the dump file's read-write access permission,eg: `chown  www:root conf/upstream.d/`
+- `load_on_init`, default value is `true`
+    - if `true`, load the data from dump file before load data from consul
+    - if `false`, ignore load data
+- `expire`, unit sec, avoiding load expired dump data when load
+    - default `0`, it is unexpired forever
+    - recommend 2592000, which is 30 days(3600 * 24 * 30)
 
 ### Register Http API Services
 
@@ -147,7 +174,9 @@ You could find more usage in the `apisix/t/discovery/consul_kv.t` file.
 
 ## Debugging API
 
-It also offers control api for debugging:
+It also offers control api for debugging.
+
+### Memory Dump API
 
 ```shell
 GET /v1/discovery/consul_kv/dump
@@ -218,5 +247,37 @@ For example:
       }
     ]
   }
+}
+```
+
+### Show Dump File API
+
+It offers another control api for dump file view now. Maybe would add more api for debugging in future.
+
+```shell
+GET /v1/discovery/consul_kv/show_dump_file
+```
+
+For example:
+
+```shell
+curl http://127.0.0.1:9090/v1/discovery/consul_kv/show_dump_file | jq
+{
+  "services": {
+    "http://172.19.5.31:8500/v1/kv/upstreams/1614480/webpages/": [
+      {
+        "host": "172.19.5.12",
+        "port": 8000,
+        "weight": 120
+      },
+      {
+        "host": "172.19.5.13",
+        "port": 8000,
+        "weight": 120
+      }
+    ]
+  },
+  "expire": 0,
+  "last_update": 1615877468
 }
 ```

--- a/docs/en/latest/discovery/consul_kv.md
+++ b/docs/en/latest/discovery/consul_kv.md
@@ -94,9 +94,9 @@ The `dump` has three optional values now:
     - make sure the dump file's parent path exist
     - make sure the `apisix` has the dump file's read-write access permission,eg: `chown  www:root conf/upstream.d/`
 - `load_on_init`, default value is `true`
-    - if `true`, will try load the data from dump file before load data from consul
-    - if `false`, ignore load data
-    - and anyhow, we don't need to prepare a dump file for apisix at anytime
+    - if `true`, just try to load the data from the dump file before loading data from  consul when starting, does not care the dump file exists or not
+    - if `false`, ignore loading data from the dump file
+    - Whether `true` or `false`, we don't need to prepare a dump file for apisix at anytime
 - `expire`, unit sec, avoiding load expired dump data when load
     - default `0`, it is unexpired forever
     - recommend 2592000, which is 30 days(equals 3600 \* 24 \* 30)

--- a/t/core/utils.t
+++ b/t/core/utils.t
@@ -317,3 +317,4 @@ apisix:
 GET /t
 --- error_log
 error: failed to query the DNS server
+--- timeout: 10

--- a/t/discovery/consul_kv_dump.t
+++ b/t/discovery/consul_kv_dump.t
@@ -97,7 +97,7 @@ location /v1/kv {
             ngx.say(json.encode(entity.services))
         }
     }
---- timeout: 12
+--- timeout: 3
 --- request
 GET /t
 --- response_body

--- a/t/discovery/consul_kv_dump.t
+++ b/t/discovery/consul_kv_dump.t
@@ -347,7 +347,7 @@ success
 
 
 
-=== TEST 12: test 500 show_dump_file
+=== TEST 12: dump file inexistence
 --- yaml_config
 apisix:
   node_listen: 1984
@@ -364,11 +364,11 @@ discovery:
 #END
 --- request
 GET /v1/discovery/consul_kv/show_dump_file
---- error_code: 500
+--- error_code: 503
 
 
 
-=== TEST 13: test 503 show_dump_file
+=== TEST 13: no dump config
 --- yaml_config
 apisix:
   node_listen: 1984

--- a/t/discovery/consul_kv_dump.t
+++ b/t/discovery/consul_kv_dump.t
@@ -1,0 +1,346 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+log_level("info");
+
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    my $http_config = $block->http_config // <<_EOC_;
+
+    server {
+        listen 30511;
+
+        location /hello {
+            content_by_lua_block {
+                ngx.say("server 1")
+            }
+        }
+    }
+_EOC_
+
+    $block->set_value("http_config", $http_config);
+});
+
+our $yaml_config = <<_EOC_;
+apisix:
+  node_listen: 1984
+  config_center: yaml
+  enable_admin: false
+  enable_control: true
+
+discovery:
+  consul_kv:
+    servers:
+      - "http://127.0.0.1:8500"
+    dump:
+      path: "consul_kv.dump"
+      load_on_init: true
+_EOC_
+
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: prepare nodes
+--- config
+location /v1/kv {
+    proxy_pass http://127.0.0.1:8500;
+}
+--- request eval
+[
+    "DELETE /v1/kv/upstreams/?recurse=true",
+    "PUT /v1/kv/upstreams/webpages/127.0.0.1:30511\n" . "{\"weight\": 1, \"max_fails\": 1, \"fail_timeout\": 1}",
+]
+--- response_body eval
+[
+    'true',
+    'true',
+    'true',
+]
+
+
+
+=== TEST 2: show dump services
+--- yaml_config eval: $::yaml_config
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local t = require("lib.test_admin")
+            ngx.sleep(2)
+
+            local code, body, res = t.test('/v1/discovery/consul_kv/show_dump_file',
+                ngx.HTTP_GET)
+            local entity = json.decode(res)
+            ngx.say(json.encode(entity.services))
+        }
+    }
+--- timeout: 12
+--- request
+GET /t
+--- response_body
+{"http://127.0.0.1:8500/v1/kv/upstreams/webpages/":[{"host":"127.0.0.1","port":30511,"weight":1}]}
+
+
+
+=== TEST 3: prepare dump file for next test
+--- yaml_config
+apisix:
+  node_listen: 1984
+  config_center: yaml
+  enable_admin: false
+  enable_control: true
+
+discovery:
+  consul_kv:
+    servers:
+      - "http://127.0.0.1:8500"
+    dump:
+      path: "/tmp/consul_kv.dump"
+      load_on_init: true
+#END
+--- apisix_yaml
+routes:
+  -
+    uri: /*
+    upstream:
+      service_name: http://127.0.0.1:8500/v1/kv/upstreams/webpages/
+      discovery_type: consul_kv
+      type: roundrobin
+#END
+--- request
+GET /hello
+--- response_body
+server 1
+
+
+
+=== TEST 4: clean registered nodes
+--- config
+location /v1/kv {
+    proxy_pass http://127.0.0.1:8500;
+}
+--- request eval
+[
+    "DELETE /v1/kv/upstreams/?recurse=true",
+]
+--- response_body eval
+[
+    'true'
+]
+
+
+
+=== TEST 5: test load dump on init
+Configure the invalid consul server addr, and loading the last test 3 generated /tmp/consul_kv.dump file into memory when initializing
+--- yaml_config
+apisix:
+  node_listen: 1984
+  config_center: yaml
+  enable_admin: false
+  enable_control: true
+
+discovery:
+  consul_kv:
+    servers:
+      - "http://127.0.0.1:38500"
+    dump:
+      path: "/tmp/consul_kv.dump"
+      load_on_init: true
+#END
+--- apisix_yaml
+routes:
+  -
+    uri: /*
+    upstream:
+      service_name: http://127.0.0.1:8500/v1/kv/upstreams/webpages/
+      discovery_type: consul_kv
+      type: roundrobin
+#END
+--- request
+GET /hello
+--- response_body
+server 1
+
+
+
+=== TEST 6: delete dump file
+--- config
+    location /t {
+        content_by_lua_block {
+            local util = require("apisix.cli.util")
+            local succ, err = util.execute_cmd("rm -f /tmp/consul_kv.dump")
+            ngx.say(succ and "success" or err)
+        }
+    }
+--- request
+GET /t
+--- response_body
+success
+
+
+
+=== TEST 7: miss load dump on init
+--- yaml_config
+apisix:
+  node_listen: 1984
+  config_center: yaml
+  enable_admin: false
+  enable_control: true
+
+discovery:
+  consul_kv:
+    servers:
+      - "http://127.0.0.1:38500"
+    dump:
+      path: "/tmp/consul_kv.dump"
+      load_on_init: true
+#END
+--- apisix_yaml
+routes:
+  -
+    uri: /*
+    upstream:
+      service_name: http://127.0.0.1:8500/v1/kv/upstreams/webpages/
+      discovery_type: consul_kv
+      type: roundrobin
+#END
+--- request
+GET /hello
+--- error_code: 503
+
+
+
+=== TEST 8: prepare expired dump file
+--- config
+    location /t {
+        content_by_lua_block {
+            local util = require("apisix.cli.util")
+            local json = require("toolkit.json")
+
+            local applications = json.decode('{"http://127.0.0.1:8500/v1/kv/upstreams/webpages/":[{"host":"127.0.0.1","port":30511,"weight":1}]}')
+            local entity = {
+                services = applications,
+                last_update = ngx.time(),
+                expire = 10,
+            }
+            local succ, err =  util.write_file("/tmp/consul_kv.dump", json.encode(entity))
+
+            ngx.sleep(2)
+            ngx.say(succ and "success" or err)
+        }
+    }
+--- timeout: 3
+--- request
+GET /t
+--- response_body
+success
+
+
+
+=== TEST 9: unexpired dump
+test load unexpired /tmp/consul_kv.dump file generated by upper test when initializing
+ when initializing
+--- yaml_config
+apisix:
+  node_listen: 1984
+  config_center: yaml
+  enable_admin: false
+  enable_control: true
+
+discovery:
+  consul_kv:
+    servers:
+      - "http://127.0.0.1:38500"
+    dump:
+      path: "/tmp/consul_kv.dump"
+      load_on_init: true
+      expire: 5
+#END
+--- apisix_yaml
+routes:
+  -
+    uri: /*
+    upstream:
+      service_name: http://127.0.0.1:8500/v1/kv/upstreams/webpages/
+      discovery_type: consul_kv
+      type: roundrobin
+#END
+--- request
+GET /hello
+--- response_body
+server 1
+
+
+
+=== TEST 10: expired dump
+test load expired ( by check: (dump_file.last_update + dump.expire) < ngx.time ) ) /tmp/consul_kv.dump file generated by upper test when initializing
+ when initializing
+--- yaml_config
+apisix:
+  node_listen: 1984
+  config_center: yaml
+  enable_admin: false
+  enable_control: true
+
+discovery:
+  consul_kv:
+    servers:
+      - "http://127.0.0.1:38500"
+    dump:
+      path: "/tmp/consul_kv.dump"
+      load_on_init: true
+      expire: 2
+#END
+--- apisix_yaml
+routes:
+  -
+    uri: /*
+    upstream:
+      service_name: http://127.0.0.1:8500/v1/kv/upstreams/webpages/
+      discovery_type: consul_kv
+      type: roundrobin
+#END
+--- request
+GET /hello
+--- error_code: 503
+--- error_log
+dump file: /tmp/consul_kv.dump had expired, ignored it
+
+
+
+=== TEST 11: delete dump file
+--- config
+    location /t {
+        content_by_lua_block {
+            local util = require("apisix.cli.util")
+            local succ, err = util.execute_cmd("rm -f /tmp/consul_kv.dump")
+            ngx.say(succ and "success" or err)
+        }
+    }
+--- request
+GET /t
+--- response_body
+success

--- a/t/discovery/consul_kv_dump.t
+++ b/t/discovery/consul_kv_dump.t
@@ -364,4 +364,23 @@ discovery:
 #END
 --- request
 GET /v1/discovery/consul_kv/show_dump_file
+--- error_code: 500
+
+
+
+=== TEST 13: test 503 show_dump_file
+--- yaml_config
+apisix:
+  node_listen: 1984
+  config_center: yaml
+  enable_admin: false
+  enable_control: true
+
+discovery:
+  consul_kv:
+    servers:
+      - "http://127.0.0.1:38500"
+#END
+--- request
+GET /v1/discovery/consul_kv/show_dump_file
 --- error_code: 503

--- a/t/discovery/consul_kv_dump.t
+++ b/t/discovery/consul_kv_dump.t
@@ -364,4 +364,4 @@ discovery:
 #END
 --- request
 GET /v1/discovery/consul_kv/show_dump_file
---- error_code: 500
+--- error_code: 503

--- a/t/discovery/consul_kv_dump.t
+++ b/t/discovery/consul_kv_dump.t
@@ -312,7 +312,7 @@ discovery:
     dump:
       path: "/tmp/consul_kv.dump"
       load_on_init: true
-      expire: 2
+      expire: 1
 #END
 --- apisix_yaml
 routes:
@@ -344,3 +344,24 @@ dump file: /tmp/consul_kv.dump had expired, ignored it
 GET /t
 --- response_body
 success
+
+
+
+=== TEST 12: test 500 show_dump_file
+--- yaml_config
+apisix:
+  node_listen: 1984
+  config_center: yaml
+  enable_admin: false
+  enable_control: true
+
+discovery:
+  consul_kv:
+    servers:
+      - "http://127.0.0.1:38500"
+    dump:
+      path: "/tmp/consul_kv.dump"
+#END
+--- request
+GET /v1/discovery/consul_kv/show_dump_file
+--- error_code: 500

--- a/t/node/invalid-route.t
+++ b/t/node/invalid-route.t
@@ -161,3 +161,4 @@ GET /server_port
 --- error_code: 503
 --- error_log
 failed to parse domain: xxxx.invalid
+--- timeout: 10

--- a/t/node/route-domain.t
+++ b/t/node/route-domain.t
@@ -80,6 +80,7 @@ hello world
 [error]
 --- error_log eval
 qr/dns resolver domain: www.apiseven.com to \d+.\d+.\d+.\d+/
+--- timeout: 10
 
 
 
@@ -125,6 +126,7 @@ GET /uri
 qr/host: httpbin.org/
 --- no_error_log
 [error]
+--- timeout: 10
 
 
 
@@ -170,3 +172,4 @@ GET /get
 qr/"Host": "httpbin.org"/
 --- no_error_log
 [error]
+--- timeout: 10


### PR DESCRIPTION
### What this PR does / why we need it:

1. Add dump support for `consul_kv`, more intro:  https://github.com/yongboy/apisix/blob/consul_dump/docs/en/latest/discovery/consul_kv.md#dump_data
2. Avoid hard code discovery module's private control api fully URI 

Define the module's control api short path, eg `/show_dump_file`

```lua
function _M.control_api()
    return {
        {
            methods = {"GET"},
            uris = {"/show_dump_file"},
            handler = show_dump_file,
        }
    }
end
```

And, when you access it,  you need to type it's fully URI:

```shell
GET /v1/discovery/{Module_Name}/show_dump_file
```

eg: 

```shell
GET /v1/discovery/consul_kv/show_dump_file
```

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**