### PR TITLE
change(kafka-logger): send logs in async mode by default

### DIFF
--- a/apisix/plugins/kafka-logger.lua
+++ b/apisix/plugins/kafka-logger.lua
@@ -18,6 +18,7 @@ local core     = require("apisix.core")
 local log_util = require("apisix.utils.log-util")
 local producer = require ("resty.kafka.producer")
 local batch_processor = require("apisix.utils.batch-processor")
+local math     = math
 local pairs    = pairs
 local type     = type
 local ipairs   = ipairs
@@ -44,6 +45,11 @@ local schema = {
             type = "object"
         },
         kafka_topic = {type = "string"},
+        producer_type = {
+            type = "string",
+            default = "async",
+            enum = {"async", "sync"},
+        },
         key = {type = "string"},
         timeout = {type = "integer", minimum = 1, default = 3},
         name = {type = "string", default = "kafka logger"},
@@ -70,7 +76,21 @@ function _M.check_schema(conf)
 end
 
 
-local function get_partition_id(sendbuffer, topic, log_message)
+local function get_partition_id(prod, topic, log_message)
+    if prod.async then
+        local ringbuffer = prod.ringbuffer
+        for i = 1, ringbuffer.size, 3 do
+            if ringbuffer.queue[i] == topic and
+                ringbuffer.queue[i+2] == log_message then
+                return math.floor(i / 3)
+            end
+        end
+        core.log.info("current topic in ringbuffer has no message")
+        return nil
+    end
+
+    -- sync mode
+    local sendbuffer = prod.sendbuffer
     if not sendbuffer.topics[topic] then
         core.log.info("current topic in sendbuffer has no message")
         return nil
@@ -115,7 +135,7 @@ local function send_kafka_data(conf, log_message, prod)
     local ok, err = prod:send(conf.kafka_topic, conf.key, log_message)
     core.log.info("partition_id: ",
                   core.log.delay_exec(get_partition_id,
-                                      prod.sendbuffer, conf.kafka_topic, log_message))
+                                      prod, conf.kafka_topic, log_message))
 
     if not ok then
         return nil, "failed to send data to Kafka topic: " .. err
@@ -164,6 +184,7 @@ function _M.log(conf, ctx)
     end
 
     broker_config["request_timeout"] = conf.timeout * 1000
+    broker_config["producer_type"] = conf.producer_type
 
     local prod, err = core.lrucache.plugin_ctx(lrucache, ctx, nil, create_producer,
                                                broker_list, broker_config)

--- a/docs/en/latest/plugins/kafka-logger.md
+++ b/docs/en/latest/plugins/kafka-logger.md
@@ -47,6 +47,7 @@ For more info on Batch-Processor in Apache APISIX please refer.
 | ---------------- | ------- | ----------- | -------------- | ------- | ---------------------------------------------------------------------------------------- |
 | broker_list      | object  | required    |                |         | An array of Kafka brokers.                                                               |
 | kafka_topic      | string  | required    |                |         | Target  topic to push data.                                                              |
+| producer_type    | string  | optional    | async          | ["async", "sync"]        | Producer's mode of sending messages.          |
 | key              | string  | optional    |                |         | Used for partition allocation of messages.                                               |
 | timeout          | integer | optional    | 3              | [1,...] | Timeout for the upstream to send data.                                                   |
 | name             | string  | optional    | "kafka logger" |         | A  unique identifier to identity the batch processor.                                     |

--- a/docs/zh/latest/plugins/kafka-logger.md
+++ b/docs/zh/latest/plugins/kafka-logger.md
@@ -45,6 +45,7 @@ title: kafka-logger
 | ---------------- | ------- | ------ | -------------- | ------- | ------------------------------------------------ |
 | broker_list      | object  | 必须   |                |         | 要推送的 kafka 的 broker 列表。                  |
 | kafka_topic      | string  | 必须   |                |         | 要推送的 topic。                                 |
+| producer_type    | string  | 可选   | async          | ["async", "sync"]        | 生产者发送消息的模式。          |
 | key              | string  | 可选   |                |         | 用于消息的分区分配。                             |
 | timeout          | integer | 可选   | 3              | [1,...] | 发送数据的超时时间。                             |
 | name             | string  | 可选   | "kafka logger" |         | batch processor 的唯一标识。                     |

--- a/t/plugin/kafka-logger.t
+++ b/t/plugin/kafka-logger.t
@@ -199,6 +199,7 @@ hello world
                                         "127.0.0.1":9093
                                       },
                                     "kafka_topic" : "test2",
+                                    "producer_type": "sync",
                                     "key" : "key1",
                                     "batch_max_size": 1
                              }
@@ -222,6 +223,7 @@ hello world
                                         "127.0.0.1":9093
                                       },
                                     "kafka_topic" : "test2",
+                                    "producer_type": "sync",
                                     "key" : "key1",
                                     "batch_max_size": 1
                                 }
@@ -627,6 +629,81 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "kafka-logger": {
+                                "broker_list" : {
+                                    "127.0.0.1": 9092
+                                },
+                                "kafka_topic" : "test3",
+                                "producer_type": "sync",
+                                "timeout" : 1,
+                                "batch_max_size": 1,
+                                "include_req_body": false
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+
+            t('/hello',ngx.HTTP_GET)
+            ngx.sleep(0.5)
+            t('/hello',ngx.HTTP_GET)
+            ngx.sleep(0.5)
+            t('/hello',ngx.HTTP_GET)
+            ngx.sleep(0.5)
+        }
+    }
+--- request
+GET /t
+--- timeout: 5s
+--- ignore_response
+--- no_error_log
+[error]
+--- error_log eval
+[qr/partition_id: 1/,
+qr/partition_id: 0/,
+qr/partition_id: 2/]
+
+
+
+=== TEST 19: report log to kafka by different partitions in async mode
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "kafka-logger": {
+                                "broker_list" : {
+                                    "127.0.0.1": 9092
+                                },
+                                "kafka_topic" : "test3",
+                                "producer_type": "async",
+                                "timeout" : 1,
+                                "batch_max_size": 1,
+                                "include_req_body": false
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
             t('/hello',ngx.HTTP_GET)
             ngx.sleep(0.5)
             t('/hello',ngx.HTTP_GET)


### PR DESCRIPTION
### What this PR does / why we need it:

It's recommend to use async [producer_type](https://github.com/doujiang24/lua-resty-kafka#new-1). The performance of sync mode is very poor.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
