### PR TITLE
fix(ext-plugin): don't use stale key

### DIFF
--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -66,6 +66,7 @@ local type = type
 local events_list
 local lrucache = core.lrucache.new({
     type = "plugin",
+    invalid_stale = true,
     ttl = helper.get_conf_token_cache_time(),
 })
 local shdict_name = "ext-plugin"


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
ext_plugin  an expired key in lrucachd  that could not find in go runner。

<!--- If it fixes an open issue, please link to the issue here. --> 

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
