### PR TITLE
docs: add notice on customize-nginx-configuration docs

### DIFF
--- a/docs/en/latest/customize-nginx-configuration.md
+++ b/docs/en/latest/customize-nginx-configuration.md
@@ -60,4 +60,4 @@ nginx_config:
 ...
 ```
 
-Pay attention to the indent of `nginx_config` and sub indent of the sub entries, the incorrect indent may cause `./bin/apisix start` failed to generate Nginx configuration in `conf/nginx.conf`.
+Pay attention to the indent of `nginx_config` and sub indent of the sub entries, the incorrect indent may cause `./bin/apisix start` to fail to generate Nginx configuration in `conf/nginx.conf`.

--- a/docs/en/latest/customize-nginx-configuration.md
+++ b/docs/en/latest/customize-nginx-configuration.md
@@ -59,3 +59,4 @@ nginx_config:
         tcp_nodelay off;
 ...
 ```
+Pay attention to the indent of `nginx_config` and sub indent of the sub entries, the incorrect indent may cause `./bin/apisix start` failed to generate Nginx configuration in `conf/nginx.conf`.

--- a/docs/en/latest/customize-nginx-configuration.md
+++ b/docs/en/latest/customize-nginx-configuration.md
@@ -59,4 +59,5 @@ nginx_config:
         tcp_nodelay off;
 ...
 ```
+
 Pay attention to the indent of `nginx_config` and sub indent of the sub entries, the incorrect indent may cause `./bin/apisix start` failed to generate Nginx configuration in `conf/nginx.conf`.

--- a/docs/zh/latest/customize-nginx-configuration.md
+++ b/docs/zh/latest/customize-nginx-configuration.md
@@ -59,3 +59,5 @@ nginx_config:
         tcp_nodelay off;
 ...
 ```
+
+注意`nginx_config`及其子项的格式缩进，在执行`./bin/apisix start`时，错误的缩进将导致更新`conf/nginx.conf`文件失败。


### PR DESCRIPTION
### What this PR does / why we need it:
the indent of `nginx_config` and sub indent of the sub entries need to be especially noted because there are many nginx configure variables in various format, which makes easy to mistake when configuring nginx_config.

this PR reduced some None critical info of this [old PR](https://github.com/apache/apisix/pull/6122) and [this issue](https://github.com/apache/apisix/issues/6072)

### Pre-submission checklist:

<!--
Please follow the PR manners:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
7. Only reviewer can click "Resolve conversation" to mark the reviewer's review resolved
-->

- [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
