### PR TITLE
test: make t/chaos/kill-chaos.t stable

### DIFF
--- a/t/chaos/kill-etcd_test.go
+++ b/t/chaos/kill-etcd_test.go
@@ -79,12 +79,12 @@ func TestGetSuccessWhenEtcdKilled(t *testing.T) {
 	go func() {
 		for {
 			go getRoute(eSilent, http.StatusOK)
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 		}
 	}()
 
-	// wait 3 seconds to let first route access returns
-	time.Sleep(3 * time.Second)
+	// wait 1 seconds to let first route access returns
+	time.Sleep(1 * time.Second)
 	bandwidthBefore, durationBefore := getIngressBandwidthPerSecond(e, g)
 	bpsBefore := bandwidthBefore / durationBefore
 	g.Expect(bpsBefore).NotTo(BeZero())

--- a/t/chaos/kill-etcd_test.go
+++ b/t/chaos/kill-etcd_test.go
@@ -83,8 +83,8 @@ func TestGetSuccessWhenEtcdKilled(t *testing.T) {
 		}
 	}()
 
-	// wait 1 seconds to let first route access returns
-	time.Sleep(1 * time.Second)
+	// wait 3 seconds to let first route access returns
+	time.Sleep(3 * time.Second)
 	bandwidthBefore, durationBefore := getIngressBandwidthPerSecond(e, g)
 	bpsBefore := bandwidthBefore / durationBefore
 	g.Expect(bpsBefore).NotTo(BeZero())

--- a/t/chaos/kill-etcd_test.go
+++ b/t/chaos/kill-etcd_test.go
@@ -85,7 +85,7 @@ func TestGetSuccessWhenEtcdKilled(t *testing.T) {
 
 	// wait 1 seconds to let first route access returns
 	time.Sleep(1 * time.Second)
-	bandwidthBefore, durationBefore := getIngressBandwidthPerSecond(e, g)
+	bandwidthBefore, durationBefore := getEgressBandwidthPerSecond(e, g)
 	bpsBefore := bandwidthBefore / durationBefore
 	g.Expect(bpsBefore).NotTo(BeZero())
 
@@ -116,7 +116,7 @@ func TestGetSuccessWhenEtcdKilled(t *testing.T) {
 		g.Expect(strings.Contains(errorLog, "failed to fetch data from etcd")).To(BeTrue())
 	})
 
-	bandwidthAfter, durationAfter := getIngressBandwidthPerSecond(e, g)
+	bandwidthAfter, durationAfter := getEgressBandwidthPerSecond(e, g)
 	bpsAfter := bandwidthAfter / durationAfter
 	t.Run("ingress bandwidth per second not change much", func(t *testing.T) {
 		t.Logf("bandwidth before: %f, after: %f", bandwidthBefore, bandwidthAfter)

--- a/t/chaos/utils.go
+++ b/t/chaos/utils.go
@@ -86,12 +86,7 @@ func setRoute(e *httpexpect.Expect, expectStatus int) {
 		Body: `{
 			 "uri": "/get",
 			 "plugins": {
-				 "prometheus": {},
-				 "limit-req": {
-					 "rate": 5,
-					 "burst": 100000,
-					 "key": "remote_addr"
-				 }
+				 "prometheus": {}
 			 },
 			 "upstream": {
 				 "nodes": {

--- a/t/chaos/utils.go
+++ b/t/chaos/utils.go
@@ -167,7 +167,7 @@ func getIngressBandwidthPerSecond(e *httpexpect.Expect, g *WithT) (float64, floa
 	// so need to calculate the duration
 	timeStart := time.Now()
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(10 * time.Second)
 	bandWidthString = getPrometheusMetric(e, g, key)
 	bandWidthEnd, err := strconv.ParseFloat(bandWidthString, 64)
 	g.Expect(err).To(BeNil())
@@ -178,7 +178,7 @@ func getIngressBandwidthPerSecond(e *httpexpect.Expect, g *WithT) (float64, floa
 
 func roughCompare(a float64, b float64) bool {
 	ratio := a / b
-	if ratio < 1.5 && ratio > 0.5 {
+	if ratio < 1.3 && ratio > 0.7 {
 		return true
 	}
 	return false

--- a/t/chaos/utils.go
+++ b/t/chaos/utils.go
@@ -86,7 +86,12 @@ func setRoute(e *httpexpect.Expect, expectStatus int) {
 		Body: `{
 			 "uri": "/get",
 			 "plugins": {
-				 "prometheus": {}
+				 "prometheus": {},
+				 "limit-req": {
+					 "rate": 5,
+					 "burst": 100000,
+					 "key": "remote_addr"
+				 }
 			 },
 			 "upstream": {
 				 "nodes": {
@@ -158,8 +163,8 @@ func getPrometheusMetric(e *httpexpect.Expect, g *WithT, key string) string {
 	return targetSlice[1]
 }
 
-func getIngressBandwidthPerSecond(e *httpexpect.Expect, g *WithT) (float64, float64) {
-	key := "apisix_bandwidth{type=\"ingress\","
+func getEgressBandwidthPerSecond(e *httpexpect.Expect, g *WithT) (float64, float64) {
+	key := "apisix_bandwidth{type=\"egress\","
 	bandWidthString := getPrometheusMetric(e, g, key)
 	bandWidthStart, err := strconv.ParseFloat(bandWidthString, 64)
 	g.Expect(err).To(BeNil())

--- a/t/chaos/utils.go
+++ b/t/chaos/utils.go
@@ -178,7 +178,7 @@ func getIngressBandwidthPerSecond(e *httpexpect.Expect, g *WithT) (float64, floa
 
 func roughCompare(a float64, b float64) bool {
 	ratio := a / b
-	if ratio < 1.3 && ratio > 0.7 {
+	if ratio < 1.5 && ratio > 0.5 {
 		return true
 	}
 	return false


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

### What this PR does / why we need it:
fix #4437 

Can not reproduce in the local environment. Try to make it stable by receiving more requests in a certain time period, to make bandwidth-per-second comparison more stable.

Also changed to egress bps comparison as measurement, since egress is what expected to be the same.

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
