### PR TITLE
chore: Bump build-tools version to v2.2.1

### DIFF
--- a/.github/workflows/centos7-ci.yml
+++ b/.github/workflows/centos7-ci.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         export VERSION=${{ steps.branch_env.outputs.version }}
         sudo gem install --no-document fpm
-        git clone -b v2.1.0 https://github.com/api7/apisix-build-tools.git
+        git clone -b v2.2.1 https://github.com/api7/apisix-build-tools.git
         cd apisix-build-tools
         make package type=rpm app=apisix version=${VERSION} checkout=release/${VERSION} image_base=centos image_tag=7 local_code_path=../apisix
         cd ..

--- a/utils/linux-install-openresty.sh
+++ b/utils/linux-install-openresty.sh
@@ -26,7 +26,7 @@ sudo apt-get update
 
 if [ "$OPENRESTY_VERSION" == "source" ]; then
     cd ..
-    wget https://raw.githubusercontent.com/api7/apisix-build-tools/v2.0.0/build-apisix-openresty.sh
+    wget https://raw.githubusercontent.com/api7/apisix-build-tools/v2.2.1/build-apisix-openresty.sh
     chmod +x build-apisix-openresty.sh
     ./build-apisix-openresty.sh latest
 


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is going to bump apisix-build-tools to `v2.2.1`, which contains:
- Bugfix: updating APISIX RPM building to fix overwriting the configuration files when updating the APISIX RPM, see https://github.com/api7/apisix-build-tools/pull/95.
- Feature: upgrading apisix_nginx_module_ver to 1.3.0, see https://github.com/api7/apisix-build-tools/pull/81.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**

Signed-off-by: imjoey <majunjie@apache.org>