### PR TITLE
fix(ext-plugin): don't use stale key

### DIFF
--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -677,6 +677,7 @@ local function create_lrucache()
 
     lrucache = core.lrucache.new({
         type = "plugin",
+    	invalid_stale = true,
         ttl = helper.get_conf_token_cache_time(),
     })
 end

--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -65,11 +65,7 @@ local type = type
 
 
 local events_list
-local lrucache = core.lrucache.new({
-    type = "plugin",
-    invalid_stale = true,
-    ttl = helper.get_conf_token_cache_time(),
-})
+local lrucache = new_lrucache()
 local shdict_name = "ext-plugin"
 local shdict = ngx.shared[shdict_name]
 
@@ -668,6 +664,15 @@ rpc_call = function (ty, conf, ctx, ...)
 end
 
 
+local function new_lrucache()
+    return core.lrucache.new({
+        type = "plugin",
+        invalid_stale = true,
+        ttl = helper.get_conf_token_cache_time(),
+    })
+end
+
+
 local function create_lrucache()
     flush_token()
 
@@ -675,11 +680,7 @@ local function create_lrucache()
         core.log.warn("flush conf token lrucache")
     end
 
-    lrucache = core.lrucache.new({
-        type = "plugin",
-    	invalid_stale = true,
-        ttl = helper.get_conf_token_cache_time(),
-    })
+    lrucache = new_lrucache()
 end
 
 

--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -65,7 +65,16 @@ local type = type
 
 
 local events_list
+
+local function new_lrucache()
+    return core.lrucache.new({
+        type = "plugin",
+        invalid_stale = true,
+        ttl = helper.get_conf_token_cache_time(),
+    })
+end
 local lrucache = new_lrucache()
+
 local shdict_name = "ext-plugin"
 local shdict = ngx.shared[shdict_name]
 
@@ -661,15 +670,6 @@ rpc_call = function (ty, conf, ctx, ...)
     end
 
     return res, nil, code, body
-end
-
-
-local function new_lrucache()
-    return core.lrucache.new({
-        type = "plugin",
-        invalid_stale = true,
-        ttl = helper.get_conf_token_cache_time(),
-    })
 end
 
 

--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -673,7 +673,7 @@ rpc_call = function (ty, conf, ctx, ...)
 end
 
 
-local function create_lrucache()
+local function recreate_lrucache()
     flush_token()
 
     if lrucache then
@@ -704,7 +704,7 @@ function _M.communicate(conf, ctx, plugin_name)
         end
 
         core.log.warn("refresh cache and try again")
-        create_lrucache()
+        recreate_lrucache()
     end
 
     core.log.error(err)
@@ -801,7 +801,7 @@ function _M.init_worker()
     )
 
     -- flush cache when runner exited
-    events.register(create_lrucache, events_list._source, events_list.runner_exit)
+    events.register(recreate_lrucache, events_list._source, events_list.runner_exit)
 
     -- note that the runner is run under the same user as the Nginx master
     if process.type() == "privileged agent" then


### PR DESCRIPTION
### What this PR does / why we need it:
ext_plugin an expired key in lrucachd that could not find in go runner。
patch for [#5309](https://github.com/apache/apisix/pull/5309)

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
