### PR TITLE
docs: added only: false to example

### DIFF
--- a/docs/en/latest/plugins/mqtt-proxy.md
+++ b/docs/en/latest/plugins/mqtt-proxy.md
@@ -57,6 +57,7 @@ For example, the following configuration represents listening on the 9100 TCP po
         http: 'radixtree_uri'
         ssl: 'radixtree_sni'
     stream_proxy:                 # TCP/UDP proxy
+      only: false                 # needed if HTTP and Stream Proxy should be enabled
       tcp:                        # TCP proxy port list
         - 9100
     dns_resolver:


### PR DESCRIPTION
added "only:false" if http and stream proxy functionality is needed

### What this PR does / why we need it:
For clearer documentation purposes and in reference to the general documentation of stream proxy.


