### PR TITLE
ci: change centos7 package name with el7

### DIFF
--- a/.github/workflows/centos7-ci.yml
+++ b/.github/workflows/centos7-ci.yml
@@ -49,7 +49,7 @@ jobs:
         sudo gem install --no-document fpm
         git clone https://github.com/api7/apisix-build-tools.git
         cd apisix-build-tools
-        make package type=rpm app=apisix version=${VERSION} checkout=release/${VERSION}
+        make package type=rpm app=apisix version=${VERSION} checkout=release/${VERSION} image_base=centos image_tag=7
         cd ..
         rm -rf $(ls -1 --ignore=apisix-build-tools --ignore=t --ignore=utils --ignore=ci --ignore=Makefile --ignore=rockspec)
 
@@ -100,7 +100,7 @@ jobs:
     - name: Install rpm package
       if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
       run: |
-        docker exec centos7Instance bash -c "cd apisix && rpm -iv --prefix=/apisix ./apisix-build-tools/output/apisix-${{ steps.branch_env.outputs.version }}-0.x86_64.rpm"
+        docker exec centos7Instance bash -c "cd apisix && rpm -iv --prefix=/apisix ./apisix-build-tools/output/apisix-${{ steps.branch_env.outputs.version }}-0.el7.x86_64.rpm"
         # Dependencies are attached with rpm, so revert `make deps`
         docker exec centos7Instance bash -c "cd apisix && rm -rf deps"
         docker exec centos7Instance bash -c "cd apisix && mv usr/bin . && mv usr/local/apisix/* ."
@@ -114,4 +114,4 @@ jobs:
       uses: actions/upload-artifact@v2.2.4
       with:
         name: "rpm"
-        path: "./apisix-build-tools/output/apisix-${{ steps.branch_env.outputs.version }}-0.x86_64.rpm"
+        path: "./apisix-build-tools/output/apisix-${{ steps.branch_env.outputs.version }}-0.el7.x86_64.rpm"


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->

The package name of apisix in CentOS7 has been added with the OS distribution name `el7`, see https://github.com/api7/apisix-build-tools/pull/67 for details. So this PR is going to change the relevant rpm name to `apisix-${version}-0.el7.x86_64.rpm` from the original `apisix-${version}-0.x86_64.rpm`. This PR will also fix the CI failures due to the stale package name.

<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
