### PR TITLE
feat: allow setting proxy_request_buffering without disabling proxy-mirror

### DIFF
--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -64,9 +64,11 @@ jobs:
           kubectl create configmap apisix-gw-config.yaml --from-file=./conf/config.yaml
           kubectl apply -f ./kubernetes/deployment.yaml
           kubectl apply -f ./kubernetes/service.yaml
-          kubectl wait pods -l app=apisix-gw --for=condition=Ready --timeout=300s
+          kubectl wait pods -l app=apisix-gw --for=condition=Ready --timeout=300s \
+            || kubectl logs -l app=apisix-gw
           kubectl apply -f https://raw.githubusercontent.com/istio/istio/master/samples/httpbin/httpbin.yaml
-          kubectl wait pods -l app=httpbin --for=condition=Ready --timeout=300s
+          kubectl wait pods -l app=httpbin --for=condition=Ready --timeout=300s \
+            || kubectl logs -l app=httpbin
           bash ./t/chaos/utils/setup_chaos_utils.sh port_forward
 
       - name: Deploy Chaos Mesh

--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -65,10 +65,10 @@ jobs:
           kubectl apply -f ./kubernetes/deployment.yaml
           kubectl apply -f ./kubernetes/service.yaml
           kubectl wait pods -l app=apisix-gw --for=condition=Ready --timeout=300s \
-            || kubectl logs -l app=apisix-gw
+            || (kubectl logs -l app=apisix-gw && exit 1)
           kubectl apply -f https://raw.githubusercontent.com/istio/istio/master/samples/httpbin/httpbin.yaml
           kubectl wait pods -l app=httpbin --for=condition=Ready --timeout=300s \
-            || kubectl logs -l app=httpbin
+            || (kubectl logs -l app=httpbin && exit 1)
           bash ./t/chaos/utils/setup_chaos_utils.sh port_forward
 
       - name: Deploy Chaos Mesh

--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -264,6 +264,7 @@ http {
 
     {% if use_apisix_openresty then %}
     apisix_delay_client_max_body_check on;
+    apisix_mirror_on_demand on;
     {% end %}
 
     access_log {* http.access_log *} main buffer=16384 flush=3;
@@ -715,9 +716,11 @@ http {
         location = /proxy_mirror {
             internal;
 
+            {% if not use_apisix_openresty then %}
             if ($upstream_mirror_host = "") {
                 return 200;
             }
+            {% end %}
 
             proxy_http_version 1.1;
             proxy_set_header Host $upstream_host;

--- a/apisix/plugins/proxy-mirror.lua
+++ b/apisix/plugins/proxy-mirror.lua
@@ -16,8 +16,10 @@
 --
 local core          = require("apisix.core")
 local math_random = math.random
-local plugin_name   = "proxy-mirror"
+local has_mod, apisix_ngx_client = pcall(require, "resty.apisix.client")
 
+
+local plugin_name   = "proxy-mirror"
 local schema = {
     type = "object",
     properties = {
@@ -55,19 +57,28 @@ function _M.check_schema(conf)
 end
 
 
+local function enable_mirror(ctx, host)
+    ctx.var.upstream_mirror_host = host
+
+    if has_mod then
+        apisix_ngx_client.enable_mirror()
+    end
+end
+
+
 function _M.rewrite(conf, ctx)
     core.log.info("proxy mirror plugin rewrite phase, conf: ", core.json.delay_encode(conf))
 
     ctx.var.upstream_host = ctx.var.host
 
     if not conf.sample_ratio or conf.sample_ratio == 1 then
-        ctx.var.upstream_mirror_host = conf.host
+        enable_mirror(ctx, conf.host)
     else
         local val = math_random()
         core.log.info("mirror request sample_ratio conf: ", conf.sample_ratio,
                                 ", random value: ", val)
         if val < conf.sample_ratio then
-            ctx.var.upstream_mirror_host = conf.host
+            enable_mirror(ctx, conf.host)
         end
     end
 

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -212,6 +212,7 @@ my $a6_ngx_directives = "";
 if ($version =~ m/\/apisix-nginx-module/) {
     $a6_ngx_directives = <<_EOC_;
     apisix_delay_client_max_body_check on;
+    apisix_mirror_on_demand on;
     wasm_vm wasmtime;
 _EOC_
 }
@@ -762,11 +763,17 @@ _EOC_
 
         location = /proxy_mirror {
             internal;
+_EOC_
 
+    if ($version !~ m/\/apisix-nginx-module/) {
+        $config .= <<_EOC_;
             if (\$upstream_mirror_host = "") {
                 return 200;
             }
+_EOC_
+    }
 
+    $config .= <<_EOC_;
             proxy_http_version 1.1;
             proxy_set_header Host \$upstream_host;
             proxy_pass \$upstream_mirror_host\$request_uri;


### PR DESCRIPTION
Fix #5347
By avoiding creating subrequest, we also speed up the route without
proxy-mirror > 5%.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
