### PR TITLE
fix: correct the return value checking of pcall, since apisix_ngx_cli…

### DIFF
--- a/apisix/plugins/client-control.lua
+++ b/apisix/plugins/client-control.lua
@@ -16,7 +16,7 @@
 --
 local require = require
 local core = require("apisix.core")
-local _, apisix_ngx_client = pcall(require, "resty.apisix.client")
+local ok, apisix_ngx_client = pcall(require, "resty.apisix.client")
 local tonumber = tonumber
 
 
@@ -48,7 +48,7 @@ end
 
 
 function _M.rewrite(conf, ctx)
-    if not apisix_ngx_client then
+    if not ok then
         core.log.error("need to build APISIX-OpenResty to support client restriction")
         return 503
     end


### PR DESCRIPTION
…ent has no chance to be nil or false

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
correct the return value checking of pcall
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
