### PR TITLE
ci: the test framework requires curl with http2 support

### DIFF
--- a/ci/centos7-ci.sh
+++ b/ci/centos7-ci.sh
@@ -23,28 +23,13 @@ install_dependencies() {
 
     # install development tools
     yum install -y wget tar gcc automake autoconf libtool make unzip \
-        git which sudo openldap-devel libev libev-devel zlib zlib-devel openssl openssl-devel
+        git which sudo openldap-devel
 
+    # curl with http2
+    wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-amd64 -O /usr/bin/curl
     # install openresty to make apisix's rpm test work
     yum install -y yum-utils && yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
     yum install -y openresty openresty-debug openresty-openssl111-debug-devel pcre pcre-devel
-
-    # build curl with http2
-    mkdir -p tmp-cache && cd tmp-cache/
-    git clone https://github.com/tatsuhiro-t/nghttp2.git
-    cd nghttp2 && autoreconf -i && automake && autoconf && ./configure && make && make install
-
-    # dynamic linking
-    echo '/usr/local/lib' > /etc/ld.so.conf.d/custom-libs.conf
-    ldconfig
-    # build curl from source
-    cd .. && git clone https://github.com/bagder/curl.git
-    cd curl && ./buildconf
-    ./configure --with-nghttp2=/usr/local --with-ssl
-    make -j4 && make install
-    cp -f ./src/curl /bin
-    cp -f ./src/curl /usr/local/bin
-    cd ../..
 
     # install luarocks
     ./utils/linux-install-luarocks.sh


### PR DESCRIPTION
### What this PR does / why we need it:
At present, centos 7 CI is using a version of curl that doesn't have the HTTP2 feature. So the PR recompiles curl from source by dynamically linking nghttp2 lib.  

Relevant PR: https://github.com/apache/apisix/pull/5299
### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
