### PR TITLE
docs: fix broken links issues on section titles

### DIFF
--- a/docs/en/latest/admin-api.md
+++ b/docs/en/latest/admin-api.md
@@ -581,11 +581,11 @@ In addition to the basic complex equalization algorithm selection, APISIX's Upst
 
 `tls.client_cert/key` can be used to communicate with upstream via mTLS.
 Their formats are the same as SSL's `cert` and `key` fields.
-This feature requires APISIX to run on [APISIX-OpenResty](./how-to-build.md#6-build-openresty-for-apisix).
+This feature requires APISIX to run on [APISIX-OpenResty](./how-to-build.md#step-6-build-openresty-for-apache-apisix).
 
 `keepalive_pool` allows the upstream to have its separate connection pool.
 Its children fields, like `requests`, can be used to configure the upstream keepalive options.
-This feature requires APISIX to run on [APISIX-OpenResty](./how-to-build.md#6-build-openresty-for-apisix).
+This feature requires APISIX to run on [APISIX-OpenResty](./how-to-build.md#step-6-build-openresty-for-apache-apisix).
 
 **Config Example:**
 

--- a/docs/en/latest/mtls.md
+++ b/docs/en/latest/mtls.md
@@ -66,7 +66,7 @@ curl --cacert /data/certs/mtls_ca.crt --key /data/certs/mtls_client.key --cert /
 
 ### How to configure
 
-You need to [build APISIX-Openresty](./how-to-build.md#6-build-openresty-for-apisix) and configure `etcd.tls` section if you want APISIX to work on an etcd cluster with mTLS enabled.
+You need to [build APISIX-Openresty](./how-to-build.md#step-6-build-openresty-for-apache-apisix) and configure `etcd.tls` section if you want APISIX to work on an etcd cluster with mTLS enabled.
 
 ```yaml
 etcd:
@@ -146,7 +146,7 @@ Sometimes the upstream requires mTLS. In this situation, the APISIX acts as the 
 
 When configuring `upstreams`, we could use parameter `tls.client_cert` and `tls.client_key` to configure the client certificate APISIX used to communicate with upstreams. Please refer to [Admin API](./admin-api.md#upstream) for details.
 
-This feature requires APISIX to run on [APISIX-OpenResty](./how-to-build.md#6-build-openresty-for-apisix).
+This feature requires APISIX to run on [APISIX-OpenResty](./how-to-build.md#step-6-build-openresty-for-apache-apisix).
 
 Here is a similar Python script to patch a existed upstream with mTLS (changes admin API url if needed):
 

--- a/docs/en/latest/plugin-develop.md
+++ b/docs/en/latest/plugin-develop.md
@@ -420,7 +420,7 @@ The above test case represents a simple scenario. Most scenarios will require mu
 
 Additionally, there are some convenience testing endpoints which can be found [here](https://github.com/apache/apisix/blob/master/t/lib/server.lua#L36). For example, see [proxy-rewrite](https://github.com/apache/apisix/blob/master/t/plugin/proxy-rewrite.lua). In test 42, the upstream `uri` is made to redirect `/test?new_uri=hello` to `/hello` (which always returns `hello world`). In test 43, the response body is confirmed to equal `hello world`, meaning the proxy-rewrite configuration added with test 42 worked correctly.
 
-Refer the following [document](how-to-build.md#4-test) to setup the testing framework.
+Refer the following [document](how-to-build.md#Step-4-Run-Test-Cases) to setup the testing framework.
 
 ### Attach the test-nginx execution process:
 

--- a/docs/en/latest/plugins/client-control.md
+++ b/docs/en/latest/plugins/client-control.md
@@ -34,7 +34,7 @@ title: client-control
 The `client-control` plugin dynamically controls the behavior of Nginx to
 handle the client request.
 
-This plugin requires APISIX to run on [APISIX-OpenResty](../how-to-build.md#6-build-openresty-for-apisix).
+This plugin requires APISIX to run on [APISIX-OpenResty](../how-to-build.md#step-6-build-openresty-for-apache-apisix).
 
 ## Attributes
 

--- a/docs/en/latest/plugins/dubbo-proxy.md
+++ b/docs/en/latest/plugins/dubbo-proxy.md
@@ -37,7 +37,7 @@ dubbo-proxy plugin allows you proxy HTTP request to [**dubbo**](http://dubbo.apa
 
 ## Requirement
 
-If you are using OpenResty, you need to build it with dubbo support, see [how to build](../how-to-build.md#6-build-openresty-for-apisix)
+If you are using OpenResty, you need to build it with dubbo support, see [how to build](../how-to-build.md#step-6-build-openresty-for-apache-apisix)
 
 To make http2dubbo work in APISIX, we enhance the dubbo module based on Tengine's `mod_dubbo`. The modifications are contributed back to Tengine, but they are not included in the latest release version (Tengine-2.3.2) yet. So Tengine itself is unsupported.
 

--- a/docs/en/latest/plugins/gzip.md
+++ b/docs/en/latest/plugins/gzip.md
@@ -33,7 +33,7 @@ title: gzip
 
 The `gzip` plugin dynamically set the gzip behavior of Nginx.
 
-This plugin requires APISIX to run on [APISIX-OpenResty](../how-to-build.md#6-build-openresty-for-apisix).
+This plugin requires APISIX to run on [APISIX-OpenResty](../how-to-build.md#step-6-build-openresty-for-apache-apisix).
 
 ## Attributes
 

--- a/docs/zh/latest/admin-api.md
+++ b/docs/zh/latest/admin-api.md
@@ -586,11 +586,11 @@ APISIX 的 Upstream 除了基本的负载均衡算法选择外，还支持对上
 
 `tls.client_cert/key` 可以用来跟上游进行 mTLS 通信。
 他们的格式和 SSL 对象的 `cert` 和 `key` 一样。
-这个特性需要 APISIX 运行于 [APISIX-OpenResty](./how-to-build.md#6-为-apisix-构建-openresty)。
+这个特性需要 APISIX 运行于 [APISIX-OpenResty](./how-to-build.md#步骤6-为-Apache-APISIX-构建-OpenResty)。
 
 `keepalive_pool` 允许 upstream 对象有自己单独的连接池。
 它下属的字段，比如 `requests`，可以用了配置上游连接保持的参数。
-这个特性需要 APISIX 运行于 [APISIX-OpenResty](./how-to-build.md#6-为-apisix-构建-openresty)。
+这个特性需要 APISIX 运行于 [APISIX-OpenResty](./how-to-build.md#步骤6-为-Apache-APISIX-构建-OpenResty)。
 
 **upstream 对象 json 配置内容：**
 

--- a/docs/zh/latest/mtls.md
+++ b/docs/zh/latest/mtls.md
@@ -66,7 +66,7 @@ curl --cacert /data/certs/mtls_ca.crt --key /data/certs/mtls_client.key --cert /
 
 ### 如何配置
 
-你需要构建 [APISIX-Openresty](./how-to-build.md#6-为-apisix-构建-openresty)，并且需要在配置文件中设定 `etcd.tls` 来使 ETCD 的双向认证功能正常工作。
+你需要构建 [APISIX-Openresty](./how-to-build.md#步骤6-为-Apache-APISIX-构建-OpenResty)，并且需要在配置文件中设定 `etcd.tls` 来使 ETCD 的双向认证功能正常工作。
 
 ```yaml
 etcd:
@@ -146,7 +146,7 @@ curl --resolve 'mtls.test.com:<APISIX_HTTPS_PORT>:<APISIX_URL>' "https://<APISIX
 
 在配置 upstream 资源时，可以使用参数 `tls.client_cert` 和 `tls.client_key` 来配置 APISIX 用于与上游进行通讯时使用的证书。可参考 [Upstream API 文档](./admin-api.md#upstream)。
 
-该功能需要 APISIX 运行在 [APISIX-OpenResty](./how-to-build.md#6-为-apisix-构建-openresty) 上。
+该功能需要 APISIX 运行在 [APISIX-OpenResty](./how-to-build.md#步骤6-为-Apache-APISIX-构建-OpenResty) 上。
 
 下面是一个与配置 SSL 时相似的 Python 脚本，可为一个已存在的 upstream 资源配置双向认证。如果需要，可修改 API 地址和API Key。
 

--- a/docs/zh/latest/plugins/dubbo-proxy.md
+++ b/docs/zh/latest/plugins/dubbo-proxy.md
@@ -37,7 +37,7 @@ title: dubbo-proxy
 
 ## 要求
 
-如果你正在使用 `OpenResty`, 你需要编译它来支持 `dubbo`, 参考 [如何编译](../how-to-build.md#6-build-openresty-for-apisix)。
+如果你正在使用 `OpenResty`, 你需要编译它来支持 `dubbo`, 参考 [如何编译](../how-to-build.md#步骤6-为-Apache-APISIX-构建-OpenResty)。
 在 `APISIX` 中为了实现使从 `http` 代理到 `dubbo`，我们在`Tengine` 的 `mod_dubbo` 基础上对 `dubbo` 模块做了改进。 所有的修改已经提交给 `Tengine`，但是还未合并到最新的 `release` 版本中(Tengine-2.3.2) 。所以目前 `Tengine` 自身是不支持此特性的。
 
 ## 运行时属性


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->

PR https://github.com/apache/apisix/pull/4577 and  https://github.com/apache/apisix/pull/4546 modified sections' titles in 'Getting Started' and 'How to build Apache APISIX' docs in EN and ZH. But the links from other files linked to some titles in these 2 docs were not modified accordingly. Thus, it creates broken links. For example, `how-to-build.md#6-build-openresty-for-apisix` should be `how-to-build.md#step-6-build-openresty-for-apache-apisix` instead. 

After checking, PR https://github.com/apache/apisix/pull/4546 did not introduce broken links, PR https://github.com/apache/apisix/pull/4577 introduced a lot of (10+) broken links. They were not technically 'broken broken', they can redirect to correct pages, but they cannot redirect to the right spot in these pages.

This PR fixed broken links from PR https://github.com/apache/apisix/pull/4577.

<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
