### PR TITLE
fix: deal with etcd grants permissions with a different prefix than t…

### DIFF
--- a/apisix/core/etcd.lua
+++ b/apisix/core/etcd.lua
@@ -100,6 +100,10 @@ function _M.get_format(res, real_key, is_dir, formatter)
         return nil, "insufficient credentials code: 401"
     end
 
+    if res.body.error == "etcdserver: permission denied" then
+        return nil, "etcd forbidden code: 403"
+    end
+
     res.headers["X-Etcd-Index"] = res.body.header.revision
 
     if not res.body.kvs then

--- a/t/core/etcd-auth-fail.t
+++ b/t/core/etcd-auth-fail.t
@@ -32,6 +32,11 @@ system('etcdctl --endpoints="http://127.0.0.1:2379" role add root');
 system('etcdctl --endpoints="http://127.0.0.1:2379" user grant-role root root');
 system('etcdctl --endpoints="http://127.0.0.1:2379" role list');
 system('etcdctl --endpoints="http://127.0.0.1:2379" user user list');
+# Grant the user access to the specified directory
+system('etcdctl --endpoints="http://127.0.0.1:2379" user add apisix:abc123');
+system('etcdctl --endpoints="http://127.0.0.1:2379" role add apisix');
+system('etcdctl --endpoints="http://127.0.0.1:2379" user grant-role apisix apisix');
+system('etcdctl --endpoints=http://127.0.0.1:2379 role grant-permission apisix --prefix=true readwrite /apisix/');
 system('etcdctl --endpoints="http://127.0.0.1:2379" auth enable');
 
 run_tests;
@@ -40,7 +45,8 @@ run_tests;
 system('etcdctl --endpoints="http://127.0.0.1:2379" --user root:5tHkHhYkjr6cQY auth disable');
 system('etcdctl --endpoints="http://127.0.0.1:2379" user delete root');
 system('etcdctl --endpoints="http://127.0.0.1:2379" role delete root');
-
+system('etcdctl --endpoints="http://127.0.0.1:2379" user delete apisix');
+system('etcdctl --endpoints="http://127.0.0.1:2379" role delete apisix');
 __DATA__
 
 === TEST 1: Set and Get a value pass
@@ -59,3 +65,28 @@ GET /t
 --- error_code: 500
 --- error_log eval
 qr /insufficient credentials code: 401/
+
+
+
+=== TEST 2: etcd grants permissions with a different prefix than the one used by apisix, etcd will forbidden
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local key = "/test_key"
+            local val = "test_value"
+            local res, err = core.etcd.set(key, val)
+            ngx.say(err)
+        }
+    }
+--- yaml_config
+etcd:
+  host:
+    - "http://127.0.0.1:2379"
+  prefix: "/apisix"
+  user: apisix
+  password: abc123
+--- request
+GET /t
+--- error_log eval
+qr /etcd forbidden code: 403/

--- a/t/core/etcd-auth.t
+++ b/t/core/etcd-auth.t
@@ -89,8 +89,8 @@ etcd:
   host:
     - "http://127.0.0.1:2379"
   prefix: "/apisix"
-  user: root
-  password: 5tHkHhYkjr6cQY
+  user: apisix
+  password: abc123
 --- request
 GET /t
 --- no_error_log

--- a/t/core/etcd-auth.t
+++ b/t/core/etcd-auth.t
@@ -32,6 +32,11 @@ system('etcdctl --endpoints="http://127.0.0.1:2379" role add root');
 system('etcdctl --endpoints="http://127.0.0.1:2379" user grant-role root root');
 system('etcdctl --endpoints="http://127.0.0.1:2379" role list');
 system('etcdctl --endpoints="http://127.0.0.1:2379" user user list');
+# Grant the user access to the specified directory
+system('etcdctl --endpoints="http://127.0.0.1:2379" user add apisix:abc123');
+system('etcdctl --endpoints="http://127.0.0.1:2379" role add apisix');
+system('etcdctl --endpoints="http://127.0.0.1:2379" user grant-role apisix apisix');
+system('etcdctl --endpoints=http://127.0.0.1:2379 role grant-permission apisix --prefix=true readwrite /apisix');
 system('etcdctl --endpoints="http://127.0.0.1:2379" auth enable');
 
 run_tests;
@@ -40,6 +45,8 @@ run_tests;
 system('etcdctl --endpoints="http://127.0.0.1:2379" --user root:5tHkHhYkjr6cQY auth disable');
 system('etcdctl --endpoints="http://127.0.0.1:2379" user delete root');
 system('etcdctl --endpoints="http://127.0.0.1:2379" role delete root');
+system('etcdctl --endpoints="http://127.0.0.1:2379" user delete apisix');
+system('etcdctl --endpoints="http://127.0.0.1:2379" role delete apisix');
 
 
 __DATA__
@@ -61,5 +68,30 @@ __DATA__
 GET /t
 --- response_body
 test_value
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: etcd grants permissions with the same prefix as apisix uses, etcd is normal
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local key = "/test_key"
+            local val = "test_value"
+            local res, err = core.etcd.set(key, val)
+            ngx.say(err)
+        }
+    }
+--- yaml_config
+etcd:
+  host:
+    - "http://127.0.0.1:2379"
+  prefix: "/apisix"
+  user: root
+  password: 5tHkHhYkjr6cQY
+--- request
+GET /t
 --- no_error_log
 [error]


### PR DESCRIPTION
…he one used by apisix, etcd will forbidden(#4143)

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
fix #4143
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
