### PR TITLE
fix(traffic-split): configure multiple "rules", the request will be confused between upstream

### DIFF
--- a/apisix/plugins/traffic-split.lua
+++ b/apisix/plugins/traffic-split.lua
@@ -278,8 +278,7 @@ function _M.access(conf, ctx)
         return
     end
 
-    local rr_up, err = core.lrucache.plugin_ctx(lrucache, ctx, nil, new_rr_obj,
-                                                weighted_upstreams)
+    local rr_up, err = lrucache(weighted_upstreams, nil, new_rr_obj, weighted_upstreams)
     if not rr_up then
         core.log.error("lrucache roundrobin failed: ", err)
         return 500

--- a/docs/en/latest/plugins/traffic-split.md
+++ b/docs/en/latest/plugins/traffic-split.md
@@ -485,11 +485,11 @@ hello 1980
 
 ### Matching rules correspond to upstream
 
-How to make different matching rules correspond to different upstreams. We can achieve this by configuring multiple `rules.match` + `rules.weighted_upstreams`.
+By configuring multiple `rules`, we can achieve one-to-one correspondence between different matching rules and upstream.
 
 **Example:**
 
-When the request header `x-api-id` is equal to 1, it hits the upstream of port 1981; when `x-api-id` is equal to 2, it hits the upstream of port 1982; otherwise, it hits the upstream of port 1980 (the upstream response data is the corresponding port number).
+When the request header `x-api-id` is equal to 1, it hits the upstream with port 1981; when `x-api-id` is equal to 2, it hits the upstream with port 1982; otherwise, it hits the upstream with port 1980 (the upstream response data is the corresponding port number).
 
 ```shell
 curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
@@ -554,21 +554,21 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
 
 **Test plugin:**
 
-The request header `x-api-id` is equal to 1, which hits the upstream of the 1981 port.
+The request header `x-api-id` is equal to 1, hitting the upstream with the 1981 port.
 
 ```shell
 $ curl http://127.0.0.1:9080/hello -H 'x-api-id: 1'
 1981
 ```
 
-The request header `x-api-id` is equal to 2, which hits the upstream of the 1982 port.
+The request header `x-api-id` is equal to 2, hitting the upstream with the 1982 port.
 
 ```shell
 $ curl http://127.0.0.1:9080/hello -H 'x-api-id: 2'
 1982
 ```
 
-The request header `x-api-id` is equal to 3, the rule does not match, and it hits the upstream of the 1980 port.
+The request header `x-api-id` is equal to 3, the rule does not match, and it hits the upstream with port 1980.
 
 ```shell
 $ curl http://127.0.0.1:9080/hello -H 'x-api-id: 3'

