### PR TITLE
fix(request-id): if the header_name is already present in the…

### DIFF
--- a/apisix/plugins/request-id.lua
+++ b/apisix/plugins/request-id.lua
@@ -211,8 +211,9 @@ end
 
 function _M.rewrite(conf, ctx)
     local headers = ngx.req.get_headers()
-    local uuid_val = get_request_id(conf.algorithm)
+    local uuid_val
     if not headers[conf.header_name] then
+        uuid_val = get_request_id(conf.algorithm)
         core.request.set_header(ctx, conf.header_name, uuid_val)
     else
         uuid_val = headers[conf.header_name]

--- a/apisix/plugins/request-id.lua
+++ b/apisix/plugins/request-id.lua
@@ -214,6 +214,8 @@ function _M.rewrite(conf, ctx)
     local uuid_val = get_request_id(conf.algorithm)
     if not headers[conf.header_name] then
         core.request.set_header(ctx, conf.header_name, uuid_val)
+    else
+        uuid_val = headers[conf.header_name]
     end
 
     if conf.include_in_response then


### PR DESCRIPTION
if the header_name is already present in the request uuid_val include_in_response should keep source

### What this PR does / why we need it:
in request-id plugin, when header_name is already present in the request, we should keep source id 

Fix https://github.com/apache/apisix/issues/6066

### Pre-submission checklist:
no