### PR TITLE
feat: add gen-vote-content script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,6 +363,7 @@ release-src: compress-tar
 	mv $(project_release_name).tgz release/$(project_release_name).tgz
 	mv $(project_release_name).tgz.asc release/$(project_release_name).tgz.asc
 	mv $(project_release_name).tgz.sha512 release/$(project_release_name).tgz.sha512
+	./utils/gen-vote-contents.sh $(VERSION)
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 

--- a/utils/gen-vote-contents.sh
+++ b/utils/gen-vote-contents.sh
@@ -88,5 +88,5 @@ EOF
 if [ ! -d release ];then
   mkdir release
 fi
-rm -rf ./release/apache-apisix-$VERSION-vote-contents.txt
-printf "$vote_contents" >> ./release/apache-apisix-$VERSION-vote-contents.txt
+
+printf "$vote_contents" > ./release/apache-apisix-$VERSION-vote-contents.txt

--- a/utils/gen-vote-contents.sh
+++ b/utils/gen-vote-contents.sh
@@ -24,7 +24,7 @@ BLOB_VERSION=$SUBSTRING1.$SUBSTRING2
 CHANGELOG_HASH=$(printf $VERSION | sed 's/\.//g')
 
 RELEASE_NOTE_PR="https://github.com/apache/apisix/blob/release/$BLOB_VERSION/CHANGELOG.md#$CHANGELOG_HASH"
