### PR TITLE
fix: ensure automic operation in limit-count plugin

### DIFF
--- a/apisix/plugins/limit-count/limit-count-redis-cluster.lua
+++ b/apisix/plugins/limit-count/limit-count-redis-cluster.lua
@@ -29,11 +29,13 @@ local mt = {
 }
 
 
-local script = "if redis.call('ttl', KEYS[1]) < 0 then "
-    .. "redis.call('set', KEYS[1], ARGV[1] - 1, 'EX', ARGV[2]) "
-    .. "return ARGV[1] - 1 "
-    .. "end "
-    .. "return redis.call('incrby', KEYS[1], -1)"
+local script = [=[
+    if redis.call('ttl', KEYS[1]) < 0 then
+        redis.call('set', KEYS[1], ARGV[1] - 1, 'EX', ARGV[2])
+        return ARGV[1] - 1
+    end
+    return redis.call('incrby', KEYS[1], -1)
+]=]
 
 
 local function new_redis_cluster(conf)

--- a/apisix/plugins/limit-count/limit-count-redis-cluster.lua
+++ b/apisix/plugins/limit-count/limit-count-redis-cluster.lua
@@ -77,57 +77,18 @@ function _M.incoming(self, key)
     local red = self.red_cli
     local limit = self.limit
     local window = self.window
-    local remaining
     key = self.plugin_name .. tostring(key)
+    local remaining,err = red:eval("if redis.call('ttl',KEYS[1]) < 0 then redis.call('set',KEYS[1],ARGV[1]-1,'EX',ARGV[2]) return ARGV[1]-1 end return redis.call('incrby',KEYS[1],-1)",1,key,limit,window)
 
-    local ret, err = red:ttl(key)
-    if not ret then
-        return false, "failed to get redis `" .. key .."` ttl: " .. err
+    if err then
+        return nil,err
     end
 
-    core.log.info("ttl key: ", key, " ret: ", ret, " err: ", err)
-    if ret < 0 then
-        local lock, err = resty_lock:new("plugin-limit-count")
-        if not lock then
-            return false, "failed to create lock: " .. err
-        end
-
-        local elapsed, err = lock:lock(key)
-        if not elapsed then
-            return false, "failed to acquire the lock: " .. err
-        end
-
-        ret = red:ttl(key)
-        if ret < 0 then
-            local ok, err = lock:unlock()
-            if not ok then
-                return false, "failed to unlock: " .. err
-            end
-
-            ret, err = red:set(key, limit -1, "EX", window)
-            if not ret then
-                return nil, err
-            end
-
-            return 0, limit -1
-        end
-
-        local ok, err = lock:unlock()
-        if not ok then
-            return false, "failed to unlock: " .. err
-        end
+    if remaining <0 then
+        core.log.error(remaining)
+        return nil,"rejected"
     end
-
-    remaining, err = red:incrby(key, -1)
-    if not remaining then
-        return nil, err
-    end
-
-    if remaining < 0 then
-        return nil, "rejected"
-    end
-
-    return 0, remaining
+    return 0,remaining
 end
 
 

--- a/apisix/plugins/limit-count/limit-count-redis-cluster.lua
+++ b/apisix/plugins/limit-count/limit-count-redis-cluster.lua
@@ -90,7 +90,6 @@ function _M.incoming(self, key)
     end
 
     if remaining <0 then
-        core.log.error(remaining)
         return nil,"rejected"
     end
     return 0,remaining

--- a/apisix/plugins/limit-count/limit-count-redis.lua
+++ b/apisix/plugins/limit-count/limit-count-redis.lua
@@ -76,65 +76,18 @@ function _M.incoming(self, key)
 
     local limit = self.limit
     local window = self.window
-    local remaining
     key = self.plugin_name .. tostring(key)
 
-    -- todo: test case
-    local ret, err = red:ttl(key)
-    if not ret then
-        return false, "failed to get redis `" .. key .."` ttl: " .. err
+    local remaining,err = red:eval("if redis.call('ttl',KEYS[1]) < 0 then redis.call('set',KEYS[1],ARGV[1]-1,'EX',ARGV[2]) return ARGV[1]-1 end return redis.call('incrby',KEYS[1],-1)",1,key,limit,window)
+
+    if err then
+        return nil,err
     end
 
-    core.log.info("ttl key: ", key, " ret: ", ret, " err: ", err)
-    if ret < 0 then
-        -- todo: test case
-        local lock, err = resty_lock:new("plugin-limit-count")
-        if not lock then
-            return false, "failed to create lock: " .. err
-        end
-
-        local elapsed, err = lock:lock(key)
-        if not elapsed then
-            return false, "failed to acquire the lock: " .. err
-        end
-
-        ret = red:ttl(key)
-        if ret < 0 then
-            ok, err = lock:unlock()
-            if not ok then
-                return false, "failed to unlock: " .. err
-            end
-
-            limit = limit -1
-            ret, err = red:set(key, limit, "EX", window)
-            if not ret then
-                return nil, err
-            end
-
-            return 0, limit
-        end
-
-        ok, err = lock:unlock()
-        if not ok then
-            return false, "failed to unlock: " .. err
-        end
+    if remaining <0 then
+        return nil,"rejected"
     end
