### PR TITLE
change(wolf-rbac): change default port number and add `authType` parameter to documentation

### DIFF
--- a/apisix/plugins/wolf-rbac.lua
+++ b/apisix/plugins/wolf-rbac.lua
@@ -49,7 +49,7 @@ local schema = {
         },
         server = {
             type = "string",
-            default = "http://127.0.0.1:10080"
+            default = "http://127.0.0.1:12180"
         },
         header_prefix = {
             type = "string",

--- a/docs/en/latest/plugins/wolf-rbac.md
+++ b/docs/en/latest/plugins/wolf-rbac.md
@@ -39,7 +39,7 @@ The rbac feature is provided by [wolf](https://github.com/iGeeky/wolf). For more
 
 | Name          | Type   | Requirement | Default                  | Valid | Description                                               |
 | ------------- | ------ | ----------- | ------------------------ | ----- | --------------------------------------------------------- |
-| server        | string | optional    | "http://127.0.0.1:10080" |       | Set the service address of `wolf-server`.                 |
+| server        | string | optional    | "http://127.0.0.1:12180" |       | Set the service address of `wolf-server`.                 |
 | appid         | string | optional    | "unset"                  |       | Set the app id. The app id must be added in wolf-console. |
 | header_prefix | string | optional    | "X-"                     |       | prefix of custom HTTP header. After authentication is successful, three headers will be added to the request header (for backend) and response header (for frontend): `X-UserId`, `X-Username`, `X-Nickname`. |
 
@@ -73,7 +73,7 @@ curl http://127.0.0.1:9080/apisix/admin/consumers  -H 'X-API-KEY: edd1c9f034335f
   "username":"wolf_rbac",
   "plugins":{
     "wolf-rbac":{
-      "server":"http://127.0.0.1:10080",
+      "server":"http://127.0.0.1:12180",
       "appid":"restful"
     }
   },

--- a/docs/en/latest/plugins/wolf-rbac.md
+++ b/docs/en/latest/plugins/wolf-rbac.md
@@ -113,13 +113,14 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f1
 #### Login and get `wolf-rbac` token:
 
 The following `appid`, `username`, and `password` must be real ones in the wolf system.
+`authType` is the authentication type, `1` is password authentication, `2` is `LDAP` authentication. The default is `1`.  `wolf` supports `LDAP` authentication since version 0.5.0
 
 * Login as `POST application/json`
 
 ```shell
 curl http://127.0.0.1:9080/apisix/plugin/wolf-rbac/login -i \
 -H "Content-Type: application/json" \
--d '{"appid": "restful", "username":"test", "password":"user-password"}'
+-d '{"appid": "restful", "username":"test", "password":"user-password", "authType":1}'
 
 HTTP/1.1 200 OK
 Date: Wed, 24 Jul 2019 10:33:31 GMT

--- a/docs/zh/latest/plugins/wolf-rbac.md
+++ b/docs/zh/latest/plugins/wolf-rbac.md
@@ -113,13 +113,14 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f1
 #### 首先进行登录获取 `wolf-rbac` token:
 
 下面的 `appid`, `username`, `password` 必须为 wolf 系统中真实存在的.
+`authType` 为认证类型, `1` 为密码认证, `2` 为 `LDAP` 认证. 默认为 `1`. `wolf` 从 0.5.0 版本开始支持了 `LDAP` 认证.
 
 * 以 POST application/json 方式登陆.
 
 ```shell
 curl http://127.0.0.1:9080/apisix/plugin/wolf-rbac/login -i \
 -H "Content-Type: application/json" \
--d '{"appid": "restful", "username":"test", "password":"user-password"}'
+-d '{"appid": "restful", "username":"test", "password":"user-password", "authType":1}'
 
 HTTP/1.1 200 OK
 Date: Wed, 24 Jul 2019 10:33:31 GMT

--- a/docs/zh/latest/plugins/wolf-rbac.md
+++ b/docs/zh/latest/plugins/wolf-rbac.md
@@ -39,7 +39,7 @@ rbac 功能由[wolf](https://github.com/iGeeky/wolf)提供, 有关 `wolf` 的更
 
 | 名称          | 类型   | 必选项 | 默认值                   | 有效值 | 描述                                                                                                                                               |
 | ------------- | ------ | ------ | ------------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| server        | string | 可选   | "http://127.0.0.1:10080" |        | 设置 `wolf-server` 的访问地址                                                                                                                      |
+| server        | string | 可选   | "http://127.0.0.1:12180" |        | 设置 `wolf-server` 的访问地址                                                                                                                      |
 | appid         | string | 可选   | "unset"                  |        | 设置应用 id, 该应用 id, 需要是在 `wolf-console` 中已经添加的应用 id                                                                                |
 | header_prefix | string | 可选   | "X-"                     |        | 自定义 http 头的前缀。`wolf-rbac`在鉴权成功后, 会在请求头(用于传给后端)及响应头(用于传给前端)中添加 3 个头: `X-UserId`, `X-Username`, `X-Nickname` |
 
@@ -73,7 +73,7 @@ curl http://127.0.0.1:9080/apisix/admin/consumers  -H 'X-API-KEY: edd1c9f034335f
   "username":"wolf_rbac",
   "plugins":{
     "wolf-rbac":{
-      "server":"http://127.0.0.1:10080",
+      "server":"http://127.0.0.1:12180",
       "appid":"restful"
     }
   },

--- a/t/plugin/wolf-rbac.t
+++ b/t/plugin/wolf-rbac.t
@@ -45,7 +45,7 @@ __DATA__
 --- request
 GET /t
 --- response_body_like eval
-qr/\{"appid":"unset","header_prefix":"X-","server":"http:\/\/127\.0\.0\.1:10080"\}/
+qr/\{"appid":"unset","header_prefix":"X-","server":"http:\/\/127\.0\.0\.1:12180"\}/
 --- no_error_log
 [error]
 


### PR DESCRIPTION
### What this PR does / why we need it:

1. `wolf` changed the port to 12180, because the old port 10080 is blocked by chrome browser. So `wolf-rbac` modified the port in the default address.
2. `wolf` supports ldap authentication, so `wolf-rbac` add the corresponding `authType` parameter description.
