### PR TITLE
Ext auth

### DIFF
--- a/apisix/ext-auth.lua
+++ b/apisix/ext-auth.lua
@@ -1,0 +1,278 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+local core = require("apisix.core")
+local http = require("resty.http")
+local ck = require("resty.cookie")
+local ngx = ngx
+local ipairs = ipairs
+local type = type
+local rawget = rawget
+local rawset = rawset
+local setmetatable = setmetatable
+local string = string
+
+local plugin_name = "ext-auth"
+local ext_lrucache = core.lrucache.new({
+    ttl = 60, count = 1024
+})
+
+local schema = {
+    type = "object",
+    properties = {
+        ext_auth_url = {
+            type = "string",
+            minLength = 1,
+            maxLength = 4096
+        },
+        ext_auth_method = {
+            type = "string",
+            default = "GET",
+            enum = { "GET", "POST" },
+        },
+        ext_headers = {
+            type = "array",
+            items = {
+                type = "string",
+                minLength = 1,
+                maxLength = 100
+            },
+            uniqueItems = true
+        },
+        ext_args = {
+            type = "array",
+            items = {
+                type = "string",
+                minLength = 1,
+                maxLength = 100
+            },
+            uniqueItems = true
+        },
+        ext_keepalive = {
+            type = "boolean",
+            default = true
+        },
+        ext_keepalive_timeout = {
+            type = "integer",
+            minimum = 1000,
+            default = 60000
+        },
+        ext_keepalive_pool = {
+            type = "integer",
+            minimum = 1,
+            default = 5
+        },
+        check_termination = {
+            type = "boolean",
+            default = true
+        },
+    },
+    required = { "ext_auth_url" },
+}
+
+local _M = {
+    version = 0.1,
+    priority = 1555,
+    name = plugin_name,
+    schema = schema,
+}
+
+function _M.check_schema(conf)
+
+    return core.schema.check(schema, conf)
+
+end
+
+local function get_auth_token(ctx)
+
+    local token = ctx.var.http_x_auth_token
+    if token then
+        return token
+    end
+
+    token = ctx.var.http_authorization
+    if token then
+        return token
+    end
+
+    token = ctx.var.arg_auth_token
+    if token then
+        return token
+    end
+
+    local cookie, err = ck:new()
+    if not cookie or err then
+        return nil
+    end
+
+    local val, error = cookie:get("auth-token")
+    if error then
+        return nil
+    end
+    return val
+
+end
+
+local function fail_response(message, init_values)
+
+    local response = init_values or {}
+    response.message = message
+    return response
+
+end
+
+local function new_table()
+    local t = {}
+    local lt = {}
+    local _mt = {
+        __index = function(t, k)
+            return rawget(lt, string.lower(k))
+        end,
+        __newindex = function(t, k, v)
+            rawset(t, k, v)
+            rawset(lt, string.lower(k), v)
+        end,
+    }
+    return setmetatable(t, _mt)
+end
+
+--proxy headers
+local function request_headers(config, ctx)
+    local req_headers = new_table()
+    local headers = core.request.headers(ctx)
+    local ext_headers = config.ext_headers
+    if not ext_headers then
+        return req_headers
+    end
+    for i, field in ipairs(ext_headers) do
+        local v = headers[field]
+        if v then
+            req_headers[field] = v
+        end
+    end
+    return req_headers
+end
+
+
+
+--proxy args
+local function get_ext_args(ext_args)
+    local req_args = new_table()
+    if not ext_args then
+        return req_args
+    end
+    local args = ngx.req.get_uri_args()
+    for i, field in ipairs(ext_args) do
+        local v = args[field]
+        if v then
+            req_args[field] = v
+        end
+    end
+    return req_args
+end
+
+-- Configure request parameters.
+local function ext_configure_params(args, config, ext_headers)
+    ext_headers["Content-Type"] = "application/json; charset=utf-8"
+    local ext_auth_params = {
+        ssl_verify = false,
+        method = config.ext_auth_method,
+        headers = ext_headers,
+    }
+    if config.ext_keepalive then
+        ext_auth_params.keepalive_timeout = config.ext_keepalive_timeout
+        ext_auth_params.keepalive_pool = config.ext_keepalive_pool
+    else
+        ext_auth_params.keepalive = config.ext_keepalive
+    end
+    local url = config.ext_auth_url .. "?" .. ngx.encode_args(args)
+    return ext_auth_params, url
+
+end
+
+-- timeout in ms
+local function http_req(url, ext_auth_params)
+    local httpc = http.new()
+    httpc:set_timeout(1000 * 10)
+    local res, err = httpc:request_uri(url, ext_auth_params)
+    if err then
+        core.log.error("FAIL REQUEST [ ", core.json.encode(ext_auth_params),
+                " ] failed! res is nil, err:", err)
+        return nil, err
+    end
+    return res
+end
+
+local function get_auth_info(config, ctx, action, path, client_ip, auth_token)
+    local ext_headers = request_headers(config, ctx)
+    ext_headers["X-Client-Ip"] = client_ip
+    ext_headers["Authorization"] = auth_token
+    local args = get_ext_args(config.ext_args)
+    args['ext_path'] = path
+    args['ext_action'] = action
+    args['ext_client_ip'] = client_ip
+    core.response.set_header("APISIX-Ext-Cache", 'no-cache')
+    local ext_auth_params, url = ext_configure_params(args, config, ext_headers)
+    local res, err = http_req(url, ext_auth_params)
+    return { res = res, err = err }
+end
+
+function _M.rewrite(conf, ctx)
+    local config = conf
+    local url = ctx.var.uri
+    local action = ctx.var.request_method
+    local client_ip = ctx.var.http_x_real_ip or core.request.get_ip(ctx)
+    local auth_token = get_auth_token(ctx)
+
+    if auth_token then
+        local res, ext_data
+        if config.ext_cache then
+            core.response.set_header("APISIX-Ext-Cache", 'cache')
+            res = ext_lrucache(plugin_name .. "#" .. auth_token, config.version,
+                    get_auth_info, config, ctx, action, url, client_ip, auth_token)
+        else
+            res = get_auth_info(config, ctx, action, url, client_ip, auth_token)
+        end
+
+        local ext_res = res.res
+        if res.err then
+            core.response.set_header("Content-Type", "application/json; charset=utf-8")
+            return 500, fail_response(res.err, { status_code = 500 })
+        end
+
+        if ext_res.status ~= 200 and config.check_termination then
+            core.response.set_header("Content-Type", "application/json; charset=utf-8")
+            return ext_res.status, fail_response('ext-auth check permission failed',
+                    { status_code = ext_res.status })
+        end
+
+        local ext_body, err = core.json.decode(ext_res.body)
+        if not ext_body and config.check_termination then
+            core.response.set_header("Content-Type", "application/json; charset=utf-8")
+            return 500, fail_response("JSON decoding failed: " .. err,
+                    { status_code = 500 })
+        end
+
+    elseif config.check_termination then
+         core.response.set_header("Content-Type", "application/json; charset=utf-8")
+         return 401, fail_response("Missing auth token in request",
+                    { status_code = 401 })
+    end
+    core.log.info("ext-auth check permission passed")
+end
+
+return _M

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -148,6 +148,7 @@ nginx_config:                     # config for render the template to generate n
 
   stream:
     lua_shared_dict:
