### PR TITLE
feat: add real_ip_recursive to nginx.conf

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -229,6 +229,10 @@ http {
     real_ip_header {* http.real_ip_header *};
     {% end %}
 
+    {% if http.real_ip_recursive then %}
+    real_ip_recursive {* http.real_ip_recursive *};
+    {% end %}
+
     {% if real_ip_from then %}
     {% print("\nDeprecated: apisix.real_ip_from has been moved to nginx_config.http.real_ip_from. apisix.real_ip_from will be removed in the future version. Please use nginx_config.http.real_ip_from first.\n\n") %}
     {% for _, real_ip in ipairs(real_ip_from) do %}

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -180,6 +180,7 @@ nginx_config:                     # config for render the template to generate n
     send_timeout: 10s              # timeout for transmitting a response to the client.then the connection is closed
     underscores_in_headers: "on"   # default enables the use of underscores in client request header fields
     real_ip_header: "X-Real-IP"    # http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
+    real_ip_recursive: "off"       # http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive
     real_ip_from:                  # http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from
       - 127.0.0.1
       - 'unix:'

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -621,3 +621,10 @@ if ! grep "keepalive_timeout 6s;" conf/nginx.conf > /dev/null; then
 fi
 
 echo "passed: found the keepalive related parameter in nginx.conf"
+
+if ! grep "real_ip_recursive off;" conf/nginx.conf > /dev/null; then
+    echo "failed: 'real_ip_recursive off;' not in nginx.conf"
+    exit 1
+fi
+
+echo "passed: disable real_ip_recursive by default in nginx.conf"

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -622,9 +622,17 @@ fi
 
 echo "passed: found the keepalive related parameter in nginx.conf"
 
-if ! grep "real_ip_recursive off;" conf/nginx.conf > /dev/null; then
-    echo "failed: 'real_ip_recursive off;' not in nginx.conf"
+echo '
+nginx_config:
+    http:
+        real_ip_recursive: "on"
+' > conf/config.yaml
+
+make init
+
+if ! grep "real_ip_recursive on;" conf/nginx.conf > /dev/null; then
+    echo "failed: 'real_ip_recursive on;' not in nginx.conf"
     exit 1
 fi
 
-echo "passed: disable real_ip_recursive by default in nginx.conf"
+echo "passed: enable real_ip_recursive in nginx.conf successfully"


### PR DESCRIPTION
### What this PR does / why we need it:
Enable to set real_ip_recursive to nginx.conf. When apisix is behind multiple layer network, the real client ip may not be recognized. See also [http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive](http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive)

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [X] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
