### PR TITLE
docs(request-id): fix typo in request-id plugin zh document.

### DIFF
--- a/docs/zh/latest/plugins/request-id.md
+++ b/docs/zh/latest/plugins/request-id.md
@@ -38,7 +38,7 @@ title: request-id
 | 名称                | 类型    | 必选项   | 默认值         | 有效值 | 描述                           |
 | ------------------- | ------- | -------- | -------------- | ------ | ------------------------------ |
 | header_name         | string  | 可选 | "X-Request-Id" |                       | Request ID header name         |
-| include_in_response | boolean | 可选 | false          |                       | 是否需要在返回头中包含该唯一ID |
+| include_in_response | boolean | 可选 | true          |                       | 是否需要在返回头中包含该唯一ID |
 | algorithm           | string  | 可选 | "uuid"         | ["uuid", "snowflake"] | ID 生成算法 |
 
 ## 如何启用


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix typo in Chinese request-id plugin document.

'request-id' plugin attribute named 'include_in_response' default value is true, not false.

lua code:

``` lua
local schema = {
    type = "object",
    properties = {
        header_name = {type = "string", default = "X-Request-Id"},
        include_in_response = {type = "boolean", default = true},
        algorithm = {type = "string", enum = {"uuid", "snowflake"}, default = "uuid"}
    }
}
```

source code: [https://github.com/apache/apisix/blob/master/apisix/plugins/request-id.lua](https://github.com/apache/apisix/blob/master/apisix/plugins/request-id.lua)

English version document:

![image](https://user-images.githubusercontent.com/1767823/146751301-f3c9206e-5b39-49a3-84aa-4023e49d39cf.png)



### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
