### PR TITLE
docs: fix error link of build apisix openresty

### DIFF
--- a/docs/zh/latest/admin-api.md
+++ b/docs/zh/latest/admin-api.md
@@ -588,11 +588,11 @@ APISIX 的 Upstream 除了基本的负载均衡算法选择外，还支持对上
 
 `tls.client_cert/key` 可以用来跟上游进行 mTLS 通信。
 他们的格式和 SSL 对象的 `cert` 和 `key` 一样。
-这个特性需要 APISIX 运行于 [APISIX-OpenResty](./how-to-build.md#步骤6-为-Apache-APISIX-构建-OpenResty)。
+这个特性需要 APISIX 运行于 [APISIX-OpenResty](./how-to-build.md#步骤6：为-Apache-APISIX-构建-OpenResty)。
 
 `keepalive_pool` 允许 upstream 对象有自己单独的连接池。
 它下属的字段，比如 `requests`，可以用了配置上游连接保持的参数。
-这个特性需要 APISIX 运行于 [APISIX-OpenResty](./how-to-build.md#步骤6-为-Apache-APISIX-构建-OpenResty)。
+这个特性需要 APISIX 运行于 [APISIX-OpenResty](./how-to-build.md#步骤6：为-Apache-APISIX-构建-OpenResty)。
 
 **upstream 对象 json 配置内容：**
 

--- a/docs/zh/latest/mtls.md
+++ b/docs/zh/latest/mtls.md
@@ -66,7 +66,7 @@ curl --cacert /data/certs/mtls_ca.crt --key /data/certs/mtls_client.key --cert /
 
 ### 如何配置
 
-你需要构建 [APISIX-Openresty](./how-to-build.md#步骤6-为-Apache-APISIX-构建-OpenResty)，并且需要在配置文件中设定 `etcd.tls` 来使 ETCD 的双向认证功能正常工作。
+你需要构建 [APISIX-Openresty](./how-to-build.md#步骤6：为-Apache-APISIX-构建-OpenResty)，并且需要在配置文件中设定 `etcd.tls` 来使 ETCD 的双向认证功能正常工作。
 
 ```yaml
 etcd:
@@ -154,7 +154,7 @@ curl --resolve 'mtls.test.com:<APISIX_HTTPS_PORT>:<APISIX_URL>' "https://<APISIX
 
 在配置 upstream 资源时，可以使用参数 `tls.client_cert` 和 `tls.client_key` 来配置 APISIX 用于与上游进行通讯时使用的证书。可参考 [Upstream API 文档](./admin-api.md#upstream)。
 
-该功能需要 APISIX 运行在 [APISIX-OpenResty](./how-to-build.md#步骤6-为-Apache-APISIX-构建-OpenResty) 上。
+该功能需要 APISIX 运行在 [APISIX-OpenResty](./how-to-build.md#步骤6：为-Apache-APISIX-构建-OpenResty) 上。
 
 下面是一个与配置 SSL 时相似的 Python 脚本，可为一个已存在的 upstream 资源配置双向认证。如果需要，可修改 API 地址和API Key。
 

--- a/docs/zh/latest/plugins/dubbo-proxy.md
+++ b/docs/zh/latest/plugins/dubbo-proxy.md
@@ -37,7 +37,7 @@ title: dubbo-proxy
 
 ## 要求
 
-如果你正在使用 `OpenResty`, 你需要编译它来支持 `dubbo`, 参考 [如何编译](../how-to-build.md#步骤6-为-Apache-APISIX-构建-OpenResty)。
+如果你正在使用 `OpenResty`, 你需要编译它来支持 `dubbo`, 参考 [如何编译](../how-to-build.md#步骤6：为-Apache-APISIX-构建-OpenResty)。
 在 `APISIX` 中为了实现使从 `http` 代理到 `dubbo`，我们在`Tengine` 的 `mod_dubbo` 基础上对 `dubbo` 模块做了改进。 所有的修改已经提交给 `Tengine`，但是还未合并到最新的 `release` 版本中(Tengine-2.3.2) 。所以目前 `Tengine` 自身是不支持此特性的。
 
 ## 运行时属性


### PR DESCRIPTION
Signed-off-by: tzssangglass <tzssangglass@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
The current Chinese documentation for `步骤6：为 Apache APISIX 构建 OpenResty` jump link looks like this:

![21632366857_ pic](https://user-images.githubusercontent.com/30819887/134450293-6a512613-7478-442d-91da-35cf04fd16bb.jpg)

The jump link does not jump to the `步骤6：为 Apache APISIX 构建 OpenResty`

After this PR is modified, it will look like this:

![31632367545_ pic_hd](https://user-images.githubusercontent.com/30819887/134450533-1a12bd26-c4e8-4d9b-ac11-969db791eff0.jpg)

<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
