### PR TITLE
chore: replace submodule tmate with github action tmate

### DIFF
--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -87,5 +87,5 @@ jobs:
       # Debug via SSH if previous steps failed
       - name: Set up tmate session
         if: ${{ failure() }}
-        uses: ./.github/actions/action-tmate
+        uses: mxschmitt/action-tmate@v3
         timeout-minutes: 15

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "t/toolkit"]
 	path = t/toolkit
 	url = https://github.com/api7/test-toolkit.git
-[submodule ".github/actions/action-tmate"]
-	path = .github/actions/action-tmate
-	url = https://github.com/mxschmitt/action-tmate
 [submodule "t/grpc_server_example"]
 	path = t/grpc_server_example
 	url = https://github.com/api7/grpc_server_example


### PR DESCRIPTION
Signed-off-by: leslie <leslie.tsang@icloud.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Use the github action tmate instead of the submodule tmate, as tmate only used in chaos workflow.
There is no need to consider it as a submodule of APISIX.
### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
