### PR TITLE
change(serverless): rename "balancer" phase to "before_proxy"

### DIFF
--- a/apisix/plugins/serverless/init.lua
+++ b/apisix/plugins/serverless/init.lua
@@ -35,7 +35,7 @@ return function(plugin_name, priority)
                 type = "string",
                 default = "access",
                 enum = {"rewrite", "access", "header_filter", "body_filter",
-                        "log", "balancer"}
+                        "log", "before_proxy"}
             },
             functions = {
                 type = "array",
@@ -114,7 +114,7 @@ return function(plugin_name, priority)
     end
 
     function _M.before_proxy(conf, ctx)
-        call_funcs('balancer', conf, ctx)
+        call_funcs('before_proxy', conf, ctx)
     end
 
     function _M.header_filter(conf, ctx)

--- a/docs/en/latest/plugins/serverless.md
+++ b/docs/en/latest/plugins/serverless.md
@@ -41,7 +41,7 @@ Both plug-ins receive the same parameters.
 
 | Name      | Type          | Requirement | Default    | Valid                                                                    | Description                                                                                                                                         |
 | --------- | ------------- | ----------- | ---------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| phase     | string        | optional    | ["access"] | ["rewrite", "access", "header_filter", "body_filter", "log", "balancer"] |                                                                                                                                                     |
+| phase     | string        | optional    | ["access"] | ["rewrite", "access", "header_filter", "body_filter", "log", "before_proxy"] |                                                                                                                                                     |
 | functions | array[string] | required    |            |                                                                          | A list of functions that are specified to run is an array type, which can contain either one function or multiple functions, executed sequentially. |
 
 Note that only function is accepted here, not other types of Lua code. For example, anonymous functions are legal:<br />
@@ -70,6 +70,8 @@ ngx.say(count)
 ```
 
 Since `v2.6`, we pass the `conf` and `ctx` as the first two arguments to the servelss function, like a regular plugin.
+
+Prior to `v2.12.0`, the phase `before_proxy` used to be called `balancer`. Considering that this method actually runs after `access` and before the request goes upstream, and has nothing to do with `balancer`, the new naming would be more appropriate.
 
 ## How To Enable
 

--- a/docs/zh/latest/plugins/serverless.md
+++ b/docs/zh/latest/plugins/serverless.md
@@ -30,7 +30,7 @@ serverless 的插件有两个，分别是 `serverless-pre-function` 和 `serverl
 
 | 名称      | 类型          | 必选项   | 默认值     | 有效值                                                                   | 描述                                                                                       |
 | --------- | ------------- | -------- | ---------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| phase     | string        | 可选 | ["access"] | ["rewrite", "access", "header_filter", "body_filter", "log", "balancer"] |                                                                                            |
+| phase     | string        | 可选 | ["access"] | ["rewrite", "access", "header_filter", "body_filter", "log", "before_proxy"] |                                                                                            |
 | functions | array[string] | 必须 |            |                                                                          | 指定运行的函数列表，是数组类型，里面可以包含一个函数，也可以是多个函数，按照先后顺序执行。 |
 
 需要注意的是，这里只接受函数，而不接受其他类型的 Lua 代码。比如匿名函数是合法的：
@@ -59,6 +59,8 @@ ngx.say(count)
 ```
 
 从 `v2.6` 版本开始，我们会把 `conf` 和 `ctx` 作为头两个参数传递给 serverless 函数，就跟一般的插件一样。
+
+`v2.12.0` 版本之前，`before_proxy` 这个 phase 曾被称作 `balancer`。考虑到这一方法事实上运行在 `access` 之后，代理到上游之前，跟 `balancer` 没有关系，新的命名会更加贴切。
 
 ## 示例
 

--- a/t/admin/schema.t
+++ b/t/admin/schema.t
@@ -143,7 +143,7 @@ location /t {
             [[{
                 "properties": {
                     "phase": {
-                        "enum": ["rewrite", "access", "header_filter", "body_filter", "log", "balancer"],
+                        "enum": ["rewrite", "access", "header_filter", "body_filter", "log", "before_proxy"],
                         "type": "string"
                     },
                     "functions": {
@@ -183,7 +183,7 @@ location /t {
             [[{
                 "properties": {
                     "phase": {
-                        "enum": ["rewrite", "access", "header_filter", "body_filter", "log", "balancer"],
+                        "enum": ["rewrite", "access", "header_filter", "body_filter", "log", "before_proxy"],
                         "type": "string"
                     },
                     "functions": {

--- a/t/plugin/serverless.t
+++ b/t/plugin/serverless.t
@@ -682,7 +682,7 @@ match uri /hello
 
 
 
-=== TEST 23: run in the balancer phase
+=== TEST 23: run in the before_proxy phase
 --- config
     location /t {
         content_by_lua_block {
@@ -692,7 +692,7 @@ match uri /hello
                  [[{
                     "plugins": {
                         "serverless-pre-function": {
-                            "phase": "balancer",
+                            "phase": "before_proxy",
                             "functions" : ["return function(conf, ctx) ngx.req.set_header('X-SERVERLESS', ctx.balancer_ip) end"]
                         }
                     },
@@ -736,7 +736,7 @@ x-serverless: 127.0.0.1
 
 
 
-=== TEST 25: exit in the balancer phase
+=== TEST 25: exit in the before_proxy phase
 --- config
     location /t {
         content_by_lua_block {
@@ -746,7 +746,7 @@ x-serverless: 127.0.0.1
                  [[{
                     "plugins": {
                         "serverless-pre-function": {
-                            "phase": "balancer",
+                            "phase": "before_proxy",
                             "functions" : ["return function(conf, ctx) ngx.exit(403) end"]
                         }
                     },
@@ -786,7 +786,7 @@ GET /log_request
 
 
 
-=== TEST 27: ensure balancer phase run correct time
+=== TEST 27: ensure before_proxy phase run correct time
 --- config
     location /t {
         content_by_lua_block {
@@ -796,8 +796,8 @@ GET /log_request
                  [[{
                     "plugins": {
                         "serverless-pre-function": {
-                            "phase": "balancer",
-                            "functions" : ["return function(conf, ctx) ngx.log(ngx.WARN, 'run balancer phase with ', ctx.balancer_ip) end"]
+                            "phase": "before_proxy",
+                            "functions" : ["return function(conf, ctx) ngx.log(ngx.WARN, 'run before_proxy phase with ', ctx.balancer_ip) end"]
                         }
                     },
                     "upstream": {
@@ -831,7 +831,7 @@ passed
 --- request
 GET /log_request
 --- grep_error_log eval
-qr/(run balancer phase with [\d.]+)/
+qr/(run before_proxy phase with [\d.]+)/
 --- grep_error_log_out
-run balancer phase with 0.0.0.0
-run balancer phase with 127.0.0.1
+run before_proxy phase with 0.0.0.0
+run before_proxy phase with 127.0.0.1


### PR DESCRIPTION
It seems this is miss during the previous rename action.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
