### PR TITLE
feat: allow configuring fallback SNI

### DIFF
--- a/apisix/ssl.lua
+++ b/apisix/ssl.lua
@@ -35,6 +35,17 @@ local pkey_cache = core.lrucache.new {
 local _M = {}
 
 
+function _M.server_name()
+    local sni, err = ngx_ssl.server_name()
+    if not err and not sni then
+        local local_conf = core.config.local_conf()
+        sni = core.table.try_read_attr(local_conf, "apisix", "ssl", "fallback_sni")
+    end
+
+    return sni, err
+end
+
+
 local _aes_128_cbc_with_iv = false
 local function get_aes_128_cbc_with_iv()
     if _aes_128_cbc_with_iv == false then

--- a/apisix/ssl/router/radixtree_sni.lua
+++ b/apisix/ssl/router/radixtree_sni.lua
@@ -128,7 +128,7 @@ function _M.match_and_set(api_ctx)
     end
 
     local sni
-    sni, err = ngx_ssl.server_name()
+    sni, err = apisix_ssl.server_name()
     if type(sni) ~= "string" then
         local advise = "please check if the client requests via IP or uses an outdated protocol" ..
                        ". If you need to report an issue, " ..

--- a/apisix/stream/router/ip_port.lua
+++ b/apisix/stream/router/ip_port.lua
@@ -18,7 +18,7 @@ local core      = require("apisix.core")
 local config_util = require("apisix.core.config_util")
 local plugin_checker = require("apisix.plugin").stream_plugin_checker
 local router_new = require("apisix.utils.router").new
-local ngx_ssl = require("ngx.ssl")
+local apisix_ssl = require("apisix.ssl")
 local error     = error
 local tonumber  = tonumber
 local ipairs = ipairs
@@ -134,7 +134,7 @@ do
             router_ver = user_routes.conf_version
         end
 
-        local sni = ngx_ssl.server_name()
+        local sni = apisix_ssl.server_name()
         if sni and tls_router then
             local sni_rev = sni:reverse()
 

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -139,9 +139,12 @@ apisix:
     ssl_ciphers: ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
     ssl_session_tickets: false              #  disable ssl_session_tickets by default for 'ssl_session_tickets' would make Perfect Forward Secrecy useless.
                                             #  ref: https://github.com/mozilla/server-side-tls/issues/135
+
     key_encrypt_salt: edd1c9f0985e76a2      #  If not set, will save origin ssl key into etcd.
                                             #  If set this, must be a string of length 16. And it will encrypt ssl key with AES-128-CBC
                                             #  !!! So do not change it after saving your ssl, it can't decrypt the ssl keys have be saved if you change !!
+
+    #fallback_sni: "my.default.domain"      # If set this, when the client doesn't send SNI during handshake, the fallback SNI will be used instead
   enable_control: true
   #control:
   #  ip: 127.0.0.1

--- a/t/stream-node/sni.t
+++ b/t/stream-node/sni.t
@@ -277,7 +277,25 @@ proxy request to 127.0.0.2:1995
 
 
 
-=== TEST 10: no sni matched, fall back to non-sni route
+=== TEST 10: use fallback sni to match route
+--- yaml_config
+apisix:
+  node_listen: 1984
+  stream_proxy:
+    tcp:
+      - 9100
+  ssl:
+    fallback_sni: a.test.com
+--- stream_tls_request
+mmm
+--- response_body
+hello world
+--- error_log
+proxy request to 127.0.0.2:1995
+
+
+
+=== TEST 11: no sni matched, fall back to non-sni route
 --- config
     location /t {
         content_by_lua_block {
@@ -301,7 +319,7 @@ passed
 
 
 
-=== TEST 11: hit route
+=== TEST 12: hit route
 --- stream_tls_request
 mmm
 --- stream_sni: b.test.com
@@ -312,7 +330,7 @@ proxy request to 127.0.0.3:1995
 
 
 
-=== TEST 12: clean up routes
+=== TEST 13: clean up routes
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
The fallback SNI works around cases that client doesn't send a SNI
during handshake.
By configuring a fallback SNI we can configure a fallback certificate
with the current SSL APIs.
Fix #3147

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
