### PR TITLE
docs: fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ There are several ways to install the Apache Release version of APISIX:
 
    The getting started guide is a great way to learn the basics of APISIX. Just follow the steps in [Getting Started](docs/en/latest/getting-started.md).
 
-   Further, you can follow the documentation to try more [plugins](docs/en/latest/plugins.md).
+   Further, you can follow the documentation to try more [plugins](docs/en/latest/plugins).
 
 3. Admin API
 

--- a/docs/ar/README.md
+++ b/docs/ar/README.md
@@ -238,7 +238,7 @@ CentOS 7, Ubuntu 16.04, Ubuntu 18.04, Debian 9, Debian 10, macOS, **ARM64** Ubun
 
    يعد دليل البدء طريقة رائعة لتعلم أساسيات أبيسكس. ما عليك سوى اتباع الخطوات الواردة في  [البدء](docs/en/latest/getting-started.md).
 
-   Further, you can follow the documentation to try more [plugins](docs/en/latest/plugins.md).
+   Further, you can follow the documentation to try more [plugins](docs/en/latest/plugins).
 
 3. مدير API
 

--- a/docs/ar/README.md
+++ b/docs/ar/README.md
@@ -238,7 +238,7 @@ CentOS 7, Ubuntu 16.04, Ubuntu 18.04, Debian 9, Debian 10, macOS, **ARM64** Ubun
 
    يعد دليل البدء طريقة رائعة لتعلم أساسيات أبيسكس. ما عليك سوى اتباع الخطوات الواردة في  [البدء](docs/en/latest/getting-started.md).
 
-   Further, you can follow the documentation to try more [plugins](docs/en/latest/plugins).
+   Further, you can follow the documentation to try more [plugins](../../en/latest/plugins).
 
 3. مدير API
 

--- a/docs/ar/README.md
+++ b/docs/ar/README.md
@@ -238,7 +238,7 @@ CentOS 7, Ubuntu 16.04, Ubuntu 18.04, Debian 9, Debian 10, macOS, **ARM64** Ubun
 
    يعد دليل البدء طريقة رائعة لتعلم أساسيات أبيسكس. ما عليك سوى اتباع الخطوات الواردة في  [البدء](docs/en/latest/getting-started.md).
 
-   Further, you can follow the documentation to try more [plugins](../../en/latest/plugins).
+   Further, you can follow the documentation to try more [plugins](../en/latest/plugins).
 
 3. مدير API
 

--- a/docs/es/latest/README.md
+++ b/docs/es/latest/README.md
@@ -235,7 +235,7 @@ Hay varias maneras de instalar la versión publicada Apache de APISIX:
 
    La Guía para Comenzar es una excelente manera de aprender los fundamentos de APISIX, basta seguir los pasos en [Getting Started](../../en/latest/getting-started.md).
 
-   Más aún, usted puede seguir la documentación para ensayar más [plugins](../../en/latest/plugins.md).
+   Más aún, usted puede seguir la documentación para ensayar más [plugins](../../en/latest/plugins).
 
 3. Admin API
 

--- a/docs/zh/latest/README.md
+++ b/docs/zh/latest/README.md
@@ -238,7 +238,7 @@ CentOS 7, Ubuntu 16.04, Ubuntu 18.04, Debian 9, Debian 10, macOS, **ARM64** Ubun
 
    入门指南是学习 APISIX 基础知识的好方法。按照 [入门指南](getting-started.md)的步骤即可。
 
-   更进一步，你可以跟着文档来尝试更多的[插件](README.md#插件)。
+   更进一步，你可以跟着文档来尝试更多的[插件](plugins)。
 
 3. Admin API
 


### PR DESCRIPTION
### What this PR does / why we need it:

There is a link error in the For Developer section:
https://github.com/apache/apisix/blob/master/docs/en/latest/plugins.md
to
https://github.com/apache/apisix/tree/master/docs/en/latest/plugins

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [X] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
