### PR TITLE
feat(kafka-logger): add server info to kafka log

### DIFF
--- a/apisix/utils/log-util.lua
+++ b/apisix/utils/log-util.lua
@@ -52,6 +52,10 @@ local function get_full_log(ngx, conf)
             headers = ngx.resp.get_headers(),
             size = var.bytes_sent
         },
+        server = {
+            hostname = core.utils.gethostname(),
+            version = core.version.VERSION
+        },
         upstream = var.upstream_addr,
         service_id = service_id,
         route_id = route_id,

--- a/docs/en/latest/plugins/kafka-logger.md
+++ b/docs/en/latest/plugins/kafka-logger.md
@@ -64,7 +64,44 @@ For more info on Batch-Processor in Apache APISIX please refer.
 - **default**:
 
     ```json
-    {"upstream":"127.0.0.1:1980","start_time":1602211788041,"client_ip":"127.0.0.1","service_id":"","route_id":"1","request":{"querystring":{"ab":"cd"},"size":90,"uri":"\/hello?ab=cd","url":"http:\/\/localhost:1984\/hello?ab=cd","headers":{"host":"localhost","content-length":"6","connection":"close"},"body":"abcdef","method":"GET"},"response":{"headers":{"content-type":"text\/plain","server":"APISIX\/1.5","connection":"close","transfer-encoding":"chunked"},"status":200,"size":153},"latency":99.000215530396}
+    {
+     "upstream": "127.0.0.1:1980",
+     "start_time": 1619414294760,
+     "client_ip": "127.0.0.1",
+     "service_id": "",
+     "route_id": "1",
+     "request": {
+       "querystring": {
+         "ab": "cd"
+       },
+       "size": 90,
+       "uri": "/hello?ab=cd",
+       "url": "http://localhost:1984/hello?ab=cd",
+       "headers": {
+         "host": "localhost",
+         "content-length": "6",
+         "connection": "close"
+       },
+       "body": "abcdef",
+       "method": "GET"
+     },
+     "response": {
+       "headers": {
+         "connection": "close",
+         "content-type": "text/plain; charset=utf-8",
+         "date": "Mon, 26 Apr 2021 05:18:14 GMT",
+         "server": "APISIX/2.5",
+         "transfer-encoding": "chunked"
+       },
+       "size": 190,
+       "status": 200
+     },
+     "server": {
+       "hostname": "localhost",
+       "version": "2.5"
+     },
+     "latency": 0
+    }
     ```
 
 - **origin**:

--- a/docs/zh/latest/plugins/kafka-logger.md
+++ b/docs/zh/latest/plugins/kafka-logger.md
@@ -62,18 +62,82 @@ title: kafka-logger
 - **default**:
 
     ```json
-    {"upstream":"127.0.0.1:1980","start_time":1602211788041,"client_ip":"127.0.0.1","service_id":"","route_id":"1","request":{"querystring":{"ab":"cd"},"size":90,"uri":"\/hello?ab=cd","url":"http:\/\/localhost:1984\/hello?ab=cd","headers":{"host":"localhost","content-length":"6","connection":"close"},"body":"abcdef","method":"GET"},"response":{"headers":{"content-type":"text\/plain","server":"APISIX\/1.5","connection":"close","transfer-encoding":"chunked"},"status":200,"size":153},"latency":99.000215530396}
+    [
+      {
+        "client_ip": "127.0.0.1",
+        "latency": 493.99995803833,
+        "request": {
+          "headers": {
+            "accept": "*/*",
+            "host": "httpbin.org",
+            "user-agent": "curl/7.29.0"
+          },
+          "method": "GET",
+          "querystring": {
+            "foo1": "bar1",
+            "foo2": "bar2"
+          },
+          "size": 98,
+          "uri": "/get?foo1=bar1&foo2=bar2",
+          "url": "http://httpbin.org:9080/get?  foo1=bar1&foo2=bar2"
+        },
+        "response": {
+          "headers": {
+            "access-control-allow-credentials":     "true",
+            "access-control-allow-origin": "*",
+            "connection": "close",
+            "content-length": "370",
+            "content-type": "application/json",
+            "date": "Mon, 26 Apr 2021 02:03:27  GMT",
+            "server": "APISIX/2.5"
+          },
+          "size": 595,
+          "status": 200
+        },
+        "route_id": "5",
+        "server": {
+          "hostname": "localhost.localdomain",
+          "version": "2.5"
+        },
+        "service_id": "",
+        "start_time": 1619402607026,
+        "upstream": "34.199.75.4:80"
+      }
+    ]
     ```
 
 - **origin**:
 
     ```http
-    GET /hello?ab=cd HTTP/1.1
-    host: localhost
-    content-length: 6
-    connection: close
+    GET /get?foo1=bar1&foo2=bar2 HTTP/1.1
+    User-Agent: curl/7.29.0
+    Accept: */*
+    Host: httpbin.org
 
-    abcdef
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+    Content-Length: 370
+    Connection: keep-alive
+    Date: Mon, 26 Apr 2021 02:03:31 GMT
+    Access-Control-Allow-Origin: *
+    Access-Control-Allow-Credentials: true
+    Server: APISIX/2.5
+
+    {
+      "args": {
+        "foo1": "bar1",
+        "foo2": "bar2"
+      },
+      "headers": {
+        "Accept": "*/*",
+        "Host": "httpbin.org",
+        "User-Agent": "curl/7.29.0",
+        "X-Amzn-Trace-Id": "Root=1-60861f73-265a57f8445eff076c072f04",
+        "X-Forwarded-Host": "httpbin.org"
+      },
+      "origin": "127.0.0.1, 129.227.137.235",
+      "url": "http://httpbin.org/get?foo1=bar1&foo2=bar2"
+    }
     ```
 
 ## 工作原理

