### PR TITLE
fix(core.log): log level need to be updated in some scenario

### DIFF
--- a/apisix/core/log.lua
+++ b/apisix/core/log.lua
@@ -24,6 +24,7 @@ local tostring = tostring
 local unpack = unpack
 -- avoid loading other module since core.log is the most foundational one
 local tab_clear = require("table.clear")
+local ngx_errlog = require("ngx.errlog")
 
 
 local _M = {version = 0.4}
@@ -42,17 +43,27 @@ local log_levels = {
 }
 
 
-local cur_level = ngx.config.subsystem == "http" and
-                  require "ngx.errlog" .get_sys_filter_level()
+local cur_level
+
 local do_nothing = function() end
+
+
+local function log_level_update()
+    -- Nginx use `notice` level in init phase instead of error_log directive config
+    -- Ref to src/core/ngx_log.c's ngx_log_init
+    if ngx.get_phase() ~= "init" then
+        cur_level = ngx.config.subsystem == "http" and ngx_errlog.get_sys_filter_level()
+    end
+end
 
 
 function _M.new(prefix)
     local m = {version = _M.version}
     setmetatable(m, {__index = function(self, cmd)
         local log_level = log_levels[cmd]
-
         local method
+        log_level_update()
+
         if cur_level and (log_level > cur_level)
         then
             method = do_nothing
@@ -74,8 +85,9 @@ end
 
 setmetatable(_M, {__index = function(self, cmd)
     local log_level = log_levels[cmd]
-
     local method
+    log_level_update()
+
     if cur_level and (log_level > cur_level)
     then
         method = do_nothing


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
log level need to be update in some scenario, such as called in init phase.

POC:
> set error_log log level as `error`
```yaml
  extra_lua_path: ""                # extend lua_package_path to load third party code
  extra_lua_cpath: ""               # extend lua_package_cpath to load third party code
  lua_module_hook: "my_project.my_hook"  # the hook module which will be used to inject third party code into APISIX
```
```lua
# code in my_project.my_hook
local core.log = require("apisix.core.log")
core_log.info("test")

# `info` func will be cached in `apisix.core.log`
# which break the expectation of the error_log log level
```

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
