### PR TITLE
docs: remove the redundant space between Chinese characters

### DIFF
--- a/docs/zh/latest/architecture-design/plugin.md
+++ b/docs/zh/latest/architecture-design/plugin.md
@@ -26,8 +26,8 @@ title: Plugin
 `Plugin` 配置可直接绑定在 `Route` 上，也可以被绑定在 `Service` 或 `Consumer`上。而对于同一
 个插件的配置，只能有一份是有效的，配置选择优先级总是 `Consumer` > `Route` > `Service`。
 
-在 `conf/config.yaml` 中，可以声明本地 APISIX 节点都支持哪些插件。这是个白名单机制，不在该
-白名单的插件配置，都将会被自动忽略。这个特性可用于临时关闭或打开特定插件，应对突发情况非常有效。
+在 `conf/config.yaml` 中，可以声明本地 APISIX 节点都支持哪些插件。这是个白名单机制，不在该白名单的插件配置，
+都将会被自动忽略。这个特性可用于临时关闭或打开特定插件，应对突发情况非常有效。
 如果你想在现有插件的基础上新增插件，注意需要拷贝 `conf/config-default.yaml` 的插件节点内容到 `conf/config.yaml` 的插件节点中。
 
 插件的配置可以被直接绑定在指定 Route 中，也可以被绑定在 Service 中，不过 Route 中的插件配置


### PR DESCRIPTION
There is an extra space after ‘该’

<img width="797" alt="image" src="https://user-images.githubusercontent.com/51607047/146216037-70a3b40a-f729-481e-9765-a7a9566df9fd.png">

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
