### PR TITLE
fix: Integration of eureka as discovery registry fail

### DIFF
--- a/ci/centos7-ci.sh
+++ b/ci/centos7-ci.sh
@@ -27,7 +27,10 @@ install_dependencies() {
 
     # install openresty to make apisix's rpm test work
     yum install -y yum-utils && yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
-    yum install -y openresty openresty-debug openresty-openssl111-debug-devel pcre pcre-devel zlib zlib-devel
+    yum install -y openresty openresty-debug openresty-openssl111-debug-devel pcre pcre-devel
+
+    # install zlib to make lua-zlib work
+    yum install -y zlib zlib-devel
 
     # install luarocks
     ./utils/linux-install-luarocks.sh

--- a/ci/centos7-ci.sh
+++ b/ci/centos7-ci.sh
@@ -27,7 +27,7 @@ install_dependencies() {
 
     # install openresty to make apisix's rpm test work
     yum install -y yum-utils && yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
-    yum install -y openresty openresty-debug openresty-openssl111-debug-devel pcre pcre-devel
+    yum install -y openresty openresty-debug openresty-openssl111-debug-devel pcre pcre-devel zlib zlib-devel
 
     # install luarocks
     ./utils/linux-install-luarocks.sh

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -256,7 +256,7 @@ etcd:
 #  eureka:
 #    host:                        # it's possible to define multiple eureka hosts addresses of the same eureka cluster.
 #      - "http://127.0.0.1:8761"
-#    prefix: /eureka/v2/
+#    prefix: /eureka/
 #    fetch_interval: 30           # default 30s
 #    weight: 100                  # default weight for node
 #    timeout:

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -256,7 +256,7 @@ etcd:
 #  eureka:
 #    host:                        # it's possible to define multiple eureka hosts addresses of the same eureka cluster.
 #      - "http://127.0.0.1:8761"
-#    prefix: /eureka/
+#    prefix: /eureka/v2/
 #    fetch_interval: 30           # default 30s
 #    weight: 100                  # default weight for node
 #    timeout:

--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -69,6 +69,7 @@ dependencies = {
     "ext-plugin-proto = 0.2.1",
     "casbin = 1.26.0",
     "api7-snowflake = 2.0-1",
+    "lua-zlib = 1.2-1",
 }
 
 build = {


### PR DESCRIPTION
I start eureka server on tomcat, and then start apisix, I found some error logs like this:
`2021/08/30 10:33:22 [error] 6232#3458399: *14278 [lua] eureka.lua:197: invalid response body: �����������Sێ�0����G����򴔠 ��EKQ�� M큸8vd;l����qBv�jժU��Ϝ9�9s�� ϕ��юM�� ��߻�@�MY���E��\ʍ@ n׻xW'�r6���4d!��>.�f���y���dsX �hY��)����4��amM��E��q~U�� J���τ���Qԥ'L@�}᪛��ИV �z��_ݭ���(����-6�w��6�E ���[{[ ;�������9����{P�BrSho�0s�f�<�Q{�K�7���+p���d�F�W�gD�I�G�F1:���C�|rM�n4�/��t���6��5>�Z��)�7ȩ[��������&��x�����2Cj����M������ͤ7����cM��4�ތF����$���n��R�����xB�d�!�u%��8ATx���Q +j�Zd�/�!�s�h��)�k^����p��U�O�ϧ���MU-��b��)����#(��S����Ky(%�Sml��@������&���s�����+����C"��N/7$:�ƾ���9I��5��-_���|�4���竗\�A�Y�,�v�F���ĵk�\��� err: Expected value but found invalid token at character 1, context: ngx.timer`

Tomcat server.xml:
```
<Connector port="8080" protocol="HTTP/1.1"
               connectionTimeout="20000"
               redirectPort="8443" URIEncoding="UTF-8" />
```

I print response headers, and noticed that the "Content-Encoding" of header is gzip, means that eureka server returned data is compressed. 
so when eureka server return compressed data, I use lua-zlib to unzip received response data

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->#4929
### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
