### PR TITLE
fix: invalid schema field for plugin `fault-injection`

### DIFF
--- a/apisix/plugins/fault-injection.lua
+++ b/apisix/plugins/fault-injection.lua
@@ -36,7 +36,7 @@ local schema = {
                 vars = {
                     type = "array",
                     maxItems = 20,
-                    item = {
+                    items = {
                         type = "array",
                     },
                 }
@@ -51,7 +51,7 @@ local schema = {
                 vars = {
                     type = "array",
                     maxItems = 20,
-                    item = {
+                    items = {
                         type = "array",
                     },
                 }

--- a/t/plugin/fault-injection.t
+++ b/t/plugin/fault-injection.t
@@ -303,7 +303,91 @@ qr/invalid request body/
 
 
 
-=== TEST 8: set route(delay 1 seconds)
+=== TEST 8: set route(invalid vars in the delay property)
+--- config
+       location /t {
+           content_by_lua_block {
+               local t = require("lib.test_admin").test
+               local code, body = t('/apisix/admin/routes/1',
+                    ngx.HTTP_PUT,
+                    [[{
+                           "plugins": {
+                               "fault-injection": {
+                                "delay": {
+                                    "duration": 0.1,
+                                    "vars": {
+                                        "a",
+                                        "b"
+                                    }
+                                },
+                               },
+                               "proxy-rewrite": {
+                                   "uri": "/hello"
+                               }
+                           },
+                           "uri": "/hello"
+                   }]]
+                   )
+
+               if code >= 300 then
+                   ngx.status = code
+               end
+               ngx.say(body)
+           }
+       }
+--- request
+GET /t
+--- error_code: 400
+--- response_body eval
+qr/invalid request body/
+--- error_log eval
+qr/invalid request body/
+
+
+
+=== TEST 9: set route(invalid vars in in the abort property)
+--- config
+       location /t {
+           content_by_lua_block {
+               local t = require("lib.test_admin").test
+               local code, body = t('/apisix/admin/routes/1',
+                    ngx.HTTP_PUT,
+                    [[{
+                           "plugins": {
+                               "fault-injection": {
+                                    "abort": {
+                                        "http_status": 200,
+                                        "vars": {
+                                            "a",
+                                            "b"
+                                        }
+                                    }
+                               },
+                               "proxy-rewrite": {
+                                   "uri": "/hello"
+                               }
+                           },
+                           "uri": "/hello"
+                   }]]
+                   )
+
+               if code >= 300 then
+                   ngx.status = code
+               end
+               ngx.say(body)
+           }
+       }
+--- request
+GET /t
+--- error_code: 400
+--- response_body eval
+qr/invalid request body/
+--- error_log eval
+qr/invalid request body/
+
+
+
+=== TEST 10: set route(delay 1 seconds)
 --- config
        location /t {
            content_by_lua_block {
@@ -347,7 +431,7 @@ passed
 
 
 
-=== TEST 9: hit route(delay 1 seconds and return hello world)
+=== TEST 11: hit route(delay 1 seconds and return hello world)
 --- request
 GET /hello HTTP/1.1
 --- response_body
@@ -357,7 +441,7 @@ hello world
 
 
 
-=== TEST 10: set route(abort with http status 200 and return "Fault Injection!\n")
+=== TEST 12: set route(abort with http status 200 and return "Fault Injection!\n")
 --- config
        location /t {
            content_by_lua_block {
@@ -402,7 +486,7 @@ passed
 
 
 
-=== TEST 11: hit route(abort with http code 200 and return "Fault Injection!\n")
+=== TEST 13: hit route(abort with http code 200 and return "Fault Injection!\n")
 --- request
 GET /hello HTTP/1.1
 --- error_code: 200
@@ -413,7 +497,7 @@ Fault Injection!
 
 
 
-=== TEST 12: set route(abort with http status 405 and return "Fault Injection!\n")
+=== TEST 14: set route(abort with http status 405 and return "Fault Injection!\n")
 --- config
        location /t {
            content_by_lua_block {
@@ -458,7 +542,7 @@ passed
 
 
 
-=== TEST 13: hit route(abort with http status 405 and return "Fault Injection!\n")
+=== TEST 15: hit route(abort with http status 405 and return "Fault Injection!\n")
 --- request
 GET /hello HTTP/1.1
 --- error_code: 405
@@ -469,7 +553,7 @@ Fault Injection!
 
 
 
-=== TEST 14: set route(play with redirect plugin)
+=== TEST 16: set route(play with redirect plugin)
 --- config
        location /t {
            content_by_lua_block {
@@ -515,7 +599,7 @@ passed
 
 
 
-=== TEST 15: hit route(abort with http status 200 and return "Fault Injection!\n")
+=== TEST 17: hit route(abort with http status 200 and return "Fault Injection!\n")
 --- request
 GET /hello HTTP/1.1
 --- error_code: 200
@@ -526,7 +610,7 @@ Fault Injection!
 
 
 
-=== TEST 16: set route (abort injection but with zero percentage)
+=== TEST 18: set route (abort injection but with zero percentage)
 --- config
        location /t {
            content_by_lua_block {
@@ -573,7 +657,7 @@ passed
 
 
 
-=== TEST 17: hit route (redirect)
+=== TEST 19: hit route (redirect)
 --- request
 GET /hello HTTP/1.1
 --- error_code: 302
@@ -582,7 +666,7 @@ GET /hello HTTP/1.1
 
 
 
-=== TEST 18: set route (delay injection but with zero percentage)
+=== TEST 20: set route (delay injection but with zero percentage)
 --- config
        location /t {
            content_by_lua_block {
@@ -627,7 +711,7 @@ passed
 
 
 
-=== TEST 19: hit route (no wait and return hello1 world)
+=== TEST 21: hit route (no wait and return hello1 world)
 --- request
 GET /hello HTTP/1.1
 --- error_code: 200
@@ -638,7 +722,7 @@ hello1 world
 
 
 
-=== TEST 20: set route(body with var)
+=== TEST 22: set route(body with var)
 --- config
        location /t {
            content_by_lua_block {
@@ -682,7 +766,7 @@ passed
 
 
 
-=== TEST 21: hit route(body with var)
+=== TEST 23: hit route(body with var)
 --- request
 GET /hello
 --- response_body
@@ -692,7 +776,7 @@ client addr: 127.0.0.1
 
 
 
-=== TEST 22: set route(abort without body)
+=== TEST 24: set route(abort without body)
 --- config
        location /t {
            content_by_lua_block {
@@ -735,7 +819,7 @@ passed
 
 
 
-=== TEST 23: hit route(abort without body)
+=== TEST 25: hit route(abort without body)
 --- request
 GET /hello
 --- response_body
@@ -744,7 +828,7 @@ GET /hello
 
 
 
-=== TEST 24: vars schema validation passed
+=== TEST 26: vars schema validation passed
 --- config
     location /t {
         content_by_lua_block {
@@ -792,7 +876,7 @@ done
 
 
 
-=== TEST 25: vars schema validation failed(abort failed)
+=== TEST 27: vars schema validation failed(abort failed)
 --- config
     location /t {
         content_by_lua_block {
@@ -835,7 +919,7 @@ qr/failed to create vars expression:.*/
 
 
 
-=== TEST 26: set route and configure the vars rule in abort
+=== TEST 28: set route and configure the vars rule in abort
 --- config
        location /t {
            content_by_lua_block {
@@ -885,7 +969,7 @@ passed
 
 
 
-=== TEST 27: hit the route (all vars rules pass), execute abort
+=== TEST 29: hit the route (all vars rules pass), execute abort
 --- request
 GET /hello?name=jack&age=18
 --- more_headers
@@ -898,7 +982,7 @@ Fault Injection!
 
 
 
-=== TEST 28: hit the route (missing apikey), execute abort
+=== TEST 30: hit the route (missing apikey), execute abort
 --- request
 GET /hello?name=jack&age=20
 --- error_code: 403
@@ -909,7 +993,7 @@ Fault Injection!
 
 
 
-=== TEST 29: hit the route (missing request parameters), execute abort
+=== TEST 31: hit the route (missing request parameters), execute abort
 --- request
 GET /hello
 --- more_headers
@@ -922,7 +1006,7 @@ Fault Injection!
 
 
 
-=== TEST 30: hit route(`vars` do not match, `age` is missing)
+=== TEST 32: hit route(`vars` do not match, `age` is missing)
 --- request
 GET /hello?name=allen
 --- response_body
@@ -932,7 +1016,7 @@ hello world
 
 
 
-=== TEST 31: hit route(all `vars` do not match)
+=== TEST 33: hit route(all `vars` do not match)
 --- request
 GET /hello
 --- response_body
@@ -942,7 +1026,7 @@ hello world
 
 
 
-=== TEST 32: set route and configure the vars rule in delay
+=== TEST 34: set route and configure the vars rule in delay
 --- config
        location /t {
            content_by_lua_block {
@@ -988,7 +1072,7 @@ passed
 
 
 
-=== TEST 33: hit route(delay 2 seconds and return hello world)
+=== TEST 35: hit route(delay 2 seconds and return hello world)
 --- request
 GET /hello?name=jack&age=22
 --- response_body
@@ -998,7 +1082,7 @@ hello world
 
 
 
-=== TEST 34: hit route (no wait and return hello1 world)
+=== TEST 36: hit route (no wait and return hello1 world)
 --- request
 GET /hello HTTP/1.1
 --- error_code: 200
@@ -1009,7 +1093,7 @@ hello world
 
 
 
-=== TEST 35: set route and configure the vars rule in abort and delay
+=== TEST 37: set route and configure the vars rule in abort and delay
 --- config
        location /t {
            content_by_lua_block {
@@ -1064,7 +1148,7 @@ passed
 
 
 
-=== TEST 36: hit the route (all vars rules are passed), execute abort and delay
+=== TEST 38: hit the route (all vars rules are passed), execute abort and delay
 --- request
 GET /hello?name=jack&age=18
 --- more_headers
@@ -1077,7 +1161,7 @@ Fault Injection!
 
 
 
-=== TEST 37: hit the route (abort rule does not match), only execute delay
+=== TEST 39: hit the route (abort rule does not match), only execute delay
 --- request
 GET /hello?name=jack&age=16
 --- more_headers


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

refer to:
https://json-schema.org/understanding-json-schema/reference/array.html
In JSON Schema, it should use `items` to define the array item type, not `item`

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
