### PR TITLE
feat(batchprocessor): support partial consumption of batch entries

### DIFF
--- a/apisix/plugins/datadog.lua
+++ b/apisix/plugins/datadog.lua
@@ -23,7 +23,6 @@ local ngx = ngx
 local udp = ngx.socket.udp
 local format = string.format
 local concat = table.concat
-local ipairs = ipairs
 local tostring = tostring
 
 local plugin_name = "datadog"
@@ -64,12 +63,14 @@ local _M = {
     metadata_schema = metadata_schema,
 }
 
+
 function _M.check_schema(conf, schema_type)
     if schema_type == core.schema.TYPE_METADATA then
         return core.schema.check(metadata_schema, conf)
     end
     return core.schema.check(schema, conf)
 end
+
 
 local function generate_tag(entry, const_tags)
     local tags
@@ -108,6 +109,119 @@ local function generate_tag(entry, const_tags)
 end
 
 
+local function send_metric_over_udp(entry, metadata)
+    local err_msg
+    local sock = udp()
+    local host, port = metadata.value.host, metadata.value.port
+
+    local ok, err = sock:setpeername(host, port)
+    if not ok then
+        return false, "failed to connect to UDP server: host[" .. host
+                    .. "] port[" .. tostring(port) .. "] err: " .. err
+    end
+
+    -- Generate prefix & suffix according dogstatsd udp data format.
+    local suffix = generate_tag(entry, metadata.value.constant_tags)
+    local prefix = metadata.value.namespace
+    if prefix ~= "" then
+        prefix = prefix .. "."
+    end
+
+    -- request counter
+    ok, err = sock:send(format("%s:%s|%s%s", prefix ..
+                                    "request.counter", 1, "c", suffix))
+    if not ok then
+        err_msg = "error sending request.counter: " .. err
+        core.log.error("failed to report request count to dogstatsd server: host[" .. host
+                .. "] port[" .. tostring(port) .. "] err: " .. err)
+    end
+
+    -- request latency histogram
+    ok, err = sock:send(format("%s:%s|%s%s", prefix ..
+                                "request.latency", entry.latency, "h", suffix))
+    if not ok then
+        err_msg = "error sending request.latency: " .. err
+        core.log.error("failed to report request latency to dogstatsd server: host["
+                .. host .. "] port[" .. tostring(port) .. "] err: " .. err)
+    end
+
+    -- upstream latency
+    if entry.upstream_latency then
+        ok, err = sock:send(format("%s:%s|%s%s", prefix ..
+                        "upstream.latency", entry.upstream_latency, "h", suffix))
+        if not ok then
+            err_msg = "error sending upstream.latency: " .. err
+            core.log.error("failed to report upstream latency to dogstatsd server: host["
+                        .. host .. "] port[" .. tostring(port) .. "] err: " .. err)
+        end
+    end
+
+    -- apisix_latency
+    ok, err = sock:send(format("%s:%s|%s%s", prefix ..
+                            "apisix.latency", entry.apisix_latency, "h", suffix))
+    if not ok then
+        err_msg = "error sending apisix.latency: " .. err
+        core.log.error("failed to report apisix latency to dogstatsd server: host[" .. host
+                .. "] port[" .. tostring(port) .. "] err: " .. err)
+    end
+
+    -- request body size timer
+    ok, err = sock:send(format("%s:%s|%s%s", prefix ..
+                                    "ingress.size", entry.request.size, "ms", suffix))
+    if not ok then
+        err_msg = "error sending ingress.size: " .. err
+        core.log.error("failed to report req body size to dogstatsd server: host[" .. host
+                .. "] port[" .. tostring(port) .. "] err: " .. err)
+    end
+
+    -- response body size timer
+    ok, err = sock:send(format("%s:%s|%s%s", prefix ..
+                                    "egress.size", entry.response.size, "ms", suffix))
+    if not ok then
+        err_msg = "error sending egress.size: " .. err
+        core.log.error("failed to report response body size to dogstatsd server: host["
+                .. host .. "] port[" .. tostring(port) .. "] err: " .. err)
+    end
+
+    ok, err = sock:close()
+    if not ok then
+        core.log.error("failed to close the UDP connection, host[",
+                        host, "] port[", port, "] ", err)
+    end
+
+    if not err_msg then
+        return true
+    end
+
+    return false, err_msg
+end
+
+
+local function push_metrics(entries)
+    -- Fetching metadata details
+    local metadata = plugin.plugin_metadata(plugin_name)
+    core.log.info("metadata: ", core.json.delay_encode(metadata))
+
+    if not metadata then
+        core.log.info("received nil metadata: using metadata defaults: ",
+                                    core.json.delay_encode(defaults, true))
+        metadata = {}
+        metadata.value = defaults
+    end
+    core.log.info("sending batch metrics to dogstatsd: ", metadata.value.host,
+                  ":", metadata.value.port)
+
+    for i = 1, #entries do
+        local ok, err = send_metric_over_udp(entries[i], metadata)
+        if not ok then
+            return false, err, i
+        end
+    end
+
+    return true
+end
+
+
 function _M.log(conf, ctx)
     local entry = fetch_log(ngx, {})
     entry.balancer_ip = ctx.balancer_ip or ""
