### PR TITLE
docs: added some explanations for the usage of the mqtt proxy

### DIFF
--- a/docs/en/latest/plugins/mqtt-proxy.md
+++ b/docs/en/latest/plugins/mqtt-proxy.md
@@ -23,11 +23,11 @@ title: mqtt-proxy
 
 ## Summary
 
-- [Summary](#summary)
-- [Name](#name)
-- [Attributes](#attributes)
-- [How To Enable](#how-to-enable)
-- [Delete Plugin](#delete-plugin)
+- [**Summary**](#summary)
+- [**Name**](#name)
+- [**Attributes**](#attributes)
+- [**How To Enable**](#how-to-enable)
+- [**Delete Plugin**](#delete-plugin)
 
 ## Name
 

--- a/docs/en/latest/plugins/mqtt-proxy.md
+++ b/docs/en/latest/plugins/mqtt-proxy.md
@@ -23,7 +23,6 @@ title: mqtt-proxy
 
 ## Summary
 
-- [**Summary**](#summary)
 - [**Name**](#name)
 - [**Attributes**](#attributes)
 - [**How To Enable**](#how-to-enable)

--- a/docs/en/latest/plugins/mqtt-proxy.md
+++ b/docs/en/latest/plugins/mqtt-proxy.md
@@ -23,10 +23,11 @@ title: mqtt-proxy
 
 ## Summary
 
-- [**Name**](#name)
-- [**Attributes**](#attributes)
-- [**How To Enable**](#how-to-enable)
-- [**Delete Plugin**](#delete-plugin)
+- [Summary](#summary)
+- [Name](#name)
+- [Attributes](#attributes)
+- [How To Enable](#how-to-enable)
+- [Delete Plugin](#delete-plugin)
 
 ## Name
 
@@ -71,7 +72,6 @@ Creates a stream route, and enable plugin `mqtt-proxy`.
 ```shell
 curl http://127.0.0.1:9080/apisix/admin/stream_routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
-    "remote_addr": "127.0.0.1",
     "plugins": {
         "mqtt-proxy": {
             "protocol_name": "MQTT",
@@ -81,13 +81,14 @@ curl http://127.0.0.1:9080/apisix/admin/stream_routes/1 -H 'X-API-KEY: edd1c9f03
     "upstream": {
         "type": "roundrobin",
         "nodes": [{
-            "host": "127.0.0.1",
+            "host": "127.0.0.1", 
             "port": 1980,
             "weight": 1
         }]
     }
 }'
 ```
+In case Docker is used in combination with MacOS `host.docker.internal` is the right parameter for `host`.
 
 ## Delete Plugin
 

--- a/docs/en/latest/plugins/mqtt-proxy.md
+++ b/docs/en/latest/plugins/mqtt-proxy.md
@@ -22,6 +22,7 @@ title: mqtt-proxy
 -->
 
 ## Summary
+
 - [Summary](#summary)
 - [Name](#name)
 - [Attributes](#attributes)

--- a/docs/en/latest/plugins/mqtt-proxy.md
+++ b/docs/en/latest/plugins/mqtt-proxy.md
@@ -88,6 +88,7 @@ curl http://127.0.0.1:9080/apisix/admin/stream_routes/1 -H 'X-API-KEY: edd1c9f03
     }
 }'
 ```
+
 In case Docker is used in combination with MacOS `host.docker.internal` is the right parameter for `host`.
 
 ## Delete Plugin

--- a/docs/en/latest/plugins/mqtt-proxy.md
+++ b/docs/en/latest/plugins/mqtt-proxy.md
@@ -22,7 +22,6 @@ title: mqtt-proxy
 -->
 
 ## Summary
-
 - [Summary](#summary)
 - [Name](#name)
 - [Attributes](#attributes)
@@ -81,7 +80,7 @@ curl http://127.0.0.1:9080/apisix/admin/stream_routes/1 -H 'X-API-KEY: edd1c9f03
     "upstream": {
         "type": "roundrobin",
         "nodes": [{
-            "host": "127.0.0.1", 
+            "host": "127.0.0.1",
             "port": 1980,
             "weight": 1
         }]


### PR DESCRIPTION
added some explanations for the usage of the mqtt proxy and removed the remote_addr key from the json example configuration

### What this PR does / why we need it:
The PR is needed to make the configuration of the mqtt proxy more clearer.
