### PR TITLE
feat: introducing prefer_name attribute in datadog plugin

### DIFF
--- a/apisix/plugins/datadog.lua
+++ b/apisix/plugins/datadog.lua
@@ -92,10 +92,7 @@ local function generate_tag(entry, const_tags)
         core.table.insert(tags, "route_name:" .. entry.route_id)
     end
 
-    if entry.prefer_name and entry.service_name and entry.service_name ~= "" then
-        core.table.insert(tags, "service_name:" .. entry.service_name)
-    elseif entry.service_id and entry.service_id ~= "" then
-        -- if name is nil, fall back to service id (even if prefer name is enabled)
+    if entry.service_id and entry.service_id ~= "" then
         core.table.insert(tags, "service_name:" .. entry.service_id)
     end
 
@@ -150,10 +147,14 @@ function _M.log(conf, ctx)
     entry.route_name = ctx.route_name or ""
     entry.scheme = ctx.upstream_scheme or ""
     entry.prefer_name = conf.prefer_name
+
     -- capture service name at request response cycle if prefer_name is set.
     if entry.prefer_name and entry.service_id and entry.service_id ~= "" then
        local svc = service_fetch(entry.service_id)
-       entry.service_name = svc and svc.value.name or ""
+
+       if svc and svc.value.name ~= "" then
+        entry.service_id =  svc.value.name
+       end
     end
 
     local log_buffer = buffers[conf]

--- a/apisix/plugins/datadog.lua
+++ b/apisix/plugins/datadog.lua
@@ -92,17 +92,11 @@ local function generate_tag(entry, const_tags)
         core.table.insert(tags, "route_name:" .. entry.route_id)
     end
 
-    if entry.service_id and entry.service_id ~= "" then
-        local svc_id = entry.service_id
-
-        if entry.prefer_name then
-            local svc = service_fetch(svc_id)
-            -- if name is nil, fall back to service id (even if prefer name is enabled)
-            if svc and svc.value.name ~= "" then
-                svc_id = svc.value.name
-            end
-        end
-        core.table.insert(tags, "service_name:" .. svc_id)
+    if entry.prefer_name and entry.service_name and entry.service_name ~= "" then
+        core.table.insert(tags, "service_name:" .. entry.service_name)
+    elseif entry.service_id and entry.service_id ~= "" then
+        -- if name is nil, fall back to service id (even if prefer name is enabled)
+        core.table.insert(tags, "service_name:" .. entry.service_id)
     end
 
     if entry.consumer and entry.consumer ~= "" then
@@ -156,6 +150,11 @@ function _M.log(conf, ctx)
     entry.route_name = ctx.route_name or ""
     entry.scheme = ctx.upstream_scheme or ""
     entry.prefer_name = conf.prefer_name
+    -- capture service name at request response cycle if prefer_name is set.
+    if entry.prefer_name and entry.service_id and entry.service_id ~= "" then
+       local svc = service_fetch(entry.service_id)
+       entry.service_name = svc and svc.value.name or ""
+    end
 
     local log_buffer = buffers[conf]
     if log_buffer then

--- a/apisix/plugins/datadog.lua
+++ b/apisix/plugins/datadog.lua
@@ -142,10 +142,9 @@ function _M.log(conf, ctx)
     entry.upstream_latency = ctx.var.upstream_response_time * 1000
     entry.balancer_ip = ctx.balancer_ip or ""
     entry.scheme = ctx.upstream_scheme or ""
-    entry.prefer_name = conf.prefer_name
 
     -- if prefer_name is set, fetch the service/route name. If the name is nil, fall back to id.
-    if entry.prefer_name then
+    if conf.prefer_name then
         if entry.service_id and entry.service_id ~= "" then
             local svc = service_fetch(entry.service_id)
 

--- a/docs/en/latest/plugins/datadog.md
+++ b/docs/en/latest/plugins/datadog.md
@@ -45,12 +45,13 @@ For more info on Batch-Processor in Apache APISIX please refer.
 
 ## Attributes
 