@@ -132,103 +246,7 @@ function _M.log(conf, ctx)
         return
     end
 
-    -- Generate a function to be executed by the batch processor
-    local func = function(entries, batch_max_size)
-        -- Fetching metadata details
-        local metadata = plugin.plugin_metadata(plugin_name)
-        if not metadata then
-            core.log.info("received nil metadata: using metadata defaults: ",
-                                core.json.delay_encode(defaults, true))
-            metadata = {}
-            metadata.value = defaults
-        end
-
-        -- Creating a udp socket
-        local sock = udp()
-        local host, port = metadata.value.host, metadata.value.port
-        core.log.info("sending batch metrics to dogstatsd: ", host, ":", port)
-
-        local ok, err = sock:setpeername(host, port)
-
-        if not ok then
-            return false, "failed to connect to UDP server: host[" .. host
-                        .. "] port[" .. tostring(port) .. "] err: " .. err
-        end
-
-        -- Generate prefix & suffix according dogstatsd udp data format.
-        local prefix = metadata.value.namespace
-        if prefix ~= "" then
-            prefix = prefix .. "."
-        end
-
-        core.log.info("datadog batch_entry: ", core.json.delay_encode(entries, true))
-        for _, entry in ipairs(entries) do
-            local suffix = generate_tag(entry, metadata.value.constant_tags)
-
-            -- request counter
-            local ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                                            "request.counter", 1, "c", suffix))
-            if not ok then
-                core.log.error("failed to report request count to dogstatsd server: host[" .. host
-                        .. "] port[" .. tostring(port) .. "] err: " .. err)
-            end
-
-
-            -- request latency histogram
-            local ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                                        "request.latency", entry.latency, "h", suffix))
-            if not ok then
-                core.log.error("failed to report request latency to dogstatsd server: host["
-                        .. host .. "] port[" .. tostring(port) .. "] err: " .. err)
-            end
-
-            -- upstream latency
-            if entry.upstream_latency then
-                local ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                                "upstream.latency", entry.upstream_latency, "h", suffix))
-                if not ok then
-                    core.log.error("failed to report upstream latency to dogstatsd server: host["
-                                .. host .. "] port[" .. tostring(port) .. "] err: " .. err)
-                end
-            end
-
-            -- apisix_latency
-            local ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                                    "apisix.latency", entry.apisix_latency, "h", suffix))
-            if not ok then
-                core.log.error("failed to report apisix latency to dogstatsd server: host[" .. host
-                        .. "] port[" .. tostring(port) .. "] err: " .. err)
-            end
-
-            -- request body size timer
-            local ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                                            "ingress.size", entry.request.size, "ms", suffix))
-            if not ok then
-                core.log.error("failed to report req body size to dogstatsd server: host[" .. host
-                        .. "] port[" .. tostring(port) .. "] err: " .. err)
-            end
-
-            -- response body size timer
-            local ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                                            "egress.size", entry.response.size, "ms", suffix))
-            if not ok then
-                core.log.error("failed to report response body size to dogstatsd server: host["
-                        .. host .. "] port[" .. tostring(port) .. "] err: " .. err)
-            end
-        end
-
-        -- Releasing the UDP socket descriptor
-        ok, err = sock:close()
-        if not ok then
-            core.log.error("failed to close the UDP connection, host[",
-                            host, "] port[", port, "] ", err)
-        end
-
-        -- Returning at the end and ensuring the resource has been released.
-        return true
-    end
-
-    batch_processor_manager:add_entry_to_new_processor(conf, entry, ctx, func)
+    batch_processor_manager:add_entry_to_new_processor(conf, entry, ctx, push_metrics)
 end
 
 return _M

--- a/apisix/plugins/datadog.lua
+++ b/apisix/plugins/datadog.lua
@@ -117,7 +117,7 @@ local function send_metric_over_udp(entry, metadata)
     local ok, err = sock:setpeername(host, port)
     if not ok then
         return false, "failed to connect to UDP server: host[" .. host
-                   .. "] port[" .. tostring(port) .. "] err: " .. err
+                      .. "] port[" .. tostring(port) .. "] err: " .. err
     end
 
     -- Generate prefix & suffix according dogstatsd udp data format.
@@ -128,65 +128,64 @@ local function send_metric_over_udp(entry, metadata)
     end
 
     -- request counter