+      etcd-cluster-health-check-stream: 10m
       lrucache-lock-stream: 10m
       plugin-limit-conn-stream: 10m
 
@@ -279,6 +280,7 @@ plugins:                          # plugin list (sorted by priority)
   - batch-requests                 # priority: 4010
   - cors                           # priority: 4000
   - ip-restriction                 # priority: 3000
+  - ua-restriction                 # priority: 2999
   - referer-restriction            # priority: 2990
   - uri-blocker                    # priority: 2900
   - request-validation             # priority: 2800
@@ -290,6 +292,7 @@ plugins:                          # plugin list (sorted by priority)
   - key-auth                       # priority: 2500
   - consumer-restriction           # priority: 2400
   - authz-keycloak                 # priority: 2000
+  - ext-auth                       # priority: 1555
   #- error-log-logger              # priority: 1091
   - proxy-mirror                   # priority: 1010
   - proxy-cache                    # priority: 1009
@@ -321,6 +324,7 @@ plugins:                          # plugin list (sorted by priority)
   - ext-plugin-post-req            # priority: -3000
 
 stream_plugins: # sorted by priority
+  - ip-restriction                 # priority: 3000
   - limit-conn                     # priority: 1003
   - mqtt-proxy                     # priority: 1000
   # <- recommend to use priority (0, 100) for your custom plugins

