### PR TITLE
change: enable HTTP when stream proxy is set and enable_admin is true

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -155,7 +155,7 @@ stream {
 }
 {% end %}
 
-{% if not (stream_proxy and stream_proxy.only ~= false) then %}
+{% if enable_admin or not (stream_proxy and stream_proxy.only ~= false) then %}
 http {
     # put extra_lua_path in front of the builtin path
     # so user can override the source code

--- a/docs/en/latest/stream-proxy.md
+++ b/docs/en/latest/stream-proxy.md
@@ -41,10 +41,13 @@ apisix:
       - "127.0.0.1:9211"
 ```
 
-If you need to enable both HTTP and stream proxy, set the `only` to false:
+If `apisix.enable_admin` is true, both HTTP and stream proxy are enabled with the configuration above.
+
+If you have set the `enable_admin` to false, and need to enable both HTTP and stream proxy, set the `only` to false:
 
 ```yaml
 apisix:
+  enable_admin: false
   stream_proxy: # TCP/UDP proxy
     only: false
     tcp: # TCP proxy address list

--- a/docs/zh/latest/stream-proxy.md
+++ b/docs/zh/latest/stream-proxy.md
@@ -40,10 +40,14 @@ apisix:
       - "127.0.0.1:9211"
 ```
 
-如果你需要同时启用 HTTP 和 stream 代理，设置 `only` 为 false：
+如果 `apisix.enable_admin` 为 true，上面的配置会同时启用 HTTP 和 stream 代理。
+If `apisix.enable_admin` is true, both HTTP and stream proxy are enabled with the configuration above.
+
+如果你设置 `enable_admin` 为 false，且需要同时启用 HTTP 和 stream 代理，设置 `only` 为 false：
 
 ```yaml
 apisix:
+  enable_admin: false
   stream_proxy: # TCP/UDP proxy
     only: false
     tcp: # TCP proxy address list

--- a/docs/zh/latest/stream-proxy.md
+++ b/docs/zh/latest/stream-proxy.md
@@ -41,7 +41,6 @@ apisix:
 ```
 
 如果 `apisix.enable_admin` 为 true，上面的配置会同时启用 HTTP 和 stream 代理。
-If `apisix.enable_admin` is true, both HTTP and stream proxy are enabled with the configuration above.
 
 如果你设置 `enable_admin` 为 false，且需要同时启用 HTTP 和 stream 代理，设置 `only` 为 false：
 

--- a/t/cli/test_core_config.sh
+++ b/t/cli/test_core_config.sh
@@ -56,7 +56,7 @@ nginx_config:
 make init
 
 count=$(grep -c "lua_max_pending_timers 10240;" conf/nginx.conf)
-if [ "$count" -ne 1 ]; then
+if [ "$count" -ne 2 ]; then
     echo "failed: failed to set lua_max_pending_timers in stream proxy"
     exit 1
 fi
@@ -64,7 +64,7 @@ fi
 echo "passed: set lua_max_pending_timers successfully in stream proxy"
 
 count=$(grep -c "lua_max_running_timers 2561;" conf/nginx.conf)
-if [ "$count" -ne 1 ]; then
+if [ "$count" -ne 2 ]; then
     echo "failed: failed to set lua_max_running_timers in stream proxy"
     exit 1
 fi

--- a/t/cli/test_dns.sh
+++ b/t/cli/test_dns.sh
@@ -53,7 +53,7 @@ apisix:
 make init
 
 count=$(grep -c "resolver 127.0.0.1 \[::1\]:5353 valid=30;" conf/nginx.conf)
-if [ "$count" -ne 1 ]; then
+if [ "$count" -ne 2 ]; then
     echo "failed: dns_resolver_valid doesn't take effect"
     exit 1
 fi
@@ -74,7 +74,7 @@ apisix:
 make init
 
 count=$(grep -c "resolver 127.0.0.1 \[::1\] \[::2\];" conf/nginx.conf)
-if [ "$count" -ne 1 ]; then
+if [ "$count" -ne 2 ]; then
     echo "failed: can't handle IPv6 resolver w/o bracket"
     exit 1
 fi

--- a/t/cli/test_stream_config.sh
+++ b/t/cli/test_stream_config.sh
@@ -21,6 +21,7 @@
 
 echo "
 apisix:
+    enable_admin: false
     stream_proxy:
         tcp:
             - addr: 9100
@@ -38,6 +39,7 @@ echo "passed: enable stream proxy only by default"
 
 echo "
 apisix:
+    enable_admin: false
     stream_proxy:
         only: false
         tcp:
@@ -49,6 +51,22 @@ make init
 count=$(grep -c "lua_package_path" conf/nginx.conf)
 if [ "$count" -ne 2 ]; then
     echo "failed: failed to enable stream proxy and http proxy"
+    exit 1
+fi
+
+echo "
+apisix:
+    enable_admin: true
+    stream_proxy:
+        tcp:
+            - addr: 9100
+" > conf/config.yaml
+
+make init
+
+count=$(grep -c "lua_package_path" conf/nginx.conf)
+if [ "$count" -ne 2 ]; then
+    echo "failed: failed to enable stream proxy and http proxy when admin is enabled"
     exit 1
 fi
 


### PR DESCRIPTION
For development, this change let us don't need to specify `only:
false` additionally.

For DP which is used as L4 proxy, this change won't bring any
difference.

Also it makes the documentation of stream plugin simpler.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
