### PR TITLE
feat:support limit_size field to the hold_body_chunk method to truncate response_body

### DIFF
--- a/apisix/plugins/limit-count.lua
+++ b/apisix/plugins/limit-count.lua
@@ -90,7 +90,7 @@ local schema = {
         group = {type = "string"},
         key = {type = "string", default = "remote_addr"},
         key_type = {type = "string",
-            enum = {"var", "var_combination"},
+            enum = {"var", "var_combination", "constant"},
             default = "var",
         },
         rejected_code = {
@@ -238,6 +238,8 @@ function _M.access(conf, ctx)
         if n_resolved == 0 then
             key = nil
         end
+    elseif conf.key_type == "constant" then
+        key = conf_key
     else
         key = ctx.var[conf_key]
     end
@@ -248,10 +250,11 @@ function _M.access(conf, ctx)
         key = ctx.var["remote_addr"]
     end
 
+    -- here we add a separator ':' to mark the boundary of the prefix and the key itself
     if not conf.group then
-        key = key .. ctx.conf_type .. ctx.conf_version
+        key = ctx.conf_type .. ctx.conf_version .. ':' .. key
     else
-        key = key .. conf.group
+        key = conf.group .. ':' .. key
     end
 
     core.log.info("limit key: ", key)

--- a/docs/en/latest/plugins/limit-count.md
+++ b/docs/en/latest/plugins/limit-count.md
@@ -39,8 +39,8 @@ Limit request rate by a fixed number of requests in a given time window.
 | ------------------- | ------- | --------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | count               | integer | required                                |               | count > 0                                                                                               | the specified number of requests threshold.                                                                                                                                                                                                                                                                |
 | time_window         | integer | required                    |               | time_window > 0                                                                                         | the time window in seconds before the request count is reset.                                                                                                                                                                                                                                              |
-| key_type      | string  | optional    |   "var"   | ["var", "var_combination"] | the type of key. |
-| key           | string  | optional    |     "remote_addr"    |  | the user specified key to limit the rate. If the `key_type` is "var", the key will be treated as a name of variable. If the `key_type` is "var_combination", the key will be a combination of variables. For example, if we use "$remote_addr $consumer_name" as keys, plugin will be restricted by two keys which are "remote_addr" and "consumer_name". If the value of the key is empty, `remote_addr` will be set as the default key.|
+| key_type      | string  | optional    |   "var"   | ["var", "var_combination", "constant"] | the type of key. |
+| key           | string  | optional    |     "remote_addr"    |  | the user specified key to limit the rate. If the `key_type` is "constant", the key will be treated as a constant. If the `key_type` is "var", the key will be treated as a name of variable. If the `key_type` is "var_combination", the key will be a combination of variables. For example, if we use "$remote_addr $consumer_name" as key, plugin will be restricted by two variables which are "remote_addr" and "consumer_name". If the value of the key is empty, `remote_addr` will be set as the default key.|
 | rejected_code       | integer | optional                                | 503           | [200,...,599]                                                                                           | The HTTP status code returned when the request exceeds the threshold is rejected, default 503.                                                                                                                                                                                                             |
 | rejected_msg       | string | optional                                |            | non-empty                                                                                           | The response body returned when the request exceeds the threshold is rejected.                                                                                                                                                                                                             |
 | policy              | string  | optional                                | "local"       | ["local", "redis", "redis-cluster"]                                                                     | The rate-limiting policies to use for retrieving and incrementing the limits. Available values are `local`(the counters will be stored locally in-memory on the node), `redis`(counters are stored on a Redis server and will be shared across the nodes, usually use it to do the global speed limit), and `redis-cluster` which works the same as `redis` but with redis cluster. |
@@ -110,7 +110,7 @@ You also can complete the above operation through the web interface, first add a
 
 It is possible to share the same limit counter across different routes. For example,
 
-```
+```shell
 curl -i http://127.0.0.1:9080/apisix/admin/services/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "plugins": {
@@ -133,7 +133,7 @@ curl -i http://127.0.0.1:9080/apisix/admin/services/1 -H 'X-API-KEY: edd1c9f0343
 
 Every route which group name is "services_1#1640140620" will share the same count limitation `1` in one minute per remote_addr.
 
-```
+```shell
 $ curl -i http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "service_id": "1",
@@ -155,6 +155,36 @@ HTTP/1.1 503 ...
 
 Note that every limit-count configuration of the same group must be the same.
 Therefore, once update the configuration, we also need to update the group name.
+
+It is also possible to share the same limit counter in all requests. For example,
+
+```shell
+curl -i http://127.0.0.1:9080/apisix/admin/services/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "plugins": {
+        "limit-count": {
+            "count": 1,
+            "time_window": 60,
+            "rejected_code": 503,
+            "key": "remote_addr",
+            "key_type": "constant",
+            "group": "services_1#1640140621"
+        }
+    },
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "127.0.0.1:1980": 1
+        }
+    }
+}'
+```
+
+Compared with the previous configuration, we set the `key_type` to `constant`.
+By setting `key_type` to `constant`, we don't evaluate the value of `key` but treat it as a constant.
+
+Now every route which group name is "services_1#1640140621" will share the same count limitation `1` in one minute among all the requests,
+even these requests are from different remote_addr.
 
 If you need a cluster-level precision traffic limit, then we can do it with the redis server. The rate limit of the traffic will be shared between different APISIX nodes to limit the rate of cluster traffic.
 

--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -32,7 +32,7 @@ description = {
 
 dependencies = {
     "lua-resty-ctxdump = 0.1-0",
-    "lua-resty-dns-client = 5.2.0",
+    "lua-resty-dns-client = 5.2.3",
     "lua-resty-template = 2.0",
     "lua-resty-etcd = 1.6.0",
     "api7-lua-resty-http = 0.2.0",

--- a/t/node/upstream-domain.t
+++ b/t/node/upstream-domain.t
@@ -399,3 +399,51 @@ GET /t
 1980, 1981, 1981
 --- no_error_log
 [error]
+
+
+
+=== TEST 15: set route(with upstream)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/hello",
+                    "upstream": {
+                        "nodes": {
+                            "foo.com.": 0,
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin",
+                        "desc": "new upstream"
+                    },
+                    "service_id": "1"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 16: hit routes, parse the domain of upstream node
+--- request
+GET /hello
+--- response_body
+hello world
+--- error_log eval
+qr/dns resolver domain: foo.com. to \d+.\d+.\d+.\d+/
+--- no_error_log
+[error]


### PR DESCRIPTION
### What this PR does / why we need it:

Fix #5915
add limit_size field to the hold_body_chunk method to truncate response_body

Combine limit_size with the context's body_buffer_size, body_hold_flag fields to control the truncation of response body, where limit_size is controlled by specific business plugins

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**