### PR TITLE
feat(gzip): support special * to match any type

### DIFF
--- a/apisix/plugins/gzip.lua
+++ b/apisix/plugins/gzip.lua
@@ -38,8 +38,7 @@ local schema = {
                     },
                 },
                 {
-                    type = "string",
-                    minLength = 1,
+                    enum = {"*"}
                 }
             },
             default = {"text/html"}
@@ -127,9 +126,7 @@ function _M.header_filter(conf, ctx)
             end
         end
     else
-        if content_type == types or types == "*" then
-            matched = true
-        end
+        matched = true
     end
     if not matched then
         return

--- a/apisix/plugins/gzip.lua
+++ b/apisix/plugins/gzip.lua
@@ -21,17 +21,26 @@ local req_http_version = ngx.req.http_version
 local str_sub = string.sub
 local ipairs = ipairs
 local tonumber = tonumber
+local type = type
 
 
 local schema = {
     type = "object",
     properties = {
         types = {
-            type = "array",
-            minItems = 1,
-            items = {
-                type = "string",
-                minLength = 1,
+            anyOf = {
+                {
+                    type = "array",
+                    minItem = 1,
+                    items = {
+                        type = "string",
+                        minLength = 1,
+                    },
+                },
+                {
+                    type = "string",
+                    minLength = 1,
+                }
             },
             default = {"text/html"}
         },
@@ -110,10 +119,16 @@ function _M.header_filter(conf, ctx)
     end
 
     local matched = false
-    for _, ty in ipairs(types) do
-        if content_type == ty then
+    if type(types) == "table" then
+        for _, ty in ipairs(types) do
+            if content_type == ty then
+                matched = true
+                break
+            end
+        end
+    else
+        if content_type == types or types == "*" then
             matched = true
-            break
         end
     end
     if not matched then

--- a/docs/en/latest/plugins/gzip.md
+++ b/docs/en/latest/plugins/gzip.md
@@ -37,15 +37,15 @@ This plugin requires APISIX to run on [APISIX-OpenResty](../how-to-build.md#step
 
 ## Attributes
 
-| Name      | Type          | Requirement | Default    | Valid                                                                    | Description                                                                                                                                         |
-| --------- | ------------- | ----------- | ---------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| types | array        | optional    |  ["text/html"]            | | dynamically set the `gzip_types` directive |
-| min_length | integer        | optional    |  20            | >= 1 | dynamically set the `gzip_min_length` directive |
-| comp_level | integer        | optional    |  1            | [1, 9] | dynamically set the `gzip_comp_level` directive |
-| http_version | number        | optional    |  1.1            | 1.1, 1.0 | dynamically set the `gzip_http_version` directive |
-| buffers.number | integer        | optional    |  32            | >= 1 | dynamically set the `gzip_buffers` directive |
-| buffers.size | integer        | optional    |  4096            | >= 1 | dynamically set the `gzip_buffers` directive |
-| vary | boolean        | optional    |  false            | | dynamically set the `gzip_vary` directive |
+| Name           | Type                 | Requirement | Default        | Valid                                                                      | Description                                                                                                                                         |
+| --------------------------------------| ------------| -------------- | -------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| types          | array[string]/string | optional    |  ["text/html"] |          | dynamically set the `gzip_types` directive |
+| min_length     | integer              | optional    |  20            | >= 1     | dynamically set the `gzip_min_length` directive |
+| comp_level     | integer              | optional    |  1             | [1, 9]   | dynamically set the `gzip_comp_level` directive |
+| http_version   | number               | optional    |  1.1           | 1.1, 1.0 | dynamically set the `gzip_http_version` directive |
+| buffers.number | integer              | optional    |  32            | >= 1     | dynamically set the `gzip_buffers` directive |
+| buffers.size   | integer              | optional    |  4096          | >= 1     | dynamically set the `gzip_buffers` directive |
+| vary | boolean                        | optional    |  false         |          | dynamically set the `gzip_vary` directive |
 
 ## How To Enable
 

--- a/docs/en/latest/plugins/gzip.md
+++ b/docs/en/latest/plugins/gzip.md
@@ -39,7 +39,7 @@ This plugin requires APISIX to run on [APISIX-OpenResty](../how-to-build.md#step
 
 | Name           | Type                 | Requirement | Default        | Valid                                                                      | Description                                                                                                                                         |
 | --------------------------------------| ------------| -------------- | -------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| types          | array[string]/string | optional    |  ["text/html"] |          | dynamically set the `gzip_types` directive |
+| types          | array[string] or "*" | optional    |  ["text/html"] |          | dynamically set the `gzip_types` directive, special value `"*"` matches any MIME type |
 | min_length     | integer              | optional    |  20            | >= 1     | dynamically set the `gzip_min_length` directive |
 | comp_level     | integer              | optional    |  1             | [1, 9]   | dynamically set the `gzip_comp_level` directive |
 | http_version   | number               | optional    |  1.1           | 1.1, 1.0 | dynamically set the `gzip_http_version` directive |

--- a/t/plugin/gzip.t
+++ b/t/plugin/gzip.t
@@ -436,7 +436,7 @@ POST /echo
 012345678
 --- more_headers
 Accept-Encoding: gzip
-Content-Type: text/html
+Content-Type: video/3gpp
 --- response_headers
 Content-Encoding: gzip
 

--- a/t/plugin/gzip.t
+++ b/t/plugin/gzip.t
@@ -395,7 +395,54 @@ Content-Encoding: gzip
 
 
 
-=== TEST 15: vary
+=== TEST 15: match all types
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/echo",
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        }
+                    },
+                    "plugins": {
+                        "gzip": {
+                            "types": "*"
+                        }
+                    }
+            }]]
+            )
+
+        if code >= 300 then
+            ngx.status = code
+        end
+        ngx.say(body)
+    }
+}
+--- response_body
+passed
+
+
+
+=== TEST 16: hit
+--- request
+POST /echo
+0123456789
+012345678
+--- more_headers
+Accept-Encoding: gzip
+Content-Type: text/html
+--- response_headers
+Content-Encoding: gzip
+
+
+
+=== TEST 17: vary
 --- config
     location /t {
         content_by_lua_block {
@@ -429,7 +476,7 @@ passed
 
 
 
-=== TEST 16: hit
+=== TEST 18: hit
 --- request
 POST /echo
 0123456789


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
right now, type of types attr is array, and we dont't have a method to support the special `gzip_types *` config in Nginx Core. So maybe we can change type of types to support single string, and support * too.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
