### PR TITLE
feat(consumer-restriction):  customize rejected_msg

### DIFF
--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -51,7 +51,8 @@ local schema = {
                 }
             }
         },
-        rejected_code = {type = "integer", minimum = 200, default = 403}
+        rejected_code = {type = "integer", minimum = 200, default = 403},
+        reject_message = {type = "string"}
     },
     anyOf = {
         {required = {"blacklist"}},
@@ -105,7 +106,11 @@ local function is_method_allowed(allowed_methods, method, user)
 end
 
 local function reject(conf)
-    return conf.rejected_code, { message = "The " .. conf.type .. " is forbidden." }
+    local reject_message = "The " .. conf.type .. " is forbidden." ;
+    if conf.reject_message then
+        reject_message = conf.reject_message;
+    end
+    return conf.rejected_code, { message = reject_message }
 end
 
 function _M.check_schema(conf)

--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -52,7 +52,7 @@ local schema = {
             }
         },
         rejected_code = {type = "integer", minimum = 200, default = 403},
-        reject_message = {type = "string"}
+        rejected_message = {type = "string"}
     },
     anyOf = {
         {required = {"blacklist"}},
@@ -106,8 +106,8 @@ local function is_method_allowed(allowed_methods, method, user)
 end
 
 local function reject(conf)
-    if conf.reject_message then
-        return conf.rejected_code , { message = conf.reject_message }
+    if conf.rejected_message then
+        return conf.rejected_code , { message = conf.rejected_message }
     end
     return conf.rejected_code , { message = "The " .. conf.type .. " is forbidden."}
 end

--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -106,11 +106,10 @@ local function is_method_allowed(allowed_methods, method, user)
 end
 
 local function reject(conf)
-    local reject_message = "The " .. conf.type .. " is forbidden." ;
     if conf.reject_message then
-        reject_message = conf.reject_message;
+        return conf.rejected_code , { message = conf.reject_message }
     end
-    return conf.rejected_code, { message = reject_message }
+    return conf.rejected_code , { message = "The " .. conf.type .. " is forbidden."}
 end
 
 function _M.check_schema(conf)

--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -52,7 +52,7 @@ local schema = {
             }
         },
         rejected_code = {type = "integer", minimum = 200, default = 403},
