### PR TITLE
ci: Remove non-exist dependency packages for CentOS 7

### DIFF
--- a/ci/centos7-ci.sh
+++ b/ci/centos7-ci.sh
@@ -39,7 +39,7 @@ install_dependencies() {
     rm -rf etcd-v3.4.0-linux-amd64
 
     # install test::nginx
-    yum install -y cpanminus build-essential libncurses5-dev libreadline-dev libssl-dev perl
+    yum install -y cpanminus perl
     cpanm --notest Test::Nginx IPC::Run > build.log 2>&1 || (cat build.log && exit 1)
 
     # install and start grpc_server_example


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->

Due to the `build-essentials`, `libncurses5-dev`, `libreadline-dev`, `libssl-dev` packages do not exist in CentOS 7, which leads to CI always complain about the following error. Although this error will not make CI CentOS 7 failed, it may mislead users to do the same action. So this PR will remove the installation of these four packages.

```
# yum install -y cpanminus build-essential libncurses5-dev libreadline-dev libssl-dev perl
Loaded plugins: fastestmirror, ovl
Loading mirror speeds from cached hostfile
 * base: mirror.dal.nexril.net
 * extras: repos.lax.quadranet.com
 * updates: mirror.vacares.com
No package build-essential available.
No package libncurses5-dev available.
No package libreadline-dev available.
No package libssl-dev available.
```

<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
