### PR TITLE
feat(stream): support stream subsystem discovery

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -823,6 +823,11 @@ function _M.stream_init_worker()
         core.config.init_worker()
     end
 
+    local discovery = require("apisix.discovery.init").discovery
+    if discovery and discovery.init_worker then
+        discovery.init_worker()
+    end
+
     load_balancer = require("apisix.balancer")
 
     local_conf = core.config.local_conf()


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
     int function init.lua:stream_init_worker() not call discovery.init_worker(), 
     so, we can't use discovery in stream subsystem.
     by this pr, we can slove it 
     of course, the current and future discovery components need to ensure that they can work in the stream subsystem 
  
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
