### PR TITLE
docs: fix the valid value interval of `max_breaker_sec`

### DIFF
--- a/docs/en/latest/plugins/api-breaker.md
+++ b/docs/en/latest/plugins/api-breaker.md
@@ -52,7 +52,7 @@ In an unhealthy state, when a request is forwarded to an upstream service and th
 | Name                    | Type          | Requirement | Default | Valid            | Description                                                                 |
 | ----------------------- | ------------- | ----------- | -------- | --------------- | --------------------------------------------------------------------------- |
 | break_response_code     | integer        | required |            | [200, ..., 599] | Return error code when unhealthy |
-| max_breaker_sec         | integer        | optional | 300        | >=60            | Maximum breaker time(seconds) |
+| max_breaker_sec         | integer        | optional | 300        | >=3             | Maximum breaker time(seconds) |
 | unhealthy.http_statuses | array[integer] | optional | {500}      | [500, ..., 599] | Status codes when unhealthy |
 | unhealthy.failures      | integer        | optional | 3          | >=1             | Number of consecutive error requests that triggered an unhealthy state |
 | healthy.http_statuses   | array[integer] | optional | {200}      | [200, ..., 499] | Status codes when healthy |

--- a/docs/zh/latest/plugins/api-breaker.md
+++ b/docs/zh/latest/plugins/api-breaker.md
@@ -52,7 +52,7 @@ title: api-breaker
 | 名称                    | 类型           | 必选项 | 默认值     | 有效值          | 描述                             |
 | ----------------------- | -------------- | ------ | ---------- | --------------- | -------------------------------- |
 | break_response_code     | integer        | 必须   | 无         | [200, ..., 599] | 不健康返回错误码                 |
-| max_breaker_sec         | integer        | 可选   | 300        | >=60            | 最大熔断持续时间                 |
+| max_breaker_sec         | integer        | 可选   | 300        | >=3             | 最大熔断持续时间                 |
 | unhealthy.http_statuses | array[integer] | 可选   | {500}      | [500, ..., 599] | 不健康时候的状态码               |
 | unhealthy.failures      | integer        | 可选   | 3          | >=1             | 触发不健康状态的连续错误请求次数 |
 | healthy.http_statuses   | array[integer] | 可选   | {200}      | [200, ..., 499] | 健康时候的状态码                 |


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
The  minimum of `max_breaker_sec` should be `3` instead of `60`:

https://github.com/apache/apisix/blob/38785557bee818c3d8a3ca1d46f788fc65ab38ab/apisix/plugins/api-breaker.lua#L38-L41
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
