### PR TITLE
ci: remove linux_apisix_master_luarocks from the CI on release branch

### DIFF
--- a/.github/workflows/cli-master.yml
+++ b/.github/workflows/cli-master.yml
@@ -1,13 +1,13 @@
-name: CLI Test
+name: CLI Test (master)
 
 on:
   push:
-    branches: [master, 'release/**']
+    branches: [master]
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
   pull_request:
-    branches: [master, 'release/**']
+    branches: [master]
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
@@ -21,16 +21,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - ubuntu-18.04
         job_name:
-          - linux_apisix_current_luarocks
-          - linux_apisix_current_luarocks_in_customed_nginx
-
-    runs-on: ${{ matrix.platform }}
+          - linux_apisix_master_luarocks
+    runs-on: ubuntu-18.04
     timeout-minutes: 15
     env:
-      SERVER_NAME: ${{ matrix.job_name }}
       OPENRESTY_VERSION: default
 
     steps:
@@ -53,9 +48,6 @@ jobs:
 
       - name: Linux Get dependencies
         run: sudo apt install -y cpanminus build-essential libncurses5-dev libreadline-dev libssl-dev perl libpcre3 libpcre3-dev libldap2-dev
-
-      - name: Linux Before install
-        run: sudo ./ci/${{ matrix.job_name }}_runner.sh before_install
 
       - name: Linux Install
         run: |


### PR DESCRIPTION
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This test can't be passed outside the master branch.

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
