### PR TITLE
feat(cli): check listen port conflicts with each other

### DIFF
--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -413,10 +413,10 @@ Please modify "admin_key" in conf/config.yaml .
     if yaml_conf.apisix.enable_control then
         if not yaml_conf.apisix.control then
             if ports_to_check[9090] ~= nil then
-                util.die("control port conflicts with node_listen, prometheus, etc.\n")
+                util.die("control port 9090 conflicts with ", ports_to_check[9090], "\n")
             end
             control_server_addr = "127.0.0.1:9090"
-            ports_to_check[9090] = true
+            ports_to_check[9090] = "control"
         else
             local ip = yaml_conf.apisix.control.ip
             local port = tonumber(yaml_conf.apisix.control.port)
@@ -430,11 +430,11 @@ Please modify "admin_key" in conf/config.yaml .
             end
 
             if ports_to_check[port] ~= nil then
-                util.die("control port conflicts with node_listen, prometheus, etc.\n")
+                util.die("control port ", port, " conflicts with ", ports_to_check[port], "\n")
             end
 
             control_server_addr = ip .. ":" .. port
-            ports_to_check[port] = true
+            ports_to_check[port] = "control"
         end
     end
 
@@ -454,11 +454,11 @@ Please modify "admin_key" in conf/config.yaml .
             end
 
             if ports_to_check[port] ~= nil then
-                util.die("prometheus port conflicts with control, node_listen, etc.\n")
+                util.die("prometheus port ", port, " conflicts with ", ports_to_check[port], "\n")
             end
 
             prometheus_server_addr = ip .. ":" .. port
-            ports_to_check[port] = true
+            ports_to_check[port] = "prometheus"
         end
     end
 
@@ -466,7 +466,8 @@ Please modify "admin_key" in conf/config.yaml .
     if type(yaml_conf.apisix.node_listen) == "number" then
 
         if ports_to_check[yaml_conf.apisix.node_listen] ~= nil then
-            util.die("node_listen port conflicts with control, prometheus, etc.\n")
+            util.die("node_listen port ", yaml_conf.apisix.node_listen,
+                    " conflicts with ", ports_to_check[yaml_conf.apisix.node_listen], "\n")
         end
 
         local node_listen = {{port = yaml_conf.apisix.node_listen}}
@@ -477,14 +478,14 @@ Please modify "admin_key" in conf/config.yaml .
             if type(value) == "number" then
 
                 if ports_to_check[value] ~= nil then
-                    util.die("node_listen port conflicts with control, prometheus, etc.\n")
+                    util.die("node_listen port ", value, " conflicts with ", ports_to_check[value], "\n")
                 end
 
                 table_insert(node_listen, index, {port = value})
             elseif type(value) == "table" then
 
                 if type(value.port) == "number" and ports_to_check[value.port] ~= nil then
-                    util.die("node_listen port conflicts with control, prometheus, etc.\n")
+                    util.die("node_listen port ", value.port, " conflicts with ", ports_to_check[value.port], "\n")
                 end
 
                 table_insert(node_listen, index, value)

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -407,11 +407,16 @@ Please modify "admin_key" in conf/config.yaml .
         util.die("missing apisix.proxy_cache for plugin proxy-cache\n")
     end
 
-    local control_port
+    local ports_to_check = {}
+
     local control_server_addr
     if yaml_conf.apisix.enable_control then
         if not yaml_conf.apisix.control then
+            if ports_to_check[9090] ~= nil then
+                util.die("control port conflicts with node_listen, prometheus, etc.\n")
+            end
             control_server_addr = "127.0.0.1:9090"
+            ports_to_check[9090] = true
         else
             local ip = yaml_conf.apisix.control.ip
             local port = tonumber(yaml_conf.apisix.control.port)
@@ -424,16 +429,44 @@ Please modify "admin_key" in conf/config.yaml .
                 port = 9090
             end
 
+            if ports_to_check[port] ~= nil then
+                util.die("control port conflicts with node_listen, prometheus, etc.\n")
+            end
+
             control_server_addr = ip .. ":" .. port
-            control_port = port
+            ports_to_check[port] = true
+        end
+    end
+
+    local prometheus_server_addr
+    if yaml_conf.plugin_attr.prometheus then
+        local prometheus = yaml_conf.plugin_attr.prometheus
+        if prometheus.enable_export_server then
+            local ip = prometheus.export_addr.ip
+            local port = tonumber(prometheus.export_addr.port)
+
+            if ip == nil then
+                ip = "127.0.0.1"
+            end
+
+            if not port then
+                port = 9091
+            end
+
+            if ports_to_check[port] ~= nil then
+                util.die("prometheus port conflicts with control, node_listen, etc.\n")
+            end
+
+            prometheus_server_addr = ip .. ":" .. port
+            ports_to_check[port] = true
         end
     end
 
     -- support multiple ports listen, compatible with the original style
     if type(yaml_conf.apisix.node_listen) == "number" then
 
