### PR TITLE
docs: Add RPM repository guide for CentOS 7

### DIFF
--- a/docs/en/latest/how-to-build.md
+++ b/docs/en/latest/how-to-build.md
@@ -59,7 +59,7 @@ This installation method is suitable for CentOS 7, please run the following comm
 sudo yum install -y https://github.com/apache/apisix/releases/download/2.10.0/apisix-2.10.0-0.el7.x86_64.rpm
 ```
 
-> You can also install the RPM package from `https://repos.apiseven.com/packages/centos/7/x86_64/apisix-2.10.0-0.el7.x86_64.rpm`.
+> You can also install the RPM package via running `sudo yum install -y https://repos.apiseven.com/packages/centos/7/x86_64/apisix-2.10.0-0.el7.x86_64.rpm`.
 
 ### Installation via Docker
 

--- a/docs/zh/latest/how-to-build.md
+++ b/docs/zh/latest/how-to-build.md
@@ -59,7 +59,7 @@ sudo yum install -y https://repos.apiseven.com/packages/centos/apache-apisix-rep
 sudo yum install -y https://github.com/apache/apisix/releases/download/2.10.0/apisix-2.10.0-0.el7.x86_64.rpm
 ```
 
-> 您也可以通过 `https://repos.apiseven.com/packages/centos/7/x86_64/apisix-2.10.0-0.el7.x86_64.rpm` 安装。
+> 您也可以运行 `sudo yum install -y https://repos.apiseven.com/packages/centos/7/x86_64/apisix-2.10.0-0.el7.x86_64.rpm` 命令安装。
 
 ### 通过 Docker 安装
 


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Happy to introduce the Apache APISIX RPM repository, currently only CentOS 7 is supported. This PR is going to add the usage guide for users. Hope this repository will help users to ease the installation.

Currently apisix-build-tools has already used this repository for building the apisix and apisix-base RPMs. Please see the successfully finished CI jobs at https://github.com/api7/apisix-build-tools/pull/111/checks?check_run_id=3902830223 and https://github.com/api7/apisix-build-tools/pull/111/checks?check_run_id=3902830222. Once this PR gets merged, I would be commit other PRs to use this repository in more cases.

Any feedback is much appreciated.

> Noted: The repositories for other OS distributions, like Fedora/Ubuntu, will be also supported in the near future. 


### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
