### PR TITLE
docs(ldap-auth): add consumer parameters for ldap

### DIFF
--- a/docs/en/latest/plugins/ldap-auth.md
+++ b/docs/en/latest/plugins/ldap-auth.md
@@ -41,13 +41,20 @@ This authentication plugin use [lualdap](https://lualdap.github.io/lualdap/) plu
 
 ## Attributes
 
+For consumer side:
+
+| Name     | Type    | Requirement | Default | Valid |                                                                                                           |Description                                                                                                                                                      |
+| -------- | ------- | ----------- | ------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| user_dn  | string  | required    |         |       | the user dn of the `ladp` client (example: `cn=user01,ou=users,dc=example,dc=org`)                        |
+
+For route side:
+
 | Name     | Type    | Requirement | Default | Valid |                                                                                                           |Description                                                                                                                                                      |
 | -------- | ------- | ----------- | ------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | base_dn  | string  | required    |         |       | the base dn of the `ldap` server (example : `ou=users,dc=example,dc=org`)                                 |
 | ldap_uri | string  | required    |         |       | the uri of the ldap server                                                                                |
 | use_tls  | boolean | optional    | `true`  |       | Boolean flag indicating if Transport Layer Security (TLS) should be used.                                 |
 | uid      | string  | optional    | `cn`    |       | the `uid` attribute                                                                                       |
-| user_dn  | string  | required    |         |       | the user dn of the `ladp` client (example: `cn=user01,ou=users,dc=example,dc=org`)                        |
 
 ## How To Enable
 

--- a/docs/en/latest/plugins/ldap-auth.md
+++ b/docs/en/latest/plugins/ldap-auth.md
@@ -41,12 +41,13 @@ This authentication plugin use [lualdap](https://lualdap.github.io/lualdap/) plu
 
 ## Attributes
 
-| Name     | Type   | Requirement | Default | Valid | Description                                                                                                                                                      |
-| -------- | ------ | ----------- | ------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| base_dn | string | required    |         |       | the base dn of the `ldap` server (example : `ou=users,dc=example,dc=org`)   |
-| ldap_uri | string | required    |         |       | the uri of the ldap server  |
-| use_tls | boolean | optional    |    `true`     |       | Boolean flag indicating if Transport Layer Security (TLS) should be used. |
-| uid | string | optional    |     `cn`      |     | the `uid` attribute |
+| Name     | Type    | Requirement | Default | Valid |                                                                                                           |Description                                                                                                                                                      |
+| -------- | ------- | ----------- | ------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| base_dn  | string  | required    |         |       | the base dn of the `ldap` server (example : `ou=users,dc=example,dc=org`)                                 |
+| ldap_uri | string  | required    |         |       | the uri of the ldap server                                                                                |
+| use_tls  | boolean | optional    | `true`  |       | Boolean flag indicating if Transport Layer Security (TLS) should be used.                                 |
+| uid      | string  | optional    | `cn`    |       | the `uid` attribute                                                                                       |
+| user_dn  | string  | required    |         |       | the user dn of the `ladp` client (example: `cn=user01,ou=users,dc=example,dc=org`)                        |
 
 ## How To Enable
 

--- a/docs/en/latest/plugins/ldap-auth.md
+++ b/docs/en/latest/plugins/ldap-auth.md
@@ -43,18 +43,18 @@ This authentication plugin use [lualdap](https://lualdap.github.io/lualdap/) plu
 
 For consumer side:
 
-| Name     | Type    | Requirement | Default | Valid |                                                                                                           |Description                                                                                                                                                      |
-| -------- | ------- | ----------- | ------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| user_dn  | string  | required    |         |       | the user dn of the `ladp` client (example: `cn=user01,ou=users,dc=example,dc=org`)                        |
+| Name     | Type    | Requirement | Default | Valid | Description |
+| -------- | ------- | ----------- | ------- | ----- | ----------- |
+| user_dn  | string  | required    |         |       | the user dn of the `ladp` client (example: `cn=user01,ou=users,dc=example,dc=org`)      |
 
 For route side:
 
-| Name     | Type    | Requirement | Default | Valid |                                                                                                           |Description                                                                                                                                                      |
-| -------- | ------- | ----------- | ------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| base_dn  | string  | required    |         |       | the base dn of the `ldap` server (example : `ou=users,dc=example,dc=org`)                                 |
-| ldap_uri | string  | required    |         |       | the uri of the ldap server                                                                                |
-| use_tls  | boolean | optional    | `true`  |       | Boolean flag indicating if Transport Layer Security (TLS) should be used.                                 |
-| uid      | string  | optional    | `cn`    |       | the `uid` attribute                                                                                       |
+| Name     | Type    | Requirement | Default | Valid | Description |
+| -------- | ------- | ----------- | ------- | ----- | ----------- |
+| base_dn  | string  | required    |         |       | the base dn of the `ldap` server (example : `ou=users,dc=example,dc=org`)                |
+| ldap_uri | string  | required    |         |       | the uri of the ldap server                                                               |
+| use_tls  | boolean | optional    | `true`  |       | Boolean flag indicating if Transport Layer Security (TLS) should be used.                |
+| uid      | string  | optional    | `cn`    |       | the `uid` attribute                                                                      |
 
 ## How To Enable
 


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
Ldap-auth plugin docs are missing parameters when configuring Consumer.
see https://apisix.apache.org/docs/apisix/plugins/ldap-auth/
And ldap-auth implementation is here https://github.com/apache/apisix/blob/master/apisix/plugins/ldap-auth.lua#L40-L47 
<!--- If it fixes an open issue, please link to the issue here. -->
resolve #5668 
### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
