### PR TITLE
Feature discovery nacos

### DIFF
--- a/apisix/discovery/nacos.lua
+++ b/apisix/discovery/nacos.lua
@@ -1,0 +1,278 @@
+local service = require "apisix.http.service"
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+local local_conf         = require("apisix.core.config_local").local_conf()
+local http               = require("resty.http")
+local core               = require("apisix.core")
+local ipmatcher          = require("resty.ipmatcher")
+local ipairs             = ipairs
+local tostring           = tostring
+local type               = type
+local math_random        = math.random
+local error              = error
+local ngx                = ngx
+local ngx_timer_at       = ngx.timer.at
+local ngx_timer_every    = ngx.timer.every
+local string_sub         = string.sub
+local str_find           = core.string.find
+local log                = core.log
+
+local default_weight
+local fetch_interval
+local services = {}
+local nacos_url
+local nacos_access_token
+local nacos_token_ttl = 18000
+
+local schema = {
+    type = "object",
+    properties = {
+        host = {
+            type = "array",
+            minItems = 1,
+            items = {
+                type = "string",
+            },
+        },
+        username = {type = "string"},
+        password = {type = "string"},
+        fetch_interval = {type = "integer", minimum = 1, default = 30},
+        prefix = {type = "string"},
+        weight = {type = "integer", minimum = 0},
+        timeout = {
+            type = "object",
+            properties = {
+                connect = {type = "integer", minimum = 1, default = 2000},
+                send = {type = "integer", minimum = 1, default = 2000},
+                read = {type = "integer", minimum = 1, default = 5000},
+            }
+        },
+    },
+    required = {"host"}
+}
+
+
+local _M = {
+    version = 0.1,
+}
+
+-- spring split function
+string.split = function(s, p)
+    local rt= {}
+    string.gsub(s, '[^'..p..']+', function(w) table.insert(rt, w) end )
+    return rt
+end
+
+-- http request
+local function request(request_uri, method, path, query, body)
+    log.info("nacos uri:", request_uri, ".")
+    local url = request_uri .. path
+    local headers = core.table.new(0, 5)
+    headers['Connection'] = 'Keep-Alive'
+    headers['Accept'] = 'application/json'
+    if body then
+    	headers['Content-Type'] = 'application/x-www-form-urlencoded'
+    end
+
+    local httpc = http.new()
+    local timeout = local_conf.discovery.nacos.timeout
+    local connect_timeout = timeout and timeout.connect or 2000
+    local send_timeout = timeout and timeout.send or 2000
+    local read_timeout = timeout and timeout.read or 5000
+    log.info("connect_timeout:", connect_timeout, ", send_timeout:", send_timeout,
+            ", read_timeout:", read_timeout, ".")
+    httpc:set_timeouts(connect_timeout, send_timeout, read_timeout)
+    return httpc:request_uri(url, {
+        version = 1.1,
+        method = method,
+        headers = headers,
+        query = query,
+        body = body,
+        ssl_verify = false,
+    })
+end
+
+-- fetch nacos accessToken, which is used in open-api
+local function fetch_access_token(username, password)
+
+    local body = "username=" .. username .. "&" .. "password=" .. password
+    local res, err = request(nacos_url, "POST", "auth/login", nil, body)
+
+    if not res then
+        log.error("failed to fetch access_token", err)
+        return
+    end
+    if not res.body or res.status ~= 200 then
+        log.error("failed to fetch access_token, status = ", res.status)
+        return
+    end
+
+    local json_str = res.body
+    local data, err = core.json.decode(json_str)
+    if not data then
+        log.error("invalid response body: ", json_str, " err: ", err)
+        return
+    end
+    return data.accessToken
+end
+
+-- nacos_url & nacos_access_token
+local function init_info()
+    local nacos = local_conf.discovery and local_conf.discovery.naocs
+    
+    -- pick one nacos cluster.
+    local host =  local_conf.discovery.nacos.host
+    local url = host[math_random(#host)]
+
+    if local_conf.discovery.nacos.prefix then
+        url = url .. local_conf.discovery.nacos.prefix
+    end
+    if string_sub(url, #url) ~= "/" then
+        url = url .. "/"
+    end
+
+    local username = local_conf.discovery.nacos.username
+    if not username then
+        log.error("do not set nacos.username")
+        return
+    end
+
+    local password = local_conf.discovery.nacos.password
+    if not password then
+        log.error("do not set nacos.password")
+        return
+    end
+    
+    nacos_url = url
+    nacos_access_token = fetch_access_token(username, password)
+end
+
+
+local function parse_instances(instances)
+    local up_instances = core.table.new(#instances, 0)
+    for _, instance in pairs(instances) do
+        core.table.insert(up_instances, {
+            host = instance.ip,
+            port = instance.port,
+            weight = instance.weight or default_weight,
+            metadata = instance.metadata,
+        })
+    end
+    return up_instances
+end
+
+local function fetch_instances(service_name)
+    if not service_name then
+        log.error("service_name could not be nil")
+        return
+    end
+    local namespaceId = "public"
+    local groupName = "DEFAULT_GROUP"
+    local serviceName = ""
+    local arr = string.split(service_name, ":")
+    if #arr == 3 then
+        namespaceId = arr[1]
+        groupName = arr[2]
+        serviceName = arr[3]
+    elseif #arr == 2 then
+        namespaceId = arr[1]
+        serviceName = arr[2]
+    elseif #arr == 1 then
+        serviceName = arr[1]
+    else
+        log.error("service_name is invalid")
+        return
+    end
+    if not nacos_access_token then
+        init_info()
+    end
+    local query = "accessToken=" .. nacos_access_token .. 
+        "&" .. "namespaceId=" .. namespaceId ..
+        "&" .. "groupName=" .. groupName ..
+	    "&" .. "serviceName=" .. serviceName ..
+	    "&" .. "healthyOnly=true"
+
+    local res, err = request(nacos_url, "GET", "ns/instance/list", query)
+
+    if not res then
+        log.error("failed to fetch service instances", err)
+        return
+    end
+    if not res.body or res.status ~= 200 then
+        log.error("failed to fetch service instances, status = ", res.status)
+        return
+    end
+
+    local json_str = res.body
+    local data, err = core.json.decode(json_str)
+    if not data then
+        log.error("invalid response body: ", json_str, " err: ", err)
+        return
+    end
+    return parse_instances(data.hosts)
+end
+
+local function fetch_full_instances(premature)
+    if premature then
+        return
+    end
+
+    if not services then
+        return
+    end
+    
+    for service_name, _ in pairs(services) do
+        services[service_name] = fetch_instances(service_name)
+    end
+end
+
+function _M.nodes(service_name)
+    if not services or
+        not services[service_name] then
+        services[service_name] = fetch_instances(service_name)
+    end
+    return services[service_name]
+end
+
+-- init
+function _M.init_worker()
+    if not local_conf.discovery.nacos or
+        not local_conf.discovery.nacos.host or #local_conf.discovery.nacos.host == 0 then
+        error("do not set nacos.host")
+        return
+    end
+
+    local ok, err = core.schema.check(schema, local_conf.discovery.nacos)
+    if not ok then
+        error("invalid nacos configuration: " .. err)
+        return
+    end
+
+    default_weight = local_conf.discovery.nacos.weight or 100
+    log.info("default_weight:", default_weight, ".")
+
+    fetch_interval = local_conf.discovery.nacos.fetch_interval or 30
+    log.info("fetch_interval:", fetch_interval, ".")
+
+    ngx_timer_at(0, init_info)
+    ngx_timer_every(nacos_token_ttl, init_info)
+    ngx_timer_every(fetch_interval, fetch_full_instances)
+end
+
+
+return _M

--- a/docs/en/latest/discovery/nacos.md
+++ b/docs/en/latest/discovery/nacos.md
@@ -1,0 +1,89 @@
+---
+title: Integration Nacos service discovery registry
+---
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+* [**Summary**](#Summary)
+* [**How to use Nacos in APISIX**](#How-to-use-Nacos-in-APISIX)
+    * [**Usage**](#Usage)
+    * [**Upstream setting**](#Upstream-setting)
+
+## Summary
+
+Common registries: Eureka, Etcd, Consul, Zookeeper, Nacos etc.
+
+Currently we support Eureka/Consul and serivce discovery via DNS. Reference [discovery](https://github.com/apache/apisix/blob/master/docs/en/latest/discovery.md)
+
+Here we discribe how to use Nacos as service discovery registry in APISIX.
+
+## How to use Nacos in APISIX
+
+### Usage
+
+At first, make sure that `apisix/discovery/` directory contains `nacos.lua`;
+
+Then, add following configuration in `conf/config.yaml`.
+
+```yaml
+discovery:                     
+  nacos:
+    host:                     # it's possible to define multiple nacos hosts addresses of the same nacos cluster.
+      - "http://{nacos_host1}:${nacos_port1}"
+      - "http://{nacos_host2}:${nacos_port2}"
+    username: ${nacos_username}
+    password: ${nacos_password}
+    prefix: "/nacos/v1/"
+    fetch_interval: 5           
+    weight: 100                 
+    timeout:
+      connect: 2000             
+      send: 2000               
+      read: 5000               
+```
+
+The username and the password is used to fetch access_token in Nacos, whose ttl is 18000s. 
+
+### Upstream setting
+
+Here is an example of routing a request with a URL of "/ping" to a service which has namespace "dev", group "DEFAULT_GROUP" and name "ping_demo" with Nacos :
+
+```shell
+$ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -i -d '
+{
+    "uri": "/ping",
+    "upstream": {
+        "name": "ping",
+        "service_name": "dev:DEFAULT_GROUP:ping_demo",
+        "type": "roundrobin",
+        "discovery_type": "nacos"
+    }
+}'
+```
+**About service name**
+
+In Nacos, namespaceId, groupName and serviceName could be used together to confirm one specific sercie. 
+
+As a result, service_name format like: `namespaceId:groupName:serviceName`.
+
+In Nacos, the default namespaceId is public, and the default groupName is DEFAULT_GROUP.
+
+When service_name contains only one`:` like `namespaceId:serviceName`, the groupName is DEFAULT_GROUP.
+
+When service_name contains no `:` like `serviceName`, the namespaceId is public and groupName is DEFAULT_GROUP.

--- a/docs/zh/latest/discovery/nacos.md
+++ b/docs/zh/latest/discovery/nacos.md
@@ -1,0 +1,87 @@
+---
+标题: 集成Nacos作为服务发现中心
+---
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+* [**摘要**](#摘要)
+* [**如何在APISIX中使用Nacos**](#如何在APISIX中使用Nacos)
+    * [**接入**](#接入)
+    * [**upstream 配置**](#upstream-配置)
+
+## 摘要
+
+常见的服务注册发现中心有：Eureka, Etcd, Consul, Zookeeper, Nacos等
+
+目前APISIX官方支持 Eureka 和基于 DNS 的服务注册发现，如 Consul 等，并实现了Eureka的接入代码。参看 [APISIX服务发现](https://github.com/apache/apisix/blob/master/docs/zh/latest/discovery.md)
+
+本文描述了在APISIX中如何使用Nacos作为注册中心
+
+## 如何在APISIX中使用Nacos
+
+### 接入
+
+首先，确保 `apisix/discovery/` 目录中包含 `nacos.lua`；
+
+然后，在 `conf/config.yaml` 增加如下格式的配置：
+
+```yaml
+discovery:                     
+  nacos:
+    host:                     # Nacos集群中可能有多个host.
+      - "http://{nacos_host1}:${nacos_port1}"
+      - "http://{nacos_host2}:${nacos_port2}"
+    username: ${nacos_username}
+    password: ${nacos_password}
+    prefix: "/nacos/v1/"
+    fetch_interval: 5           
+    weight: 100                 
+    timeout:
+      connect: 2000             
+      send: 2000               
+      read: 5000               
+```
+
+username和password用来获取Nacos的access_token，它的ttl是18000s。
+
+### upstream 配置
+
+这里是一个例子，路由请求"/ping"，到Nacos中注册的服务（该服务的Namespace是dev，group是DEFAULT_GROUP，服务名称是ping_demo)。
+
+```shell
+$ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -i -d '
+{
+    "uri": "/ping",
+    "upstream": {
+        "name": "ping",
+        "service_name": "dev:DEFAULT_GROUP:ping_demo",
+        "type": "roundrobin",
+        "discovery_type": "nacos"
+    }
+}'
+```
+**服务名称说明**
+
+在Nacos中定位一个服务是从namespace、group和service三个维度进行的。所以service_name里面可以同时传入三个维度的值，格式：`namespaceId:groupName:serviceName`
+
+Nacos的默认namespaceId是public，默认groupName是DEFAULT_GROUP；
+
+当service_name中，仅有一个`:`时，表示`namespaceId:serviceName`，此时groupName是DEFAULT_GROUP
+
+当service_name中，没有`:`时，表示`serviceName`，此时namespaceId是public，groupName是DEFAULT_GROUP

--- a/t/discovery/nacos.t
+++ b/t/discovery/nacos.t
@@ -1,0 +1,118 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+log_level('info');
+no_root_location();
+no_shuffle();
+
+our $yaml_config = <<_EOC_;
+apisix:
+  node_listen: 9080
+  config_center: yaml
+  enable_admin: false
+discovery:
+  nacos:
+    host:
+      - "http://127.0.0.1:8848"
+    username: nacos
+    password: nacos
+    prefix: "/nacos/v1/"
+    fetch_interval: 30
+    weight: 100
+    timeout:
+      connect: 2000
+      send: 2000
+      read: 5000
+_EOC_
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: get APISIX-Nacos info from Nacos
+--- yaml_config eval: $::yaml_config
+--- apisix_yaml
+routes:
+  -
+    uri: /ping
+    upstream:
+      service_name: dev:DEFAULT_GROUP:ping_demo
+      discovery_type: nacos
+      type: roundrobin
+#END
+--- request
+GET /ping
+--- response_body
+pong from Nacos
+--- no_error_log
+[error]
+
+=== TEST 2: get APISIX-Nacos info from Nacos with default groupName: DEFAULT_GROUP
+--- yaml_config eval: $::yaml_config
+--- apisix_yaml
+routes:
+  -
+    uri: /ping
+    upstream:
+      service_name: dev:ping_demo
+      discovery_type: nacos
+      type: roundrobin
+#END
+--- request
+GET /ping
+--- response_body
+pong from Nacos
+--- no_error_log
+[error]
+
+=== TEST 3: error service_name with default namespaceId: public
+--- yaml_config eval: $::yaml_config
+--- apisix_yaml
+routes:
+  -
+    uri: /ping
+    upstream:
+      service_name: ping_demo
+      discovery_type: nacos
+      type: roundrobin
+#END
+--- request
+GET /ping
+--- error_code: 503
+
+=== TEST 4: with proxy-rewrite
+--- yaml_config eval: $::yaml_config
+--- apisix_yaml
+routes:
+  -
+    uri: /nacos-test/*
+    plugins:
+      proxy-rewrite:
+        regex_uri: ["^/nacos-test/(.*)", "/${1}"]
+    upstream:
+      service_name: dev:DEFAULT_GROUP:ping_demo
+      discovery_type: nacos
+      type: roundrobin
+#END
+--- request
+GET /nacos-test/ping
+--- response_body_like
+pong from Nacos.*
+--- no_error_log
+[error]


### PR DESCRIPTION
Nacos is wildly used as service discovery registery. 

Here add the nacos in APISIX discovery.

The codes considers followings:
1. When use Nacos in produce env, nacos_username and nacos_password are needed to get the access_token, which is used in Nacos admin API, and access_token's ttl is 18000s.
2. In Nacos, namespaceId, groupName and serviceName are used together to confirm one specific sercie.  And the default namespaceId is public, default groupName is DEFAULT_GROUP.
3. Only fetch instances of those Nacos services that are used in APISIX, but not fetch instances of all services in Nacos.
4. There is cache for instances of Nacos services and the intances fetch interval could be configured. 
