### PR TITLE
chore(ci): bump build-tools version to v2.1.0

### DIFF
--- a/.github/workflows/centos7-ci.yml
+++ b/.github/workflows/centos7-ci.yml
@@ -47,9 +47,9 @@ jobs:
       run: |
         export VERSION=${{ steps.branch_env.outputs.version }}
         sudo gem install --no-document fpm
-        git clone -b v2.0.0 https://github.com/api7/apisix-build-tools.git
+        git clone -b v2.1.0 https://github.com/api7/apisix-build-tools.git
         cd apisix-build-tools
-        make package type=rpm app=apisix version=${VERSION} checkout=release/${VERSION} image_base=centos image_tag=7
+        make package type=rpm app=apisix version=${VERSION} checkout=release/${VERSION} image_base=centos image_tag=7 local_code_path=../apisix
         cd ..
         rm -rf $(ls -1 --ignore=apisix-build-tools --ignore=t --ignore=utils --ignore=ci --ignore=Makefile --ignore=rockspec)
 


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->

Bump the apisix-build-tools to version v2.1.0, which supports the parameter `local_code_path` for packaging apisix. This PR also uses this new feature to reduce network/time costs in CI.

<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
