### PR TITLE
feat: support to use path parameter with plugin's control api

### DIFF
--- a/apisix/control/router.lua
+++ b/apisix/control/router.lua
@@ -98,8 +98,8 @@ function fetch_control_api_router()
 
     local with_parameter = false
     local conf = core.config.local_conf()
-    if conf and conf.apisix and conf.apisix.router then
-        if conf.apisix.router.control == "radixtree_uri_with_parameter" then
+    if conf.apisix.enable_control and conf.apisix.control then
+        if conf.apisix.control.router == "radixtree_uri_with_parameter" then
             with_parameter = true
         end
     end

--- a/apisix/control/router.lua
+++ b/apisix/control/router.lua
@@ -96,14 +96,6 @@ do
 function fetch_control_api_router()
     core.table.clear(routes)
 
-    local with_parameter = false
-    local conf = core.config.local_conf()
-    if conf.apisix.enable_control and conf.apisix.control then
-        if conf.apisix.control.router == "radixtree_uri_with_parameter" then
-            with_parameter = true
-        end
-    end
-
     for _, plugin in ipairs(plugin_mod.plugins) do
         local api_fun = plugin.control_api
         if api_fun then
@@ -162,6 +154,14 @@ function fetch_control_api_router()
         end,
         handler = empty_func,
     })
+
+    local with_parameter = false
+    local conf = core.config.local_conf()
+    if conf.apisix.enable_control and conf.apisix.control then
+        if conf.apisix.control.router == "radixtree_uri_with_parameter" then
+            with_parameter = true
+        end
+    end
 
     if with_parameter then
         return radixtree.new(routes)

--- a/docs/en/latest/control-api.md
+++ b/docs/en/latest/control-api.md
@@ -38,6 +38,9 @@ apisix:
     port: 9090
 ```
 
+The control API server does not support parameter matching by default, if you want to enable parameter matching
+you can add `router: 'radixtree_uri_with_parameter'` to the `control` section.
+
 Note that the control API server should not be configured to listen to the public traffic!
 
 ## Control API Added via plugin

--- a/docs/en/latest/control-api.md
+++ b/docs/en/latest/control-api.md
@@ -38,7 +38,7 @@ apisix:
     port: 9090
 ```
 
-The control API server does not support parameter matching in plugin's control API by default, if you want to enable parameter matching
+The control API server does not support parameter matching by default, if you want to enable parameter matching in plugin's control API
 you can add `router: 'radixtree_uri_with_parameter'` to the `control` section.
 
 Note that the control API server should not be configured to listen to the public traffic!

--- a/docs/en/latest/control-api.md
+++ b/docs/en/latest/control-api.md
@@ -38,7 +38,7 @@ apisix:
     port: 9090
 ```
 
-The control API server does not support parameter matching by default, if you want to enable parameter matching
+The control API server does not support parameter matching in plugin's control API by default, if you want to enable parameter matching
 you can add `router: 'radixtree_uri_with_parameter'` to the `control` section.
 
 Note that the control API server should not be configured to listen to the public traffic!

--- a/docs/zh/latest/control-api.md
+++ b/docs/zh/latest/control-api.md
@@ -37,7 +37,7 @@ apisix:
     port: 9090
 ```
 
-control API 的路由在默认情况下不支持参数匹配，如果想启用参数匹配功能可以在 control 部分添加 `router: 'radixtree_uri_with_parameter'`
+插件的 control API 在默认情况下不支持参数匹配，如果想启用参数匹配功能可以在 control 部分添加 `router: 'radixtree_uri_with_parameter'`
 
 注意: control API server 不应该被配置成监听公网地址。
 

--- a/docs/zh/latest/control-api.md
+++ b/docs/zh/latest/control-api.md
@@ -37,6 +37,8 @@ apisix:
     port: 9090
 ```
 
+control API 的路由在默认情况下不支持参数匹配，如果想启用参数匹配功能可以在 control 部分添加 `router: 'radixtree_uri_with_parameter'`
+
 注意: control API server 不应该被配置成监听公网地址。
 
 ## 通过插件添加的 control API


### PR DESCRIPTION
### What this PR does / why we need it:
This PR resolves issue #5882 by adding the following configuration to the `config.yaml` to enable path parameter support for the control api in the plugins
```yaml
apisix:
    router:
        control: 'radixtree_uri_with_parameter'
```

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
