### PR TITLE
test: we don't need to check the response of http://apisix.apache.org

### DIFF
--- a/t/misc/patch.t
+++ b/t/misc/patch.t
@@ -144,13 +144,13 @@ apisix:
                 ngx.log(ngx.ERR, err)
                 return
             end
-            ngx.say(res.status)
+            ngx.say("ok")
         }
     }
 --- request
 GET /t
 --- response_body
-200
+ok
 
 
 
@@ -176,11 +176,11 @@ apisix:
             ngx.log(ngx.ERR, err)
             return ngx.exit(-1)
         end
-        sock:send(res.status)
+        sock:send("ok")
     }
 --- stream_request eval
 m
---- stream_response: 200
+--- stream_response: ok
 --- no_error_log
 [error]
 


### PR DESCRIPTION
Once we can connect it, we know the address is resolved by ourselves.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
