### PR TITLE
perf(kafka-logger): directly return when can't identify the broker

### DIFF
--- a/apisix/plugins/kafka-logger.lua
+++ b/apisix/plugins/kafka-logger.lua
@@ -142,7 +142,7 @@ end
 
 local function send_kafka_data(conf, log_message, prod)
     if core.table.nkeys(conf.broker_list) == 0 then
-        core.log.error("failed to identify the broker specified")
+        return nil, "failed to identify the broker specified"
     end
 
     local ok, err = prod:send(conf.kafka_topic, conf.key, log_message)


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Directly return when can't identify the broker, and don't continue exec the send logic.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