-
-    remaining, err = red:incrby(key, -1)
-    if not remaining then
-        return nil, err
-    end
-
-    local ok, err = red:set_keepalive(10000, 100)
-    if not ok then
-        return nil, err
-    end
-
-    if remaining < 0 then
-        return nil, "rejected"
-    end
-
-    return 0, remaining
+    return 0,remaining
 end
 
 

--- a/apisix/plugins/limit-count/limit-count-redis.lua
+++ b/apisix/plugins/limit-count/limit-count-redis.lua
@@ -29,11 +29,11 @@ local mt = {
 }
 
 
-local script = "if redis.call('ttl',KEYS[1]) < 0 then "
-    .. "redis.call('set',KEYS[1],ARGV[1]-1,'EX',ARGV[2]) "
-    .. "return ARGV[1]-1 "
+local script = "if redis.call('ttl', KEYS[1]) < 0 then "
+    .. "redis.call('set', KEYS[1], ARGV[1] - 1, 'EX', ARGV[2]) "
+    .. "return ARGV[1] - 1 "
     .. "end "
-    .. "return redis.call('incrby',KEYS[1],-1)"
+    .. "return redis.call('incrby', KEYS[1], -1)"
 
 
 function _M.new(plugin_name, limit, window, conf)
@@ -82,17 +82,19 @@ function _M.incoming(self, key)
 
     local limit = self.limit
     local window = self.window
+    local remaining
     key = self.plugin_name .. tostring(key)
-    local remaining, err = red:eval(script,1,key,limit,window)
+
+    remaining, err = red:eval(script, 1, key, limit, window)
 
     if err then
-        return nil,err
+        return nil, err
     end
 
-    if remaining <0 then
-        return nil,"rejected"
+    if remaining < 0 then
+        return nil, "rejected"
     end
-    return 0,remaining
+    return 0, remaining
 end
 
 

--- a/apisix/plugins/limit-count/limit-count-redis.lua
+++ b/apisix/plugins/limit-count/limit-count-redis.lua
@@ -29,11 +29,13 @@ local mt = {
 }
 
 
-local script = "if redis.call('ttl', KEYS[1]) < 0 then "
-    .. "redis.call('set', KEYS[1], ARGV[1] - 1, 'EX', ARGV[2]) "
-    .. "return ARGV[1] - 1 "
-    .. "end "
-    .. "return redis.call('incrby', KEYS[1], -1)"
+local script = [=[
+    if redis.call('ttl', KEYS[1]) < 0 then
+        redis.call('set', KEYS[1], ARGV[1] - 1, 'EX', ARGV[2])
+        return ARGV[1] - 1
+    end
+    return redis.call('incrby', KEYS[1], -1)
+]=]
 
 
 function _M.new(plugin_name, limit, window, conf)

--- a/apisix/plugins/limit-count/limit-count-redis.lua
+++ b/apisix/plugins/limit-count/limit-count-redis.lua
@@ -16,7 +16,6 @@
 --
 local redis_new = require("resty.redis").new
 local core = require("apisix.core")
-local resty_lock = require("resty.lock")
 local assert = assert
 local setmetatable = setmetatable
 local tostring = tostring
@@ -28,6 +27,13 @@ local _M = {version = 0.3}
 local mt = {
     __index = _M
 }
+
+
+local script = "if redis.call('ttl',KEYS[1]) < 0 then "
+    .. "redis.call('set',KEYS[1],ARGV[1]-1,'EX',ARGV[2]) "
+    .. "return ARGV[1]-1 "
+    .. "end "
+    .. "return redis.call('incrby',KEYS[1],-1)"
 
 
 function _M.new(plugin_name, limit, window, conf)
@@ -77,8 +83,7 @@ function _M.incoming(self, key)
     local limit = self.limit
     local window = self.window
     key = self.plugin_name .. tostring(key)
-
-    local remaining,err = red:eval("if redis.call('ttl',KEYS[1]) < 0 then redis.call('set',KEYS[1],ARGV[1]-1,'EX',ARGV[2]) return ARGV[1]-1 end return redis.call('incrby',KEYS[1],-1)",1,key,limit,window)
+    local remaining, err = red:eval(script,1,key,limit,window)
 
     if err then
         return nil,err


### PR DESCRIPTION
### What this PR does / why we need it:

Use redis's eval() to ensure atomic operations of ttl and incrby, and solve the situation where a small number of requests are accidentally killed in high concurrency scenarios

使用redis的eval()确保ttl和incrby的原子性操作，解决高并发场景下少量请求被误杀的情况

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
