### PR TITLE
fix(ext-plugin): avoid using 0 as the default http status code

### DIFF
--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -431,7 +431,12 @@ local rpc_handlers = {
                 end
                 body = ffi_str(body, len)
             end
-            return true, nil, stop:Status(), body
+            local code = stop:Status()
+            -- avoid using 0 as the default http status code
+            if code == 0 then
+                 code = 200
+            end
+            return true, nil, code, body
         end
 
         if action_type == http_req_call_action.Rewrite then

--- a/t/lib/ext-plugin.lua
+++ b/t/lib/ext-plugin.lua
@@ -185,7 +185,9 @@ function _M.go(case)
             local vec = builder:EndVector(len)
 
             http_req_call_stop.Start(builder)
-            http_req_call_stop.AddStatus(builder, 405)
+            if case.stop_no_code ~= true then
+                http_req_call_stop.AddStatus(builder, 405)
+            end
             http_req_call_stop.AddBody(builder, b)
             http_req_call_stop.AddHeaders(builder, vec)
             local action = http_req_call_stop.End(builder)

--- a/t/lib/ext-plugin.lua
+++ b/t/lib/ext-plugin.lua
@@ -185,7 +185,7 @@ function _M.go(case)
             local vec = builder:EndVector(len)
 
             http_req_call_stop.Start(builder)
-            if case.stop_no_code ~= true then
+            if case.check_default_status ~= true then
                 http_req_call_stop.AddStatus(builder, 405)
             end
             http_req_call_stop.AddBody(builder, b)

--- a/t/plugin/ext-plugin/http-req-call.t
+++ b/t/plugin/ext-plugin/http-req-call.t
@@ -124,28 +124,7 @@ X-Req: bar
 
 
 
-=== TEST 3: stop without setting status code
---- request
-GET /hello
---- response_body chomp
-cat
---- extra_stream_config
-    server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
-
-        content_by_lua_block {
-            local ext = require("lib.ext-plugin")
-            ext.go({stop = true, stop_no_code = true})
-        }
-    }
---- error_code: 200
---- response_headers
-X-Resp: foo
-X-Req: bar
-
-
-
-=== TEST 4: check input
+=== TEST 3: check input
 --- request
 PUT /hello?xx=y&xx=z&&y=&&z
 --- more_headers
@@ -164,7 +143,7 @@ X-Resp: cat
 
 
 
