### PR TITLE
fix: making APISIX compatible on macOS with ARM chip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ifeq ($(shell test -d $(addprefix $(OR_PREFIX), openssl111) && echo -n yes), yes
 endif
 
 ifeq ($(UNAME), Darwin)
-LUAROCKS=luarocks --lua-dir=/usr/local/opt/lua@5.1
+LUAROCKS=luarocks --lua-dir=$(HOMEBREW_PREFIX)/opt/lua@5.1
 ifeq ($(shell test -d /usr/local/opt/openresty-openssl && echo yes), yes)
 	OPENSSL_PREFIX=/usr/local/opt/openresty-openssl
 endif

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,11 @@ endif
 
 ifeq ($(UNAME), Darwin)
 LUAROCKS=luarocks --lua-dir=$(HOMEBREW_PREFIX)/opt/lua@5.1
-ifeq ($(shell test -d /usr/local/opt/openresty-openssl && echo yes), yes)
-	OPENSSL_PREFIX=/usr/local/opt/openresty-openssl
+ifeq ($(shell test -d $(HOMEBREW_PREFIX)/opt/openresty-openssl && echo yes), yes)
+	OPENSSL_PREFIX=$(HOMEBREW_PREFIX)/opt/openresty-openssl
 endif
-ifeq ($(shell test -d /usr/local/opt/openresty-openssl111 && echo yes), yes)
-	OPENSSL_PREFIX=/usr/local/opt/openresty-openssl111
+ifeq ($(shell test -d $(HOMEBREW_PREFIX)/opt/openresty-openssl111 && echo yes), yes)
+	OPENSSL_PREFIX=$(HOMEBREW_PREFIX)/opt/openresty-openssl111
 endif
 endif
 


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
use the environment variable HOMEBREW_PREFIX to determine the location of the brew command installer, to adapt this pr for homebrew https://github.com/Homebrew/install/pull/373/files
<!--- If it fixes an open issue, please link to the issue here. -->
fix #4245 

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
