### PR TITLE
change: rename plugin's balancer method to before_proxy

### DIFF
--- a/apisix/balancer.lua
+++ b/apisix/balancer.lua
@@ -321,7 +321,7 @@ function _M.run(route, ctx, plugin_funcs)
             end
         end
 
-        local _, run = plugin_funcs("balancer")
+        local _, run = plugin_funcs("before_proxy")
         -- always recreate request as the request may be changed by plugins
         if (run or header_changed) and balancer.recreate_request then
             balancer.recreate_request()

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -518,8 +518,8 @@ function _M.http_access_phase()
 
     set_upstream_headers(api_ctx, server)
 
-    -- run the balancer phase in access phase first to avoid always reinit request
-    common_phase("balancer")
+    -- run the before_proxy method in access phase first to avoid always reinit request
+    common_phase("before_proxy")
 
     local ref = ctxdump.stash_ngx_ctx()
     core.log.info("stash ngx ctx: ", ref)
@@ -913,8 +913,8 @@ function _M.stream_preread_phase()
 
     api_ctx.picked_server = server
 
-    -- run the balancer phase in preread phase first to avoid always reinit request
-    common_phase("balancer")
+    -- run the before_proxy method in preread phase first to avoid always reinit request
+    common_phase("before_proxy")
 end
 
 

--- a/apisix/plugins/serverless/init.lua
+++ b/apisix/plugins/serverless/init.lua
@@ -113,7 +113,7 @@ return function(plugin_name, priority)
         call_funcs('access', conf, ctx)
     end
 
-    function _M.balancer(conf, ctx)
+    function _M.before_proxy(conf, ctx)
         call_funcs('balancer', conf, ctx)
     end
 


### PR DESCRIPTION
It is confusing to have plugin's balancer method and user-defined
balancer.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
