### PR TITLE
fix: bump lua-resty-rocketmq to 0.2.1-3

### DIFF
--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -72,7 +72,7 @@ dependencies = {
     "api7-snowflake = 2.0-1",
     "inspect == 3.1.1",
     "lualdap = 1.2.6-1",
-    "lua-resty-rocketmq = 0.2.1-1",
+    "lua-resty-rocketmq = 0.2.1-3",
 }
 
 build = {


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
the known issue of lua-resty-rocketmq fail to start if worker pid is greater than 65535 is fixed in https://github.com/yuz10/lua-resty-rocketmq/commit/6e0d19ab8b62552a2cdc1bcbf05766b9cfb4694d

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
