### PR TITLE
feat(nacos): support aliyun_ram authorization

### DIFF
--- a/apisix/discovery/nacos.lua
+++ b/apisix/discovery/nacos.lua
@@ -115,9 +115,10 @@ local function get_aliyun_ram_sign_headers(param_values, access_key, secret_key)
     local time_ngx = ngx.utctime()
     local time_change = string.gsub(time_ngx, " ", "T")
     local time_utc = time_change .. 'Z'
-    local headers = {}
-    headers['Spas-AccessKey'] = access_key
-    headers['Timestamp'] = time_utc
+    local headers = {
+        ['Spas-AccessKey'] = access_key,
+        ['Timestamp'] = time_utc
+    }
 
     if secret_key then
         local resource

--- a/apisix/discovery/nacos.lua
+++ b/apisix/discovery/nacos.lua
@@ -60,12 +60,12 @@ local schema = {
         authentication= {
             type = 'object',
             properties = {
-                type = {type = 'string', default = 'basic_auth'},
+                type = {type = 'string', default = 'default'},
                 access_key = {type = 'string', default = ''},
                 secret_key = {type = 'string', default = ''},
             },
             default = {
-                type = 'basic_auth',
+                type = 'default',
                 access_key = '',
                 secret_key = '',
             }

--- a/docs/en/latest/discovery/nacos.md
+++ b/docs/en/latest/discovery/nacos.md
@@ -38,6 +38,8 @@ discovery:
   nacos:
     host:
       - "http://${username}:${password}@${host1}:${port1}"
+    authentication:
+      type: "default"     # default authentication type
     prefix: "/nacos/v1/"
     fetch_interval: 30    # default 30 sec
     weight: 100           # default 100
@@ -54,6 +56,19 @@ discovery:
   nacos:
     host:
       - "http://192.168.33.1:8848"
+```
+
+Using [AliCloud MSE Nacos](https://cn.aliyun.com/product/aliware/mse) authentication please refer to this configuration:
+
+```yaml
+discovery:
+  nacos:
+    host:
+      - "http://192.168.33.1:8848"
+    authentication:
+      type: "aliyun_ram"  # aliyun mse nacos ram
+      access_key: ""      # aliyun access key
+      secret_key: ""      # aliyun access secret
 ```
 
 ### Upstream setting


### PR DESCRIPTION
feat: 新增支持阿里云 MSE Nacos RAM 认证鉴权方式

开源版的 Nacos 自建的话，可以使用 用户名 及 密码进行加强安全验证，也可以不使用，但 阿里云 MSE Nacos 的商业版本在安全认证的方面仅支持 AccessKey & Access Secret 进行 OpenAPI 交互；

详见：[阿里云 MSE Nacos 配置中心鉴权 官方文档](https://help.aliyun.com/document_detail/202281.html)

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
