### PR TITLE
ci(workflow): support auto build and publish RPM package to Repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,109 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Build and Publish Package
+
+on:
+  create
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish_apisix:
+    name: Build and Publish RPM Package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2.3.5
+        with:
+          submodules: recursive
+
+      - name: Extract Tags name
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        id: tag_env
+        shell: bash
+        run: |
+          echo "##[set-output name=version;]$(echo ${GITHUB_REF##*/})"
+
+      - name: Clone apisix-build-tools
+        run: |
+          git clone https://github.com/api7/apisix-build-tools.git
+
+      - name: Build apisix RPM Package
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          cd ./apisix-build-tools
+          # build apisix
+          make package type=rpm app=apisix checkout=${{ steps.tag_env.outputs.version }} version=${{ steps.tag_env.outputs.version }} image_base=centos image_tag=7
+          cd ../
+          mv ./apisix-build-tools/output/apisix-${{ steps.tag_env.outputs.version }}-0.el7.x86_64.rpm ./
+
+      - name: Build apisix-base RPM Package
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          cd ./apisix-build-tools
+          # build apisix-base
+          make package type=rpm app=apisix-base checkout=${{ steps.tag_env.outputs.version }} version=${{ steps.tag_env.outputs.version }} image_base=centos image_tag=7
+          cd ../
+          mv ./apisix-build-tools/output/apisix-base-${{ steps.tag_env.outputs.version }}-0.el7.x86_64.rpm ./
+
+      - name: Upload apisix Artifact
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/upload-artifact@v2.2.3
+        with:
+          name: "apisix-${{ steps.tag_env.outputs.version }}-0.el7.x86_64.rpm"
+          path: "./apisix-${{ steps.tag_env.outputs.version }}-0.el7.x86_64.rpm"
+
+      - name: Upload apisix-base Artifact
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/upload-artifact@v2.2.3
+        with:
+          name: "apisix-base-${{ steps.tag_env.outputs.version }}-0.el7.x86_64.rpm"
+          path: "./apisix-base-${{ steps.tag_env.outputs.version }}-0.el7.x86_64.rpm"
+
+      - name: Push apisix RPM Package to Aliyun OSS
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          if echo $GITHUB_REF | grep "tags"; then
+            echo "[Credentials]" >> /tmp/ossutilconfig
+            echo "language=EN" >> /tmp/ossutilconfig
+            echo "endpoint=oss-cn-shenzhen.aliyuncs.com" >> /tmp/ossutilconfig
+            echo "accessKeyID=${{ secrets.ACCESS_KEY_ID }}" >> /tmp/ossutilconfig
+            echo "accessKeySecret=${{ secrets.ACCESS_KEY_SECRET }}" >> /tmp/ossutilconfig
+            wget http://gosspublic.alicdn.com/ossutil/1.7.3/ossutil64
+            chmod 755 ossutil64
+            ./ossutil64 cp -f ./apisix-${{ steps.tag_env.outputs.version }}-0.el7.x86_64.rpm oss://apisix-repo/packages/centos/7/x86_64/ --config-file=/tmp/ossutilconfig
+          fi
+
+      - name: Push apisix-base RPM Package to Aliyun OSS
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          if echo $GITHUB_REF | grep "tags"; then
+            echo "[Credentials]" >> /tmp/ossutilconfig
+            echo "language=EN" >> /tmp/ossutilconfig
+            echo "endpoint=oss-cn-shenzhen.aliyuncs.com" >> /tmp/ossutilconfig
+            echo "accessKeyID=${{ secrets.ACCESS_KEY_ID }}" >> /tmp/ossutilconfig
+            echo "accessKeySecret=${{ secrets.ACCESS_KEY_SECRET }}" >> /tmp/ossutilconfig
+            wget http://gosspublic.alicdn.com/ossutil/1.7.3/ossutil64
+            chmod 755 ossutil64
+            ./ossutil64 cp -f ./apisix-base-${{ steps.tag_env.outputs.version }}-0.el7.x86_64.rpm oss://apisix-repo/packages/centos/7/x86_64/ --config-file=/tmp/ossutilconfig
+          fi


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

+ Auto Build RPM Package when creating a new tag.
+ Auto Publish RPM Package to RPM Repo after building when creating a new tag.

> PS: need to set two secrets variables which are **ACCESS_KEY_ID** and **ACCESS_KEY_SECRET**

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
