### PR TITLE
ci: chaos test could not directly read error.log

### DIFF
--- a/t/chaos/go.mod
+++ b/t/chaos/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/chaos-mesh/chaos-mesh v1.1.1
 	github.com/gavv/httpexpect/v2 v2.1.0
 	github.com/onsi/gomega v1.9.0
+	github.com/pkg/errors v0.9.1
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0

--- a/t/chaos/kill-etcd_test.go
+++ b/t/chaos/kill-etcd_test.go
@@ -93,7 +93,8 @@ func TestGetSuccessWhenEtcdKilled(t *testing.T) {
 	apisixPod := getPod(g, cliSet.ctrlCli, metav1.NamespaceDefault, listOption)
 
 	t.Run("error log not contains etcd error", func(t *testing.T) {
-		errorLog := execInPod(g, cliSet.kubeCli, apisixPod, "cat logs/error.log")
+		errorLog, err := log(apisixPod, cliSet.kubeCli)
+		g.Expect(err).To(BeNil())
 		g.Expect(strings.Contains(errorLog, "failed to fetch data from etcd")).To(BeFalse())
 	})
 
@@ -110,7 +111,8 @@ func TestGetSuccessWhenEtcdKilled(t *testing.T) {
 	testPrometheusEtcdMetric(e, 0)
 
 	t.Run("error log contains etcd error", func(t *testing.T) {
-		errorLog := execInPod(g, cliSet.kubeCli, apisixPod, "cat logs/error.log")
+		errorLog, err := log(apisixPod, cliSet.kubeCli)
+		g.Expect(err).To(BeNil())
 		g.Expect(strings.Contains(errorLog, "failed to fetch data from etcd")).To(BeTrue())
 	})
 


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

### What this PR does / why we need it:
After https://github.com/apache/apisix-docker/pull/176 got merged, chaos test could not directly read logs from `error.log`, but should read from kubernetes logs, since that PR forward `error.log` to docker logs interface.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
