### PR TITLE
fix: add error handling when use customized config 

### DIFF
--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -43,6 +43,7 @@ local floor = math.floor
 local str_find = string.find
 local str_byte = string.byte
 local str_sub = string.sub
+local len = string.len
 
 
 local _M = {}
@@ -657,8 +658,17 @@ local function start(env, ...)
     if customized_yaml then
         profile.apisix_home = env.apisix_home .. "/"
         local local_conf_path = profile:yaml_path("config")
-        util.execute_cmd("mv " .. local_conf_path .. " " .. local_conf_path .. ".bak")
-        util.execute_cmd("ln " .. customized_yaml .. " " .. local_conf_path)
+
+        local err = util.execute_cmd_with_error("mv " .. local_conf_path .. " " .. local_conf_path .. ".bak")
+        if len(err) > 0 then
+            util.die("failed to mv config to backup, error: ", err)
+        end
+        err = util.execute_cmd_with_error("ln " .. customized_yaml .. " " .. local_conf_path)
+        if len(err) > 0 then
+            util.execute_cmd("mv " .. local_conf_path .. ".bak " .. local_conf_path)
+            util.die("failed to link customized config, error: ", err)
+        end
+
         print("Use customized yaml: ", customized_yaml)
     end
 
@@ -673,8 +683,14 @@ local function stop(env)
     local local_conf_path = profile:yaml_path("config")
     local bak_exist = io_open(local_conf_path .. ".bak")
     if bak_exist then
-        util.execute_cmd("rm " .. local_conf_path)
-        util.execute_cmd("mv " .. local_conf_path .. ".bak " .. local_conf_path)
+        local err = util.execute_cmd_with_error("rm " .. local_conf_path)
+        if len(err) > 0 then
+            print("failed to remove customized config, error: ", err)
+        end
+        err = util.execute_cmd_with_error("mv " .. local_conf_path .. ".bak " .. local_conf_path)
+        if len(err) > 0 then
+            util.die("failed to mv original config file, error: ", err)
+        end
     end
     local cmd = env.openresty_args .. [[ -s stop]]
     util.execute_cmd(cmd)

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -660,11 +660,11 @@ local function start(env, ...)
 
         local err = util.execute_cmd_with_error("mv " .. local_conf_path .. " "
                                                 .. local_conf_path .. ".bak")
-        if #err then
+        if #err > 0 then
             util.die("failed to mv config to backup, error: ", err)
         end
         err = util.execute_cmd_with_error("ln " .. customized_yaml .. " " .. local_conf_path)
-        if #err then
+        if #err > 0 then
             util.execute_cmd("mv " .. local_conf_path .. ".bak " .. local_conf_path)
             util.die("failed to link customized config, error: ", err)
         end
@@ -684,11 +684,11 @@ local function stop(env)
     local bak_exist = io_open(local_conf_path .. ".bak")
     if bak_exist then
         local err = util.execute_cmd_with_error("rm " .. local_conf_path)
-        if #err then
+        if #err > 0 then
             print("failed to remove customized config, error: ", err)
         end
         err = util.execute_cmd_with_error("mv " .. local_conf_path .. ".bak " .. local_conf_path)
-        if #err then
+        if #err > 0 then
             util.die("failed to mv original config file, error: ", err)
         end
     end

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -43,7 +43,6 @@ local floor = math.floor
 local str_find = string.find
 local str_byte = string.byte
 local str_sub = string.sub
-local len = string.len
 
 
 local _M = {}
@@ -661,11 +660,11 @@ local function start(env, ...)
 
         local err = util.execute_cmd_with_error("mv " .. local_conf_path .. " "
                                                 .. local_conf_path .. ".bak")
-        if len(err) > 0 then
+        if #err then
             util.die("failed to mv config to backup, error: ", err)
         end
         err = util.execute_cmd_with_error("ln " .. customized_yaml .. " " .. local_conf_path)
-        if len(err) > 0 then
+        if #err then
             util.execute_cmd("mv " .. local_conf_path .. ".bak " .. local_conf_path)
             util.die("failed to link customized config, error: ", err)
         end
@@ -685,11 +684,11 @@ local function stop(env)
     local bak_exist = io_open(local_conf_path .. ".bak")
     if bak_exist then
         local err = util.execute_cmd_with_error("rm " .. local_conf_path)
-        if len(err) > 0 then
+        if #err then
             print("failed to remove customized config, error: ", err)
         end
         err = util.execute_cmd_with_error("mv " .. local_conf_path .. ".bak " .. local_conf_path)
-        if len(err) > 0 then
+        if #err then
             util.die("failed to mv original config file, error: ", err)
         end
     end

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -659,7 +659,8 @@ local function start(env, ...)
         profile.apisix_home = env.apisix_home .. "/"
         local local_conf_path = profile:yaml_path("config")
 
-        local err = util.execute_cmd_with_error("mv " .. local_conf_path .. " " .. local_conf_path .. ".bak")
+        local err = util.execute_cmd_with_error("mv " .. local_conf_path .. " "
+                                                .. local_conf_path .. ".bak")
         if len(err) > 0 then
             util.die("failed to mv config to backup, error: ", err)
         end

--- a/apisix/cli/util.lua
+++ b/apisix/cli/util.lua
@@ -49,7 +49,7 @@ end
 
 _M.execute_cmd = execute_cmd
 
--- For ls and mv which stdout would be always be empty,
+-- For commands which stdout would be always be empty,
 -- forward stderr to stdout to get the error msg
 function _M.execute_cmd_with_error(cmd)
     return execute_cmd(cmd .. " 2>&1")

--- a/apisix/cli/util.lua
+++ b/apisix/cli/util.lua
@@ -46,8 +46,8 @@ local function execute_cmd(cmd)
 
     return data
 end
-
 _M.execute_cmd = execute_cmd
+
 
 -- For commands which stdout would be always be empty,
 -- forward stderr to stdout to get the error msg

--- a/apisix/cli/util.lua
+++ b/apisix/cli/util.lua
@@ -29,7 +29,7 @@ local _M = {}
 
 -- Note: The `execute_cmd` return value will have a line break at the end,
 -- it is recommended to use the `trim` function to handle the return value.
-function _M.execute_cmd(cmd)
+local function execute_cmd(cmd)
     local t, err = popen(cmd)
     if not t then
         return nil, "failed to execute command: "
@@ -45,6 +45,14 @@ function _M.execute_cmd(cmd)
     end
 
     return data
+end
+
+_M.execute_cmd = execute_cmd
+
+-- For ls and mv which stdout would be always be empty,
+-- forward stderr to stdout to get the error msg
+function _M.execute_cmd_with_error(cmd)
+    return execute_cmd(cmd .. " 2>&1")
 end
 
 

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -435,6 +435,11 @@ cp conf/config.yaml conf/config_original.yaml
 
 make init
 
+if ./bin/apisix start -c conf/not_existed_config.yaml; then
+    echo "failed: apisix still start with invalid customized config.yaml"
+    exit 1
+fi
+
 ./bin/apisix start -c conf/customized_config.yaml
 
 if cmp -s "conf/config.yaml" "conf/config_original.yaml"; then


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

### What this PR does / why we need it:
Ref: #4337 

When implementing with #2101, no error handling is implemented so with the invalid config file, apisix would still start without the correct config setup. Here to fix it.

One thing to mention, since I failed to figure out how to get stderr separately when running shell command in Lua, considering normally stdout of `ls` and `mv` would always be empty (on ubuntu), I forward stderr to stdout to get the error msg and fail fast. Not sure if it's working in all OS.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
