### PR TITLE
feat: add 50x html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,12 +158,14 @@ reload: default
 install: default
 	$(INSTALL) -d /usr/local/apisix/
 	$(INSTALL) -d /usr/local/apisix/logs/
+	$(INSTALL) -d /usr/local/apisix/html/
 	$(INSTALL) -d /usr/local/apisix/conf/cert
 	$(INSTALL) conf/mime.types /usr/local/apisix/conf/mime.types
 	$(INSTALL) conf/config.yaml /usr/local/apisix/conf/config.yaml
 	$(INSTALL) conf/config-default.yaml /usr/local/apisix/conf/config-default.yaml
 	$(INSTALL) conf/debug.yaml /usr/local/apisix/conf/debug.yaml
 	$(INSTALL) conf/cert/* /usr/local/apisix/conf/cert/
+	$(INSTALL) html/* /usr/local/apisix/html/
 
 	$(INSTALL) -d $(INST_LUADIR)/apisix
 	$(INSTALL) apisix/*.lua $(INST_LUADIR)/apisix/

--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -236,6 +236,10 @@ http {
     {% if http_configuration_snippet then %}
     {* http_configuration_snippet *}
     {% end %}
+
+    # error_page
+    error_page 500 502 503 504 /50x.html;
+
     # http configuration snippet ends
 
     upstream apisix_backend {
@@ -285,6 +289,10 @@ http {
                 apisix.http_control()
             }
         }
+
+        location = /50x.html {
+            root   html;
+        } 
     }
     {% end %}
 
@@ -362,6 +370,10 @@ http {
                 apisix.http_admin()
             }
         }
+
+        location = /50x.html {
+            root   html;
+        } 
     }
     {% end %}
 
@@ -612,6 +624,10 @@ http {
             proxy_pass $upstream_mirror_host$request_uri;
         }
         {% end %}
+
+        location = /50x.html {
+            root   html;
+        } 
     }
     # http end configuration snippet starts
     {% if http_end_configuration_snippet then %}

--- a/html/50x.html
+++ b/html/50x.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+<meta content="utf-8" http-equiv="encoding">
+<title>Error</title>
+<style>
+    body {
+        width: 35em;
+        margin: 0 auto;
+        font-family: Tahoma, Verdana, Arial, sans-serif;
+    }
+</style>
+</head>
+<body>
+<h1>An error occurred.</h1>
+<p>You can report issue to <a href="https://github.com/apache/apisix/issues">APISIX</a></p>
+<p><em>Faithfully yours, <a href="https://apisix.apache.org/">APISIX</a>.</em></p>
+</body>
+</html>

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -370,6 +370,8 @@ _EOC_
     lua_socket_log_errors off;
     client_body_buffer_size 8k;
 
+    error_page 500 502 503 504 /50x.html;
+
     upstream apisix_backend {
         server 0.0.0.1;
         balancer_by_lua_block {
@@ -506,6 +508,10 @@ _EOC_
             content_by_lua_block {
                 apisix.http_admin()
             }
+        }
+
+        location = /50x.html {
+            root   html;
         }
 
         location /v1/ {

--- a/t/error_page/error_page.t
+++ b/t/error_page/error_page.t
@@ -1,0 +1,117 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+log_level('debug');
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: set route with serverless-post-function plugin
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "plugins": {
+                        "serverless-post-function": {
+                            "functions" : ["return function() if ngx.var.http_x_test_status ~= nil then;ngx.exit(tonumber(ngx.var.http_x_test_status));end;end"]
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/*"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: test apisix with internal error code 500
+--- request
+GET /hello
+--- more_headers
+X-Test-Status: 500
+--- error_code: 500
+--- response_body_like
+apisix.apache.org
+
+
+
+=== TEST 3: test apisix with internal error code 502
+--- request
+GET /hello
+--- more_headers
+X-Test-Status: 502
+--- error_code: 502
+--- response_body_like
+apisix.apache.org
+
+
+
+=== TEST 4: test apisix with internal error code 503
+--- request
+GET /hello
+--- more_headers
+X-Test-Status: 503
+--- error_code: 503
+--- response_body_like
+apisix.apache.org
+
+
+
+=== TEST 5: test apisix with internal error code 504
+--- request
+GET /hello
+--- more_headers
+X-Test-Status: 504
+--- error_code: 504
+--- response_body_like
+apisix.apache.org
+
+
+
+=== TEST 12: test apisix with upstream error code 500
+--- request
+GET /specific_status
+--- more_headers
+X-Test-Upstream-Status: 500
+--- error_code: 500
+--- response_body
+upstream status: 500

--- a/t/error_page/error_page.t
+++ b/t/error_page/error_page.t
@@ -107,7 +107,7 @@ apisix.apache.org
 
 
 
-=== TEST 12: test apisix with upstream error code 500
+=== TEST 6: test apisix with upstream error code 500
 --- request
 GET /specific_status
 --- more_headers


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As we discussed in the [email](https://lists.apache.org/thread.html/rbb88d707eeaf0dbcba4d73f1f741f3621f90e84785899c47479a8557%40%3Cdev.apisix.apache.org%3E), we should have our own 50x HTML and index.html.Index.html maybe not necessary because of apisix is a grateway, there is no opportunity to show the index.html.

This PR is about to add 50x html into error_page. So when we had an error in apisix, we will show the html.
If the upstream returns 5xx error, we will show the upstream response rather than the 50x.html.

Fix: #3251

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
