### PR TITLE
fix: bug about merge config node_listen

### DIFF
--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -112,6 +112,28 @@ local function tinyyaml_type(t)
 end
 
 
+local function path_is_multi_type(path, type_val)
+    if str_sub(path, 1, 14) == "nginx_config->" and
+            (type_val == "number" or type_val == "string") then
+        return true
+    end
+
+    if path == "apisix->node_listen" and type_val == "number" then
+        return true
+    end
+
+    if path == "apisix->ssl->listen_port" and type_val == "number" then
+        return true
+    end
+
+    if path == "apisix->ssl->listen" and type_val == "number" then
+        return true
+    end
+
+    return false
+end
+
+
 local function merge_conf(base, new_tab, ppath)
     ppath = ppath or ""
 
@@ -143,12 +165,11 @@ local function merge_conf(base, new_tab, ppath)
             if base[key] == nil then
                 base[key] = val
             elseif type(base[key]) ~= type_val then
-                if (ppath == "nginx_config" or str_sub(ppath, 1, 14) == "nginx_config->") and
-                    (type_val == "number" or type_val == "string")
-                then
+                local path = ppath == "" and key or ppath .. "->" .. key
+
+                if path_is_multi_type(path, type_val) then
                     base[key] = val
                 else
-                    local path = ppath == "" and key or ppath .. "->" .. key
                     return nil, "failed to merge, path[" .. path ..  "] expect: " ..
                                 type(base[key]) .. ", but got: " .. type_val
                 end

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -20,7 +20,9 @@
 #
 
 apisix:
-  node_listen: 9080                # APISIX listening port
+  # node_listen: 9080              # APISIX listening port
+  node_listen:                     # This style support multiple ports
+    - 9080
   enable_admin: true
   enable_admin_cors: true          # Admin API support CORS response headers.
   enable_debug: false


### PR DESCRIPTION
Signed-off-by: wayne-cheng <zhengwei@tiduyun.com>
This PR is used to solve a bug found in another PR (#4856).

When the conifg `apisix.node_liste`  is set to a array in the `conifg-default.yaml`, but the user's `config.yaml` use the type number,
a error will occur.

More detail, Please see https://github.com/apache/apisix/pull/4856#issuecomment-903545790

PTAL @spacewander 

You can use the existing test cases for testing, since the vaule type of the config `apisix.node_listen` in the `config-default.yaml` is changed to the  type array.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
