### PR TITLE
chore: add sudo privilege for make install command at installing luarocks

### DIFF
--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -18,7 +18,7 @@ jobs:
         export OPENRESTY_VERSION=default
 
         ./utils/linux-install-openresty.sh
-        sudo ./utils/linux-install-luarocks.sh
+        ./utils/linux-install-luarocks.sh
         sudo luarocks install luacheck
 
     - name: Script

--- a/.github/workflows/fuzzing-ci.yaml
+++ b/.github/workflows/fuzzing-ci.yaml
@@ -53,7 +53,7 @@ jobs:
         sudo add-apt-repository -y "deb http://openresty.org/package/ubuntu $(lsb_release -sc) main"
         sudo apt-get update
         sudo apt-get install -y git openresty curl openresty-openssl111-dev unzip make gcc
-        sudo ./utils/linux-install-luarocks.sh
+        ./utils/linux-install-luarocks.sh
 
         make deps
         make init

--- a/utils/linux-install-luarocks.sh
+++ b/utils/linux-install-luarocks.sh
@@ -39,8 +39,7 @@ fi
     > build.log 2>&1 || (cat build.log && exit 1)
 
 make build > build.log 2>&1 || (cat build.log && exit 1)
-msg="rerun this script with 'sudo' if you failed to make install because of privilege problem."
-sudo make install > build.log 2>&1 || (cat build.log && echo "$msg" && exit 1)
+sudo make install > build.log 2>&1 || (cat build.log && exit 1)
 cd .. || exit
 rm -rf luarocks-3.4.0
 

--- a/utils/linux-install-luarocks.sh
+++ b/utils/linux-install-luarocks.sh
@@ -40,7 +40,7 @@ fi
 
 make build > build.log 2>&1 || (cat build.log && exit 1)
 msg="rerun this script with 'sudo' if you failed to make install because of privilege problem."
-make install > build.log 2>&1 || (cat build.log && echo "$msg" && exit 1)
+sudo make install > build.log 2>&1 || (cat build.log && echo "$msg" && exit 1)
 cd .. || exit
 rm -rf luarocks-3.4.0
 


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->

For now, the package `luarocks` will be installed at `/usr/local` via `make install` command. If simply running the `curl https://raw.githubusercontent.com/apache/apisix/master/utils/linux-install-luarocks.sh -sL | bash -`, we will encounter an error due to privilege errors. For details, please refer to #4703. 

As discussed with @spacewander, we decide to add the `sudo` back via this PR. This would let users install APISIX without any interruptions.

With this patch merged in my environment, I could successfully install luarocks in CentOS 7 as both **non-root** and **root** users.

<!--- If it fixes an open issue, please link to the issue here. -->
#4703 

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
