### PR TITLE
fix: init dns resolvers in stream subsystem

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -85,7 +85,11 @@ stream {
     init_by_lua_block {
         require "resty.core"
         apisix = require("apisix")
-        apisix.stream_init()
+        local dns_resolver = { {% for _, dns_addr in ipairs(dns_resolver or {}) do %} "{*dns_addr*}", {% end %} }
+        local args = {
+            dns_resolver = dns_resolver,
+        }
+        apisix.stream_init(args)
     }
 
     init_worker_by_lua_block {

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -715,8 +715,10 @@ function _M.http_control()
 end
 
 
-function _M.stream_init()
+function _M.stream_init(args)
     core.log.info("enter stream_init")
+
+    core.resolver.init_resolver(args)
 
     if core.config.init then
         local ok, err = core.config.init()

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -263,7 +263,10 @@ _EOC_
         require "resty.core"
 
         apisix = require("apisix")
-        apisix.stream_init()
+        local args = {
+            dns_resolver = $dns_addrs_tbl_str,
+        }
+        apisix.stream_init(args)
 _EOC_
 
     $stream_config .= <<_EOC_;

--- a/t/misc/patch.t
+++ b/t/misc/patch.t
@@ -162,18 +162,25 @@ apisix:
 --- stream_enable
 --- stream_server_config
     content_by_lua_block {
+        local sock = ngx.req.socket(true)
+        -- drain the buffer
+        local _, err = sock:receive(1)
+        if err ~= nil then
+          ngx.log(ngx.ERR, err)
+          return ngx.exit(-1)
+        end
         local http = require("resty.http")
         local httpc = http.new()
         local res, err = httpc:request_uri("http://apisix")
         if not res then
             ngx.log(ngx.ERR, err)
-            return
+            return ngx.exit(-1)
         end
-        ngx.say(res.status)
+        sock:send(res.status)
     }
 --- stream_request eval
-mmm
---- stream_response
-301
+m
+--- stream_response: 301
+
 --- no_error_log
 [error]

--- a/t/misc/patch.t
+++ b/t/misc/patch.t
@@ -151,3 +151,29 @@ apisix:
 GET /t
 --- response_body
 301
+
+
+
+=== TEST 5: resolve host by ourselves (in stream sub-system)
+--- yaml_config
+apisix:
+  node_listen: 1984
+  enable_resolv_search_opt: true
+--- stream_enable
+--- stream_server_config
+    content_by_lua_block {
+        local http = require("resty.http")
+        local httpc = http.new()
+        local res, err = httpc:request_uri("http://apisix")
+        if not res then
+            ngx.log(ngx.ERR, err)
+            return
+        end
+        ngx.say(res.status)
+    }
+--- stream_request eval
+mmm
+--- stream_response
+301
+--- no_error_log
+[error]


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since f914807, the connect of tcpsock was patched by using our own DNS
resolvers. It relies on a dns_resolvers variable which should be
initialized in init_by_lua* phase, however, the initialization step in
stream sub-system is missed so once users enable the stream proxy and
the tcpsock:connect is invoked with a non-IP host, Lua runtime errors
will be thrown.

This PR fixed this issue by initializing the DNS resolvers in the stream
sub-subsystem.

#### Examples

If we use the ETCD FQDN, we may see the following errors continuously.

![image](https://user-images.githubusercontent.com/10428333/117251298-07cabb00-ae77-11eb-9c5c-173e7e2c6730.png)


### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