-        if yaml_conf.apisix.node_listen == control_port then
-            util.die("control port conflicts with node_listen port\n")
+        if ports_to_check[yaml_conf.apisix.node_listen] ~= nil then
+            util.die("node_listen port conflicts with control, prometheus, etc.\n")
         end
 
         local node_listen = {{port = yaml_conf.apisix.node_listen}}
@@ -443,15 +476,15 @@ Please modify "admin_key" in conf/config.yaml .
         for index, value in ipairs(yaml_conf.apisix.node_listen) do
             if type(value) == "number" then
 
-                if value == control_port then
-                    util.die("control port conflicts with node_listen port\n")
+                if ports_to_check[value] ~= nil then
+                    util.die("node_listen port conflicts with control, prometheus, etc.\n")
                 end
 
                 table_insert(node_listen, index, {port = value})
             elseif type(value) == "table" then
 
-                if type(value.port) == "number" and value.port == control_port then
-                    util.die("control port conflicts with node_listen port\n")
+                if type(value.port) == "number" and ports_to_check[value.port] ~= nil then
+                    util.die("node_listen port conflicts with control, prometheus, etc.\n")
                 end
 
                 table_insert(node_listen, index, value)
@@ -538,6 +571,7 @@ Please modify "admin_key" in conf/config.yaml .
         dubbo_upstream_multiplex_count = dubbo_upstream_multiplex_count,
         tcp_enable_ssl = tcp_enable_ssl,
         control_server_addr = control_server_addr,
+        prometheus_server_addr = prometheus_server_addr,
     }
 
     if not yaml_conf.apisix then
@@ -561,23 +595,6 @@ Please modify "admin_key" in conf/config.yaml .
         sys_conf[k] = v
     end
 
-    if yaml_conf.plugin_attr.prometheus then
-        local prometheus = yaml_conf.plugin_attr.prometheus
-        if prometheus.enable_export_server then
-            local ip = prometheus.export_addr.ip
-            local port = tonumber(prometheus.export_addr.port)
-
-            if ip == nil then
-                ip = "127.0.0.1"
-            end
-
-            if not port then
-                port = 9091
-            end
-
-            sys_conf.prometheus_server_addr = ip .. ":" .. port
-        end
-    end
 
     local wrn = sys_conf["worker_rlimit_nofile"]
     local wc = sys_conf["event"]["worker_connections"]

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -478,14 +478,16 @@ Please modify "admin_key" in conf/config.yaml .
             if type(value) == "number" then
 
                 if ports_to_check[value] ~= nil then
-                    util.die("node_listen port ", value, " conflicts with ", ports_to_check[value], "\n")
+                    util.die("node_listen port ", value, " conflicts with ",
+                            ports_to_check[value], "\n")
                 end
 
                 table_insert(node_listen, index, {port = value})
             elseif type(value) == "table" then
 
                 if type(value.port) == "number" and ports_to_check[value.port] ~= nil then
-                    util.die("node_listen port ", value.port, " conflicts with ", ports_to_check[value.port], "\n")
+                    util.die("node_listen port ", value.port, " conflicts with ",
+                            ports_to_check[value.port], "\n")
                 end
 
                 table_insert(node_listen, index, value)

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -479,7 +479,7 @@ Please modify "admin_key" in conf/config.yaml .
 
                 if ports_to_check[value] ~= nil then
                     util.die("node_listen port ", value, " conflicts with ",
-                            ports_to_check[value], "\n")
+                        ports_to_check[value], "\n")
                 end
 
                 table_insert(node_listen, index, {port = value})
@@ -487,7 +487,7 @@ Please modify "admin_key" in conf/config.yaml .
 
                 if type(value.port) == "number" and ports_to_check[value.port] ~= nil then
                     util.die("node_listen port ", value.port, " conflicts with ",
-                            ports_to_check[value.port], "\n")
+                        ports_to_check[value.port], "\n")
                 end
 
                 table_insert(node_listen, index, value)

--- a/t/cli/test_control.sh
+++ b/t/cli/test_control.sh
@@ -124,7 +124,26 @@ apisix:
 ' > conf/config.yaml
 
 out=$(make init 2>&1 || true)
-if ! echo "$out" | grep "control port conflicts with node_listen port"; then
+if ! echo "$out" | grep "control port conflicts with node_listen, prometheus, etc."; then
+    echo "failed: can't detect port conflicts"
+    exit 1
+fi
+
+echo '
+apisix:
+  node_listen: 9091
+  enable_control: true
+  control:
+    port: 9090
+plugin_attr:
+  prometheus:
+    export_addr:
+      ip: "127.0.0.1"
+      port: 9090
+' > conf/config.yaml
+
+out=$(make init 2>&1 || true)
+if ! echo "$out" | grep "prometheus port conflicts with control, node_listen, etc."; then
     echo "failed: can't detect port conflicts"
     exit 1
 fi

--- a/t/cli/test_control.sh
+++ b/t/cli/test_control.sh
@@ -124,7 +124,7 @@ apisix:
 ' > conf/config.yaml
 
 out=$(make init 2>&1 || true)
-if ! echo "$out" | grep "control port conflicts with node_listen, prometheus, etc."; then
+if ! echo "$out" | grep "node_listen port conflicts with control, prometheus, etc."; then
     echo "failed: can't detect port conflicts"
     exit 1
 fi

