### PR TITLE
fix: ignore changes of /apisix/plugins/

### DIFF
--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -275,13 +275,15 @@ function _M.load(config)
         stream_plugin_names = {}
         local plugins_conf = config.value
         -- plugins_conf can be nil when another instance writes into etcd key "/apisix/plugins/"
-        if plugins_conf then
-            for _, conf in ipairs(plugins_conf) do
-                if conf.stream then
-                    core.table.insert(stream_plugin_names, conf.name)
-                else
-                    core.table.insert(http_plugin_names, conf.name)
-                end
+        if not plugins_conf then
+            return local_plugins
+        end
+
+        for _, conf in ipairs(plugins_conf) do
+            if conf.stream then
+                core.table.insert(stream_plugin_names, conf.name)
+            else
+                core.table.insert(http_plugin_names, conf.name)
             end
         end
     end

--- a/t/cli/test_admin.sh
+++ b/t/cli/test_admin.sh
@@ -229,3 +229,114 @@ fi
 make stop
 
 echo "pass: sync /apisix/plugins from etcd when disabling admin successfully"
+
+
+
+# ignore changes to /apisix/plugins/ due to init_etcd
+echo '
+apisix:
+  enable_admin: false
+plugins:
+  - node-status
+nginx_config:
+  error_log_level:  info
+' > conf/config.yaml
+
+rm logs/error.log
+make init
+make run
+
+# first time check node status api
+code=$(curl -v -k -i -m 20 -o /dev/null -s -w %{http_code} http://127.0.0.1:9080/apisix/status)
+if [ ! $code -eq 200 ]; then
+    echo "failed: first time check node status api failed"
+    exit 1
+fi
+
+# mock another instance init etcd dir
+make init
+sleep 1
+
+# second time check node status api
+code=$(curl -v -k -i -m 20 -o /dev/null -s -w %{http_code} http://127.0.0.1:9080/apisix/status)
+if [ ! $code -eq 200 ]; then
+    echo "failed: second time check node status api failed"
+    exit 1
+fi
+
+make stop
+
+echo "pass: ignore changes to /apisix/plugins/ due to init_etcd successfully"
+
+
+# accept changes to /apisix/plugins when enable_admin is false
+echo '
+apisix:
+  enable_admin: false
+plugins:
+  - node-status
+stream_plugins:
+' > conf/config.yaml
+
+rm logs/error.log
+make init
+make run
+
+# first time check node status api
+code=$(curl -v -k -i -m 20 -o /dev/null -s -w %{http_code} http://127.0.0.1:9080/apisix/status)
+if [ ! $code -eq 200 ]; then
+    echo "failed: first time check node status api failed"
+    exit 1
+fi
+
+sleep 0.5
+
+# check http plugins load list
+if ! grep -E 'new plugins: {"node-status":true}' logs/error.log; then
+    echo "failed: first time load http plugins list failed"
+    exit 1
+fi
+
+# check stream plugins(no plugins under stream, it will be added below)
+if ! grep -E 'failed to read stream plugin list from local file' logs/error.log; then
+    echo "failed: first time load stream plugins list failed"
+    exit 1
+fi
+
+# mock another instance add /apisix/plugins
+res=$(etcdctl put "/apisix/plugins" '[{"name":"node-status"},{"name":"example-plugin"},{"stream":true,"name":"mqtt-proxy"}]')
+if [[ $res != "OK" ]]; then
+    echo "failed: first time check node status api failed"
+    exit 1
+fi
+
+sleep 0.5
+
+# second time check node status api
+code=$(curl -v -k -i -m 20 -o /dev/null -s -w %{http_code} http://127.0.0.1:9080/apisix/status)
+if [ ! $code -eq 200 ]; then
+    echo "failed: second time check node status api failed"
+    exit 1
+fi
+
+# check http plugins load list
+if ! grep -E 'new plugins: {"node-status":true}' logs/error.log; then
+    echo "failed: first time load http plugins list failed"
+    exit 1
+fi
+
+# check stream plugins load list
+if ! grep -E 'new plugins: {.*example-plugin' logs/error.log; then
+    echo "failed: first time load stream plugins list failed"
+    exit 1
+fi
+
+
+if grep -E 'new plugins: {}' logs/error.log; then
+    echo "failed: second time load plugins list failed"
+    exit 1
+fi
+
+make stop
+
+echo "pass: ccept changes to /apisix/plugins successfully"

--- a/t/cli/test_admin.sh
+++ b/t/cli/test_admin.sh
@@ -306,7 +306,7 @@ fi
 # mock another instance add /apisix/plugins
 res=$(etcdctl put "/apisix/plugins" '[{"name":"node-status"},{"name":"example-plugin"},{"stream":true,"name":"mqtt-proxy"}]')
 if [[ $res != "OK" ]]; then
-    echo "failed: first time check node status api failed"
+    echo "failed: failed to set /apisix/plugins to add more plugins"
     exit 1
 fi
 
@@ -321,13 +321,13 @@ fi
 
 # check http plugins load list
 if ! grep -E 'new plugins: {"node-status":true}' logs/error.log; then
-    echo "failed: first time load http plugins list failed"
+    echo "failed: second time load http plugins list failed"
     exit 1
 fi
 
 # check stream plugins load list
 if ! grep -E 'new plugins: {.*example-plugin' logs/error.log; then
-    echo "failed: first time load stream plugins list failed"
+    echo "failed: second time load stream plugins list failed"
     exit 1
 fi
 


### PR DESCRIPTION
Signed-off-by: tzssangglass <tzssangglass@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
changes of /apisix/plugins/ in etcd would make chaos with plugin
loading, only the init_etcd phase actually modifies this key, but this
key should be ignored.

<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
