### PR TITLE
chore: fix typo in init.lua

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -315,7 +315,7 @@ local function verify_tls_client(ctx)
             if res == "NONE" then
                 core.log.error("client certificate was not present")
             else
-                core.log.error("clent certificate verification is not passed: ", res)
+                core.log.error("client certificate verification is not passed: ", res)
             end
 
             return false

--- a/t/node/client-mtls.t
+++ b/t/node/client-mtls.t
@@ -303,4 +303,4 @@ GET /mtls3
 Host: localhost
 --- error_code: 400
 --- error_log
-clent certificate verification is not passed: FAILED:self signed certificate
+client certificate verification is not passed: FAILED:self signed certificate


### PR DESCRIPTION
change `clent` to `client`
https://github.com/apache/apisix/blob/6096d7f9f72c64b9f290b282be37a51010d1e493/apisix/init.lua#L318

Signed-off-by: leslie tsang <leslie.tsang@icloud.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
