### PR TITLE
feat: support resolve default value when environment not set

### DIFF
--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -70,7 +70,7 @@ local function resolve_conf_var(conf)
                 local default
                 if i and j then
                     default = string.sub(var, i+1, j)
-                    var = string.sub(var, 1, i)
+                    var = string.sub(var, 1, i-1)
                 end
 
                 local v = getenv(var) or default

--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -65,8 +65,15 @@ local function resolve_conf_var(conf)
             local var_used = false
             -- we use '${{var}}' because '$var' and '${var}' are taken
             -- by Nginx
-            local new_val = val:gsub("%$%{%{%s*([%w_]+)%s*%}%}", function(var)
-                local v = getenv(var)
+            local new_val = val:gsub("%$%{%{%s*([%w_]+[%:%w+]*)%s*%}%}", function(var)
+                local i, j = string.find(var, "%:%w+")
+                local default
+                if i and j then
+                    default = string.sub(var, i+1, j)
+                    var = string.sub(var, 1, i)
+                end
+
+                local v = getenv(var) or default
                 if v then
                     if not exported_vars then
                         exported_vars = {}

--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -65,11 +65,11 @@ local function resolve_conf_var(conf)
             local var_used = false
             -- we use '${{var}}' because '$var' and '${var}' are taken
             -- by Nginx
-            local new_val = val:gsub("%$%{%{%s*([%w_]+[%:%w+]*)%s*%}%}", function(var)
-                local i, j = var:find("%:%w+")
+            local new_val = val:gsub("%$%{%{%s*([%w_]+[%:%:[%w%-%.%:%?%/=]+]?)%s*%}%}", function(var)
+                local i, j = var:find("%:%:[%w%-%.%:%?%/=]*")
                 local default
                 if i and j then
-                    default = var:sub(i + 1, j)
+                    default = var:sub(i + 2, j)
                     var = var:sub(1, i - 1)
                 end
 

--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -66,11 +66,11 @@ local function resolve_conf_var(conf)
             -- we use '${{var}}' because '$var' and '${var}' are taken
             -- by Nginx
             local new_val = val:gsub("%$%{%{%s*([%w_]+[%:%w+]*)%s*%}%}", function(var)
-                local i, j = string.find(var, "%:%w+")
+                local i, j = var:find("%:%w+")
                 local default
                 if i and j then
-                    default = string.sub(var, i+1, j)
-                    var = string.sub(var, 1, i-1)
+                    default = var:sub(i + 1, j)
+                    var = var:sub(1, i - 1)
                 end
 
                 local v = getenv(var) or default

--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -66,7 +66,7 @@ local function resolve_conf_var(conf)
             -- we use '${{var}}' because '$var' and '${var}' are taken
             -- by Nginx
             local new_val = val:gsub("%$%{%{%s*([%w_]+[%:%:[%w%-%.%:%?%/=]+]?)%s*%}%}", function(var)
-                local i, j = var:find("%:%:[%w%-%.%:%?%/=]*")
+                local i, j = var:find("%:%:[%w%-%.%:%?%/=]+")
                 local default
                 if i and j then
                     default = var:sub(i + 2, j)

--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -65,11 +65,12 @@ local function resolve_conf_var(conf)
             local var_used = false
             -- we use '${{var}}' because '$var' and '${var}' are taken
             -- by Nginx
-            local new_val = val:gsub("%$%{%{%s*([%w_]+[%:%:[%w%-%.%:%?%/=]+]?)%s*%}%}", function(var)
-                local i, j = var:find("%:%:[%w%-%.%:%?%/=]+")
+            local new_val = val:gsub("%$%{%{%s*([%w_]+[%:%=]?.-)%s*%}%}", function(var)
+                local i, j = var:find("%:%=")
                 local default
                 if i and j then
-                    default = var:sub(i + 2, j)
+                    default = var:sub(i + 2, #var)
+                    default = default:gsub('^%s*(.-)%s*$', '%1')
                     var = var:sub(1, i - 1)
                 end
 

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -30,6 +30,16 @@
 # And then run `export ETCD_HOST=$your_host` before `make init`.
 #
 # If the configured environment variable can't be found, an error will be thrown.
+#
+# Also, If you want to use default value when using environment variable not set,
+# Use `${{VAR:default_value}}` instead. For instance:
+#
+# etcd:
+#     host:
+#       - http://${{ETCD_HOST:localhost}}:2379
+#
+# This will find environment variable `ETCD_HOST` first, and if it's not exist it will use `localhost` as default value.
+#
 apisix:
   admin_key:
     - name: admin

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -31,7 +31,7 @@
 #
 # If the configured environment variable can't be found, an error will be thrown.
 #
-# Also, If you want to use default value when using environment variable not set,
+# Also, If you want to use default value when the environment variable not set,
 # Use `${{VAR:default_value}}` instead. For instance:
 #
 # etcd:

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -32,11 +32,11 @@
 # If the configured environment variable can't be found, an error will be thrown.
 #
 # Also, If you want to use default value when the environment variable not set,
-# Use `${{VAR:default_value}}` instead. For instance:
+# Use `${{VAR::default_value}}` instead. For instance:
 #
 # etcd:
 #     host:
-#       - http://${{ETCD_HOST:localhost}}:2379
+#       - http://${{ETCD_HOST::localhost}}:2379
 #
 # This will find environment variable `ETCD_HOST` first, and if it's not exist it will use `localhost` as default value.
 #

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -32,11 +32,11 @@
 # If the configured environment variable can't be found, an error will be thrown.
 #
 # Also, If you want to use default value when the environment variable not set,
-# Use `${{VAR::default_value}}` instead. For instance:
+# Use `${{VAR:=default_value}}` instead. For instance:
 #
 # etcd:
 #     host:
-#       - http://${{ETCD_HOST::localhost}}:2379
+#       - http://${{ETCD_HOST:=localhost}}:2379
 #
 # This will find environment variable `ETCD_HOST` first, and if it's not exist it will use `localhost` as default value.
 #

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -265,34 +265,6 @@ if ! grep "env ETCD_HOST=127.0.0.1;" conf/nginx.conf > /dev/null; then
     exit 1
 fi
 
-# support default value when environment not set
-echo '
-etcd:
-    host:
-        - "http://${{ETCD_HOST:192.168.1.1}}:${{ETCD_PORT}}"
-' > conf/config.yaml
-
-ETCD_PORT=2379 make init
-
-if ! grep "env ETCD_HOST=192.168.1.1;" conf/nginx.conf > /dev/null; then
-    echo "failed: support environment variables in local_conf"
-    exit 1
-fi
-
-# support default value when environment not set
-echo '
-etcd:
-    host:
-        - "http://${{ETCD_HOST:192.168.1.1}}:${{ETCD_PORT}}"
-' > conf/config.yaml
-
-ETCD_HOST=127.0.0.1 ETCD_PORT=2379 make init
-
-if ! grep "env ETCD_HOST=127.0.0.1;" conf/nginx.conf > /dev/null; then
-    echo "failed: support environment variables in local_conf"
-    exit 1
-fi
-
 # don't override user's envs configuration
 echo '
 etcd:
@@ -337,6 +309,35 @@ if ! grep "env ETCD_HOST=1.1.1.1;" conf/nginx.conf > /dev/null; then
 fi
 
 echo "pass: support environment variables in local_conf"
+
+# support default value when environment not set
+echo '
+etcd:
+    host:
+        - "http://${{ETCD_HOST:192.168.1.1}}:${{ETCD_PORT}}"
+' > conf/config.yaml
+
+ETCD_PORT=2379 make init
+
+if ! grep "env ETCD_HOST=192.168.1.1;" conf/nginx.conf > /dev/null; then
+    echo "failed: support default value when environment not set"
+    exit 1
+fi
+
+echo '
+etcd:
+    host:
+        - "http://${{ETCD_HOST:192.168.1.1}}:${{ETCD_PORT}}"
+' > conf/config.yaml
+
+ETCD_HOST=127.0.0.1 ETCD_PORT=2379 make init
+
+if ! grep "env ETCD_HOST=127.0.0.1;" conf/nginx.conf > /dev/null; then
+    echo "failed: support default value when environment not set"
+    exit 1
+fi
+
+echo "pass: support default value when environment not set"
 
 # support merging worker_processes
 echo '

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -310,10 +310,10 @@ fi
 
 echo "pass: support environment variables in local_conf"
 
-# should use default value when environment not set
+# support default value when environment not set
 echo '
 tests:
-    key: ${{TEST_ENV::1.1.1.1}}
+    key: ${{TEST_ENV:=1.1.1.1}}
 ' > conf/config.yaml
 
 make init
@@ -325,7 +325,7 @@ fi
 
 echo '
 tests:
-    key: ${{TEST_ENV::very-long-domain-with-many-symbols.absolutely-non-exists-123ss.com:1234/path?param1=value1}}
+    key: ${{TEST_ENV:=very-long-domain-with-many-symbols.absolutely-non-exists-123ss.com:1234/path?param1=value1}}
 ' > conf/config.yaml
 
 make init
@@ -337,17 +337,17 @@ fi
 
 echo '
 tests:
-    key: ${{TEST_ENV::192.168.1.1}}
+    key: ${{TEST_ENV:=192.168.1.1}}
 ' > conf/config.yaml
 
 TEST_ENV=127.0.0.1 make init
 
 if ! grep "env TEST_ENV=127.0.0.1;" conf/nginx.conf > /dev/null; then
-    echo "failed: should use default value when environment not set"
+    echo "failed: should use environment variable when environment is set"
     exit 1
 fi
 
-echo "pass: should use default value when environment not set"
+echo "pass: support default value when environment not set"
 
 # support merging worker_processes
 echo '

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -312,27 +312,37 @@ echo "pass: support environment variables in local_conf"
 
 # should use default value when environment not set
 echo '
-etcd:
-    host:
-        - "http://${{ETCD_HOST:192.168.1.1}}:${{ETCD_PORT}}"
+tests:
+    key: ${{TEST_ENV::1.1.1.1}}
 ' > conf/config.yaml
 
-ETCD_PORT=2379 make init
+make init
 
-if ! grep "env ETCD_HOST=192.168.1.1;" conf/nginx.conf > /dev/null; then
+if ! grep "env TEST_ENV=1.1.1.1;" conf/nginx.conf > /dev/null; then
     echo "failed: should use default value when environment not set"
     exit 1
 fi
 
 echo '
-etcd:
-    host:
-        - "http://${{ETCD_HOST:192.168.1.1}}:${{ETCD_PORT}}"
+tests:
+    key: ${{TEST_ENV::very-long-domain-with-many-symbols.absolutely-non-exists-123ss.com:1234/path?param1=value1}}
 ' > conf/config.yaml
 
-ETCD_HOST=127.0.0.1 ETCD_PORT=2379 make init
+make init
 
-if ! grep "env ETCD_HOST=127.0.0.1;" conf/nginx.conf > /dev/null; then
+if ! grep "env TEST_ENV=very-long-domain-with-many-symbols.absolutely-non-exists-123ss.com:1234/path?param1=value1;" conf/nginx.conf > /dev/null; then
+    echo "failed: should use default value when environment not set"
+    exit 1
+fi
+
+echo '
+tests:
+    key: ${{TEST_ENV::192.168.1.1}}
+' > conf/config.yaml
+
+TEST_ENV=127.0.0.1 make init
+
+if ! grep "env TEST_ENV=127.0.0.1;" conf/nginx.conf > /dev/null; then
     echo "failed: should use default value when environment not set"
     exit 1
 fi

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -265,6 +265,34 @@ if ! grep "env ETCD_HOST=127.0.0.1;" conf/nginx.conf > /dev/null; then
     exit 1
 fi
 
+# support default value when environment not set
+echo '
+etcd:
+    host:
+        - "http://${{ETCD_HOST:192.168.1.1}}:${{ETCD_PORT}}"
+' > conf/config.yaml
+
+ETCD_PORT=2379 make init
+
+if ! grep "env ETCD_HOST=192.168.1.1;" conf/nginx.conf > /dev/null; then
+    echo "failed: support environment variables in local_conf"
+    exit 1
+fi
+
+# support default value when environment not set
+echo '
+etcd:
+    host:
+        - "http://${{ETCD_HOST:192.168.1.1}}:${{ETCD_PORT}}"
+' > conf/config.yaml
+
+ETCD_HOST=127.0.0.1 ETCD_PORT=2379 make init
+
+if ! grep "env ETCD_HOST=127.0.0.1;" conf/nginx.conf > /dev/null; then
+    echo "failed: support environment variables in local_conf"
+    exit 1
+fi
+
 # don't override user's envs configuration
 echo '
 etcd:

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -310,7 +310,7 @@ fi
 
 echo "pass: support environment variables in local_conf"
 
-# support default value when environment not set
+# should use default value when environment not set
 echo '
 etcd:
     host:
@@ -320,7 +320,7 @@ etcd:
 ETCD_PORT=2379 make init
 
 if ! grep "env ETCD_HOST=192.168.1.1;" conf/nginx.conf > /dev/null; then
-    echo "failed: support default value when environment not set"
+    echo "failed: should use default value when environment not set"
     exit 1
 fi
 
@@ -333,11 +333,11 @@ etcd:
 ETCD_HOST=127.0.0.1 ETCD_PORT=2379 make init
 
 if ! grep "env ETCD_HOST=127.0.0.1;" conf/nginx.conf > /dev/null; then
-    echo "failed: support default value when environment not set"
+    echo "failed: should use default value when environment not set"
     exit 1
 fi
 
-echo "pass: support default value when environment not set"
+echo "pass: should use default value when environment not set"
 
 # support merging worker_processes
 echo '


### PR DESCRIPTION
Thanks for review my first pull request for apisix.
And this is my first time use lua. Give me some advices if possible, thanks.

This is about read default value when ENV not set, I think this may helpful when using k8s in different environment and did not want to set so many ENV variable

result:
etcd.host = http://${{ETCD_HOST}}:2379

![image](https://user-images.githubusercontent.com/31196226/144431185-3a7593c4-18c8-422e-94ba-ae1c537bc452.png)

etcd.host = http://${{ETCD_HOST:123ss}}:2379
![image](https://user-images.githubusercontent.com/31196226/144431261-8351f67e-ce36-4ef7-8556-3fa2b9d203b2.png)

etcd.host = http://${{ETCD_HOST:123ss:123aa}}:2379
![image](https://user-images.githubusercontent.com/31196226/144431359-5bd4a789-45d6-4d4b-afb7-edbb773490cc.png)

