### PR TITLE
fix: modify the value of HOMEBREW_PREFIX in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,13 @@ INST_LUADIR ?= $(INST_PREFIX)/share/lua/5.1
 INST_BINDIR ?= /usr/bin
 INSTALL ?= install
 UNAME ?= $(shell uname)
+UNAME_MACHINE ?= $(shell uname -m)
 OR_EXEC ?= $(shell which openresty || which nginx)
 LUAROCKS ?= luarocks
 LUAROCKS_VER ?= $(shell luarocks --version | grep -E -o  "luarocks [0-9]+.")
 OR_PREFIX ?= $(shell $(OR_EXEC) -V 2>&1 | grep -Eo 'prefix=(.*)/nginx\s+' | grep -Eo '/.*/')
 OPENSSL_PREFIX ?= $(addprefix $(OR_PREFIX), openssl)
+HOMEBREW_PREFIX ?= /usr/local
 
 # OpenResty 1.17.8 or higher version uses openssl111 as the openssl dirname.
 ifeq ($(shell test -d $(addprefix $(OR_PREFIX), openssl111) && echo -n yes), yes)
@@ -33,6 +35,9 @@ ifeq ($(shell test -d $(addprefix $(OR_PREFIX), openssl111) && echo -n yes), yes
 endif
 
 ifeq ($(UNAME), Darwin)
+ifeq ($(UNAME_MACHINE), arm64)
+	HOMEBREW_PREFIX=/opt/homebrew
+endif
 LUAROCKS=luarocks --lua-dir=$(HOMEBREW_PREFIX)/opt/lua@5.1
 ifeq ($(shell test -d $(HOMEBREW_PREFIX)/opt/openresty-openssl && echo yes), yes)
 	OPENSSL_PREFIX=$(HOMEBREW_PREFIX)/opt/openresty-openssl


### PR DESCRIPTION
I found HOMEBREW_PREFIX variable in Makefile is not assigned correctly, which leads to the error of 'make deps' operation on the Mac.
