### PR TITLE
chore: remove legacy code

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -710,10 +710,6 @@ function _M.http_log_phase()
         api_ctx.server_picker.after_balance(api_ctx, false)
     end
 
-    if api_ctx.uri_parse_param then
-        core.tablepool.release("uri_parse_param", api_ctx.uri_parse_param)
-    end
-
     core.ctx.release_vars(api_ctx)
     if api_ctx.plugins then
         core.tablepool.release("plugins", api_ctx.plugins)


### PR DESCRIPTION
api_ctx.uri_parse_param is used when APISIXe still used the r3 router,
this table now no longer exists.

Signed-off-by: tzssangglass <tzssangglass@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