-COMMIT_ID=`git rev-parse --short HEAD`
+COMMIT_ID=$(git rev-parse --short HEAD)
 
 vote_contents=$(cat <<EOF
 Hello, Community,

--- a/utils/gen-vote-contents.sh
+++ b/utils/gen-vote-contents.sh
@@ -28,7 +28,7 @@ read -p "Please enter release commit id: " COMMIT_ID
 vote_contents=$(cat <<EOF
 Hello, Community,
 
-This is a call for the vote to release Apache APISIX version 
+This is a call for the vote to release Apache APISIX version
 
 Release notes:
 

--- a/utils/gen-vote-contents.sh
+++ b/utils/gen-vote-contents.sh
@@ -21,9 +21,10 @@ VERSION=$1
 SUBSTRING1=$(echo $VERSION| cut -d'.' -f 1)
 SUBSTRING2=$(echo $VERSION| cut -d'.' -f 2)
 BLOB_VERSION=$SUBSTRING1.$SUBSTRING2
+CHANGELOG_HASH=$(printf $VERSION | sed 's/\.//g')
 
-read -p "Please enter release note pr: " RELEASE_NOTE_PR
-read -p "Please enter release commit id: " COMMIT_ID
+RELEASE_NOTE_PR="https://github.com/apache/apisix/blob/release/$BLOB_VERSION/CHANGELOG.md#$CHANGELOG_HASH"
+COMMIT_ID=`git rev-parse --short HEAD`
 
 vote_contents=$(cat <<EOF
 Hello, Community,

--- a/utils/gen-vote-contents.sh
+++ b/utils/gen-vote-contents.sh
@@ -17,69 +17,76 @@
 # limitations under the License.
 #
 VERSION=$1
+
+SUBSTRING1=$(echo $VERSION| cut -d'.' -f 1)
+SUBSTRING2=$(echo $VERSION| cut -d'.' -f 2)
+BLOB_VERSION=$SUBSTRING1.$SUBSTRING2
+
 read -p "Please enter release note pr: " RELEASE_NOTE_PR
-read -p "Please enter commit id: " COMMIT_ID
+read -p "Please enter release commit id: " COMMIT_ID
 
-vote_contents="\n
-Hello, Community,\n
+vote_contents=$(cat <<EOF
+Hello, Community,
 
-This is a call for the vote to release Apache APISIX version $VERSION\n\n
+This is a call for the vote to release Apache APISIX version 
 
-Release notes:\n\n
+Release notes:
 
-$RELEASE_NOTE_PR\n\n
+$RELEASE_NOTE_PR
 
-The release candidates:\n\n
+The release candidates:
 
-https://dist.apache.org/repos/dist/dev/apisix/$VERSION/\n\n
+https://dist.apache.org/repos/dist/dev/apisix/$VERSION/
 
-Release Commit ID:\n\n
+Release Commit ID:
 
-https://github.com/apache/apisix/commit/$COMMIT_ID\n\n
+https://github.com/apache/apisix/commit/$COMMIT_ID
 
-Keys to verify the Release Candidate:\n\n
+Keys to verify the Release Candidate:
 
-https://dist.apache.org/repos/dist/dev/apisix/KEYS\n\n
+https://dist.apache.org/repos/dist/dev/apisix/KEYS
 
-Steps to validating the release:\n\n
+Steps to validating the release:
 
-1. Download the release\n\n
+1. Download the release
 
-wget https://dist.apache.org/repos/dist/dev/apisix/$VERSION/apache-apisix-$VERSION-src.tgz\n\n
+wget https://dist.apache.org/repos/dist/dev/apisix/$VERSION/apache-apisix-$VERSION-src.tgz
 
 2. Checksums and signatures
 
-wget https://dist.apache.org/repos/dist/dev/apisix/KEYS\n\n
+wget https://dist.apache.org/repos/dist/dev/apisix/KEYS
 
-wget https://dist.apache.org/repos/dist/dev/apisix/$VERSION/apache-apisix-$VERSION-src.tgz.asc\n\n
+wget https://dist.apache.org/repos/dist/dev/apisix/$VERSION/apache-apisix-$VERSION-src.tgz.asc
 
-wget https://dist.apache.org/repos/dist/dev/apisix/$VERSION/apache-apisix-$VERSION-src.tgz.sha512\n\n
+wget https://dist.apache.org/repos/dist/dev/apisix/$VERSION/apache-apisix-$VERSION-src.tgz.sha512
 
-gpg --import KEYS\n\n
+gpg --import KEYS
 
-shasum -c apache-apisix-$VERSION-src.tgz.sha512\n\n
+shasum -c apache-apisix-$VERSION-src.tgz.sha512
 
-gpg --verify apache-apisix-$VERSION-src.tgz.asc apache-apisix-$VERSION-src.tgz\n\n
+gpg --verify apache-apisix-$VERSION-src.tgz.asc apache-apisix-$VERSION-src.tgz
 
-3. Unzip and Check files\n\n
+3. Unzip and Check files
 
-tar zxvf apache-apisix-$VERSION-src.tgz\n\n
+tar zxvf apache-apisix-$VERSION-src.tgz
 
-4. Build Apache APISIX:\n\n
+4. Build Apache APISIX:
 
-https://github.com/apache/apisix/blob/release/$VERSION/docs/en/latest/how-to-build.md#installation-via-source-release-package\n\n
+https://github.com/apache/apisix/blob/release/$BLOB_VERSION/docs/en/latest/how-to-build.md#installation-via-source-release-package
 
 The vote will be open for at least 72 hours or until necessary number of
-votes are reached.\n\n
+votes are reached.
 
-Please vote accordingly:\n\n
+Please vote accordingly:
 
-[ ] +1 approve\n
-[ ] +0 no opinion\n
-[ ] -1 disapprove with the reason"
+[ ] +1 approve
+[ ] +0 no opinion
+[ ] -1 disapprove with the reason
+EOF
+)
 
 if [ ! -d release ];then
   mkdir release
 fi
-rm -rf ./release/vote-contents.txt
-echo $vote_contents >> ./release/apache-apisix-$VERSION-vote-contents.txt
+rm -rf ./release/apache-apisix-$VERSION-vote-contents.txt
+printf "$vote_contents" >> ./release/apache-apisix-$VERSION-vote-contents.txt

--- a/utils/gen-vote-contents.sh
+++ b/utils/gen-vote-contents.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+VERSION=$1
+read -p "Please enter release note pr: " RELEASE_NOTE_PR
+read -p "Please enter commit id: " COMMIT_ID
+
+vote_contents="\n
+Hello, Community,\n
+
+This is a call for the vote to release Apache APISIX version $VERSION\n\n
+
+Release notes:\n\n
+
+$RELEASE_NOTE_PR\n\n
+
+The release candidates:\n\n
+
+https://dist.apache.org/repos/dist/dev/apisix/$VERSION/\n\n
+
+Release Commit ID:\n\n
+
+https://github.com/apache/apisix/commit/$COMMIT_ID\n\n
+
+Keys to verify the Release Candidate:\n\n
+
+https://dist.apache.org/repos/dist/dev/apisix/KEYS\n\n
+
+Steps to validating the release:\n\n
+
+1. Download the release\n\n
+
+wget https://dist.apache.org/repos/dist/dev/apisix/$VERSION/apache-apisix-$VERSION-src.tgz\n\n
+
+2. Checksums and signatures
+
+wget https://dist.apache.org/repos/dist/dev/apisix/KEYS\n\n
+
+wget https://dist.apache.org/repos/dist/dev/apisix/$VERSION/apache-apisix-$VERSION-src.tgz.asc\n\n
+
+wget https://dist.apache.org/repos/dist/dev/apisix/$VERSION/apache-apisix-$VERSION-src.tgz.sha512\n\n
+
+gpg --import KEYS\n\n
+
+shasum -c apache-apisix-$VERSION-src.tgz.sha512\n\n
+
+gpg --verify apache-apisix-$VERSION-src.tgz.asc apache-apisix-$VERSION-src.tgz\n\n
+
+3. Unzip and Check files\n\n
+
+tar zxvf apache-apisix-$VERSION-src.tgz\n\n
+
+4. Build Apache APISIX:\n\n
+
+https://github.com/apache/apisix/blob/release/$VERSION/docs/en/latest/how-to-build.md#installation-via-source-release-package\n\n
+
+The vote will be open for at least 72 hours or until necessary number of
+votes are reached.\n\n
+
+Please vote accordingly:\n\n
+
+[ ] +1 approve\n
+[ ] +0 no opinion\n
+[ ] -1 disapprove with the reason"
+
+if [ ! -d release ];then
+  mkdir release
+fi
+rm -rf ./release/vote-contents.txt
+echo $vote_contents >> ./release/apache-apisix-$VERSION-vote-contents.txt


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
When there is a new version ready to be released and need to vote on the mailing list, the information of the email content sometimes will be wrong, in order to reduce the probability of the wrong content of the email, I wrote a small script to automatically generate the email content, you can go directly to the release directory after the execution of VERSION=x.y.z make release-src and paste the automatically generated content to initiate a mailing list poll

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
