### PR TITLE
feat(google-cloud-logging): set token type based on the Oauth response

### DIFF
--- a/apisix/plugins/google-cloud-logging.lua
+++ b/apisix/plugins/google-cloud-logging.lua
@@ -155,7 +155,7 @@ local function send_to_google(oauth, entries)
         }),
         headers = {
             ["Content-Type"] = "application/json",
-            ["Authorization"] = "Bearer " .. access_token,
+            ["Authorization"] = (oauth.access_token_type or "Bearer") .. " " .. access_token,
         },
     })
 

--- a/apisix/plugins/google-cloud-logging/oauth.lua
+++ b/apisix/plugins/google-cloud-logging/oauth.lua
@@ -74,8 +74,9 @@ function _M:refresh_access_token()
         return
     end
 
-    self.access_token_expire_time = get_timestamp() + res.expires_in
     self.access_token = res.access_token
+    self.access_token_type = res.token_type
+    self.access_token_expire_time = get_timestamp() + res.expires_in
 end
 
 
@@ -106,6 +107,7 @@ function _M:new(config)
         auth_uri = config.auth_uri or "https://accounts.google.com/o/oauth2/auth",
         entries_uri = config.entries_uri or "https://logging.googleapis.com/v2/entries:write",
         access_token = nil,
+        access_token_type = nil,
         access_token_expire_time = 0,
     }
 

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -497,7 +497,7 @@ function _M.google_logging_entries()
         ngx.say(json_encode({ error = "authentication header not exists" }))
         return
     end
-    
+
     token = string.sub(token, string.len(args_token_type) + 2)
     local verify = jwt:verify(rsa_public_key, token)
     if not verify.verified then
@@ -514,7 +514,7 @@ function _M.google_logging_entries()
         return
     end
 
-    local expire_time =  (verify.payload.exp or ngx.time()) - ngx.time()
+    local expire_time = (verify.payload.exp or ngx.time()) - ngx.time()
     if expire_time <= 0 then
         ngx.status = 403
         ngx.say(json_encode({ error = "token has expired" }))

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -444,6 +444,8 @@ function _M._well_known_openid_configuration()
 end
 
 function _M.google_logging_token()
+    local args = ngx.req.get_uri_args()
+    local args_token_type = args.token_type or "Bearer"
     ngx.req.read_body()
     local data = ngx.decode_args(ngx.req.get_body_data())
     local jwt = require("resty.jwt")
@@ -476,11 +478,13 @@ function _M.google_logging_token()
     ngx.say(json_encode({
         access_token = jwt_token,
         expires_in = expire_time,
-        token_type = "Bearer"
+        token_type = args_token_type
     }))
 end
 
 function _M.google_logging_entries()
+    local args = ngx.req.get_uri_args()
+    local args_token_type = args.token_type or "Bearer"
     ngx.req.read_body()
     local data = ngx.req.get_body_data()
     local jwt = require("resty.jwt")
@@ -493,8 +497,8 @@ function _M.google_logging_entries()
         ngx.say(json_encode({ error = "authentication header not exists" }))
         return
     end
-
-    token = string.sub(token, string.len("Bearer") + 2)
+    
+    token = string.sub(token, string.len(args_token_type) + 2)
     local verify = jwt:verify(rsa_public_key, token)
     if not verify.verified then
         ngx.status = 401

--- a/t/plugin/google-cloud-logging.t
+++ b/t/plugin/google-cloud-logging.t
@@ -376,3 +376,136 @@ GET /hello
 --- wait: 2
 --- response_body
 hello world
