### PR TITLE
feat(cli): check if control port conflicts with the node port

### DIFF
--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -433,7 +433,7 @@ Please modify "admin_key" in conf/config.yaml .
     if type(yaml_conf.apisix.node_listen) == "number" then
 
         if yaml_conf.apisix.node_listen == control_port then
-            util.die("control port conflict with node_listen port\n")
+            util.die("control port conflicts with node_listen port\n")
         end
 
         local node_listen = {{port = yaml_conf.apisix.node_listen}}
@@ -444,14 +444,14 @@ Please modify "admin_key" in conf/config.yaml .
             if type(value) == "number" then
 
                 if value == control_port then
-                    util.die("control port conflict with node_listen port\n")
+                    util.die("control port conflicts with node_listen port\n")
                 end
 
                 table_insert(node_listen, index, {port = value})
             elseif type(value) == "table" then
 
                 if type(value.port) == "number" and value.port == control_port then
-                    util.die("control port conflict with node_listen port\n")
+                    util.die("control port conflicts with node_listen port\n")
                 end
 
                 table_insert(node_listen, index, value)

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -24,7 +24,6 @@ local profile = require("apisix.core.profile")
 local template = require("resty.template")
 local argparse = require("argparse")
 local pl_path = require("pl.path")
-local pl_stringx = require("pl.stringx")
 local jsonschema = require("jsonschema")
 
 local stderr = io.stderr
@@ -408,16 +407,53 @@ Please modify "admin_key" in conf/config.yaml .
         util.die("missing apisix.proxy_cache for plugin proxy-cache\n")
     end
 
+    local control_port = 9090
+    local control_server_addr = ""
+    if yaml_conf.apisix.enable_control then
+        if not yaml_conf.apisix.control then
+            control_server_addr = "127.0.0.1:9090"
+        else
+            local ip = yaml_conf.apisix.control.ip
+            local port = tonumber(yaml_conf.apisix.control.port)
+
+            if ip == nil then
+                ip = "127.0.0.1"
+            end
+
+            if not port then
+                port = 9090
+            end
+
+            control_server_addr = ip .. ":" .. port
+            control_port = port
+        end
+    end
+
     -- support multiple ports listen, compatible with the original style
     if type(yaml_conf.apisix.node_listen) == "number" then
+
+        if yaml_conf.apisix.node_listen == control_port then
+            util.die("control port conflict with node_listen port\n")
+        end
+
         local node_listen = {{port = yaml_conf.apisix.node_listen}}
         yaml_conf.apisix.node_listen = node_listen
     elseif type(yaml_conf.apisix.node_listen) == "table" then
         local node_listen = {}
         for index, value in ipairs(yaml_conf.apisix.node_listen) do
             if type(value) == "number" then
+
+                if value == control_port then
+                    util.die("control port conflict with node_listen port\n")
+                end
+
                 table_insert(node_listen, index, {port = value})
             elseif type(value) == "table" then
+
+                if type(value.port) == "number" and value.port == control_port then
+                    util.die("control port conflict with node_listen port\n")
+                end
+
                 table_insert(node_listen, index, value)
             end
         end
@@ -501,6 +537,7 @@ Please modify "admin_key" in conf/config.yaml .
         enabled_plugins = enabled_plugins,
         dubbo_upstream_multiplex_count = dubbo_upstream_multiplex_count,
         tcp_enable_ssl = tcp_enable_ssl,
+        control_server_addr = control_server_addr,
     }
 
     if not yaml_conf.apisix then
@@ -522,48 +559,6 @@ Please modify "admin_key" in conf/config.yaml .
     end
     for k,v in pairs(yaml_conf.nginx_config) do
         sys_conf[k] = v
-    end
-
-    if yaml_conf.apisix.enable_control then
-        if not yaml_conf.apisix.control then
-            sys_conf.control_server_addr = "127.0.0.1:9090"
-        else
-            local ip = yaml_conf.apisix.control.ip
-            local port = tonumber(yaml_conf.apisix.control.port)
-
-            if ip == nil then
-                ip = "127.0.0.1"
-            end
-
-            if not port then
-                port = 9090
-            end
-
-            sys_conf.control_server_addr = ip .. ":" .. port
-        end
-    end
-
-    -- check control port conflict when batch-requests is enabled
-    if enabled_plugins["batch-requests"] and yaml_conf.apisix.enable_control then
-        local split = pl_stringx.split
-        local ip_port = split(sys_conf.control_server_addr, ":")
-        local port = tonumber(ip_port[#ip_port])
-        if port == nil then
-            util.die("port not number, should not happen\n")
-        end
-
-        if type(yaml_conf.apisix.node_listen) == "number" then
-            if port == yaml_conf.apisix.node_listen then
-                util.die("control port conflict node_listen port when batch-requests is on\n")
-            end
-        elseif type(yaml_conf.apisix.node_listen) == "table" then
-            for _, value in ipairs(yaml_conf.apisix.node_listen) do
-                if type(value) == "table" and type(value.port) == "number"
-                        and value.port == port then
-                    util.die("control port conflict node_listen port when batch-requests is on\n")
-                end
-            end
-        end
     end
 
     if yaml_conf.plugin_attr.prometheus then

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -407,8 +407,8 @@ Please modify "admin_key" in conf/config.yaml .
         util.die("missing apisix.proxy_cache for plugin proxy-cache\n")
     end
 
-    local control_port = 9090
-    local control_server_addr = ""
+    local control_port
+    local control_server_addr
     if yaml_conf.apisix.enable_control then
         if not yaml_conf.apisix.control then
             control_server_addr = "127.0.0.1:9090"

--- a/t/cli/test_control.sh
+++ b/t/cli/test_control.sh
@@ -119,6 +119,8 @@ echo '
 apisix:
   node_listen: 9090
   enable_control: true
+  control:
+    port: 9090
 ' > conf/config.yaml
 
 out=$(make init 2>&1 || true)

--- a/t/cli/test_control.sh
+++ b/t/cli/test_control.sh
@@ -124,8 +124,8 @@ apisix:
 ' > conf/config.yaml
 
 out=$(make init 2>&1 || true)
-if ! echo "$out" | grep "control port conflict with node_listen port"; then
-    echo "failed: can't detect port conflict"
+if ! echo "$out" | grep "control port conflicts with node_listen port"; then
+    echo "failed: can't detect port conflicts"
     exit 1
 fi
 

--- a/t/cli/test_control.sh
+++ b/t/cli/test_control.sh
@@ -115,4 +115,16 @@ if grep "listen 127.0.0.1:9090;" conf/nginx.conf > /dev/null; then
     exit 1
 fi
 
+echo '
+apisix:
+  node_listen: 9090
+  enable_control: true
+' > conf/config.yaml
+
+out=$(make init 2>&1 || true)
+if ! echo "$out" | grep "control port conflict with node_listen port"; then
+    echo "failed: can't detect port conflict"
+    exit 1
+fi
+
 echo "pass: access control server"


### PR DESCRIPTION
batch-requests plugin is working based on routing all the the request to 127.0.0.1:9080, if enable-control is on and port is the same with node_listen port, it will add configuration file like this：

```
  server {
      listen 127.0.0.1:9080;
      access_log off;
      location / {
          content_by_lua_block {
              local prometheus = require("apisix.plugins.prometheus")
              prometheus.export_metrics()
          }
      }
  }
```

this will cause all the 127.0.0.1:9080/* request route to this control api server, and all the expected  batch-requests  url return 404.

I add some force  check when batch-requests  is enabled.
