### PR TITLE
docs: add the helm chart link in the k8s deployment apisix doc

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -21,6 +21,8 @@
 
 There are some yaml files for deploying apisix in Kubernetes.
 
+**Note: You can also install Apache APISIX in Kubernetes by [Helm Chart](https://github.com/apache/apisix-helm-chart).**
+
 ### Prerequisites
 
 - use `etcd`, if there is no `etcd` service, please install and set etcd address in `../conf/config.yaml`


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Signed-off-by: Firstsawyou yuelinz99@gmail.com

In the k8s deployment apisix document, add the deployment link of the helm chart method.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
