### PR TITLE
chore: Bump apisix-build-tools to v2.5.0

### DIFF
--- a/.github/workflows/centos7-ci.yml
+++ b/.github/workflows/centos7-ci.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         export VERSION=${{ steps.branch_env.outputs.version }}
         sudo gem install --no-document fpm
-        git clone -b v2.2.1 https://github.com/api7/apisix-build-tools.git
+        git clone -b v2.5.0 https://github.com/api7/apisix-build-tools.git
 
         # move codes under build tool
         mkdir ./apisix-build-tools/apisix

--- a/utils/linux-install-openresty.sh
+++ b/utils/linux-install-openresty.sh
@@ -26,7 +26,7 @@ sudo apt-get update
 
 if [ "$OPENRESTY_VERSION" == "source" ]; then
     cd ..
-    wget https://raw.githubusercontent.com/api7/apisix-build-tools/v2.4.0/build-apisix-base.sh
+    wget https://raw.githubusercontent.com/api7/apisix-build-tools/v2.5.0/build-apisix-base.sh
     chmod +x build-apisix-base.sh
     ./build-apisix-base.sh latest
 


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is going to bump apisix-build-tools to the latest v2.5.0. This new release fixed a critical bug which would lead to build out the incorrect APISIX rpm package. See the PR https://github.com/api7/apisix-build-tools/pull/125 which fixed the issues: https://github.com/api7/apisix-build-tools/issues/117 and https://github.com/api7/apisix-build-tools/issues/107.

It's noted that the v2.5.0 is backward compatible with v2.2.1 and v2.4.0, so no more changes here.

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
