### PR TITLE
ci: should not cancel "duplicated" workflow in master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
       - 'docs/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

### What this PR does / why we need it:
Currently with `concurrency` support in Github Actions, duplicate workflows would be canceled when commits uploaded. 
But the same situation also happens to master branch that, when two PR merged continuously, the CI of the first commit would be canceled, which looks like CI failed.
![image](https://user-images.githubusercontent.com/34589752/127752244-ad53d0f1-91a4-46fe-b13c-190d6ab11220.png)

So try to fix it. Tested in personal repo: 
![image](https://user-images.githubusercontent.com/34589752/127752255-78175e77-f8fa-48e6-86c7-83495c17d301.png)
Commits in master branch would not be canceled. Only commits in non-master branch and PR would be canceled.

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
