### PR TITLE
fix(authz-keycloak): set permissions as empty table when lazy_load_path is false

### DIFF
--- a/apisix/plugins/authz-keycloak.lua
+++ b/apisix/plugins/authz-keycloak.lua
@@ -51,7 +51,8 @@ local schema = {
                 type = "string",
                 minLength = 1, maxLength = 100
             },
-            uniqueItems = true
+            uniqueItems = true,
+            default = {}
         },
         lazy_load_paths = {type = "boolean", default = false},
         http_method_as_scope = {type = "boolean", default = false},
@@ -83,6 +84,9 @@ local schema = {
                 {
                     properties = {
                         lazy_load_paths = {enum = {false}},
+                    },
+                    anyOf = {
+                        {required = {"permissions"}}
                     }
                 },
                 {

--- a/apisix/plugins/authz-keycloak.lua
+++ b/apisix/plugins/authz-keycloak.lua
@@ -84,9 +84,6 @@ local schema = {
                 {
                     properties = {
                         lazy_load_paths = {enum = {false}},
-                    },
-                    anyOf = {
-                        {required = {"permissions"}}
                     }
                 },
                 {

--- a/t/plugin/authz-keycloak.t
+++ b/t/plugin/authz-keycloak.t
@@ -152,7 +152,33 @@ done
 
 
 
-=== TEST 6: full schema check
+=== TEST 6: no permissions when lazy_load_paths=false
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.authz-keycloak")
+            local ok, err = plugin.check_schema({
+                                token_endpoint = "https://host.domain/auth/realms/foo/protocol/openid-connect/token",
+                                client_id = "University",
+                                lazy_load_paths = false
+                            })
+            if not ok then
+                ngx.say(err)
+            end
+
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+--- no_error_log
+[error]
+
+
+
+=== TEST 7: full schema check
 --- config
     location /t {
         content_by_lua_block {
@@ -192,7 +218,7 @@ done
 
 
 
-=== TEST 7: token_endpoint and discovery both missing
+=== TEST 8: token_endpoint and discovery both missing
 --- config
     location /t {
         content_by_lua_block {
@@ -215,7 +241,7 @@ done
 
 
 
-=== TEST 8: client_id and audience both missing
+=== TEST 9: client_id and audience both missing
 --- config
     location /t {
         content_by_lua_block {
@@ -238,7 +264,7 @@ done
 
 
 
-=== TEST 9: resource_registration_endpoint and discovery both missing and lazy_load_paths is true
+=== TEST 10: resource_registration_endpoint and discovery both missing and lazy_load_paths is true
 --- config
     location /t {
         content_by_lua_block {
@@ -265,7 +291,7 @@ done
 
 
 
-=== TEST 10: Add https endpoint with ssl_verify true (default)
+=== TEST 11: Add https endpoint with ssl_verify true (default)
 --- config
     location /t {
         content_by_lua_block {
@@ -331,7 +357,7 @@ passed
 
 
 
-=== TEST 11: TEST with fake token and https endpoint
+=== TEST 12: TEST with fake token and https endpoint
 --- config
     location /t {
         content_by_lua_block {
@@ -361,7 +387,7 @@ Error while sending authz request to https://127.0.0.1:8443/auth/realms/Universi
 
 
 
-=== TEST 12: Add https endpoint with ssl_verify false
+=== TEST 13: Add https endpoint with ssl_verify false
 --- config
     location /t {
         content_by_lua_block {
@@ -429,7 +455,7 @@ passed
 
 
 
-=== TEST 13: TEST for https based token verification with ssl_verify false
+=== TEST 14: TEST for https based token verification with ssl_verify false
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/authz-keycloak.t
+++ b/t/plugin/authz-keycloak.t
@@ -152,33 +152,7 @@ done
 
 
 
-=== TEST 6: no permissions when lazy_load_paths=false
---- config
-    location /t {
-        content_by_lua_block {
-            local plugin = require("apisix.plugins.authz-keycloak")
-            local ok, err = plugin.check_schema({
-                                token_endpoint = "https://host.domain/auth/realms/foo/protocol/openid-connect/token",
-                                client_id = "University",
-                                lazy_load_paths = false
-                            })
-            if not ok then
-                ngx.say(err)
-            end
-
-            ngx.say("done")
-        }
-    }
---- request
-GET /t
---- response_body
-done
---- no_error_log
-[error]
-
-
-
-=== TEST 7: full schema check
+=== TEST 6: full schema check
 --- config
     location /t {
         content_by_lua_block {
@@ -218,7 +192,7 @@ done
 
 
 
-=== TEST 8: token_endpoint and discovery both missing
+=== TEST 7: token_endpoint and discovery both missing
 --- config
     location /t {
         content_by_lua_block {
@@ -241,7 +215,7 @@ done
 
 
 
-=== TEST 9: client_id and audience both missing
+=== TEST 8: client_id and audience both missing
 --- config
     location /t {
         content_by_lua_block {
@@ -264,7 +238,7 @@ done
 
 
 
-=== TEST 10: resource_registration_endpoint and discovery both missing and lazy_load_paths is true
+=== TEST 9: resource_registration_endpoint and discovery both missing and lazy_load_paths is true
 --- config
     location /t {
         content_by_lua_block {
@@ -291,7 +265,7 @@ done
 
 
 
-=== TEST 11: Add https endpoint with ssl_verify true (default)
+=== TEST 10: Add https endpoint with ssl_verify true (default)
 --- config
     location /t {
         content_by_lua_block {
@@ -357,7 +331,7 @@ passed
 
 
 
-=== TEST 12: TEST with fake token and https endpoint
+=== TEST 11: TEST with fake token and https endpoint
 --- config
     location /t {
         content_by_lua_block {
@@ -387,7 +361,7 @@ Error while sending authz request to https://127.0.0.1:8443/auth/realms/Universi
 
 
 
-=== TEST 13: Add https endpoint with ssl_verify false
+=== TEST 12: Add https endpoint with ssl_verify false
 --- config
     location /t {
         content_by_lua_block {
@@ -455,7 +429,7 @@ passed
 
 
 
-=== TEST 14: TEST for https based token verification with ssl_verify false
+=== TEST 13: TEST for https based token verification with ssl_verify false
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION


### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix: #4840 
### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