--- a/t/cli/test_control.sh
+++ b/t/cli/test_control.sh
@@ -81,12 +81,12 @@ echo '
 apisix:
   enable_control: true
   control:
-    port: 9091
+    port: 9092
 ' > conf/config.yaml
 
 make init
 
-if ! grep "listen 127.0.0.1:9091;" conf/nginx.conf > /dev/null; then
+if ! grep "listen 127.0.0.1:9092;" conf/nginx.conf > /dev/null; then
     echo "failed: customize address for control server"
     exit 1
 fi
@@ -94,7 +94,7 @@ fi
 make run
 
 sleep 0.1
-code=$(curl -v -k -i -m 20 -o /dev/null -s -w %{http_code} http://127.0.0.1:9091/v1/schema)
+code=$(curl -v -k -i -m 20 -o /dev/null -s -w %{http_code} http://127.0.0.1:9092/v1/schema)
 
 if [ ! $code -eq 200 ]; then
     echo "failed: access control server"
@@ -131,15 +131,15 @@ fi
 
 echo '
 apisix:
-  node_listen: 9091
+  node_listen: 9080
   enable_control: true
   control:
-    port: 9090
+    port: 9091
 plugin_attr:
   prometheus:
     export_addr:
       ip: "127.0.0.1"
-      port: 9090
+      port: 9091
 ' > conf/config.yaml
 
 out=$(make init 2>&1 || true)

--- a/t/cli/test_control.sh
+++ b/t/cli/test_control.sh
@@ -124,7 +124,7 @@ apisix:
 ' > conf/config.yaml
 
 out=$(make init 2>&1 || true)
-if ! echo "$out" | grep "node_listen port conflicts with control, prometheus, etc."; then
+if ! echo "$out" | grep "node_listen port 9090 conflicts with control"; then
     echo "failed: can't detect port conflicts"
     exit 1
 fi
@@ -143,7 +143,7 @@ plugin_attr:
 ' > conf/config.yaml
 
 out=$(make init 2>&1 || true)
-if ! echo "$out" | grep "prometheus port conflicts with control, node_listen, etc."; then
+if ! echo "$out" | grep "prometheus port 9091 conflicts with control"; then
     echo "failed: can't detect port conflicts"
     exit 1
 fi

--- a/t/cli/test_prometheus.sh
+++ b/t/cli/test_prometheus.sh
@@ -90,4 +90,20 @@ fi
 
 make stop
 
+echo '
+apisix:
+  node_listen: ${{PORT}}
+plugin_attr:
+  prometheus:
+    export_addr:
+      ip: ${{IP}}
+      port: ${{PORT}}
+' > conf/config.yaml
+
+out=$(IP=127.0.0.1 PORT=9092 make init 2>&1 || true)
+if ! echo "$out" | grep "node_listen port conflicts with control, prometheus, etc."; then
+    echo "failed: can't detect port conflicts"
+    exit 1
+fi
+
 echo "passed: should listen at previous prometheus address"

--- a/t/cli/test_prometheus.sh
+++ b/t/cli/test_prometheus.sh
@@ -91,6 +91,20 @@ fi
 make stop
 
 echo '
+plugin_attr:
+  prometheus:
+    export_addr:
+      ip: ${{IP}}
+      port: ${{PORT}}
+' > conf/config.yaml
+
+out=$(IP=127.0.0.1 PORT=9090 make init 2>&1 || true)
+if ! echo "$out" | grep "prometheus port 9090 conflicts with control"; then
+    echo "failed: can't detect port conflicts"
+    exit 1
+fi
+
+echo '
 apisix:
   node_listen: ${{PORT}}
 plugin_attr:
@@ -100,8 +114,8 @@ plugin_attr:
       port: ${{PORT}}
 ' > conf/config.yaml
 
-out=$(IP=127.0.0.1 PORT=9090 make init 2>&1 || true)
-if ! echo "$out" | grep "node_listen port conflicts with control, prometheus, etc."; then
+out=$(IP=127.0.0.1 PORT=9092 make init 2>&1 || true)
+if ! echo "$out" | grep "node_listen port 9092 conflicts with prometheus"; then
     echo "failed: can't detect port conflicts"
     exit 1
 fi

--- a/t/cli/test_prometheus.sh
+++ b/t/cli/test_prometheus.sh
@@ -100,7 +100,7 @@ plugin_attr:
       port: ${{PORT}}
 ' > conf/config.yaml
 
-out=$(IP=127.0.0.1 PORT=9092 make init 2>&1 || true)
+out=$(IP=127.0.0.1 PORT=9090 make init 2>&1 || true)
 if ! echo "$out" | grep "node_listen port conflicts with control, prometheus, etc."; then
     echo "failed: can't detect port conflicts"
     exit 1


### PR DESCRIPTION
check node_listen, control, prometheus port listen conflicts

### What this PR does / why we need it:
This pr is a further port conflict check between, node_listen, control, prometheus.
based on my previous pr: #4504

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
