### PR TITLE
ci: fix the broken VERSION env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Create tarball
         if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
         run: |
-          make compress-tar project_version=${{ steps.branch_env.outputs.version }}
+          make compress-tar VERSION=${{ steps.branch_env.outputs.version }}
 
       - name: Remove source code
         if: ${{ startsWith(github.ref, 'refs/heads/release/') }}

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ SHELL := /bin/bash -o pipefail
 
 
 # Project basic setting
+VERSION                ?= master
 project_name           ?= apache-apisix
-project_version        ?= master
 project_compose_ci     ?= ci/pod/docker-compose.yml
-project_release_name   ?= $(project_name)-$(project_version)-src
+project_release_name   ?= $(project_name)-$(VERSION)-src
 
 
 # Hyperconverged Infrastructure
@@ -365,11 +365,13 @@ release-src: compress-tar
 
 .PHONY: compress-tar
 compress-tar:
+	# The $VERSION can be major.minor.patch (from developer)
+	# or major.minor (from the branch name in the CI)
 	$(ENV_TAR) -zcvf $(project_release_name).tgz \
 	./apisix \
 	./bin \
 	./conf \
-	./rockspec/apisix-$(project_version)-*.rockspec \
+	./rockspec/apisix-$(VERSION)*.rockspec \
 	./rockspec/apisix-master-0.rockspec \
 	LICENSE \
 	Makefile \


### PR DESCRIPTION
The env name is changed by accident during the Makefile refactor

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