-        rejected_message = {type = "string"}
+        rejected_msg = {type = "string"}
     },
     anyOf = {
         {required = {"blacklist"}},
@@ -106,8 +106,8 @@ local function is_method_allowed(allowed_methods, method, user)
 end
 
 local function reject(conf)
-    if conf.rejected_message then
-        return conf.rejected_code , { message = conf.rejected_message }
+    if conf.rejected_msg then
+        return conf.rejected_code , { message = conf.rejected_msg }
     end
     return conf.rejected_code , { message = "The " .. conf.type .. " is forbidden."}
 end

--- a/docs/en/latest/plugins/consumer-restriction.md
+++ b/docs/en/latest/plugins/consumer-restriction.md
@@ -42,7 +42,7 @@ The `consumer-restriction` makes corresponding access restrictions based on diff
 | whitelist | array[string] | required   |               |                                 | Grant full access to all users specified in the provided list , **has the priority over `allowed_by_methods`** |
 | blacklist | array[string] | required   |               |                                 | Reject connection to all users specified in the provided list , **has the priority over `whitelist`** |
 | rejected_code | integer | optional     | 403           | [200,...]                       | The HTTP status code returned when the request is rejected.                                                                         |
-| rejected_message | string | optional     |            |                        | The message returned when the request is rejected.                                                                         |
+| rejected_msg | string | optional     |            |                        | The message returned when the request is rejected.                                                                         |
 | allowed_by_methods | array[object] | optional     |            |                        | Set a list of allowed HTTP methods for the selected user , HTTP methods can be `["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT", "TRACE"]`                                                                        |
 
 For the `type` field is an enumerated type, it can be `consumer_name` or `service_id`. They stand for the following meanings:

--- a/docs/en/latest/plugins/consumer-restriction.md
+++ b/docs/en/latest/plugins/consumer-restriction.md
@@ -42,6 +42,7 @@ The `consumer-restriction` makes corresponding access restrictions based on diff
 | whitelist | array[string] | required   |               |                                 | Grant full access to all users specified in the provided list , **has the priority over `allowed_by_methods`** |
 | blacklist | array[string] | required   |               |                                 | Reject connection to all users specified in the provided list , **has the priority over `whitelist`** |
 | rejected_code | integer | optional     | 403           | [200,...]                       | The HTTP status code returned when the request is rejected.                                                                         |
+| rejected_message | string | optional     |            |                        | The message returned when the request is rejected.                                                                         |
 | allowed_by_methods | array[object] | optional     |            |                        | Set a list of allowed HTTP methods for the selected user , HTTP methods can be `["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT", "TRACE"]`                                                                        |
 
 For the `type` field is an enumerated type, it can be `consumer_name` or `service_id`. They stand for the following meanings:

--- a/docs/zh/latest/plugins/consumer-restriction.md
+++ b/docs/zh/latest/plugins/consumer-restriction.md
@@ -42,6 +42,7 @@ title: consumer-restriction
 | whitelist | array[string] | 必选    |                  |                                 | 与`blacklist`二选一，只能单独启用白名单或黑名单，两个不能一起使用。 |
 | blacklist | array[string] | 必选    |                  |                                 | 与`whitelist`二选一，只能单独启用白名单或黑名单，两个不能一起使用。 |
 | rejected_code | integer   | 可选    | 403              | [200,...]                       | 当请求被拒绝时，返回的 HTTP 状态码。|
+| rejected_messgae | String   | 可选    |               |                        | 当请求被拒绝时，返回的消息内容。|
 
 对于 `type` 字段是个枚举类型，它可以是 `consumer_name` 或 `service_id` 。分别代表以下含义：
 

--- a/docs/zh/latest/plugins/consumer-restriction.md
+++ b/docs/zh/latest/plugins/consumer-restriction.md
@@ -42,7 +42,7 @@ title: consumer-restriction
 | whitelist | array[string] | 必选    |                  |                                 | 与`blacklist`二选一，只能单独启用白名单或黑名单，两个不能一起使用。 |
 | blacklist | array[string] | 必选    |                  |                                 | 与`whitelist`二选一，只能单独启用白名单或黑名单，两个不能一起使用。 |
 | rejected_code | integer   | 可选    | 403              | [200,...]                       | 当请求被拒绝时，返回的 HTTP 状态码。|
-| rejected_message | String   | 可选    |               |                        | 当请求被拒绝时，返回的消息内容。|
+| rejected_msg | String   | 可选    |               |                        | 当请求被拒绝时，返回的消息内容。|
 
 对于 `type` 字段是个枚举类型，它可以是 `consumer_name` 或 `service_id` 。分别代表以下含义：
 

--- a/docs/zh/latest/plugins/consumer-restriction.md
+++ b/docs/zh/latest/plugins/consumer-restriction.md
@@ -42,7 +42,7 @@ title: consumer-restriction
 | whitelist | array[string] | 必选    |                  |                                 | 与`blacklist`二选一，只能单独启用白名单或黑名单，两个不能一起使用。 |
 | blacklist | array[string] | 必选    |                  |                                 | 与`whitelist`二选一，只能单独启用白名单或黑名单，两个不能一起使用。 |
 | rejected_code | integer   | 可选    | 403              | [200,...]                       | 当请求被拒绝时，返回的 HTTP 状态码。|
-| rejected_messgae | String   | 可选    |               |                        | 当请求被拒绝时，返回的消息内容。|
+| rejected_message | String   | 可选    |               |                        | 当请求被拒绝时，返回的消息内容。|
 
 对于 `type` 字段是个枚举类型，它可以是 `consumer_name` 或 `service_id` 。分别代表以下含义：
 

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -264,7 +264,7 @@ Authorization: Basic amFjazIwMjA6MTIzNDU2
                                  "blacklist": [
                                      "jack1"
                                  ],
-                                 "rejected_message": "request is forbidden"
+                                 "rejected_msg": "request is forbidden"
                             }
                         }
                 }]]
@@ -303,7 +303,7 @@ GET /hello
 Authorization: Basic amFjazIwMTk6MTIzNDU2
 --- error_code: 403
 --- response_body
-{"message":"The consumer_name is forbidden."}
+{"message":"request is forbidden"}
 --- no_error_log
 [error]
 

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -263,7 +263,8 @@ Authorization: Basic amFjazIwMjA6MTIzNDU2
                             "consumer-restriction": {
                                  "blacklist": [
                                      "jack1"
-                                 ]
+                                 ],
+                                 "rejected_message": "request is forbidden"
                             }
                         }
                 }]]
@@ -1757,68 +1758,6 @@ passed
             local code, body = t( '/apisix/admin/services/2', ngx.HTTP_DELETE )
 
             ngx.status = code
-            ngx.say(body)
-        }
-    }
---- request
-GET /t
---- response_body
-passed
---- no_error_log
-[error]
-
-
-=== TEST 54:  whitelist > rejected_message
---- config
-    location /t {
-        content_by_lua_block {
-            local plugin = require("apisix.plugins.consumer-restriction")
-            local ok, err = plugin.check_schema({whitelist={"jack1"}, rejected_message="forbidden"})
-            if not ok then
-                ngx.say(err)
-            end
-
-            ngx.say("done")
-        }
-    }
---- request
-GET /t
---- response_body
-done
---- no_error_log
-[error]
-
-
-
-=== TEST 55: set rejected_message
---- config
-    location /t {
-        content_by_lua_block {
-            local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/routes/1',
-                 ngx.HTTP_PUT,
-                 [[{
-                        "uri": "/hello",
-                        "upstream": {
-                            "type": "roundrobin",
-                            "nodes": {
-                                "127.0.0.1:1980": 1
-                            }
-                        },
-                        "plugins": {
-                            "basic-auth": {},
-                            "consumer-restriction": {
-                                "rejected_message":"forbidden",
-                                "type":"service_id",
-                                "whitelist":["test"]
-                            }
-                        }
-                }]]
-                )
-
-            if code >= 300 then
-                ngx.status = code
-            end
             ngx.say(body)
         }
     }


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
consumer-restriction plugin add reject_message parameter support user to custom define return message when request rejected.
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
