### PR TITLE
ci: fix the rpm build

### DIFF
--- a/.github/workflows/centos7-ci.yml
+++ b/.github/workflows/centos7-ci.yml
@@ -48,8 +48,13 @@ jobs:
         export VERSION=${{ steps.branch_env.outputs.version }}
         sudo gem install --no-document fpm
         git clone -b v2.2.1 https://github.com/api7/apisix-build-tools.git
+
+        # move codes under build tool
+        mkdir ./apisix-build-tools/apisix
+        for dir in `ls|grep -v "^apisix-build-tools$"`;do cp -r $dir ./apisix-build-tools/apisix/;done
+
         cd apisix-build-tools
-        make package type=rpm app=apisix version=${VERSION} checkout=release/${VERSION} image_base=centos image_tag=7 local_code_path=../apisix
+        make package type=rpm app=apisix version=${VERSION} checkout=release/${VERSION} image_base=centos image_tag=7 local_code_path=./apisix
         cd ..
         rm -rf $(ls -1 --ignore=apisix-build-tools --ignore=t --ignore=utils --ignore=ci --ignore=Makefile --ignore=rockspec)
 


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As docker does not support `COPY` files outside from context. This PR is going to move the apisix for building under apisix-build-tools directory.

The testing has passed by pushing to a new branch `release/trpmfailure`, see https://github.com/apache/apisix/runs/3696433553.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
