### PR TITLE
docs: the link should be to dashboard instead of APISIX

### DIFF
--- a/docs/en/latest/getting-started.md
+++ b/docs/en/latest/getting-started.md
@@ -262,7 +262,7 @@ $ curl -i -X GET 'http://127.0.0.1:9080/samplePrefix/get?param1=foo&param2=bar' 
 
 ### APISIX Dashboard
 
-Apache APISIX provides a [Dashboard](https://github.com/apache/apisix) to let us operate Apache APISIX more easier.
+Apache APISIX provides a [Dashboard](https://github.com/apache/apisix-dashboard) to let us operate Apache APISIX more easier.
 
 ![Dashboard](../../assets/images/dashboard.jpeg)
 

--- a/docs/zh/latest/getting-started.md
+++ b/docs/zh/latest/getting-started.md
@@ -267,7 +267,7 @@ $ curl -i -X  GET 'http://127.0.0.1:9080/samplePrefix/get?param1=foo&param2=bar'
 
 ### APISIX Dashboard（控制台）
 
-Apache APISIX 提供了一个 [Dashboard](https://github.com/apache/apisix)，让我们的操作更直观更轻松。
+Apache APISIX 提供了一个 [Dashboard](https://github.com/apache/apisix-dashboard)，让我们的操作更直观更轻松。
 
 ![Dashboard](../../assets/images/dashboard.jpeg)
 


### PR DESCRIPTION
### What this PR does / why we need it:
fix: #4079 

