### PR TITLE
feat : Add ldap-auth plugin 

### DIFF
--- a/apisix/plugins/ldap-auth.lua
+++ b/apisix/plugins/ldap-auth.lua
@@ -1,0 +1,146 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+local core = require("apisix.core")
+local ngx = ngx
+local ngx_re = require("ngx.re")
+local ipairs = ipairs
+local consumer = require("apisix.consumer")
+
+local lrucache = core.lrucache.new({
+    ttl = 300, count = 512
+})
+local consumers_lrucache = core.lrucache.new({
+    type = "plugin",
+})
+
+local schema = {
+    type = "object",
+    title = "work with route or service object",
+    properties = {
+        basedn = { type = "string" },
+        ldapuri = { type = "string" },
+        usetls = { type = "boolean" },
+        uid = { type = "string" },
+    },
+    required = {"basedn","ldapuri"},
+    additionalProperties = false,
+}
+
+local consumer_schema = {
+    type = "object",
+    title = "work with consumer object",
+    properties = {
+        userdn = { type = "string" },
+    },
+    required = {"userdn"},
+    additionalProperties = false,
+}
+
+local plugin_name = "ldap-auth"
+
+local _M = {
+    version = 0.1,
+    priority = 2520,
+    type = 'auth',
+    name = plugin_name,
+    schema = schema,
+    consumer_schema = consumer_schema
+}
+
+function _M.check_schema(conf, schema_type)
+    local ok, err
+    if schema_type == core.schema.TYPE_CONSUMER then
+        ok, err = core.schema.check(consumer_schema, conf)
+    else
+        ok, err = core.schema.check(schema, conf)
+    end
+
+    if not ok then
+        return false, err
+    end
+
+    return true
+end
+
+local function extract_auth_header(authorization)
+    local obj = { username = "", password = "" }
+
+    local m, err = ngx.re.match(auth, "Basic\\s(.+)", "jo")
+    if err then
+        -- error authorization
+        return nil, err
+    end
+
+    local decoded = ngx.decode_base64(m[1])
+
+    local res
+    res, err = ngx_re.split(decoded, ":")
+    if err then
+        return nil, "split authorization err:" .. err
+    end
+
+    obj.username = ngx.re.gsub(res[1], "\\s+", "", "jo")
+    obj.password = ngx.re.gsub(res[2], "\\s+", "", "jo")
+    core.log.info("plugin access phase, authorization: ",
+                  obj.username, ": ", obj.password)
+
+    return obj, nil
+end
+
+function _M.rewrite(conf, ctx)
+    core.log.info("plugin access phase, conf: ", core.json.delay_encode(conf))
+
+    -- 1. extract authorization from header
+    local auth_header = core.request.header(ctx, "Authorization")
+    if not auth_header then
+        core.response.set_header("WWW-Authenticate", "Basic realm='.'")
+        return 401, { message = "Missing authorization in request" }
+    end
+
+    local username, password, err = extract_auth_header(auth_header)
+    if err then
+        return 401, { message = err }
+    end
+
+    -- 2. try authenticate the user against the ldap server
+    local consumer_conf = consumer.plugin(plugin_name)
+    if not consumer_conf then
+        return 401, { message = "Missing related consumer" }
+    end
+    local uid = "cn"
+    if conf.uid then 
+        uid = conf.uid
+    end
+    local ld = assert (lualdap.open_simple (conf.ldapuri,
+                uid+"="+username+","+conf.basedn,
+                password))
+
+    if not ld then
+        return 401, { message = "Invalid user authorization" }
+    end
+
+    -- 3. Create temporary consumer for authorization plugin
+    local consumer = {consumer_name = "", auth_conf = {username = ""}}
+    consumer.consumer_name = username
+    consumer.auth_conf.username = username
+
+    consumer.attach_consumer(ctx, consumer, consumer_conf)
+
+    core.log.info("hit basic-auth access")
+end
+
+return _M

--- a/apisix/plugins/ldap-auth.lua
+++ b/apisix/plugins/ldap-auth.lua
@@ -36,7 +36,7 @@ local schema = {
         ldapuri = { type = "string" },
         usetls = { type = "boolean" },
         uid = { type = "string" },
-        auto_create_consummer = {type ="boolean"}
+        auto_create_consumer = {type ="boolean"}
     },
     required = {"basedn","ldapuri"},
     additionalProperties = false,
@@ -141,13 +141,13 @@ function _M.rewrite(conf, ctx)
         uid = conf.uid
     end
     local userdn =  uid .. "=" .. user.username .. "," .. conf.basedn