+
+
+
+=== TEST 12: set route (customize auth type)
+--- config
+    location /t {
+        content_by_lua_block {
+            local config = {
+                uri = "/hello",
+                upstream = {
+                    type = "roundrobin",
+                    nodes = {
+                        ["127.0.0.1:1980"] = 1
+                    }
+                },
+                plugins = {
+                    ["google-cloud-logging"] = {
+                        auth_config = {
+                            private_key = [[
+-----BEGIN RSA PRIVATE KEY-----
+MIIBOgIBAAJBAKebDxlvQMGyEesAL1r1nIJBkSdqu3Hr7noq/0ukiZqVQLSJPMOv
+0oxQSutvvK3hoibwGakDOza+xRITB7cs2cECAwEAAQJAYPWh6YvjwWobVYC45Hz7
++pqlt1DWeVQMlN407HSWKjdH548ady46xiQuZ5Cfx3YyCcnsfVWaQNbC+jFbY4YL
+wQIhANfASwz8+2sKg1xtvzyaChX5S5XaQTB+azFImBJumixZAiEAxt93Td6JH1RF
+IeQmD/K+DClZMqSrliUzUqJnCPCzy6kCIAekDsRh/UF4ONjAJkKuLedDUfL3rNFb
+2M4BBSm58wnZAiEAwYLMOg8h6kQ7iMDRcI9I8diCHM8yz0SfbfbsvzxIFxECICXs
+YvIufaZvBa8f+E/9CANlVhm5wKAyM8N8GJsiCyEG
+-----END RSA PRIVATE KEY-----]],
+                            project_id = "apisix",
+                            token_uri = "http://127.0.0.1:1980/google/logging/token?token_type=Basic",
+                            scopes = {
+                                "https://apisix.apache.org/logs:admin"
+                            },
+                            entries_uri = "http://127.0.0.1:1980/google/logging/entries?token_type=Basic",
+                        },
+                        inactive_timeout = 1,
+                        batch_max_size = 1,
+                    }
+                }
+            }
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, config)
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 13: test route(customize auth type)
+--- request
+GET /hello
+--- wait: 2
+--- response_body
+hello world
+
+
+
+=== TEST 14: set route (customize auth type error)
+--- config
+    location /t {
+        content_by_lua_block {
+            local config = {
+                uri = "/hello",
+                upstream = {
+                    type = "roundrobin",
+                    nodes = {
+                        ["127.0.0.1:1980"] = 1
+                    }
+                },
+                plugins = {
+                    ["google-cloud-logging"] = {
+                        auth_config = {
+                            private_key = [[
+-----BEGIN RSA PRIVATE KEY-----
+MIIBOgIBAAJBAKebDxlvQMGyEesAL1r1nIJBkSdqu3Hr7noq/0ukiZqVQLSJPMOv
+0oxQSutvvK3hoibwGakDOza+xRITB7cs2cECAwEAAQJAYPWh6YvjwWobVYC45Hz7
++pqlt1DWeVQMlN407HSWKjdH548ady46xiQuZ5Cfx3YyCcnsfVWaQNbC+jFbY4YL
+wQIhANfASwz8+2sKg1xtvzyaChX5S5XaQTB+azFImBJumixZAiEAxt93Td6JH1RF
+IeQmD/K+DClZMqSrliUzUqJnCPCzy6kCIAekDsRh/UF4ONjAJkKuLedDUfL3rNFb
+2M4BBSm58wnZAiEAwYLMOg8h6kQ7iMDRcI9I8diCHM8yz0SfbfbsvzxIFxECICXs
+YvIufaZvBa8f+E/9CANlVhm5wKAyM8N8GJsiCyEG
+-----END RSA PRIVATE KEY-----]],
+                            project_id = "apisix",
+                            token_uri = "http://127.0.0.1:1980/google/logging/token?token_type=Basic",
+                            scopes = {
+                                "https://apisix.apache.org/logs:admin"
+                            },
+                            entries_uri = "http://127.0.0.1:1980/google/logging/entries",
+                        },
+                        inactive_timeout = 1,
+                        batch_max_size = 1,
+                    }
+                }
+            }
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, config)
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 15: test route(customize auth type error)
+--- request
+GET /hello
+--- wait: 2
+--- response_body
+hello world
+--- grep_error_log eval
+qr/\{\"error\"\:\"[\w+\s+]*\"\}/
+--- grep_error_log_out
+{"error":"identity authentication failed"}
+--- error_log
+Batch Processor[google-cloud-logging] failed to process entries
+Batch Processor[google-cloud-logging] exceeded the max_retry_count


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Set the type and token of the write log according to the token type in the Google Oauth response.
https://developers.google.com/identity/protocols/oauth2/openid-connect#exchangecode

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
