### PR TITLE
chore: Add tips for awk failures in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,8 @@ endif
 
 
 ### help : Show Makefile rules
+### 	If there're awk failures, please make sure
+### 	you are using awk or gawk
 .PHONY: help
 help:
 	@$(call func_echo_success_status, "Makefile rules:")


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In most case, the command `awk` is linked to `awk` or `gawk`. While in some Ubuntu/Debian distributions, it may be linked to`mawk`, which  would cause failed to build APISIX, see https://github.com/api7/apisix-build-tools/runs/3901433499. So this PR is going to add relevant tips for users.

Because macOS is using the original `awk` command, so we cannot force all uses to use `gawk`. Any feedbacks are appreciated. Thanks.


### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
