### PR TITLE
chore: Use build-tools release v2.0.0 instead of the master branch

### DIFF
--- a/.github/workflows/centos7-ci.yml
+++ b/.github/workflows/centos7-ci.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         export VERSION=${{ steps.branch_env.outputs.version }}
         sudo gem install --no-document fpm
-        git clone https://github.com/api7/apisix-build-tools.git
+        git clone -b v2.0.0 https://github.com/api7/apisix-build-tools.git
         cd apisix-build-tools
         make package type=rpm app=apisix version=${VERSION} checkout=release/${VERSION} image_base=centos image_tag=7
         cd ..

--- a/utils/linux-install-openresty.sh
+++ b/utils/linux-install-openresty.sh
@@ -26,7 +26,7 @@ sudo apt-get update
 
 if [ "$OPENRESTY_VERSION" == "source" ]; then
     cd ..
-    wget https://raw.githubusercontent.com/api7/apisix-build-tools/master/build-apisix-openresty.sh
+    wget https://raw.githubusercontent.com/api7/apisix-build-tools/v2.0.0/build-apisix-openresty.sh
     chmod +x build-apisix-openresty.sh
     ./build-apisix-openresty.sh latest
 


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
The apisix CIs are using the master code of apisix-build-tools for building and packaging. While this would lead to unexpected errors if anything is incompatible. In other words, we should always rely on a stable version. This PR is going to use the `v2.0.0` of apisix-build-tools, which is also heading to the same commit with the latest code of the current master branch.

<!--- If it fixes an open issue, please link to the issue here. -->
Related to https://github.com/api7/apisix-build-tools/issues/75.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
