### PR TITLE
feat: proxy-mirror support set mirror rate

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -181,6 +181,10 @@ http {
     {% end %}
     {% end %}
 
+    {% if proxy_mirror then %}
+    limit_req_zone $binary_remote_addr zone=proxy_mirror_limit:{* proxy_mirror.limit_size *} rate={* proxy_mirror.rate *};
+    {% end %}
+
     {% if enabled_plugins["proxy-cache"] then %}
     # for proxy cache
     {% for _, cache in ipairs(proxy_cache.zones) do %}
@@ -670,7 +674,14 @@ http {
         {% if enabled_plugins["proxy-mirror"] then %}
         location = /proxy_mirror {
             internal;
-
+            {% if proxy_mirror then %}
+            {% if proxy_mirror.burst then %}
+            limit_req zone=proxy_mirror_limit burst={* proxy_mirror.burst *} {* proxy_mirror.delay_parameter *};
+            {% else %}
+            limit_req zone=proxy_mirror_limit;
+            {% end %}
+            {% end %}
+            
             if ($upstream_mirror_host = "") {
                 return 200;
             }

--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -681,7 +681,7 @@ http {
             limit_req zone=proxy_mirror_limit;
             {% end %}
             {% end %}
-            
+
             if ($upstream_mirror_host = "") {
                 return 200;
             }

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -60,6 +60,12 @@ apisix:
       #  disk_path: "/tmp/disk_cache_two"
       #  cache_levels: "1:2"
 
+  # proxy_mirror:                 # Proxy mirror configuration
+  #   limit_size: 10m             # the shared memory zone
+  #   rate: 5r/s                  # defined rate
+  #   burst: 10                   # the maximum burst size of requests
+  #   delay_parameter: nodelay    # nodelay | delay=number, see http://nginx.org/en/docs/http/ngx_http_limit_req_module.html
+
   allow_admin:                  # http://nginx.org/en/docs/http/ngx_http_access_module.html#allow
     - 127.0.0.0/24              # If we don't set any IP list, then any IP access is allowed by default.
     #- "::/64"

--- a/docs/en/latest/plugins/proxy-mirror.md
+++ b/docs/en/latest/plugins/proxy-mirror.md
@@ -32,6 +32,7 @@ The proxy-mirror plugin, which provides the ability to mirror client requests.
 | host | string | optional    |         |       | Specify a mirror service address, e.g. http://127.0.0.1:9797 (address needs to contain schema: http or https, not URI part) |
 
 If you want to set the mirror rate, can configure it in the in the `conf/config.yaml` file:
+
 ```yaml
 proxy_mirror:                   # Proxy mirror configuration, see http://nginx.org/en/docs/http/ngx_http_limit_req_module.html
     limit_size: 10m             # the shared memory zone

--- a/docs/en/latest/plugins/proxy-mirror.md
+++ b/docs/en/latest/plugins/proxy-mirror.md
@@ -31,6 +31,15 @@ The proxy-mirror plugin, which provides the ability to mirror client requests.
 | ---- | ------ | ----------- | ------- | ----- | --------------------------------------------------------------------------------------------------------------------------- |
 | host | string | optional    |         |       | Specify a mirror service address, e.g. http://127.0.0.1:9797 (address needs to contain schema: http or https, not URI part) |
 
+If you want to set the mirror rate, can configure it in the in the `conf/config.yaml` file:
+```yaml
+proxy_mirror:                   # Proxy mirror configuration, see http://nginx.org/en/docs/http/ngx_http_limit_req_module.html
+    limit_size: 10m             # the shared memory zone
+    rate: 5r/s                  # defined rate
+    burst: 10                   # the maximum burst size of requests
+    delay_parameter: nodelay    # nodelay | delay=number
+```
+
 ### Examples
 
 #### Enable the plugin

--- a/docs/zh/latest/plugins/proxy-mirror.md
+++ b/docs/zh/latest/plugins/proxy-mirror.md
@@ -32,6 +32,7 @@ title: proxy-mirror
 | host | string | 必须   |        |        | 指定镜像服务地址，例如：http://127.0.0.1:9797（地址中需要包含 schema ：http或https，不能包含 URI 部分） |
 
 如果您想设置镜像速率，可以在`conf/config.yaml`文件中进行配置：
+
 ```yaml
 proxy_mirror:                   # Proxy mirror 配置, 可查看 http://nginx.org/en/docs/http/ngx_http_limit_req_module.html
     limit_size: 10m             # 共享内存区域

--- a/docs/zh/latest/plugins/proxy-mirror.md
+++ b/docs/zh/latest/plugins/proxy-mirror.md
@@ -31,7 +31,7 @@ title: proxy-mirror
 | ---- | ------ | ------ | ------ | ------ | ------------------------------------------------------------------------------------------------------- |
 | host | string | 必须   |        |        | 指定镜像服务地址，例如：http://127.0.0.1:9797（地址中需要包含 schema ：http或https，不能包含 URI 部分） |
 
-如果您想设置镜像速率,可以在`conf/config.yaml`文件中进行配置:
+如果您想设置镜像速率，可以在`conf/config.yaml`文件中进行配置：
 ```yaml
 proxy_mirror:                   # Proxy mirror 配置, 可查看 http://nginx.org/en/docs/http/ngx_http_limit_req_module.html
     limit_size: 10m             # 共享内存区域

--- a/docs/zh/latest/plugins/proxy-mirror.md
+++ b/docs/zh/latest/plugins/proxy-mirror.md
@@ -31,6 +31,15 @@ title: proxy-mirror
 | ---- | ------ | ------ | ------ | ------ | ------------------------------------------------------------------------------------------------------- |
 | host | string | 必须   |        |        | 指定镜像服务地址，例如：http://127.0.0.1:9797（地址中需要包含 schema ：http或https，不能包含 URI 部分） |
 
+如果您想设置镜像速率,可以在`conf/config.yaml`文件中进行配置:
+```yaml
+proxy_mirror:                   # Proxy mirror 配置, 可查看 http://nginx.org/en/docs/http/ngx_http_limit_req_module.html
+    limit_size: 10m             # 共享内存区域
+    rate: 5r/s                  # 定义速率
+    burst: 10                   # 请求最大突发大小
+    delay_parameter: nodelay    # nodelay | delay=number
+```
+
 ### 示例
 
 #### 启用插件


### PR DESCRIPTION
### What this PR does / why we need it:
fix: https://github.com/apache/apisix/issues/3753

But one question.
When the rate is exceeded, the error log will generate error messages at the same time. For example
```
[error] 29604#29604: *620 limiting requests, excess: 10.580 by zone "proxy_mirror_limit", client: 127.0.0.1, server: _, request: "GET /hello HTTP/1.1", subrequest: "/proxy_mirror", host: "127.0.0.1:9080"
```
Does this need to be modified to ignore the error? If it lasts for a long time and there are a lot of requests, the disk space occupied by the error log will grow very fast.

### Pre-submission checklist:

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [X] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
