### PR TITLE
fix: remove unexpected blocking in background timer

### DIFF
--- a/apisix/core/timer.lua
+++ b/apisix/core/timer.lua
@@ -35,14 +35,17 @@ local function _internal(timer)
         local ok, err = pcall(timer.callback_fun)
         if not ok then
             log.error("failed to run the timer: ", timer.name, " err: ", err)
-            sleep(timer.sleep_fail)
+
+            if timer.sleep_fail > 0 then
+                sleep(timer.sleep_fail)
+            end
 
         elseif timer.sleep_succ > 0 then
             sleep(timer.sleep_succ)
         end
 
         update_time()
-    until timer.each_ttl and now() >= timer.start_time + timer.each_ttl
+    until timer.each_ttl <= 0 or now() >= timer.start_time + timer.each_ttl
 end
 
 local function run_timer(premature, self)

--- a/apisix/timers.lua
+++ b/apisix/timers.lua
@@ -21,7 +21,7 @@ local unpack = unpack
 local thread_spawn = ngx.thread.spawn
 local thread_wait = ngx.thread.wait
 
-local check_interval = 0.5
+local check_interval = 1
 
 local timers = {}
 
@@ -30,6 +30,10 @@ local _M = {}
 
 
 local function background_timer()
+    if core.table.nkeys(timers) == 0 then
+        return
+    end
+
     local threads = {}
     for name, timer in pairs(timers) do
         core.log.info("run timer[", name, "]")
@@ -59,6 +63,8 @@ end
 
 function _M.init_worker()
     local opts = {
+        each_ttl = 0,
+        sleep_succ = 0,
         check_interval = check_interval,
     }
     local timer, err = core.timer.new("background", background_timer, opts)

--- a/t/misc/timers.t
+++ b/t/misc/timers.t
@@ -41,8 +41,6 @@ __DATA__
     location /t {
         content_by_lua_block {
             local timers = require("apisix.timers")
-            local ngx_now = ngx.now
-            local start_at = ngx_now()
             timers.register_timer("t", function()
                 ngx.log(ngx.WARN, "fire")
             end)

--- a/t/misc/timers.t
+++ b/t/misc/timers.t
@@ -1,0 +1,60 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!$block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+    if (!defined $block->error_log && !defined $block->no_error_log) {
+        $block->set_value("no_error_log", "[error]");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: always start a new timer even the previous one is blocked
+--- config
+    location /t {
+        content_by_lua_block {
+            local timers = require("apisix.timers")
+            local ngx_now = ngx.now
+            local start_at = ngx_now()
+            timers.register_timer("t", function()
+                ngx.log(ngx.WARN, "fire")
+            end)
+            timers.register_timer("c", function()
+                ngx.sleep(5)
+            end)
+
+            ngx.sleep(2.1)
+        }
+    }
+--- grep_error_log eval
+qr/fire/
+--- grep_error_log_out
+fire
+fire


### PR DESCRIPTION
Previously we actually run background timer each second.
And the backgroud timer will be blocked if there is not timer registered
To be compatible, now we increase the interval to 1 second.

Fix #3923

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
