### PR TITLE
feat: set the basic id attribute when creating a resource via POST

### DIFF
--- a/apisix/core/etcd.lua
+++ b/apisix/core/etcd.lua
@@ -310,10 +310,10 @@ function _M.push(key, value, ttl)
     -- manually add suffix
     local index = res.body.header.revision
     index = string.format("%020d", index)
-    
+
     -- set the basic id attribute
     value.id = index
-    
+
     res, err = set(key .. "/" .. index, value, ttl)
     if not res then
         return nil, err

--- a/apisix/core/etcd.lua
+++ b/apisix/core/etcd.lua
@@ -310,7 +310,10 @@ function _M.push(key, value, ttl)
     -- manually add suffix
     local index = res.body.header.revision
     index = string.format("%020d", index)
-
+    
+    -- set the basic id property
+    value.id = index
+    
     res, err = set(key .. "/" .. index, value, ttl)
     if not res then
         return nil, err

--- a/apisix/core/etcd.lua
+++ b/apisix/core/etcd.lua
@@ -311,7 +311,7 @@ function _M.push(key, value, ttl)
     local index = res.body.header.revision
     index = string.format("%020d", index)
     
-    -- set the basic id property
+    -- set the basic id attribute
     value.id = index
     
     res, err = set(key .. "/" .. index, value, ttl)

--- a/t/admin/routes2.t
+++ b/t/admin/routes2.t
@@ -197,6 +197,7 @@ GET /t
             res.node.key = nil
             res.node.value.create_time = nil
             res.node.value.update_time = nil
+            res.node.value.id = nil
             ngx.say(json.encode(res))
         }
     }

--- a/t/admin/routes2.t
+++ b/t/admin/routes2.t
@@ -197,6 +197,7 @@ GET /t
             res.node.key = nil
             res.node.value.create_time = nil
             res.node.value.update_time = nil
+            assert(res.node.value.id ~= nil)
             res.node.value.id = nil
             ngx.say(json.encode(res))
         }

--- a/t/admin/services2.t
+++ b/t/admin/services2.t
@@ -66,6 +66,7 @@ __DATA__
             res.node.key = nil
             res.node.value.create_time = nil
             res.node.value.update_time = nil
+            res.node.value.id = nil
             ngx.say(json.encode(res))
         }
     }

--- a/t/admin/services2.t
+++ b/t/admin/services2.t
@@ -66,6 +66,7 @@ __DATA__
             res.node.key = nil
             res.node.value.create_time = nil
             res.node.value.update_time = nil
+            assert(res.node.value.id ~= nil)
             res.node.value.id = nil
             ngx.say(json.encode(res))
         }

--- a/t/admin/ssl2.t
+++ b/t/admin/ssl2.t
@@ -65,6 +65,7 @@ __DATA__
             res.node.value.update_time = nil
             res.node.value.cert = ""
             res.node.value.key = ""
+            assert(res.node.value.id ~= nil)
             res.node.value.id = nil
             ngx.say(json.encode(res))
         }

--- a/t/admin/ssl2.t
+++ b/t/admin/ssl2.t
@@ -65,6 +65,7 @@ __DATA__
             res.node.value.update_time = nil
             res.node.value.cert = ""
             res.node.value.key = ""
+            res.node.value.id = nil
             ngx.say(json.encode(res))
         }
     }

--- a/t/admin/stream-routes.t
+++ b/t/admin/stream-routes.t
@@ -445,6 +445,7 @@ GET /t
             res.node.key = nil
             res.node.value.create_time = nil
             res.node.value.update_time = nil
+            res.node.value.id = nil
             ngx.say(json.encode(res))
         }
     }

--- a/t/admin/stream-routes.t
+++ b/t/admin/stream-routes.t
@@ -197,6 +197,8 @@ GET /t
             assert(create_time ~= nil, "create_time is nil")
             local update_time = ret.body.node.value.update_time
             assert(update_time ~= nil, "update_time is nil")
+            id = ret.body.node.value.id
+            assert(id ~= nil, "id is nil")
 
             code, message = t('/apisix/admin/stream_routes/' .. id,
                 ngx.HTTP_DELETE,

--- a/t/admin/stream-routes.t
+++ b/t/admin/stream-routes.t
@@ -447,6 +447,7 @@ GET /t
             res.node.key = nil
             res.node.value.create_time = nil
             res.node.value.update_time = nil
+            assert(res.node.value.id ~= nil)
             res.node.value.id = nil
             ngx.say(json.encode(res))
         }

--- a/t/admin/upstream2.t
+++ b/t/admin/upstream2.t
@@ -64,6 +64,7 @@ __DATA__
             res.node.key = nil
             res.node.value.create_time = nil
             res.node.value.update_time = nil
+            assert(res.node.value.id ~= nil)
             res.node.value.id = nil
             ngx.say(json.encode(res))
         }

--- a/t/admin/upstream2.t
+++ b/t/admin/upstream2.t
@@ -64,6 +64,7 @@ __DATA__
             res.node.key = nil
             res.node.value.create_time = nil
             res.node.value.update_time = nil
+            res.node.value.id = nil
             ngx.say(json.encode(res))
         }
     }


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When fetching resource list by the admin-api, some results include the basic id attribute (which created through the manager-api), but some results don't include it (which created through the admin-api). So set the basic id attribute when creating a resource by the admin-api in order to the result consistent.

![image](https://user-images.githubusercontent.com/75366457/126876179-d1301988-0193-45d0-9fb2-bdc2c7f9f22e.png)

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
