### PR TITLE
fix(prometheus): avoid negative latency caused by inconsistent Nginx metrics

### DIFF
--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -153,6 +153,12 @@ function _M.log(conf, ctx)
         metrics.latency:observe(upstream_latency,
             gen_arr("upstream", route_id, service_id, consumer_name, balancer_ip))
         apisix_latency =  apisix_latency - upstream_latency
+
+        -- TODO: bug founded, ref to `https://github.com/apache/apisix/issues/5146`
+        if apisix_latency < 0 then
+            apisix_latency = 0
+        end
+
     end
     metrics.latency:observe(apisix_latency,
         gen_arr("apisix", route_id, service_id, consumer_name, balancer_ip))
@@ -165,9 +171,10 @@ function _M.log(conf, ctx)
 end
 
 
-    local ngx_status_items = {"active", "accepted", "handled", "total",
-                             "reading", "writing", "waiting"}
-    local label_values = {}
+local ngx_status_items = {"active", "accepted", "handled", "total",
+                         "reading", "writing", "waiting"}
+local label_values = {}
+
 local function nginx_status()
     local res = ngx_capture("/apisix/nginx_status")
     if not res or res.status ~= 200 then

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -155,7 +155,7 @@ function _M.log(conf, ctx)
         apisix_latency =  apisix_latency - upstream_latency
 
         -- The latency might be negative, as Nginx uses different time measurements in
-        -- different metrics. 
+        -- different metrics.
         -- See https://github.com/apache/apisix/issues/5146#issuecomment-928919399
         if apisix_latency < 0 then
             apisix_latency = 0

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -154,7 +154,9 @@ function _M.log(conf, ctx)
             gen_arr("upstream", route_id, service_id, consumer_name, balancer_ip))
         apisix_latency =  apisix_latency - upstream_latency
 
-        -- TODO: bug founded, ref to `https://github.com/apache/apisix/issues/5146`
+        -- The latency might be negative, as Nginx uses different time measurements in
+        -- different metrics. 
+        -- See https://github.com/apache/apisix/issues/5146#issuecomment-928919399
         if apisix_latency < 0 then
             apisix_latency = 0
         end


### PR DESCRIPTION
Fix #5146 

prometheus don't work as expected, change latency to zero when it's negative.

Signed-off-by: leslie tsang <leslie.tsang@icloud.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
