### PR TITLE
test: fix http status code

### DIFF
--- a/t/misc/patch.t
+++ b/t/misc/patch.t
@@ -139,7 +139,7 @@ apisix:
         content_by_lua_block {
             local http = require("resty.http")
             local httpc = http.new()
-            local res, err = httpc:request_uri("http://apisix", {headers={Host="apisix.apache.org"}})
+            local res, err = httpc:request_uri("https://apisix", {headers={Host="apisix.apache.org"}})
             if not res then
                 ngx.log(ngx.ERR, err)
                 return
@@ -171,7 +171,7 @@ apisix:
         end
         local http = require("resty.http")
         local httpc = http.new()
-        local res, err = httpc:request_uri("http://apisix", {headers={Host="apisix.apache.org"}})
+        local res, err = httpc:request_uri("https://apisix", {headers={Host="apisix.apache.org"}})
         if not res then
             ngx.log(ngx.ERR, err)
             return ngx.exit(-1)


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
CI is breaking, fix the HTTP 200 status code for HTTP scheme (quite obvious, hitting HTTP  scheme redirects that to HTTPS domain).

```
$ curl -i http://apisix.apache.org       
HTTP/1.1 301 Moved Permanently
Server: Varnish
Retry-After: 0
Location: https://apisix.apache.org/
Content-Length: 0
Accept-Ranges: bytes
Date: Mon, 06 Dec 2021 03:41:47 GMT
Via: 1.1 varnish
Connection: close
X-Served-By: cache-del21738-DEL
X-Cache: HIT
X-Cache-Hits: 0
X-Timer: S1638762108.739976,VS0,VE0
Strict-Transport-Security: max-age=300

```
see 
https://github.com/apache/apisix/runs/4421210670?check_suite_focus=true#step:14:835
https://github.com/apache/apisix/runs/4411923874?check_suite_focus=true#step:10:716
### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