-    ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                       "request.counter", 1, "c", suffix))
+    ok, err = sock:send(format("%s:%s|%s%s", prefix .. "request.counter", 1, "c", suffix))
     if not ok then
         err_msg = "error sending request.counter: " .. err
         core.log.error("failed to report request count to dogstatsd server: host[" .. host
-                .. "] port[" .. tostring(port) .. "] err: " .. err)
+                       .. "] port[" .. tostring(port) .. "] err: " .. err)
     end
 
     -- request latency histogram
-    ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                       "request.latency", entry.latency, "h", suffix))
+    ok, err = sock:send(format("%s:%s|%s%s", prefix .. "request.latency",
+                               entry.latency, "h", suffix))
     if not ok then
         err_msg = "error sending request.latency: " .. err
         core.log.error("failed to report request latency to dogstatsd server: host["
-                .. host .. "] port[" .. tostring(port) .. "] err: " .. err)
+                       .. host .. "] port[" .. tostring(port) .. "] err: " .. err)
     end
 
     -- upstream latency
     if entry.upstream_latency then
-        ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                           "upstream.latency", entry.upstream_latency, "h", suffix))
+        ok, err = sock:send(format("%s:%s|%s%s", prefix .. "upstream.latency",
+                                   entry.upstream_latency, "h", suffix))
         if not ok then
             err_msg = "error sending upstream.latency: " .. err
             core.log.error("failed to report upstream latency to dogstatsd server: host["
-                        .. host .. "] port[" .. tostring(port) .. "] err: " .. err)
+                           .. host .. "] port[" .. tostring(port) .. "] err: " .. err)
         end
     end
 
     -- apisix_latency
-    ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                       "apisix.latency", entry.apisix_latency, "h", suffix))
+    ok, err = sock:send(format("%s:%s|%s%s", prefix .. "apisix.latency",
+                               entry.apisix_latency, "h", suffix))
     if not ok then
         err_msg = "error sending apisix.latency: " .. err
         core.log.error("failed to report apisix latency to dogstatsd server: host[" .. host
-                .. "] port[" .. tostring(port) .. "] err: " .. err)
+                       .. "] port[" .. tostring(port) .. "] err: " .. err)
     end
 
     -- request body size timer
-    ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                       "ingress.size", entry.request.size, "ms", suffix))
+    ok, err = sock:send(format("%s:%s|%s%s", prefix .. "ingress.size",
+                               entry.request.size, "ms", suffix))
     if not ok then
         err_msg = "error sending ingress.size: " .. err
         core.log.error("failed to report req body size to dogstatsd server: host[" .. host
-                .. "] port[" .. tostring(port) .. "] err: " .. err)
+                       .. "] port[" .. tostring(port) .. "] err: " .. err)
     end
 
     -- response body size timer
-    ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                       "egress.size", entry.response.size, "ms", suffix))
+    ok, err = sock:send(format("%s:%s|%s%s", prefix .. "egress.size",
+                               entry.response.size, "ms", suffix))
     if not ok then
         err_msg = "error sending egress.size: " .. err
         core.log.error("failed to report response body size to dogstatsd server: host["
-                .. host .. "] port[" .. tostring(port) .. "] err: " .. err)
+                       .. host .. "] port[" .. tostring(port) .. "] err: " .. err)
     end
 
     ok, err = sock:close()
     if not ok then
         core.log.error("failed to close the UDP connection, host[",
-                        host, "] port[", port, "] ", err)
+                       host, "] port[", port, "] ", err)
     end
 
     if not err_msg then
@@ -204,7 +203,7 @@ local function push_metrics(entries)
 
     if not metadata then
         core.log.info("received nil metadata: using metadata defaults: ",
-                                    core.json.delay_encode(defaults, true))
+                      core.json.delay_encode(defaults, true))
         metadata = {}
         metadata.value = defaults
     end

--- a/apisix/plugins/datadog.lua
+++ b/apisix/plugins/datadog.lua
@@ -117,7 +117,7 @@ local function send_metric_over_udp(entry, metadata)
     local ok, err = sock:setpeername(host, port)
     if not ok then
         return false, "failed to connect to UDP server: host[" .. host
-                    .. "] port[" .. tostring(port) .. "] err: " .. err
+                   .. "] port[" .. tostring(port) .. "] err: " .. err
     end
 
     -- Generate prefix & suffix according dogstatsd udp data format.
@@ -129,7 +129,7 @@ local function send_metric_over_udp(entry, metadata)
 
     -- request counter
     ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                                    "request.counter", 1, "c", suffix))
+                       "request.counter", 1, "c", suffix))
     if not ok then
         err_msg = "error sending request.counter: " .. err
         core.log.error("failed to report request count to dogstatsd server: host[" .. host
@@ -138,7 +138,7 @@ local function send_metric_over_udp(entry, metadata)
 
     -- request latency histogram
     ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                                "request.latency", entry.latency, "h", suffix))
