### PR TITLE
chore(client-control): return 501 when APISIX-OpenResty missed

### DIFF
--- a/apisix/plugins/client-control.lua
+++ b/apisix/plugins/client-control.lua
@@ -50,7 +50,7 @@ end
 function _M.rewrite(conf, ctx)
     if not ok then
         core.log.error("need to build APISIX-OpenResty to support client restriction")
-        return 503
+        return 501
     end
 
     if conf.max_body_size then


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
to be consistent with with gzip and real-ip plugins' behavior.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