--- a/docs/en/latest/plugins/ext-auth.md
+++ b/docs/en/latest/plugins/ext-auth.md
@@ -1,0 +1,119 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+-[English](../../plugins/auth-hook.md)
+
+# table of Contents
+
+- [**Name**](#name)
+- [**Attribute**](#Attribute)
+- [**Dependencies**](#Dependencies)
+- [**How to enable**](#How-to-enable)
+- [**Test plugin**](#Test-plugin)
+- [**Disable plugins**](#Disable-plugins)
+
+## Name
+`ext-auth` checks whether the incoming request is authorized by calling an external authorization service. If the request is deemed unauthorized by the network filter, the connection will be closed.
+We configured `ext-auth` as the first filter in the filter chain to authorize the request before the remaining filters process the request.
+
+## Attributes
+
+| Name                      | Type          | Required | Default Value | Valid Value | Description                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------- | ------------- | -------- | ------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| ext_auth_url             | string        | 必选   |         |        | Set the access route of `auth-server` The plug-in will automatically carry the requested `path, action, client_ip` to the back of the domain name as the query parameter `?path=path&action=action&client_ip=client_ip`                                                                                                    |
+| ext_auth_id              | string        | optional   | "unset" |        | Set `ext_auth_id`, the `ext_auth_id` will be carried in the header `Auth-Hook-Id` to request a custom auth-server service                                                                                                                                                                      |
+| ext_auth_method          | string        | optional   | "GET"   |        | Set the access method of `auth-server`, the default is `GET`, only `POST`, `GET` are allowed                                                                                                                                                                                                           |
+| ext_headers              | array[string] | optional   |         |        | Specify the header parameter of the business request. Proxy request ext_auth service, which will carry `Authorization` by default                                                                                                                                                                                               |
+| ext_args                 | array[string] | optional   |         |        | Specify the request query parameter The proxy requests the ext_auth service with the query parameter                                                                                                                                                                                                                     |
+| ext_auth_res_to_headers       | array[string] | optional   |         |        | |
+| ext_auth_res_to_header_prefix | string        | optional   |     |        | |                                                                                                                                                                                                     |
+| ext_auth_cache                | boolean       | optional   | false   |        | Whether to cache the data body of the same token request ext_auth service, the default is `false` According to your business situation, if it is enabled, it will be cached for 60S                                                                                                                                                                         |
+| check_termination         | boolean       | optional   | true    |        |   Whether to request the auth-server to interrupt the request immediately after verification and return an error message, `true` is enabled by default to intercept and return immediately. If you set `false`, if the auth-server returns an error, it will continue to let you go, and set all the settings of `ext_auth_res_to_headers` Delete the mapping header field.                                                               |
+
+## Dependencies
+
+### Deploy your own auth service
+
+The service needs to provide auth interface routing, and at least the following data structure is required to return the data body, we need the `data` data body
+
+```json
+{
+    "message":"success",
+    "data":{
+        "user_id":15,
+        "......": "......"
+    }
+}
+```
+
+## How to enable
+
+1. Create a Route or Service object and enable the `ext-auth` plugin.
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "methods": ["GET"],
+    "uri": "/*",
+    "plugins": {
+        "auth-hook": {
+            "ext_auth_id": "order",
+            "ext_auth_method": "POST",
+            "ext_auth_url": "http://common-user-pro_1.dev.xthktech.cn/api/user/gateway-auth",
+            "ext_auth_cache": false,
+            "ext_auth_check_termination": true,
+            "ext_auth_headers": [
+                "X-app-name"   ],
+            "ext_auth_res_to_header_prefix": "XT-",
+            "ext_auth_res_to_header": [
+                "user_id",
+                "student_id"]
+            }
+    },
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "www.baidu.com:80": 1
+        }
+    }
+ }'
+```
+
+## Test plugin
+
+
+## Disable plugin
+
+When you want to remove the `ext-auth` plug-in, it is very simple, just delete the corresponding `plug-in` configuration in the plug-in configuration in routes, no need to restart the service, it will take effect immediately:
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -H'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "methods": ["GET"],
+    "uri": "/*",
+    "plugins": {
+    },
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "www.baidu.com:80": 1
+        }
+    }
+}'
+```

--- a/docs/zh/latest/plugins/ext-auth.md
+++ b/docs/zh/latest/plugins/ext-auth.md
@@ -1,0 +1,122 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+- [English](../../plugins/auth-hook.md)
+
+# 目录
+
+- [**名字**](#名字)
+- [**属性**](#属性)
+- [**依赖项**](#依赖项)
+- [**如何启用**](#如何启用)
+- [**测试插件**](#测试插件)
+- [**禁用插件**](#禁用插件)
+
+## 名字
+
+`ext-auth` 通过调用外部授权服务来检查传入请求是否经过授权。如果该请求被网络过滤器认为是未经授权的，那么连接将被关闭。
+我们将过`ext-auth` 配置为过滤器链中的第一个过滤器，以便在其余过滤器处理请求之前对请求进行授权。
+
+
+## 属性
+
+| 名称                      | 类型          | 必选项 | 默认值  | 有效值 | 描述                                                                                                                                                                                                                                                                    |
+| ------------------------- | ------------- | ------ | ------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ext_auth_url             | string        | 必选   |         |        | 设置`auth-server` 的访问路由 插件会自动携带请求的`path,action,client_ip`携带到域名后面作为 query 参数`?path=path&action=action&client_ip=client_ip`                                                                                                      |
+| ext_auth_id              | string        | 可选   | "unset" |        | 设置`ext_auth_id`, 该`ext_auth_id`将携带在 header 中`Auth-Hook-Id`请求自定义的 auth-server 服务                                                                                                                                                                       |
+| ext_auth_method          | string        | 可选   | "GET"   |        | 设置 `auth-server` 的访问方法，默认是`GET`,只允许`POST`,`GET`                                                                                                                                                                                                           |
+| ext_headers              | array[string] | 可选   |         |        | 指定业务请求的 header 参数 代理请求 ext_auth 服务，默认会携带`Authorization`                                                                                                                                                                                                |
+| ext_args                 | array[string] | 可选   |         |        | 指定请求 query 参数 代理以 query 参数请求 ext_auth 服务                                                                                                                                                                                                                     |
+| ext_auth_res_to_headers       | array[string] | 可选   |         |        | |
+| ext_auth_res_to_header_prefix | string        | 可选   |     |        | |                                                                                                                                                                                                     |
+| ext_auth_cache                | boolean       | 可选   | false   |        | 是否缓存相同 token 请求 ext_auth 服务的数据体，默认`false` 根据自己业务情况考虑,若开启，将缓存 60S                                                                                                                                                                          |
+| check_termination         | boolean       | 可选   | true    |        | 是否请求 auth-server 验证后立即中断请求并返回错误信息，`true` 默认开启立即拦截返回，若设置`false` ，auth-server 若返回错误，也将继续放行，同时将 `ext_auth_res_to_headers` 设置的所有映射 header 字段删除。                                                                 |
+
+## 依赖项
+
+### 部署自己 auth 服务
+
+服务需要提供 auth 接口路由，并且至少需要以下数据结构返回数据数据体，我们需要其中的`data`数据体
+
+```json
+{
+    "message":"success",
+    "data":{
+        "user_id":15,
+        "......":"......"
+    }
+}
+```
+
+## 如何启用
+
+1. 创建 Route 或 Service 对象，并开启 `ext-auth` 插件。
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "methods": ["GET"],
+    "uri": "/*",
+    "plugins": {
+        "auth-hook": {
+            "ext_auth_id": "order",
+            "ext_auth_method": "POST",
+            "ext_auth_url": "http://common-user-pro_1.dev.xthktech.cn/api/user/gateway-auth",
+            "ext_auth_cache": false,
+            "ext_auth_check_termination": true,
+            "ext_auth_headers": [
+                "X-app-name"   ],
+            "ext_auth_res_to_header_prefix": "XT-",
+            "ext_auth_res_to_header": [
+                "user_id",
+                "student_id"]
+            }
+    },
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "www.baidu.com:80": 1
+        }
+    }
+ }'
+```
+
+## 测试插件
+
+```
+
+## 禁用插件
+
+当你想去掉 `ext-auth` 插件的时候，很简单，在 routes 中的插件配置中把对应的 `插件` 配置删除即可，无须重启服务，即刻生效：
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "methods": ["GET"],
+    "uri": "/*",
+    "plugins": {
+    },
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "www.baidu.com:80": 1
+        }
+    }
+}'
+```


### PR DESCRIPTION
### What this PR does / why we need it:
 fix: [Work from](https://github.com/apache/apisix/issues/3115)， Thank you very much  [ShaoZeMing](https://github.com/ShaoZeMing) for his contribution. 

### Pre-submission checklist:


Thank you very much for the contribution provided by [ShaoZeMing](https://github.com/ShaoZeMing). I will develop on the basis of his contribution, and I am very grateful for the suggestions given by [spacewander](https://github.com/spacewander).

# 目录

- [**名字**](#名字)
- [**属性**](#属性)
- [**依赖项**](#依赖项)
- [**如何启用**](#如何启用)
- [**测试插件**](#测试插件)
- [**禁用插件**](#禁用插件)

## 名字

`ext-auth` 通过调用外部授权服务来检查传入请求是否经过授权。如果该请求被网络过滤器认为是未经授权的，那么连接将被关闭。
我们将过`ext-auth` 配置为过滤器链中的第一个过滤器，以便在其余过滤器处理请求之前对请求进行授权。


## 属性

| 名称                      | 类型          | 必选项 | 默认值  | 有效值 | 描述                                                                                                                                                                                                                                                                    |
| ------------------------- | ------------- | ------ | ------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| ext_auth_url             | string        | 必选   |         |        | 设置`auth-server` 的访问路由 插件会自动携带请求的`path,action,client_ip`携带到域名后面作为 query 参数`?path=path&action=action&client_ip=client_ip`                                                                                                      |
| ext_auth_id              | string        | 可选   | "unset" |        | 设置`ext_auth_id`, 该`ext_auth_id`将携带在 header 中`Auth-Hook-Id`请求自定义的 auth-server 服务                                                                                                                                                                       |
| ext_auth_method          | string        | 可选   | "GET"   |        | 设置 `auth-server` 的访问方法，默认是`GET`,只允许`POST`,`GET`                                                                                                                                                                                                           |
| ext_headers              | array[string] | 可选   |         |        | 指定业务请求的 header 参数 代理请求 ext_auth 服务，默认会携带`Authorization`                                                                                                                                                                                                |
| ext_args                 | array[string] | 可选   |         |        | 指定请求 query 参数 代理以 query 参数请求 ext_auth 服务                                                                                                                                                                                                                     |
| ext_auth_res_to_headers       | array[string] | 可选   |         |        | |
| ext_auth_res_to_header_prefix | string        | 可选   |     |        | |                                                                                                                                                                                                     |
| ext_auth_cache                | boolean       | 可选   | false   |        | 是否缓存相同 token 请求 ext_auth 服务的数据体，默认`false` 根据自己业务情况考虑,若开启，将缓存 60S                                                                                                                                                                          |
| check_termination         | boolean       | 可选   | true    |        | 是否请求 auth-server 验证后立即中断请求并返回错误信息，`true` 默认开启立即拦截返回，若设置`false` ，auth-server 若返回错误，也将继续放行，同时将 `ext_auth_res_to_headers` 设置的所有映射 header 字段删除。                                                                 |

## 依赖项

### 部署自己 auth 服务

服务需要提供 auth 接口路由，并且至少需要以下数据结构返回数据数据体，我们需要其中的`data`数据体

```json
{
    "message":"success",
    "data":{
        "user_id":15,
        "......":"......"
    }
}
```

## 如何启用

1. 创建 Route 或 Service 对象，并开启 `ext-auth` 插件。

```shell
curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
{
    "methods": ["GET"],
    "uri": "/*",
    "plugins": {
        "auth-hook": {
            "ext_auth_id": "order",
            "ext_auth_method": "POST",
            "ext_auth_url": "http://common-user-pro_1.dev.xthktech.cn/api/user/gateway-auth",
            "ext_auth_cache": false,
            "ext_auth_check_termination": true,
            "ext_auth_headers": [
                "X-app-name"   ],
            "ext_auth_res_to_header_prefix": "XT-",
            "ext_auth_res_to_header": [
                "user_id",
                "student_id"]
            }
    },
    "upstream": {
        "type": "roundrobin",
        "nodes": {
            "www.baidu.com:80": 1
        }
    }
 }'
```

## 测试插件

```

## 禁用插件

当你想去掉 `ext-auth` 插件的时候，很简单，在 routes 中的插件配置中把对应的 `插件` 配置删除即可，无须重启服务，即刻生效：

```shell
curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
{
    "methods": ["GET"],
    "uri": "/*",
    "plugins": {
    },
    "upstream": {
        "type": "roundrobin",
        "nodes": {
            "www.baidu.com:80": 1
        }
    }
}'
```

