### PR TITLE
feat: add separately install support for `install-dependencies.sh`

### DIFF
--- a/utils/install-dependencies.sh
+++ b/utils/install-dependencies.sh
@@ -150,7 +150,7 @@ function main() {
             multi_distro_installation
         ;;
         *)
-            echo "Unsupported method"
+            echo "Unsupported method: ${case_opt}"
         ;;
     esac
 }

--- a/utils/install-dependencies.sh
+++ b/utils/install-dependencies.sh
@@ -125,15 +125,34 @@ function install_luarocks() {
 # Entry
 function main() {
     OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
-    if [[ "${OS_NAME}" == "linux" ]]; then
-        multi_distro_installation
-        install_luarocks
-        install_etcd
-    elif [[ "${OS_NAME}" == "darwin" ]]; then
-        install_dependencies_on_mac_osx
-    else
-        echo "Non-surported distribution"
+    if [[ "$#" == 0 ]]; then
+        if [[ "${OS_NAME}" == "linux" ]]; then
+            multi_distro_installation
+            install_luarocks
+            install_etcd
+        elif [[ "${OS_NAME}" == "darwin" ]]; then
+            install_dependencies_on_mac_osx
+        else
+            echo "Non-surported distribution"
+        fi
+        return
     fi
+
+    case_opt=$1
+    case "${case_opt}" in
+        "install_etcd")
+            install_etcd
+        ;;
+        "install_luarocks")
+            install_luarocks
+        ;;
+        "multi_distro_installation")
+            multi_distro_installation
+        ;;
+        *)
+            echo "Unsupported method"
+        ;;
+    esac
 }
 
-main
+main "$@"


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add separately install support for [install-dependencies.sh](https://github.com/apache/apisix/blob/master/utils/install-dependencies.sh)
fix #5795 
> Now we can install via
```bash
./utils/install-dependencies.sh install_etcd
```
### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
