### PR TITLE
docs: removed navigation title from sidebar to docs dropdown

### DIFF
--- a/docs/en/latest/config.json
+++ b/docs/en/latest/config.json
@@ -2,11 +2,6 @@
   "version": 2.6,
   "sidebar": [
     {
-      "type": "link",
-      "label": "Apache APISIX",
-      "href" : "https://apisix.apache.org/docs/apisix/getting-started"
-    },
-    {
       "type": "category",
       "label": "Architecture Design",
       "items": [


### PR DESCRIPTION
### What this PR does / why we need it:
 To remove navigation title from sidebar to docs dropdown
[#361 from apisix-website](https://github.com/apache/apisix-website/issues/361)

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
