### PR TITLE
chore: only reviewer can mark the review resolved

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,13 +5,14 @@
 ### Pre-submission checklist:
 
 <!--
-Please follow the requirements:
+Please follow the PR manners:
 1. Use Draft if the PR is not ready to be reviewed
 2. Test is required for the feat/fix PR, unless you have a good reason
 3. Doc is required for the feat PR
 4. Use a new commit to resolve review instead of `push -f`
 5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
 6. Use "request review" to notify the reviewer once you have resolved the review
+7. Only reviewer can click "Resolve conversation" to mark the reviewer's review resolved
 -->
 
 * [ ] Did you explain what problem does this PR solve? Or what new features have been added?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ Once we've discussed your changes and you've got your code ready, make sure that
 * References the original issue in the description, e.g. "Resolves #123".
 * Has a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 * Ensure your pull request's title starts from one of the word in the `types` section of [semantic.yml](https://github.com/apache/apisix/blob/master/.github/semantic.yml).
+* Follow the [PR manners](https://raw.githubusercontent.com/apache/apisix/master/.github/PULL_REQUEST_TEMPLATE.md)
 
 ## Contribution Guidelines for Documentation
 


### PR DESCRIPTION
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
