### PR TITLE
feat: add management fields for `stream_route` and `proto` in schema

### DIFF
--- a/apisix/admin/proto.lua
+++ b/apisix/admin/proto.lua
@@ -17,6 +17,7 @@
 local type = type
 local ipairs = ipairs
 local core = require("apisix.core")
+local utils = require("apisix.admin.utils")
 local get_routes = require("apisix.router").http_routes
 local get_services = require("apisix.http.service").services
 local tostring = tostring
@@ -63,6 +64,12 @@ function _M.put(id, conf)
     end
 
     local key = "/proto/" .. id
+
+    local ok, err = utils.inject_conf_with_prev_conf("proto", key, conf)
+    if not ok then
+        return 500, {error_msg = err}
+    end
+
     local res, err = core.etcd.set(key, conf)
     if not res then
         core.log.error("failed to put proto[", key, "]: ", err)
@@ -96,6 +103,9 @@ function _M.post(id, conf)
     end
 
     local key = "/proto"
+
+    utils.inject_timestamp(conf)
+
     -- core.log.info("key: ", key)
     local res, err = core.etcd.push("/proto", conf)
     if not res then

--- a/apisix/admin/stream_routes.lua
+++ b/apisix/admin/stream_routes.lua
@@ -15,6 +15,7 @@
 -- limitations under the License.
 --
 local core = require("apisix.core")
+local utils = require("apisix.admin.utils")
 local schema_plugin = require("apisix.admin.plugins").stream_check_schema
 local tostring = tostring
 
@@ -86,6 +87,12 @@ function _M.put(id, conf)
     end
 
     local key = "/stream_routes/" .. id
+
+    local ok, err = utils.inject_conf_with_prev_conf("stream_routes", key, conf)
+    if not ok then
+        return 500, {error_msg = err}
+    end
+
     local res, err = core.etcd.set(key, conf)
     if not res then
         core.log.error("failed to put stream route[", key, "]: ", err)
@@ -119,6 +126,9 @@ function _M.post(id, conf)
     end
 
     local key = "/stream_routes"
+
+    utils.inject_timestamp(conf)
+
     local res, err = core.etcd.push("/stream_routes", conf)
     if not res then
         core.log.error("failed to post stream route[", key, "]: ", err)

--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -664,6 +664,10 @@ _M.ssl = {
 _M.proto = {
     type = "object",
     properties = {
+        id = id_schema,
+        desc = desc_def,
+        create_time = timestamp_def,
+        update_time = timestamp_def,
         content = {
             type = "string", minLength = 1, maxLength = 1024*1024
         }
@@ -690,6 +694,9 @@ _M.stream_route = {
     type = "object",
     properties = {
         id = id_schema,
+        desc = desc_def,
+        create_time = timestamp_def,
+        update_time = timestamp_def,
         remote_addr = remote_addr_def,
         server_addr = {
             description = "server IP",

--- a/t/admin/schema.t
+++ b/t/admin/schema.t
@@ -291,3 +291,23 @@ GET /apisix/admin/schema/global_rule
 qr/("update_time":\{"type":"integer"\}.*"create_time":\{"type":"integer"\}|"create_time":\{"type":"integer"\}.*"update_time":\{"type":"integer"\})/
 --- no_error_log
 [error]
+
+
+
+=== TEST 16: get proto schema to check if it contains `create_time` and `update_time`
+--- request
+GET /apisix/admin/schema/proto
+--- response_body eval
+qr/("update_time":\{"type":"integer"\}.*"create_time":\{"type":"integer"\}|"create_time":\{"type":"integer"\}.*"update_time":\{"type":"integer"\})/
+--- no_error_log
+[error]
+
+
+
+=== TEST 17: get stream_route schema to check if it contains `create_time` and `update_time`
+--- request
+GET /apisix/admin/schema/stream_route
+--- response_body eval
+qr/("update_time":\{"type":"integer"\}.*"create_time":\{"type":"integer"\}|"create_time":\{"type":"integer"\}.*"update_time":\{"type":"integer"\})/
+--- no_error_log
+[error]

--- a/t/admin/stream-routes.t
+++ b/t/admin/stream-routes.t
@@ -515,7 +515,11 @@ GET /t
 
             res = json.decode(res)
             assert(res.count ~= nil)
+            assert(res.node.value.create_time ~= nil)
+            assert(res.node.value.update_time ~= nil)
             res.count = nil
+            res.node.value.create_time = nil
+            res.node.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }

--- a/t/admin/stream-routes.t
+++ b/t/admin/stream-routes.t
@@ -215,7 +215,7 @@ GET /t
 [delete] code: 200 message: passed
 --- no_error_log
 [error]
---- ONLY
+
 
 
 === TEST 5: set route with plugin

--- a/t/admin/stream-routes.t
+++ b/t/admin/stream-routes.t
@@ -188,15 +188,16 @@ GET /t
                 return
             end
 
-            local ret = assert(etcd.get('/stream_routes/1'))
+            ngx.say("[push] code: ", code, " message: ", message)
+
+            local id = string.sub(res.node.key, #"/apisix/stream_routes/" + 1)
+
+            local ret = assert(etcd.get('/stream_routes/' .. id))
             local create_time = ret.body.node.value.create_time
             assert(create_time ~= nil, "create_time is nil")
             local update_time = ret.body.node.value.update_time
             assert(update_time ~= nil, "update_time is nil")
 
-            ngx.say("[push] code: ", code, " message: ", message)
-
-            local id = string.sub(res.node.key, #"/apisix/stream_routes/" + 1)
             code, message = t('/apisix/admin/stream_routes/' .. id,
                 ngx.HTTP_DELETE,
                 nil,
@@ -214,7 +215,7 @@ GET /t
 [delete] code: 200 message: passed
 --- no_error_log
 [error]
-
+--- ONLY
 
 
 === TEST 5: set route with plugin

--- a/t/plugin/grpc-transcode.t
+++ b/t/plugin/grpc-transcode.t
@@ -64,7 +64,7 @@ __DATA__
             end
             ngx.say(body)
 
-            local res = assert(etcd.get('/stream_routes/1'))
+            local res = assert(etcd.get('/proto/1'))
             local create_time = res.body.node.value.create_time
             assert(create_time ~= nil, "create_time is nil")
             local update_time = res.body.node.value.update_time

--- a/t/plugin/grpc-transcode.t
+++ b/t/plugin/grpc-transcode.t
@@ -41,6 +41,7 @@ __DATA__
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
+            local etcd = require("apisix.core.etcd")
             local code, body = t('/apisix/admin/proto/1',
                  ngx.HTTP_PUT,
                  [[{
@@ -62,6 +63,13 @@ __DATA__
                 ngx.status = code
             end
             ngx.say(body)
+
+            local res = assert(etcd.get('/stream_routes/1'))
+            local create_time = res.body.node.value.create_time
+            assert(create_time ~= nil, "create_time is nil")
+            local update_time = res.body.node.value.update_time
+            assert(update_time ~= nil, "update_time is nil")
+
         }
     }
 --- request


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->

In order to facilitate management and viewing in the dashboard, we need to add response fields (create_time, update_time, desc) in the schema.
This PR is going to  add these fields and relevant test cases. 

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
