### PR TITLE
fix(stream): sni router is broken when session reuses

### DIFF
--- a/apisix/ssl/router/radixtree_sni.lua
+++ b/apisix/ssl/router/radixtree_sni.lua
@@ -171,8 +171,6 @@ function _M.match_and_set(api_ctx)
         end
     end
 
-    api_ctx.sni_rev = sni_rev
-
     local matched_ssl = api_ctx.matched_ssl
     core.log.info("debug - matched: ", core.json.delay_encode(matched_ssl, true))
 

--- a/apisix/stream/router/ip_port.lua
+++ b/apisix/stream/router/ip_port.lua
@@ -19,7 +19,6 @@ local config_util = require("apisix.core.config_util")
 local plugin_checker = require("apisix.plugin").stream_plugin_checker
 local router_new = require("apisix.utils.router").new
 local ngx_ssl = require("ngx.ssl")
-local ngx_lua_version = ngx.config.ngx_lua_version -- get the version of stream-lua-nginx-module
 local error     = error
 local tonumber  = tonumber
 local ipairs = ipairs
@@ -135,17 +134,9 @@ do
             router_ver = user_routes.conf_version
         end
 
-        if ngx_lua_version < 9 then
-            -- be compatible with old OpenResty
-            local sni = ngx_ssl.server_name()
-            if sni then
-                local sni_rev = sni:reverse()
-                api_ctx.sni_rev = sni_rev
-            end
-        end
-
-        if api_ctx.sni_rev and tls_router then
-            local sni_rev = api_ctx.sni_rev
+        local sni = ngx_ssl.server_name()
+        if sni and tls_router then
+            local sni_rev = sni:reverse()
 
             core.table.clear(match_opts)
             match_opts.vars = api_ctx.var

--- a/t/stream-node/sni.t
+++ b/t/stream-node/sni.t
@@ -128,7 +128,23 @@ proxy request to 127.0.0.1:1995
 
 
 
-=== TEST 3: hit route, wildcard SNI
+=== TEST 3: hit route (session reuse)
+--- stream_tls_request
+mmm
+--- stream_sni: a.test.com
+--- stream_session_reuse
+--- response_body
+hello world
+hello world
+--- grep_error_log eval
+qr/proxy request to 127.0.0.\d:1995/
+--- grep_error_log_out
+proxy request to 127.0.0.1:1995
+proxy request to 127.0.0.1:1995
+
+
+
+=== TEST 4: hit route, wildcard SNI
 --- stream_tls_request
 mmm
 --- stream_sni: b.test.com
@@ -139,7 +155,7 @@ proxy request to 127.0.0.2:1995
 
 
 
-=== TEST 4: hit route, no TLS
+=== TEST 5: hit route, no TLS
 --- stream_enable
 --- stream_request
 mmm
@@ -150,7 +166,7 @@ proxy request to 127.0.0.3:1995
 
 
 
-=== TEST 5: set different stream route with the same sni
+=== TEST 6: set different stream route with the same sni
 --- config
     location /t {
         content_by_lua_block {
@@ -204,7 +220,7 @@ passed
 
 
 
-=== TEST 6: hit route
+=== TEST 7: hit route
 --- stream_tls_request
 mmm
 --- stream_sni: a.test.com
@@ -215,7 +231,7 @@ proxy request to 127.0.0.4:1995
 
 
 
-=== TEST 7: change a.test.com route to fall back to wildcard route
+=== TEST 8: change a.test.com route to fall back to wildcard route
 --- config
     location /t {
         content_by_lua_block {
@@ -250,7 +266,7 @@ passed
 
 
 
-=== TEST 8: hit route
+=== TEST 9: hit route
 --- stream_tls_request
 mmm
 --- stream_sni: a.test.com
@@ -261,7 +277,7 @@ proxy request to 127.0.0.2:1995
 
 
 
-=== TEST 9: no sni matched, fall back to non-sni route
+=== TEST 10: no sni matched, fall back to non-sni route
 --- config
     location /t {
         content_by_lua_block {
@@ -285,7 +301,7 @@ passed
 
 
 
-=== TEST 10: hit route
+=== TEST 11: hit route
 --- stream_tls_request
 mmm
 --- stream_sni: b.test.com
@@ -296,7 +312,7 @@ proxy request to 127.0.0.3:1995
 
 
 
-=== TEST 11: clean up routes
+=== TEST 12: clean up routes
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
Reuse TLS session won't run the ssl_certificate phase.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
