### PR TITLE
fix: fix peer missed in skywalking

### DIFF
--- a/apisix/plugins/skywalking.lua
+++ b/apisix/plugins/skywalking.lua
@@ -93,6 +93,7 @@ function _M.body_filter(conf, ctx)
     if ctx.skywalking_sample and ngx.arg[2] then
         Span.setComponentId(ngx.ctx.exitSpan, 6002)
         Span.setComponentId(ngx.ctx.entrySpan, 6002)
+        ngx.ctx.exitSpan.peer = ctx.balancer_ip .. ":" .. ctx.balancer_port
         sw_tracer:finish()
         core.log.info("tracer finish")
     end


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

So far, `peer` of the exit span is a hard code, "upstream service". This is PR intends to fix it by getting `ip:port` from dynamic balancer.

I tried to get the information at the `rewrite` phase, but it seems like cannot get it. Because of that, I move it into the `body_filter` phase.

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
