### PR TITLE
feat: enhance the verification of the configuration

### DIFF
--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -893,6 +893,8 @@ end
 
 local function quit(env)
     cleanup()
+    -- reinit nginx.conf
+    init(env)
 
     local cmd = env.openresty_args .. [[ -s quit]]
     util.execute_cmd(cmd)
@@ -901,6 +903,8 @@ end
 
 local function stop(env)
     cleanup()
+    -- reinit nginx.conf
+    init(env)
 
     local cmd = env.openresty_args .. [[ -s stop]]
     util.execute_cmd(cmd)
@@ -932,6 +936,23 @@ local function reload(env)
 end
 
 
+local function test(env)
+    -- reinit nginx.conf
+    init(env)
+
+    local test_cmd = env.openresty_args .. [[ -t -q ]]
+    -- When success,
+    -- On linux, os.execute returns 0,
+    -- On macos, os.execute returns 3 values: true, exit, 0, and we need the first.
+    local test_ret = execute((test_cmd))
+    if (test_ret == 0 or test_ret == true) then
+        print("configuration test is successful")
+        return
+    end
+
+    print("configuration test failed")
+end
+
 
 local action = {
     help = help,
@@ -943,6 +964,7 @@ local action = {
     quit = quit,
     restart = restart,
     reload = reload,
+    test = test,
 }
 
 

--- a/docs/en/latest/how-to-build.md
+++ b/docs/en/latest/how-to-build.md
@@ -93,6 +93,15 @@ Run the following command to initialize the NGINX configuration file and etcd.
 apisix init
 ```
 
+### Test configuration file
+
+Run the following command to test the configuration file. APISIX will generate `nginx.conf` from `config.yaml` and check whether the syntax of `nginx.conf` is correct.
+
+```shell
+# generate `nginx.conf` from `config.yaml` and test it
+apisix test
+```
+
 ### Start Apache APISIX
 
 Run the following command to start Apache APISIX.

--- a/docs/zh/latest/how-to-build.md
+++ b/docs/zh/latest/how-to-build.md
@@ -93,6 +93,15 @@ sudo yum install -y https://github.com/apache/apisix/releases/download/2.10.0/ap
 apisix init
 ```
 
+### 测试配置文件
+
+运行以下命令测试配置文件。 APISIX 将根据 `config.yaml` 生成 `nginx.conf` ，并检查 `nginx.conf` 的语法是否正确。
+
+```shell
+# generate `nginx.conf` from `config.yaml` and test it
+apisix test
+```
+
 ### 启动 Apache APISIX
 
 运行以下命令启动 Apache APISIX。

--- a/t/cli/test_prometheus.sh
+++ b/t/cli/test_prometheus.sh
@@ -60,7 +60,7 @@ if [ ! $code -eq 200 ]; then
     exit 1
 fi
 
-make stop
+IP=127.0.0.1 PORT=9092 make stop
 
 echo "passed: should listen at configured prometheus address"
 
@@ -88,7 +88,7 @@ if [ ! $code -eq 200 ]; then
     exit 1
 fi
 
-make stop
+IP=127.0.0.1 PORT=9092 make stop
 
 echo "passed: should listen at previous prometheus address"
 


### PR DESCRIPTION
### What this PR does / why we need it:
1. add command `apisix test` to test configuration file
2. when run `apisix stop` or `apisix restart`, regenerate `nginx.conf` to avoid failure to restart


### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
