### PR TITLE
fix(response-rewrite): properly base64 process the nil and empty body

### DIFF
--- a/apisix/plugins/response-rewrite.lua
+++ b/apisix/plugins/response-rewrite.lua
@@ -127,7 +127,7 @@ function _M.body_filter(conf, ctx)
         return
     end
 
-    if conf.body and #conf.body > 0 then
+    if conf.body then
 
         if conf.body_base64 then
             ngx.arg[1] = ngx.decode_base64(conf.body)

--- a/apisix/plugins/response-rewrite.lua
+++ b/apisix/plugins/response-rewrite.lua
@@ -100,6 +100,9 @@ function _M.check_schema(conf)
     end
 
     if conf.body_base64 then
+        if not conf.body or #conf.body == 0 then
+            return false, 'invalid base64 content'
+        end
         local body = ngx.decode_base64(conf.body)
         if not body then
             return  false, 'invalid base64 content'
@@ -124,7 +127,7 @@ function _M.body_filter(conf, ctx)
         return
     end
 
-    if conf.body then
+    if conf.body and #conf.body > 0 then
 
         if conf.body_base64 then
             ngx.arg[1] = ngx.decode_base64(conf.body)

--- a/t/plugin/response-rewrite.t
+++ b/t/plugin/response-rewrite.t
@@ -662,7 +662,7 @@ invalid base64 content
         content_by_lua_block {
             local plugin = require("apisix.plugins.response-rewrite")
             local ok, err = plugin.check_schema({
-                            body_base64 =  true
+                            body_base64 = true
             })
             if not ok then
                 ngx.say(err)

--- a/t/plugin/response-rewrite.t
+++ b/t/plugin/response-rewrite.t
@@ -639,7 +639,7 @@ hello world
             local plugin = require("apisix.plugins.response-rewrite")
             local ok, err = plugin.check_schema({
                             body = "",
-                            body_base64 =  true
+                            body_base64 = true
             })
             if not ok then
                 ngx.say(err)

--- a/t/plugin/response-rewrite.t
+++ b/t/plugin/response-rewrite.t
@@ -629,3 +629,50 @@ hello world
 200
 --- no_error_log
 [error]
+
+
+
+=== TEST 22: set an empty body with setting body_base64 to true
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.response-rewrite")
+            local ok, err = plugin.check_schema({
+                            body = "",
+                            body_base64 =  true
+            })
+            if not ok then
+                ngx.say(err)
+                return
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+invalid base64 content
+--- no_error_log
+[error]
+
+
+
+=== TEST 23: set an nil body with setting body_base64 to true
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.response-rewrite")
+            local ok, err = plugin.check_schema({
+                            body_base64 =  true
+            })
+            if not ok then
+                ngx.say(err)
+                return
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+invalid base64 content
+--- no_error_log
+[error]


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Related to #4150, this PR is going to generate a proper error response when the `body` is a `nil` or an `empty` string. This would prevent APISIX from getting uncaught errors, as the error log mentioned in #4150.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
