### PR TITLE
fix: default value of request-id according to docs

### DIFF
--- a/apisix/plugins/request-id.lua
+++ b/apisix/plugins/request-id.lua
@@ -23,7 +23,7 @@ local schema = {
     type = "object",
     properties = {
         header_name = {type = "string", default = "X-Request-Id"},
-        include_in_response = {type = "boolean", default = true}
+        include_in_response = {type = "boolean", default = false}
     }
 }
 


### PR DESCRIPTION
### What this PR does / why we need it:
To make the default value of include_in_response according to documentation i.e; false
https://github.com/apache/apisix-dashboard/issues/1960

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