-=== TEST 5: check input (ipv6)
+=== TEST 4: check input (ipv6)
 --- config
 location /t {
     content_by_lua_block {
@@ -185,7 +164,7 @@ location /t {
 
 
 
-=== TEST 6: rewrite
+=== TEST 5: rewrite
 --- request
 GET /hello
 --- more_headers
@@ -209,7 +188,7 @@ x-real-ip: 127.0.0.1
 
 
 
-=== TEST 7: rewrite host
+=== TEST 6: rewrite host
 --- request
 GET /hello
 --- extra_stream_config
@@ -228,7 +207,7 @@ x-real-ip: 127.0.0.1
 
 
 
-=== TEST 8: rewrite args
+=== TEST 7: rewrite args
 --- request
 GET /hello?c=foo&d=bar
 --- extra_stream_config
@@ -247,7 +226,7 @@ c: bar
 
 
 
-=== TEST 9: proxy-rewrite + rewrite host
+=== TEST 8: proxy-rewrite + rewrite host
 --- config
     location /t {
         content_by_lua_block {
@@ -288,7 +267,7 @@ passed
 
 
 
-=== TEST 10: hit
+=== TEST 9: hit
 --- request
 GET /hello
 --- extra_stream_config
@@ -307,7 +286,7 @@ x-real-ip: 127.0.0.1
 
 
 
-=== TEST 11: proxy-rewrite + rewrite path
+=== TEST 10: proxy-rewrite + rewrite path
 --- config
     location /t {
         content_by_lua_block {
@@ -348,7 +327,7 @@ passed
 
 
 
-=== TEST 12: hit
+=== TEST 11: hit
 --- request
 GET /hello
 --- extra_stream_config
@@ -367,7 +346,7 @@ x-real-ip: 127.0.0.1
 
 
 
-=== TEST 13: proxy-rewrite + rewrite path with args
+=== TEST 12: proxy-rewrite + rewrite path with args
 --- config
     location /t {
         content_by_lua_block {
@@ -408,7 +387,7 @@ passed
 
 
 
-=== TEST 14: hit
+=== TEST 13: hit
 --- request
 GET /hello
 --- extra_stream_config
@@ -428,7 +407,7 @@ x: z
 
 
 
-=== TEST 15: rewrite args only
+=== TEST 14: rewrite args only
 --- config
     location /t {
         content_by_lua_block {
@@ -466,7 +445,7 @@ passed
 
 
 
-=== TEST 16: hit
+=== TEST 15: hit
 --- request
 GET /plugin_proxy_rewrite_args
 --- extra_stream_config
@@ -485,7 +464,7 @@ c: bar
 
 
 
-=== TEST 17: rewrite, bad path
+=== TEST 16: rewrite, bad path
 --- config
     location /t {
         content_by_lua_block {
@@ -523,7 +502,7 @@ passed
 
 
 
-=== TEST 18: hit
+=== TEST 17: hit
 --- request
 GET /hello
 --- extra_stream_config
@@ -538,3 +517,24 @@ GET /hello
 --- access_log
 GET /plugin_proxy_rewrite_args%3Fa=2
 --- error_code: 404
+
+
+
+=== TEST 18: stop without setting status code
+--- request
+GET /hello
+--- response_body chomp
+cat
+--- extra_stream_config
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+
+        content_by_lua_block {
+            local ext = require("lib.ext-plugin")
+            ext.go({stop = true, stop_no_code = true})
+        }
+    }
+--- error_code: 200
+--- response_headers
+X-Resp: foo
+X-Req: bar

--- a/t/plugin/ext-plugin/http-req-call.t
+++ b/t/plugin/ext-plugin/http-req-call.t
@@ -531,10 +531,9 @@ cat
 
         content_by_lua_block {
             local ext = require("lib.ext-plugin")
-            ext.go({stop = true, stop_no_code = true})
+            ext.go({stop = true, check_default_status = true})
         }
     }
---- error_code: 200
 --- response_headers
 X-Resp: foo
 X-Req: bar

--- a/t/plugin/ext-plugin/http-req-call.t
+++ b/t/plugin/ext-plugin/http-req-call.t
@@ -124,7 +124,28 @@ X-Req: bar
 
 
 
-=== TEST 3: check input
+=== TEST 3: stop without setting status code
+--- request
+GET /hello
+--- response_body chomp
+cat
+--- extra_stream_config
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+
+        content_by_lua_block {
+            local ext = require("lib.ext-plugin")
+            ext.go({stop = true, stop_no_code = true})
+        }
+    }
+--- error_code: 200
+--- response_headers
+X-Resp: foo
+X-Req: bar
+
+
+
+=== TEST 4: check input
 --- request
 PUT /hello?xx=y&xx=z&&y=&&z
 --- more_headers
@@ -143,7 +164,7 @@ X-Resp: cat
 
 
 
-=== TEST 4: check input (ipv6)
+=== TEST 5: check input (ipv6)
 --- config
 location /t {
     content_by_lua_block {
@@ -164,7 +185,7 @@ location /t {
 
 
 
-=== TEST 5: rewrite
+=== TEST 6: rewrite
 --- request
 GET /hello
 --- more_headers
@@ -188,7 +209,7 @@ x-real-ip: 127.0.0.1
 
 
 
-=== TEST 6: rewrite host
+=== TEST 7: rewrite host
 --- request
 GET /hello
 --- extra_stream_config
@@ -207,7 +228,7 @@ x-real-ip: 127.0.0.1
 
 
 
-=== TEST 7: rewrite args
+=== TEST 8: rewrite args
 --- request
 GET /hello?c=foo&d=bar
 --- extra_stream_config
@@ -226,7 +247,7 @@ c: bar
 
 
 
-=== TEST 8: proxy-rewrite + rewrite host
+=== TEST 9: proxy-rewrite + rewrite host
 --- config
     location /t {
         content_by_lua_block {
@@ -267,7 +288,7 @@ passed
 
 
 
-=== TEST 9: hit
+=== TEST 10: hit
 --- request
 GET /hello
 --- extra_stream_config
@@ -286,7 +307,7 @@ x-real-ip: 127.0.0.1
 
 
 
-=== TEST 10: proxy-rewrite + rewrite path
+=== TEST 11: proxy-rewrite + rewrite path
 --- config
     location /t {
         content_by_lua_block {
@@ -327,7 +348,7 @@ passed
 
 
 
-=== TEST 11: hit
+=== TEST 12: hit
 --- request
 GET /hello
 --- extra_stream_config
@@ -346,7 +367,7 @@ x-real-ip: 127.0.0.1
 
 
 
-=== TEST 12: proxy-rewrite + rewrite path with args
+=== TEST 13: proxy-rewrite + rewrite path with args
 --- config
     location /t {
         content_by_lua_block {
@@ -387,7 +408,7 @@ passed
 
 
 
-=== TEST 13: hit
+=== TEST 14: hit
 --- request
 GET /hello
 --- extra_stream_config
@@ -407,7 +428,7 @@ x: z
 
 
 
-=== TEST 14: rewrite args only
+=== TEST 15: rewrite args only
 --- config
     location /t {
         content_by_lua_block {
@@ -445,7 +466,7 @@ passed
 
 
 
-=== TEST 15: hit
+=== TEST 16: hit
 --- request
 GET /plugin_proxy_rewrite_args
 --- extra_stream_config
@@ -464,7 +485,7 @@ c: bar
 
 
 
-=== TEST 16: rewrite, bad path
+=== TEST 17: rewrite, bad path
 --- config
     location /t {
         content_by_lua_block {
@@ -502,7 +523,7 @@ passed
 
 
 
-=== TEST 17: hit
+=== TEST 18: hit
 --- request
 GET /hello
 --- extra_stream_config


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
If the plugin-runner sends a stop request but does not set an Http Status Code, APISIX will use 0 as the default status code, causing the current request to run later phases.
<!--- If it fixes an open issue, please link to the issue here. -->
see: https://github.com/apache/apisix-java-plugin-runner/issues/55
### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