--- a/docs/zh/latest/plugins/traffic-split.md
+++ b/docs/zh/latest/plugins/traffic-split.md
@@ -30,6 +30,7 @@ title: traffic-split
   - [灰度发布](#灰度发布)
   - [蓝绿发布](#蓝绿发布)
   - [自定义发布](#自定义发布)
+  - [匹配规则与上游对应](#匹配规则与上游对应)
 - [禁用插件](#禁用插件)
 
 ## 名字
@@ -491,6 +492,98 @@ Content-Type: text/html; charset=utf-8
 ......
 
 hello 1980
+```
+
+### 匹配规则与上游对应
+
+如何让不同的匹配规则对应到不同的上游，我们可以通过配置多个 `rules.match` + `rules.weighted_upstreams` 来实现。
+
+**示例：**
+
+当请求头 `x-api-id` 等于 1 时，命中 1981 端口的上游；当 `x-api-id` 等于 2 时，命中 1982 端口的上游；否则，命中 1980 端口的上游（上游响应数据为对应的端口号）。
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "uri": "/hello",
+    "plugins": {
+        "traffic-split": {
+            "rules": [
+                {
+                    "match": [
+                        {
+                            "vars": [
+                                ["http_x-api-id","==","1"]
+                            ]
+                        }
+                    ],
+                    "weighted_upstreams": [
+                        {
+                            "upstream": {
+                                "name": "upstream-A",
+                                "type": "roundrobin",
+                                "nodes": {
+                                    "127.0.0.1:1981":1
+                                }
+                            },
+                            "weight": 3
+                        }
+                    ]
+                },
+                {
+                    "match": [
+                        {
+                            "vars": [
+                                ["http_x-api-id","==","2"]
+                            ]
+                        }
+                    ],
+                    "weighted_upstreams": [
+                        {
+                            "upstream": {
+                                "name": "upstream-B",
+                                "type": "roundrobin",
+                                "nodes": {
+                                    "127.0.0.1:1982":1
+                                }
+                            },
+                            "weight": 3
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "upstream": {
+            "type": "roundrobin",
+            "nodes": {
+                "127.0.0.1:1980": 1
+            }
+    }
+}'
+```
+
+**测试插件：**
+
+请求头 `x-api-id` 等于 1，命中 1981 端口的上游。
+
+```shell
+$ curl http://127.0.0.1:9080/hello -H 'x-api-id: 1'
+1981
+```
+
+请求头 `x-api-id` 等于 2，命中 1982 端口的上游。
+
+```shell
+$ curl http://127.0.0.1:9080/hello -H 'x-api-id: 2'
+1982
+```
+
+请求头 `x-api-id` 等于 3，规则不匹配，命中 1980 端口的上游。
+
+```shell
+$ curl http://127.0.0.1:9080/hello -H 'x-api-id: 3'
+1980
 ```
 
 ## 禁用插件

--- a/docs/zh/latest/plugins/traffic-split.md
+++ b/docs/zh/latest/plugins/traffic-split.md
@@ -496,7 +496,7 @@ hello 1980
 
 ### 匹配规则与上游对应
 
-如何让不同的匹配规则对应到不同的上游，我们可以通过配置多个 `rules.match` + `rules.weighted_upstreams` 来实现。
+通过配置多个 `rules`，我们可以实现不同的匹配规则与上游一一对应。
 
 **示例：**
 
@@ -565,21 +565,21 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
 
 **测试插件：**
 
-请求头 `x-api-id` 等于 1，命中 1981 端口的上游。
+请求头 `x-api-id` 等于 1，命中带 1981 端口的上游。
 
 ```shell
 $ curl http://127.0.0.1:9080/hello -H 'x-api-id: 1'
 1981
 ```
 
-请求头 `x-api-id` 等于 2，命中 1982 端口的上游。
+请求头 `x-api-id` 等于 2，命中带 1982 端口的上游。
 
 ```shell
 $ curl http://127.0.0.1:9080/hello -H 'x-api-id: 2'
 1982
 ```
 
-请求头 `x-api-id` 等于 3，规则不匹配，命中 1980 端口的上游。
+请求头 `x-api-id` 等于 3，规则不匹配，命中带 1980 端口的上游。
 
 ```shell
 $ curl http://127.0.0.1:9080/hello -H 'x-api-id: 3'

--- a/t/plugin/traffic-split2.t
+++ b/t/plugin/traffic-split2.t
@@ -410,7 +410,8 @@ hash_on: header
 chash_key: "hello"
 
 
-=== TEST 12: the plugin has multiple weighted_upstreams
+
+=== TEST 12: the plugin has multiple weighted_upstreams(upstream method)
 --- config
     location /t {
         content_by_lua_block {
@@ -425,9 +426,7 @@ chash_key: "hello"
                                 {
                                     "match": [
                                         {
-                                            "vars": [
-                                                ["arg_id","==","1"]
-                                            ]
+                                            "vars": [["arg_id","==","1"]]
                                         }
                                     ],
                                     "weighted_upstreams": [
@@ -446,9 +445,7 @@ chash_key: "hello"
                                 {
                                     "match": [
                                         {
-                                            "vars": [
-                                                ["arg_id","==","2"]
-                                            ]
+                                            "vars": [["arg_id","==","2"]]
                                         }
                                     ],
                                     "weighted_upstreams": [
@@ -528,9 +525,7 @@ qr/1980, 1981, 1982, 1980, 1981, 1982, 1980, 1981, 1982/
                                 {
                                     "match": [
                                         {
-                                            "vars": [
-                                                ["arg_id","==","1"]
-                                            ]
+                                            "vars": [["arg_id","==","1"]]
                                         }
                                     ],
                                     "weighted_upstreams": [
@@ -552,9 +547,7 @@ qr/1980, 1981, 1982, 1980, 1981, 1982, 1980, 1981, 1982/
                                 {
                                     "match": [
                                         {
-                                            "vars": [
-                                                ["arg_id","==","2"]
-                                            ]
+                                            "vars": [["arg_id","==","2"]]
                                         }
                                     ],
                                     "weighted_upstreams": [
@@ -597,7 +590,7 @@ passed
 
 
 
-=== TEST 11: every weighted_upstreams in the plugin is hit
+=== TEST 15: every weighted_upstreams in the plugin is hit
 --- config
 location /t {
     content_by_lua_block {
@@ -616,5 +609,139 @@ location /t {
 }
 --- response_body eval
 qr/1980, 1980, 1980, 1980, 1981, 1981, 1982, 1982/
+--- no_error_log
+[error]
+
+
+
+=== TEST 16: set upstream(upstream_id: 1, upstream_id: 2)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/upstreams/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "nodes": {
+                        "127.0.0.1:1981": 1
+                    },
+                    "type": "roundrobin",
+                    "desc": "new upstream A"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+            end
+
+            code, body = t('/apisix/admin/upstreams/2',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "nodes": {
+                        "127.0.0.1:1982": 1
+                    },
+                    "type": "roundrobin",
+                    "desc": "new upstream B"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 17: the plugin has multiple weighted_upstreams(upstream_id method)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PATCH,
+                [=[{
+                    "uri": "/server_port",
+                    "plugins": {
+                        "traffic-split": {
+                            "rules": [
+                                {
+                                    "match": [
+                                        {
+                                            "vars": [["arg_id","==","1"]]
+                                        }
+                                    ],
+                                    "weighted_upstreams": [
+                                        {
+                                            "upstream_id": 1,
+                                            "weight": 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    "match": [
+                                        {
+                                            "vars": [["arg_id","==","2"]]
+                                        }
+                                    ],
+                                    "weighted_upstreams": [
+                                        {
+                                            "upstream_id": 2,
+                                            "weight": 1
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                    }
+                }]=]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 18: hit each upstream separately
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local bodys = {}
+        for i = 1, 9, 3 do
+            local _, _, body = t('/server_port', ngx.HTTP_GET)
+            local _, _, body2 = t('/server_port?id=1', ngx.HTTP_GET)
+            local _, _, body3 = t('/server_port?id=2', ngx.HTTP_GET)
+            bodys[i] = body
+            bodys[i+1] = body2
+            bodys[i+2] = body3
+        end
+
+        ngx.say(table.concat(bodys, ", "))
+    }
+}
+--- response_body eval
+qr/1980, 1981, 1982, 1980, 1981, 1982, 1980, 1981, 1982/
 --- no_error_log
 [error]

--- a/t/plugin/traffic-split2.t
+++ b/t/plugin/traffic-split2.t
@@ -614,7 +614,7 @@ qr/1980, 1980, 1980, 1980, 1981, 1981, 1982, 1982/
 
 
 
-=== TEST 16: set upstream(upstream_id: 1, upstream_id: 2)
+=== TEST 16: set upstream(upstream_id: 1, upstream_id: 2) and add route
 --- config
     location /t {
         content_by_lua_block {
@@ -648,25 +648,10 @@ qr/1980, 1980, 1980, 1980, 1981, 1981, 1982, 1982/
 
             if code >= 300 then
                 ngx.status = code
+                ngx.say(body)
             end
-            ngx.say(body)
-        }
-    }
---- request
-GET /t
---- response_body
-passed
---- no_error_log
-[error]
 
-
-
-=== TEST 17: the plugin has multiple weighted_upstreams(upstream_id method)
---- config
-    location /t {
-        content_by_lua_block {
-            local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/routes/1',
+            code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PATCH,
                 [=[{
                     "uri": "/server_port",
@@ -716,6 +701,8 @@ passed
             ngx.say(body)
         }
     }
+--- request
+GET /t
 --- response_body
 passed
 --- no_error_log
@@ -723,7 +710,7 @@ passed
 
 
 
-=== TEST 18: hit each upstream separately
+=== TEST 17: hit each upstream separately
 --- config
 location /t {
     content_by_lua_block {

--- a/t/plugin/traffic-split2.t
+++ b/t/plugin/traffic-split2.t
@@ -408,3 +408,213 @@ hash_on: header
 chash_key: "world"
 hash_on: header
 chash_key: "hello"
+
+
+=== TEST 12: the plugin has multiple weighted_upstreams
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PATCH,
+                [=[{
+                    "uri": "/server_port",
+                    "plugins": {
+                        "traffic-split": {
+                            "rules": [
+                                {
+                                    "match": [
+                                        {
+                                            "vars": [
+                                                ["arg_id","==","1"]
+                                            ]
+                                        }
+                                    ],
+                                    "weighted_upstreams": [
+                                        {
+                                            "upstream": {
+                                                "name": "upstream_A",
+                                                "type": "roundrobin",
+                                                "nodes": {
+                                                    "127.0.0.1:1981":1
+                                                }
+                                            },
+                                            "weight": 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    "match": [
+                                        {
+                                            "vars": [
+                                                ["arg_id","==","2"]
+                                            ]
+                                        }
+                                    ],
+                                    "weighted_upstreams": [
+                                        {
+                                            "upstream": {
+                                                "name": "upstream_B",
+                                                "type": "roundrobin",
+                                                "nodes": {
+                                                    "127.0.0.1:1982":1
+                                                }
+                                            },
+                                            "weight": 1
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                    }
+                }]=]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 13: hit each upstream separately
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local bodys = {}
+        for i = 1, 9, 3 do
+            local _, _, body = t('/server_port', ngx.HTTP_GET)
+            local _, _, body2 = t('/server_port?id=1', ngx.HTTP_GET)
+            local _, _, body3 = t('/server_port?id=2', ngx.HTTP_GET)
+            bodys[i] = body
+            bodys[i+1] = body2
+            bodys[i+2] = body3
+        end
+
+        ngx.say(table.concat(bodys, ", "))
+    }
+}
+--- response_body eval
+qr/1980, 1981, 1982, 1980, 1981, 1982, 1980, 1981, 1982/
+--- no_error_log
+[error]
+
+
+
+=== TEST 14: the plugin has multiple weighted_upstreams and has a default routing weight in weighted_upstreams
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PATCH,
+                [=[{
+                    "uri": "/server_port",
+                    "plugins": {
+                        "traffic-split": {
+                            "rules": [
+                                {
+                                    "match": [
+                                        {
+                                            "vars": [
+                                                ["arg_id","==","1"]
+                                            ]
+                                        }
+                                    ],
+                                    "weighted_upstreams": [
+                                        {
+                                            "upstream": {
+                                                "name": "upstream_A",
+                                                "type": "roundrobin",
+                                                "nodes": {
+                                                    "127.0.0.1:1981":1
+                                                }
+                                            },
+                                            "weight": 1
+                                        },
+                                        {
+                                            "weight": 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    "match": [
+                                        {
+                                            "vars": [
+                                                ["arg_id","==","2"]
+                                            ]
+                                        }
+                                    ],
+                                    "weighted_upstreams": [
+                                        {
+                                            "upstream": {
+                                                "name": "upstream_B",
+                                                "type": "roundrobin",
+                                                "nodes": {
+                                                    "127.0.0.1:1982":1
+                                                }
+                                            },
+                                            "weight": 1
+                                        },
+                                        {
+                                            "weight": 1
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                    }
+                }]=]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 11: every weighted_upstreams in the plugin is hit
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local bodys = {}
+        for i = 1, 8, 2 do
+            local _, _, body = t('/server_port?id=1', ngx.HTTP_GET)
+            local _, _, body2 = t('/server_port?id=2', ngx.HTTP_GET)
+            bodys[i] = body
+            bodys[i+1] = body2
+        end
+
+        table.sort(bodys)
+        ngx.say(table.concat(bodys, ", "))
+    }
+}
+--- response_body eval
+qr/1980, 1980, 1980, 1980, 1981, 1981, 1982, 1982/
+--- no_error_log
+[error]


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When the rules array object in the traffic-split plugin has multiple upstream conditions (weighted_upstreams + match), the request will be confused among multiple upstreams. The following example:

```shell
curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
{
    "uri": "/hello",
    "plugins": {
        "traffic-split": {
            "rules": [
                {
                    "match": [
                        {
                            "vars": [
                                ["http_id","==","1"]
                            ]
                        }
                    ],
                    "weighted_upstreams": [
                        {
                            "upstream": {
                                "name": "upstream_A",
                                "type": "roundrobin",
                                "nodes": {
                                    "127.0.0.1:1981":1
                                }
                            },
                            "weight": 3
                        }
                    ]
                },
                {
                    "match": [
                        {
                            "vars": [
                                ["http_id","==","2"]
                            ]
                        }
                    ],
                    "weighted_upstreams": [
                        {
                            "upstream": {
                                "name": "upstream_B",
                                "type": "roundrobin",
                                "nodes": {
                                    "127.0.0.1:1982":1
                                }
                            },
                            "weight": 3
                        }
                    ]
                }
            ]
        }
    },
    "upstream": {
            "type": "roundrobin",
            "nodes": {
                "127.0.0.1:1980": 1
            }
    }
}'
```

**Test :**

Match the upstream of the 1981 port and return the 1981 port number:

```
for i in `seq 1 5`; do curl http://127.0.0.1:9080/hello -H 'id: 1'; done
1981
1981
1981
1981
1981
```

Matches the upstream of the 1982 port, and is expected to return the 1982 port number, but it actually hits the upstream of the 1981 and 1982 port：

```shell
for i in `seq 1 5`; do curl http://127.0.0.1:9080/hello -H 'id: 2'; done
1981
1981
1982
1982
1981
```

Does not match the upstream of the plugin, the upstream of the default route, returns the 1980 port number:
```shell
for i in `seq 1 5`; do curl http://127.0.0.1:9080/hello -H 'id: 4'; done
1980
1980
1980
1980
1980
```

This PR is used to fix the problem.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