+                       "request.latency", entry.latency, "h", suffix))
     if not ok then
         err_msg = "error sending request.latency: " .. err
         core.log.error("failed to report request latency to dogstatsd server: host["
@@ -148,7 +148,7 @@ local function send_metric_over_udp(entry, metadata)
     -- upstream latency
     if entry.upstream_latency then
         ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                        "upstream.latency", entry.upstream_latency, "h", suffix))
+                           "upstream.latency", entry.upstream_latency, "h", suffix))
         if not ok then
             err_msg = "error sending upstream.latency: " .. err
             core.log.error("failed to report upstream latency to dogstatsd server: host["
@@ -158,7 +158,7 @@ local function send_metric_over_udp(entry, metadata)
 
     -- apisix_latency
     ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                            "apisix.latency", entry.apisix_latency, "h", suffix))
+                       "apisix.latency", entry.apisix_latency, "h", suffix))
     if not ok then
         err_msg = "error sending apisix.latency: " .. err
         core.log.error("failed to report apisix latency to dogstatsd server: host[" .. host
@@ -167,7 +167,7 @@ local function send_metric_over_udp(entry, metadata)
 
     -- request body size timer
     ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                                    "ingress.size", entry.request.size, "ms", suffix))
+                       "ingress.size", entry.request.size, "ms", suffix))
     if not ok then
         err_msg = "error sending ingress.size: " .. err
         core.log.error("failed to report req body size to dogstatsd server: host[" .. host
@@ -176,7 +176,7 @@ local function send_metric_over_udp(entry, metadata)
 
     -- response body size timer
     ok, err = sock:send(format("%s:%s|%s%s", prefix ..
-                                    "egress.size", entry.response.size, "ms", suffix))
+                       "egress.size", entry.response.size, "ms", suffix))
     if not ok then
         err_msg = "error sending egress.size: " .. err
         core.log.error("failed to report response body size to dogstatsd server: host["

--- a/apisix/plugins/loggly.lua
+++ b/apisix/plugins/loggly.lua
@@ -292,7 +292,7 @@ local function handle_log(entries)
         for i = 1, #entries do
             local ok, err = send_data_over_udp(entries[i], metadata)
             if not ok then
-                return false, err
+                return false, err, i
             end
         end
     else

--- a/docs/en/latest/batch-processor.md
+++ b/docs/en/latest/batch-processor.md
@@ -70,7 +70,10 @@ function _M.log(conf, ctx)
         -- serialize to json array core.json.encode(entries)
         -- process/send data
         return true
-        -- return false, err_msg if failed
+        -- return false, err_msg, first_fail if failed
+        -- first_fail(optional) indicates first_fail-1 entries have been successfully processed
+        -- and during processing of entries[first_fail], the error occurred. So the batch processor
+        -- only retries for the entries having index >= first_fail as per the retry policy.
     end
     batch_processor_manager:add_entry_to_new_processor(conf, entry, ctx, func)
 end
@@ -120,7 +123,7 @@ local err
 local func = function(entries)
     ...
     return true
-    -- return false, err_msg if failed
+    -- return false, err_msg, first_fail if failed
 end
 log_buffer, err = batch_processor:new(func, config_bat)
 

--- a/docs/zh/latest/batch-processor.md
+++ b/docs/zh/latest/batch-processor.md
@@ -68,7 +68,10 @@ function _M.log(conf, ctx)
         -- serialize to json array core.json.encode(entries)
         -- process/send data
         return true
-        -- return false, err_msg if failed
+        -- return false, err_msg, first_fail if failed
+        -- first_fail(optional) indicates first_fail-1 entries have been successfully processed
+        -- and during processing of entries[first_fail], the error occurred. So the batch processor
+        -- only retries for the entries having index >= first_fail as per the retry policy.
     end
     batch_processor_manager:add_entry_to_new_processor(conf, entry, ctx, func)
 end
@@ -118,7 +121,7 @@ local err
 local func = function(entries)
     ...
     return true
-    -- return false, err_msg if failed
+    -- return false, err_msg, first_fail if failed
 end
 log_buffer, err = batch_processor:new(func, config_bat)
 


### PR DESCRIPTION
Signed-off-by: Bisakh Mondal <bisakhmondal00@gmail.com>



### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Helpful where the batch processor entries can't be processed in one go (transactional) and an error occurs during the middle of the consumption. With this PR, the batch processor takes a hint from the consumer so that the already consumed entries don't get retried in the next run.

Use case: https://github.com/apache/apisix/pull/6113#discussion_r790424879, datadog plugin etc (where entries can't be processed as a bulk)

### Pre-submission checklist:

<!--
Please follow the PR manners:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
7. Only reviewer can click "Resolve conversation" to mark the reviewer's review resolved
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
