### PR TITLE
feat:(plugins) make the ip-restriction plugin support mutil-level proxy agent

### DIFF
--- a/apisix/plugins/ip-restriction/init.lua
+++ b/apisix/plugins/ip-restriction/init.lua
@@ -89,8 +89,13 @@ end
 
 function _M.restrict(conf, ctx)
     local block = false
-    local remote_addr = ctx.var.remote_addr
-
+    local remote_addr_arr = ctx.var.http_x_forwarded_for
+    local ipList = {}
+    local reps = ","
+    string.gsub(remote_addr_arr, '[^' .. reps .. ']+', function(w)
+        table.insert(ipList, w)
+    end)
+    local remote_addr = remote_addr_arr[1]
     if conf.blacklist then
         local matcher = lrucache(conf.blacklist, nil,
                                  core.ip.create_ip_matcher, conf.blacklist)


### PR DESCRIPTION
### What this PR does / why we need it:
now the ip-restriction can not work if we use mutil-level proxy agent like slb
I chage the ngx var remote_addr to http_x_forwarded_for 
to make the ip-restriction plugin support mutil-level proxy agent 

### Pre-submission checklist:

<!--
Please follow the PR manners:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
7. Only reviewer can click "Resolve conversation" to mark the reviewer's review resolved
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
