### PR TITLE
docs: fix the problem of how-to-build note block display

### DIFF
--- a/docs/en/latest/getting-started.md
+++ b/docs/en/latest/getting-started.md
@@ -76,9 +76,7 @@ curl --location --request GET "http://httpbin.org/get?foo1=bar1&foo2=bar2"
 
 - We use the [curl](https://curl.se/docs/manpage.html) command for API testing. You can also use other tools such as [Postman](https://www.postman.com/) for testing.
 
-:::note Note
-If you already have Apache APISIX installed, please skip Step 1, and go to [Step 2](getting-started.md#step-2-create-a-route) directly.
-:::
+> **_NOTE:_** If you already have Apache APISIX installed, please skip Step 1, and go to [Step 2](getting-started.md#step-2-create-a-route) directly.
 
 ## Step 1: Install Apache APISIX
 
@@ -172,9 +170,7 @@ curl "http://127.0.0.1:9080/apisix/admin/upstreams/1" -H "X-API-KEY: edd1c9f0343
 
 We use `roundrobin` as the load balancing mechanism, and set `httpbin.org:80` as our upstream target (Upstream service) with an ID of `1`. For more information on the fields, see [Admin API](./admin-api.md).
 
-:::note Note
-Creating an Upstream service is not actually necessary, as we can use [Plugin](./architecture-design/plugin.md) to intercept the request and then respond directly. However, for the purposes of this guide, we assume that at least one Upstream service needs to be set up.
-:::
+> **_NOTE:_** Creating an Upstream service is not actually necessary, as we can use [Plugin](./architecture-design/plugin.md) to intercept the request and then respond directly. However, for the purposes of this guide, we assume that at least one Upstream service needs to be set up.
 
 ### Bind the Route to the Upstream
 
@@ -275,9 +271,7 @@ Apache APISIX provides a [Dashboard](https://github.com/apache/apisix-dashboard)
 
 ![Dashboard](../../assets/images/dashboard.jpeg)
 
-:::note Note
-APISIX Dashboard is an experimental feature for now.
-:::
+> **_NOTE:_** APISIX Dashboard is an experimental feature for now.
 
 ### Troubleshooting
 

--- a/docs/en/latest/how-to-build.md
+++ b/docs/en/latest/how-to-build.md
@@ -151,9 +151,7 @@ make help
 
   - Or you can specify the NGINX binary path by running this command: `TEST_NGINX_BINARY=/usr/local/bin/openresty prove -Itest-nginx/lib -r t`.
 
-  :::note Note
-  Some of the tests rely on external services and system configuration modification. For a complete test environment build, you can refer to `ci/linux_openresty_common_runner.sh`.
-  :::
+  > **_NOTE:_** Some of the tests rely on external services and system configuration modification. For a complete test environment build, you can refer to `ci/linux_openresty_common_runner.sh`.
 
 ### Troubleshoot Testing
 

--- a/docs/zh/latest/getting-started.md
+++ b/docs/zh/latest/getting-started.md
@@ -74,9 +74,7 @@ curl --location --request GET "http://httpbin.org/get?foo1=bar1&foo2=bar2"
 
 - 本文使用 [curl](https://curl.se/docs/manpage.html) 命令行进行 API 测试。您也可以使用其他工具例如 [Postman](https://www.postman.com/)等，进行测试。
 
-:::note 说明
-如果您已经安装了 Apache APISIX，请直接阅读 [第二步](getting-started.md#第二步：创建路由)
-:::
+> **_NOTE:_** 如果您已经安装了 Apache APISIX，请直接阅读 [第二步](getting-started.md#第二步：创建路由)
 
 ## 第一步：安装 Apache APISIX
 
@@ -170,9 +168,7 @@ curl "http://127.0.0.1:9080/apisix/admin/upstreams/1" -H "X-API-KEY: edd1c9f0343
 
 我们使用 `roundrobin` 作为负载均衡机制，并将 `httpbin.org:80` 设置为我们的上游服务，其 ID 为 `1`。更多字段信息，请参阅 [Admin API](./admin-api.md)。
 
-:::note 注意
-创建上游服务实际上并不是必需的，因为我们可以使用 [插件](./architecture-design/plugin.md) 拦截请求，然后直接响应。但在本指南中，我们假设需要设置至少一个上游服务。
-:::
+> **_NOTE:_** 创建上游服务实际上并不是必需的，因为我们可以使用 [插件](./architecture-design/plugin.md) 拦截请求，然后直接响应。但在本指南中，我们假设需要设置至少一个上游服务。
 
 ### 绑定路由与上游服务
 
@@ -273,9 +269,7 @@ Apache APISIX 提供了一个 [Dashboard](https://github.com/apache/apisix-dashb
 
 ![Dashboard](../../assets/images/dashboard.jpeg)
 
-:::note 注意
-APISIX Dashboard 目前仍然是一个实验性功能。
-:::
+> **_NOTE:_** APISIX Dashboard 目前仍然是一个实验性功能。
 
 ### 常见问题排查
 

--- a/docs/zh/latest/how-to-build.md
+++ b/docs/zh/latest/how-to-build.md
@@ -149,9 +149,7 @@ make help
 
   - 或指定 NGINX 二进制路径：`TEST_NGINX_BINARY=/usr/local/bin/openresty prove -Itest-nginx/lib -r t`。
 
-  :::note 说明
-  部分测试需要依赖外部服务和修改系统配置。如果想要完整地构建测试环境，可以参考 `ci/linux_openresty_common_runner.sh`。
-  :::
+  > **_NOTE:_** 部分测试需要依赖外部服务和修改系统配置。如果想要完整地构建测试环境，可以参考 `ci/linux_openresty_common_runner.sh`。
 
 ### 问题排查
 


### PR DESCRIPTION
### What this PR does / why we need it:
`:::note Note` is not displayed and affects reading. Insert a blockquote can be solved.

from: `:::note Note Some of the tests rely` to `NOTE: Some of the tests rely`.

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [X] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
