### PR TITLE
chore: check if the configuration file is loaded

### DIFF
--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -231,7 +231,13 @@ function _M.load(config)
 
     if not config then
         -- called during starting or hot reload in admin
-        local_conf = core.config.local_conf(true)
+        local err
+        local_conf, err = core.config.local_conf(true)
+        if not local_conf then
+            -- the error is unrecoverable, so we need to raise it
+            error("failed to load the configuration file: ", err)
+        end
+
         http_plugin_names = local_conf.plugins
         stream_plugin_names = local_conf.stream_plugins
     else


### PR DESCRIPTION
Previously we already check it in the cli. But it seems sometimes
the check is bypassed, see #4897

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