-| Name             | Type   | Requirement  | Default      | Valid | Description                                                                                |
-| -----------      | ------ | -----------  | -------      | ----- | ------------------------------------------------------------                               |
-| batch_max_size   | integer | optional    | 5000         | [1,...] | Max buffer size of each batch                                                            |
-| inactive_timeout | integer | optional    | 5            | [1,...] | Maximum age in seconds when the buffer will be flushed if inactive                       |
-| buffer_duration  | integer | optional    | 60           | [1,...] | Maximum age in seconds of the oldest entry in a batch before the batch must be processed |
-| max_retry_count  | integer | optional    | 1            | [1,...] | Maximum number of retries if one entry fails to reach dogstatsd server                   |
+| Name             | Type   | Requirement  | Default      | Valid       | Description                                                                                |
+| -----------      | ------ | -----------  | -------      | -----       | ------------------------------------------------------------                               |
+| prefer_name      | boolean | optional    | true         | true/false  | If set to `false`, would use route/service id instead of name(default) with metric tags.   |
+| batch_max_size   | integer | optional    | 5000         | [1,...]     | Max buffer size of each batch                                                              |
+| inactive_timeout | integer | optional    | 5            | [1,...]     | Maximum age in seconds when the buffer will be flushed if inactive                         |
+| buffer_duration  | integer | optional    | 60           | [1,...]     | Maximum age in seconds of the oldest entry in a batch before the batch must be processed   |
+| max_retry_count  | integer | optional    | 1            | [1,...]     | Maximum number of retries if one entry fails to reach dogstatsd server                     |
 
 ## Metadata
 
@@ -80,13 +81,12 @@ The metrics will be sent to the DogStatsD agent with the following tags:
 
 > If there is no suitable value for any particular tag, the tag will simply be omitted.
 
-- **route_name**: Name specified in the route schema definition. If not present, it will fall back to the route id value.
-  - Note: If multiple routes have the same name duplicated, we suggest you to visualize graphs on the Datadog dashboard over multiple tags that could compositely pinpoint a particular route/service. If it's still insufficient for your needs, feel free to drop a feature request at [apisix/issues](https://github.com/apache/apisix/issues).
-- **service_id**: If a route has been created with the abstraction of service, the particular service id will be used.
+- **route_name**: Name specified in the route schema definition. If not present or plugin attribute `prefer_name` is set to `false`, it will fall back to the route id value.
+- **service_name**: If a route has been created with the abstraction of service, the particular service name/id (based on plugin `prefer_name` attribute) will be used.
 - **consumer**: If the route has a linked consumer, the consumer Username will be added as a tag.
 - **balancer_ip**: IP of the Upstream balancer that has processed the current request.
 - **response_status**: HTTP response status code.
-- **scheme**: Scheme that has been used to make the request. e.g. HTTP, gRPC, gRPCs etc.
+- **scheme**: Scheme that has been used to make the request, such as HTTP, gRPC, gRPCs etc.
 
 ## How To Enable
 

--- a/t/plugin/datadog.t
+++ b/t/plugin/datadog.t
@@ -396,6 +396,8 @@ message received: apisix\.ingress\.size:[\d]+\|ms\|#source:apisix,new_tag:must,r
 message received: apisix\.egress\.size:[\d]+\|ms\|#source:apisix,new_tag:must,route_name:1,balancer_ip:[\d.]+,response_status:200,scheme:http
 /
 
+
+
 === TEST 8: testing behaviour with service id
 --- config
     location /t {
@@ -474,6 +476,7 @@ message received: apisix\.egress\.size:[\d]+\|ms\|#source:apisix,new_tag:must,ro
 /
 
 
+
 === TEST 9: testing behaviour with prefer_name is false and service name is nil
 --- config
     location /t {
@@ -530,4 +533,3 @@ message received: apisix\.apisix\.latency:[\d.]+\|h\|#source:apisix,new_tag:must
 message received: apisix\.ingress\.size:[\d]+\|ms\|#source:apisix,new_tag:must,route_name:1,service_name:1,balancer_ip:[\d.]+,response_status:200,scheme:http
 message received: apisix\.egress\.size:[\d]+\|ms\|#source:apisix,new_tag:must,route_name:1,service_name:1,balancer_ip:[\d.]+,response_status:200,scheme:http
 /
-


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As discussed offline with @spacewander, this PR adds an additional attribute in plugin schema `prefer_name` to provide the flexibility of choosing route/service id over the name (in case of name conflict/user preference).
### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
