### PR TITLE
ci: use chaos mesh released version but not latest

### DIFF
--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Deploy Chaos Mesh
         run: |
-          curl -sSL https://mirrors.chaos-mesh.org/latest/install.sh | bash
+          curl -sSL https://mirrors.chaos-mesh.org/v2.0.1/install.sh | bash
 
 
       - name: Install Ginkgo


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

### What this PR does / why we need it:
A recent change in Chaos Mesh installation script make CI failed, and it's also risky to use the latest version compared to the released version.

### Pre-submission checklist:

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
