### PR TITLE
feat: support custom variables_hash_max_size parameters in config.yaml

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -213,6 +213,7 @@ http {
     client_header_timeout {* http.client_header_timeout *};
     client_body_timeout {* http.client_body_timeout *};
     send_timeout {* http.send_timeout *};
+    variables_hash_max_size {* http.variables_hash_max_size *};
 
     server_tokens off;
 

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -198,6 +198,7 @@ nginx_config:                     # config for render the template to generate n
       keepalive_timeout: 60s       # Sets a timeout during which an idle keepalive connection to an upstream server will stay open.
     charset: utf-8                 # Adds the specified charset to the "Content-Type" response header field, see
                                    # http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset
+    variables_hash_max_size: 2048  # Sets the maximum size of the variables hash table.
 
 etcd:
   host:                           # it's possible to define multiple etcd hosts addresses of the same etcd cluster.

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -657,3 +657,21 @@ if ! grep "real_ip_recursive on;" conf/nginx.conf > /dev/null; then
 fi
 
 echo "passed: found 'real_ip_recursive on' in nginx.conf"
+
+# check the variables_hash_max_size setting
+git checkout conf/config.yaml
+
+echo '
+nginx_config:
+  http:
+    variables_hash_max_size: 1024
+' > conf/config.yaml
+
+make init
+
+if ! grep "variables_hash_max_size 1024;" conf/nginx.conf > /dev/null; then
+    echo "failed: 'variables_hash_max_size 1024;' not in nginx.conf"
+    exit 1
+fi
+
+echo "passed: found the 'variables_hash_max_size 1024;' in nginx.conf"


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Signed-off-by: Firstsawyou yuelinz99@gmail.com

When apisix is ​​in `make run`, it will prompt the following warning message:

```shell
$ make run
./bin/apisix start
/usr/local/openresty/luajit/bin/luajit ./apisix/cli/apisix.lua start
nginx: [warn] could not build optimal variables_hash, you should increase either variables_hash_max_size: 1024 or variables_hash_bucket_size: 64; ignoring variables_hash_bucket_size
```

Therefore, this PR will add the `variables_hash_max_size` parameter to solve the above warning problem.
Since the value of `variables_hash_max_size: 1024` is not enough, set `variables_hash_max_size: 2048`

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