--- a/docs/zh/latest/plugins/kafka-logger.md
+++ b/docs/zh/latest/plugins/kafka-logger.md
@@ -62,82 +62,55 @@ title: kafka-logger
 - **default**:
 
     ```json
-    [
-      {
-        "client_ip": "127.0.0.1",
-        "latency": 493.99995803833,
-        "request": {
-          "headers": {
-            "accept": "*/*",
-            "host": "httpbin.org",
-            "user-agent": "curl/7.29.0"
-          },
-          "method": "GET",
-          "querystring": {
-            "foo1": "bar1",
-            "foo2": "bar2"
-          },
-          "size": 98,
-          "uri": "/get?foo1=bar1&foo2=bar2",
-          "url": "http://httpbin.org:9080/get?  foo1=bar1&foo2=bar2"
-        },
-        "response": {
-          "headers": {
-            "access-control-allow-credentials":     "true",
-            "access-control-allow-origin": "*",
-            "connection": "close",
-            "content-length": "370",
-            "content-type": "application/json",
-            "date": "Mon, 26 Apr 2021 02:03:27  GMT",
-            "server": "APISIX/2.5"
-          },
-          "size": 595,
-          "status": 200
-        },
-        "route_id": "5",
-        "server": {
-          "hostname": "localhost.localdomain",
-          "version": "2.5"
-        },
-        "service_id": "",
-        "start_time": 1619402607026,
-        "upstream": "34.199.75.4:80"
-      }
-    ]
+    {
+     "upstream": "127.0.0.1:1980",
+     "start_time": 1619414294760,
+     "client_ip": "127.0.0.1",
+     "service_id": "",
+     "route_id": "1",
+     "request": {
+       "querystring": {
+         "ab": "cd"
+       },
+       "size": 90,
+       "uri": "/hello?ab=cd",
+       "url": "http://localhost:1984/hello?ab=cd",
+       "headers": {
+         "host": "localhost",
+         "content-length": "6",
+         "connection": "close"
+       },
+       "body": "abcdef",
+       "method": "GET"
+     },
+     "response": {
+       "headers": {
+         "connection": "close",
+         "content-type": "text/plain; charset=utf-8",
+         "date": "Mon, 26 Apr 2021 05:18:14 GMT",
+         "server": "APISIX/2.5",
+         "transfer-encoding": "chunked"
+       },
+       "size": 190,
+       "status": 200
+     },
+     "server": {
+       "hostname": "localhost",
+       "version": "2.5"
+     },
+     "latency": 0
+    }
     ```
 
 - **origin**:
 
     ```http
-    GET /get?foo1=bar1&foo2=bar2 HTTP/1.1
-    User-Agent: curl/7.29.0
-    Accept: */*
-    Host: httpbin.org
+    GET /hello?ab=cd HTTP/1.1
+    host: localhost
+    content-length: 6
+    connection: close
 
-    HTTP/1.1 200 OK
-    Content-Type: application/json
-    Content-Length: 370
-    Connection: keep-alive
-    Date: Mon, 26 Apr 2021 02:03:31 GMT
-    Access-Control-Allow-Origin: *
-    Access-Control-Allow-Credentials: true
-    Server: APISIX/2.5
-
-    {
-      "args": {
-        "foo1": "bar1",
-        "foo2": "bar2"
-      },
-      "headers": {
-        "Accept": "*/*",
-        "Host": "httpbin.org",
-        "User-Agent": "curl/7.29.0",
-        "X-Amzn-Trace-Id": "Root=1-60861f73-265a57f8445eff076c072f04",
-        "X-Forwarded-Host": "httpbin.org"
-      },
-      "origin": "127.0.0.1, 129.227.137.235",
-      "url": "http://httpbin.org/get?foo1=bar1&foo2=bar2"
-    }
+    abcdef
     ```
 
 ## 工作原理


### PR DESCRIPTION
Signed-off-by: libo.huang <huanglibo2010@gmail.com>

### What this PR does / why we need it:
1. add server info to kafka log
   ```json
   "server": {
     "hostname": "localhost",
     "version": "2.5"
   }
   ```

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
