### PR TITLE
change: use a new name to customize lua_shared_dict in nginx.conf

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -189,6 +189,11 @@ http {
     lua_shared_dict access-tokens {* http.lua_shared_dict["access-tokens"] *}; # cache for service account access tokens
 
     # for custom shared dict
+    {% if http.custom_lua_shared_dict then %}
+    {% for cache_key, cache_size in pairs(http.custom_lua_shared_dict) do %}
+    lua_shared_dict {*cache_key*} {*cache_size*};
+    {% end %}
+    {% end %}
     {% if http.lua_shared_dicts then %}
     {% for cache_key, cache_size in pairs(http.lua_shared_dicts) do %}
     lua_shared_dict {*cache_key*} {*cache_size*};

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -265,7 +265,7 @@ local config_schema = {
         http = {
             type = "object",
             properties = {
-                lua_shared_dicts = {
+                custom_lua_shared_dict = {
                     type = "object",
                 }
             }
@@ -748,6 +748,11 @@ Please modify "admin_key" in conf/config.yaml .
     local env_worker_processes = getenv("APISIX_WORKER_PROCESSES")
     if env_worker_processes then
         sys_conf["worker_processes"] = floor(tonumber(env_worker_processes))
+    end
+
+    if sys_conf["http"]["lua_shared_dicts"] then
+        stderr:write("lua_shared_dicts is deprecated, " ..
+                     "custom_lua_shared_dict instead\n")
     end
 
     local exported_vars = file.get_exported_vars()

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -752,7 +752,7 @@ Please modify "admin_key" in conf/config.yaml .
 
     if sys_conf["http"]["lua_shared_dicts"] then
         stderr:write("lua_shared_dicts is deprecated, " ..
-                     "custom_lua_shared_dict instead\n")
+                     "use custom_lua_shared_dict instead\n")
     end
 
     local exported_vars = file.get_exported_vars()

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -214,7 +214,7 @@ nginx_config:                     # config for render the template to generate n
     real_ip_from:                  # http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from
       - 127.0.0.1
       - "unix:"
-    #lua_shared_dicts:             # add custom shared cache to nginx.conf
+    #custom_lua_shared_dict:       # add custom shared cache to nginx.conf
     #  ipc_shared_dict: 100m       # custom shared cache, format: `cache-key: cache-size`
 
     # Enables or disables passing of the server name through TLS Server Name Indication extension (SNI, RFC 6066)

--- a/t/cli/test_http_config.sh
+++ b/t/cli/test_http_config.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+. ./t/cli/common.sh
+
+git checkout conf/config.yaml
+
+echo '
+nginx_config:
+  http:
+    custom_lua_shared_dict:
+      my_dict: 1m
+' > conf/config.yaml
+
+make init
+
+if ! grep "lua_shared_dict my_dict 1m;" conf/nginx.conf > /dev/null; then
+    echo "failed: define custom shdict"
+    exit 1
+fi
+
+echo "passed: define custom shdict"
+
+git checkout conf/config.yaml
+
+echo '
+nginx_config:
+  http:
+    lua_shared_dicts:
+      my_dict: 1m
+' > conf/config.yaml
+
+make init
+
+if ! grep "lua_shared_dict my_dict 1m;" conf/nginx.conf > /dev/null; then
+    echo "failed: define custom shdict in the old way"
+    exit 1
+fi
+
+echo "passed: define custom shdict in the old way"

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -514,26 +514,6 @@ fi
 rm conf/config_original.yaml conf/customized_config.yaml
 echo "passed: customized config.yaml copied and reverted succeeded"
 
-# allow to merge configuration without middle layer
-
-git checkout conf/config.yaml
-
-echo '
-nginx_config:
-  http:
-    lua_shared_dicts:
-      my_dict: 1m
-' > conf/config.yaml
-
-make init
-
-if ! grep "lua_shared_dict my_dict 1m;" conf/nginx.conf > /dev/null; then
-    echo "failed: 'my_dict' not in nginx.conf"
-    exit 1
-fi
-
-echo "passed: found 'my_dict' in nginx.conf"
-
 # check disable cpu affinity
 git checkout conf/config.yaml
 


### PR DESCRIPTION
The previous name is easy to mess up with another "lua_shared_dict"
configuration.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
