### PR TITLE
feat: allow plugin running in the balancer phase

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -707,6 +707,7 @@ function _M.http_balancer_phase()
     end
 
     load_balancer.run(api_ctx.matched_route, api_ctx)
+    common_phase("balancer")
 end
 
 
@@ -917,6 +918,7 @@ function _M.stream_balancer_phase()
     end
 
     load_balancer.run(api_ctx.matched_route, api_ctx)
+    common_phase("balancer")
 end
 
 


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**

I found, now, APISIX does not invoke plugin's balancer function.
As far as I learned, we have added `common_phase("balancer")` at the end of the balancer function.
At actually, it really works.