### PR TITLE
fix: has_route_not_under_apisix value is wrongly assigned

### DIFF
--- a/apisix/api_router.lua
+++ b/apisix/api_router.lua
@@ -89,21 +89,18 @@ function fetch_api_router()
             core.log.debug("fetched api routes: ",
                            core.json.delay_encode(api_routes, true))
             for _, route in ipairs(api_routes) do
-                if has_route_not_under_apisix then
-                    break
-                end
                 local typ_uri = type(route.uri)
-                if typ_uri == "string" then
-                    if not core.string.has_prefix(route.uri, "/apisix/") then
-                        has_route_not_under_apisix = true
-                    end
-                else
-                    for _, uri in ipairs(route.uri) do
-                        if has_route_not_under_apisix then
-                            break
-                        end
-                        if not core.string.has_prefix(uri, "/apisix/") then
+                if not has_route_not_under_apisix then
+                    if typ_uri == "string" then
+                        if not core.string.has_prefix(route.uri, "/apisix/") then
                             has_route_not_under_apisix = true
+                        end
+                    else
+                        for _, uri in ipairs(route.uri) do
+                            if not core.string.has_prefix(uri, "/apisix/") then
+                                has_route_not_under_apisix = true
+                                break
+                            end
                         end
                     end
                 end

--- a/apisix/api_router.lua
+++ b/apisix/api_router.lua
@@ -89,13 +89,20 @@ function fetch_api_router()
             core.log.debug("fetched api routes: ",
                            core.json.delay_encode(api_routes, true))
             for _, route in ipairs(api_routes) do
+                if has_route_not_under_apisix then
+                    break
+                end
                 local typ_uri = type(route.uri)
                 if typ_uri == "string" then
-                    has_route_not_under_apisix =
-                        not core.string.has_prefix(route.uri, "/apisix/")
+                    if not core.string.has_prefix(route.uri, "/apisix/") then
+                        has_route_not_under_apisix = true
+                    end
                 else
                     for _, uri in ipairs(route.uri) do
-                        if not core.string.has_prefix(route.uri, "/apisix/") then
+                        if has_route_not_under_apisix then
+                            break
+                        end
+                        if not core.string.has_prefix(uri, "/apisix/") then
                             has_route_not_under_apisix = true
                         end
                     end


### PR DESCRIPTION
has_route_not_under_apisix is wrongly assigned, which will  cause router strange  behaviour.

`has_route_not_under_apisix` is initiated to `false`, and fetch_api_router() method is iterating all the route api to find if exists some router api not start with "/apisix".

if the router list appear like this:

```
local api_routes = {
    { uri = "/foo/bar", },
    { uri = "/apisix/aa", },
}
```

has_route_not_under_apisix is first set to `true`, but second loop the value is set to `false`. which is toally wrong.

code is simplifed like this:
```
local api_routes = {
    { uri = "/apisi", },
    { uri = "/apisix/aa", },
}

local has_route_not_under_apisix = false

for _, route in ipairs(api_routes) do
    local typ_uri = type(route.uri)
    if typ_uri == "string" then
        -- bug here, first loop: true, second loop: false
        has_route_not_under_apisix = not string.starts(route.uri, "/apisix/")
    else
        for _, uri in ipairs(route.uri) do
            --if has_route_not_under_apisix then
            --    break
            --end
            if not string.starts(uri, "/apisix/") then
                has_route_not_under_apisix = true
            end
        end
    end
end
```

this bug is introduced in this pr https://github.com/apache/apisix/pull/2826

the second problem is that, the check value is wrongly assigned.

![](https://store-tg1.cvte.com/pics_2021070716256718362790.jpg)




### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
