### PR TITLE
docs: Add ARM64 support for getting-started guide

### DIFF
--- a/docs/en/latest/getting-started.md
+++ b/docs/en/latest/getting-started.md
@@ -103,6 +103,8 @@ cd apisix-docker/example
 docker-compose -p docker-apisix up -d
 ```
 
+> Apache APISIX has already supported ARM64 architecture. For ARM64 users, please use `docker-compose -p docker-apisix -f docker-compose-arm64.yml up -d` instead in the last step.
+
 It will take some time to download all required files, please be patient.
 
 Once the download is complete, execute the `curl` command on the host running Docker to access the Admin API, and determine if Apache APISIX was successfully started based on the returned data.

--- a/docs/zh/latest/getting-started.md
+++ b/docs/zh/latest/getting-started.md
@@ -101,6 +101,8 @@ cd apisix-docker/example
 docker-compose -p docker-apisix up -d
 ```
 
+> Apache APISIX 已支持 ARM64 架构。如果您正在使用 ARM64，请在最后一步执行 `docker-compose -p docker-apisix -f docker-compose-arm64.yml up -d`。
+
 下载所需的所有文件将花费一些时间，这取决于您的网络，请耐心等待。
 
 下载完成后，在运行 Docker 的宿主机上执行`curl`命令访问 Admin API，根据返回数据判断 Apache APISIX 是否成功启动。


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since PR https://github.com/apache/apisix-docker/pull/216 got merged, this PR is going to add some guides for users to run Apache APISIX via docker compose in ARM64 architecture.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