-    local ld = lualdap.open_simple (conf.ldapuri, userdn, user.password)
+    local ld = lualdap.open_simple (conf.ldapuri, userdn, user.password, conf.usetls)
     if not ld then
         return 401, { message = "Invalid user authorization" }
     end
     
     -- 3. Retreive consumer for authorization plugin
-    if conf.auto_create_consummer then 
+    if conf.auto_create_consumer then 
         local tmpCustomer = {consumer_name = userdn, auth_conf = {username = userdn}}
         local tmpCustomerConf = {conf_version = "1", consumer_name="ldapauth"}
         consumer_mod.attach_consumer(ctx, tmpCustomer, tmpCustomerConf)

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -242,6 +242,7 @@ plugins:                          # plugin list (sorted in alphabetical order)
   - jwt-auth
   - kafka-logger
   - key-auth
+  - ldap-auth
   - limit-conn
   - limit-count
   - limit-req

--- a/docs/en/latest/plugins/ldap-auth.md
+++ b/docs/en/latest/plugins/ldap-auth.md
@@ -47,7 +47,7 @@ This authentication plugin use [lualdap](https://lualdap.github.io/lualdap/) plu
 | ldapuri | string | required    |         |       | the uri of the ldap server  |
 | usetls | boolean | optional    |    `true`     |       | Boolean flag indicating if Transport Layer Security (TLS) should be used. |
 | uid | string | optional    |     `cn`      |     | the user's password |
-| uiauto_create_consummer | boolean | optional    |    `false`     |       | enable this to automatically create consumer for each authentication , the consumer name will be the full `dn` of the user |
+| auto_create_consumer | boolean | optional    |    `false`     |       | enable this to automatically create consumer for each authentication , the consumer name will be the full `dn` of the user |
 
 ## How To Enable
 

--- a/docs/en/latest/plugins/ldap-auth.md
+++ b/docs/en/latest/plugins/ldap-auth.md
@@ -1,0 +1,152 @@
+---
+title: ldap-auth
+---
+
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+## Summary
+
+- [**Name**](#name)
+- [**Attributes**](#attributes)
+- [**How To Enable**](#how-to-enable)
+- [**Test Plugin**](#test-plugin)
+- [**Disable Plugin**](#disable-plugin)
+
+## Name
+
+`ldap-auth` is an authentication plugin that can works with `consumer`. Add Ldap Authentication to a `service` or `route`.
+
+The `consumer` then authenticate against the Ldap server using Basic authentication.
+
+For more information on Basic authentication, refer to [Wiki](https://en.wikipedia.org/wiki/Basic_access_authentication) for more information.
+
+This authentication plugin use [lualdap](https://lualdap.github.io/lualdap/) plugin to connect against the ldap server
+
+## Attributes
+
+| Name     | Type   | Requirement | Default | Valid | Description                                                                                                                                                      |
+| -------- | ------ | ----------- | ------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| basedn | string | required    |         |       | the base dn of the `ldap` server (example : `dc=example,dc=org`)   |
+| ldapuri | string | required    |         |       | the uri of the ldap server  |
+| usetls | boolean | optional    |    `true`     |       | Boolean flag indicating if Transport Layer Security (TLS) should be used. |
+| uid | string | optional    |     `cn`      |     | the user's password |
+| uiauto_create_consummer | boolean | optional    |    `false`     |       | enable this to automatically create consumer for each authentication , the consumer name will be the full `dn` of the user |
+
+## How To Enable
+
+### 1. set a consumer and config the value of the `ldap-auth` option
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/consumers -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "username": "foo",
+    "plugins": {
+        "ldap-auth": {
+            "userdn": "cn=user01,dc=example,dc=org"
+        }
+    }
+}'
+```
+
+you can visit Dashboard `http://127.0.0.1:9080/apisix/dashboard/` and add a Consumer through the web console.
+
+then add ldap-auth plugin in the Consumer page
+
+### 2. add a Route or add a Service, and enable the `ldap-auth` plugin
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "methods": ["GET"],
+    "uri": "/hello",
+    "plugins": {
+        "ldap-auth": {
+            "basedn": "dc=example,dc=org",
+            "ldapuri": "172.19.0.1",
+            "uid": "cn"
+        },
+    },
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "127.0.0.1:1980": 1
+        }
+    }
+}'
+```
+
+## Test Plugin
+
+- missing Authorization header
+
+```shell
+$ curl -i http://127.0.0.1:9080/hello
+HTTP/1.1 401 Unauthorized
+...
+{"message":"Missing authorization in request"}
+```
+
+- user is not exists:
+
+```shell
+$ curl -i -uuser:password1 http://127.0.0.1:9080/hello
+HTTP/1.1 401 Unauthorized
+...
+{"message":"Invalid user key in authorization"}
+```
+
+- password is invalid:
+
+```shell
+$ curl -i -uuser01:passwordfalse http://127.0.0.1:9080/hello
+HTTP/1.1 401 Unauthorized
+...
+{"message":"Password is error"}
+```
+
+- success:
+
+```shell
+$ curl -i -uuser01:password1 http://127.0.0.1:9080/hello
+HTTP/1.1 200 OK
+...
+hello, world
+```
+
+## Disable Plugin
+
+When you want to disable the `ldap-auth` plugin, it is very simple,
+ you can delete the corresponding json configuration in the plugin configuration,
+  no need to restart the service, it will take effect immediately:
+
+```shell
+$ curl http://127.0.0.1:2379/apisix/admin/routes/1 -X PUT -d value='
+{
+    "methods": ["GET"],
+    "uri": "/hello",
+    "plugins": {},
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "127.0.0.1:1980": 1
+        }
+    }
+}'
+```

--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -66,7 +66,7 @@ dependencies = {
     "luasec = 0.9-1",
     "lua-resty-consul = 0.3-2",
     "penlight = 1.9.2-1",
-    "lualdap = 1.2.5",
+    "lualdap = 1.2.5-1",
 }
 
 build = {

--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -66,6 +66,7 @@ dependencies = {
     "luasec = 0.9-1",
     "lua-resty-consul = 0.3-2",
     "penlight = 1.9.2-1",
+    "lualdap = 1.2.5",
 }
 
 build = {

--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -66,7 +66,7 @@ dependencies = {
     "luasec = 0.9-1",
     "lua-resty-consul = 0.3-2",
     "penlight = 1.9.2-1",
-    "lualdap = 1.2.5-1",
+    "lualdap = 1.2.3-1",
 }
 
 build = {

--- a/t/plugin/ldap-auth.t
+++ b/t/plugin/ldap-auth.t
@@ -1,0 +1,372 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(2);
+no_long_string();
+no_root_location();
+no_shuffle();
+run_tests;
+
+__DATA__
+
+=== TEST 1: sanity
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local plugin = require("apisix.plugins.ldap-auth")
+            local ok, err = plugin.check_schema({userdn = 'foo'}, core.schema.TYPE_CONSUMER)
+            if not ok then
+                ngx.say(err)
+            end
+
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: wrong type of string
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth")
+            local ok, err = plugin.check_schema({basedn = 123})
+            if not ok then
+                ngx.say(err)
+            end
+
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body_like eval
+qr/wrong type: expected string, got number
+done
+/
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: add consumer with username and plugins
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "foo",
+                    "plugins": {
+                        "ldap-auth": {
+                            "userdn": "cn=foo,dc=example,dc=org"
+                        }
+                    }
+                }]],
+                [[{
+                    "node": {
+                        "value": {
+                            "username": "user1",
+                            "plugins": {
+                                "ldap-auth": {
+                                    "userdn": "cn=user01,dc=example,dc=org"
+                                }
+                            }
+                        }
+                    },
+                    "action": "set"
+                }]]
+                )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: enable basic auth plugin using admin api
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "ldap-auth": {
+                            "basedn": "dc=example,dc=org",
+                            "ldapuri": "172.19.0.1",
+                            "uid": "cn",
+                            "auto_create_consummer": true
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: verify, missing authorization
+--- request
+GET /hello
+--- error_code: 401
+--- response_body
+{"message":"Missing authorization in request"}
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: verify, invalid password
+--- request
+GET /hello
+--- more_headers
+Authorization: Basic Zm9vOmZvbwo=
+--- error_code: 401
+--- response_body
+{"message":"Invalid user authorization"}
+--- no_error_log
+[error]
+
+
+
+=== TEST 7: verify
+--- request
+GET /hello
+--- more_headers
+Authorization: Basic dXNlcjAxOnBhc3N3b3JkMQ==
+--- response_body
+hello world
+--- no_error_log
+[error]
+--- error_log
+find consumer cn=user01,dc=example,dc=org
+
+
+
+=== TEST 8: enable basic auth plugin using admin api
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "ldap-auth": {
+                            "basedn": "dc=example,dc=org",
+                            "ldapuri": "172.19.0.1", // TO Update with openldap from Github action (bitnami/openldap:2)
+                            "uid": "cn",
+                            "auto_create_consummer": false
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 9: verify
+--- request
+GET /hello
+--- more_headers
+Authorization: Basic dXNlcjAxOnBhc3N3b3JkMQ==
+--- response_body
+hello world
+--- no_error_log
+[error]
+--- error_log
+find consumer user01
+
+
+
+=== TEST 10: invalid schema, not field given
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "foo",
+                    "plugins": {
+                        "ldap-auth": {
+                        }
+                    }
+                }]]
+                )
+
+            ngx.status = code
+            ngx.print(body)
+        }
+    }
+--- request
+GET /t
+--- error_code: 400
+--- response_body_like eval
+qr/\{"error_msg":"invalid plugins configuration: failed to check the configuration of plugin ldap-auth err: property \\"(userdn)\\" is required"\}/
+--- no_error_log
+[error]
+
+
+
+=== TEST 11: invalid schema, not a table
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "foo",
+                    "plugins": {
+                        "ldap-auth": "blah"
+                    }
+                }]]
+                )
+
+            ngx.status = code
+            ngx.print(body)
+        }
+    }
+--- request
+GET /t
+--- error_code: 400
+--- response_body
+{"error_msg":"invalid plugins configuration: invalid plugin conf \"blah\" for plugin [ldap-auth]"}
+--- no_error_log
+[error]
+
+
+
+=== TEST 12: get the default schema
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/schema/plugins/ldap-auth',
+                ngx.HTTP_GET,
+                nil,
+                [[
+{"properties":{"disable":{"type":"boolean"}},"title":"work with route or service object","additionalProperties":false,"type":"object"}
+                ]]
+                )
+            ngx.status = code
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+
+
+
+=== TEST 13: get the schema by schema_type
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/schema/plugins/ldap-auth?schema_type=consumer',
+                ngx.HTTP_GET,
+                nil,
+                [[
+{"title":"work with consumer object","additionalProperties":false,"required":["userdn"],"properties":{"userdn":{"type":"string"}},"type":"object"}
+                ]]
+                )
+            ngx.status = code
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+
+
+
+=== TEST 14: get the schema by error schema_type
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/schema/plugins/ldap-auth?schema_type=consumer123123',
+                ngx.HTTP_GET,
+                nil,
+                [[
+{"properties":{"disable":{"type":"boolean"}},"title":"work with route or service object","additionalProperties":false,"type":"object"}
+                ]]
+                )
+            ngx.status = code
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]

--- a/t/plugin/ldap-auth.t
+++ b/t/plugin/ldap-auth.t
@@ -127,7 +127,7 @@ passed
                             "basedn": "dc=example,dc=org",
                             "ldapuri": "172.19.0.1",
                             "uid": "cn",
-                            "auto_create_consummer": true
+                            "auto_create_consumer": true
                         }
                     },
                     "upstream": {
@@ -206,7 +206,7 @@ find consumer cn=user01,dc=example,dc=org
                             "basedn": "dc=example,dc=org",
                             "ldapuri": "172.19.0.1", // TO Update with openldap from Github action (bitnami/openldap:2)
                             "uid": "cn",
-                            "auto_create_consummer": false
+                            "auto_create_consumer": false
                         }
                     },
                     "upstream": {


### PR DESCRIPTION
### What this PR does / why we need it:
This PR add a new authentication plugin that use a LDAP server to authenticate the user

This add a new type of `consumer` 
```
"ldap-auth": {
    "userdn": "cn=user01,dc=example,dc=org"
 }
```

This plugin can also automatically create a consumer upon request if `auto_create_consumer = true`
This fixes : #3861 and #1128

**Test cases are not fully operational yet.**

### Help needed
Also need help to add the deployment of an Openldap server on Github Action.
FYI i used the (bitnami/openldap:2)(https://hub.docker.com/r/bitnami/openldap/) docker image
```
openldap:
    image: bitnami/openldap:2
    ports:
      - '389:1389'
      - '636:1636'
    environment:
      - LDAP_ADMIN_USERNAME=admin
      - LDAP_ADMIN_PASSWORD=adminpassword
      - LDAP_USERS=user01,user02
      - LDAP_PASSWORDS=password1,password2
```

### Next feature 
Add a group variable in the consumer , this group would come from the `memberOf (configurable)` attribute of the ldap user and add it in the consumer.
Then plugins such as `consumer_restriction` could be updated to take into account groups -> (which can also be used on `basic-auth (and more)` plugin where a `consumer` can also be part of a group)

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [-] Have you added corresponding test cases?
* [X] Have you modified the corresponding document?
* [X] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
