### PR TITLE
docs: change prometheus  scrape interval

### DIFF
--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -106,6 +106,7 @@ For example like this:
 ```yaml
 scrape_configs:
   - job_name: 'apisix'
+    scrape_interval: 20s
     metrics_path: '/apisix/prometheus/metrics'
     static_configs:
     - targets: ['127.0.0.1:9091']

--- a/docs/zh/latest/plugins/prometheus.md
+++ b/docs/zh/latest/plugins/prometheus.md
@@ -105,6 +105,7 @@ curl -i http://127.0.0.1:9091/apisix/prometheus/metrics
 ```yaml
 scrape_configs:
   - job_name: "apisix"
+    scrape_interval: 20s
     metrics_path: "/apisix/prometheus/metrics"
     static_configs:
       - targets: ["127.0.0.1:9091"]


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

prometheus default scrape interval is 1min(60s) , but  promql expression use 30s and 1m(min) , data may not be available.

https://github.com/apache/apisix/blob/master/docs/assets/other/json/apisix-grafana-dashboard.json#L521-L527

https://github.com/apache/apisix/blob/master/docs/assets/other/json/apisix-grafana-dashboard.json#L621-L632

https://github.com/apache/apisix/blob/master/docs/assets/other/json/apisix-grafana-dashboard.json#L726-L738

https://github.com/apache/apisix/blob/master/docs/assets/other/json/apisix-grafana-dashboard.json#L854-L863

https://github.com/apache/apisix/blob/master/docs/assets/other/json/apisix-grafana-dashboard.json#L966-L981

...

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
