### PR TITLE
fix(batch-requests): should be disabled by default

### DIFF
--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -329,7 +329,7 @@ plugins:                          # plugin list (sorted by priority)
   - request-id                     # priority: 11010
   - fault-injection                # priority: 11000
   - serverless-pre-function        # priority: 10000
-  - batch-requests                 # priority: 4010
+  #- batch-requests                # priority: 4010
   - cors                           # priority: 4000
   - ip-restriction                 # priority: 3000
   - ua-restriction                 # priority: 2999

--- a/t/admin/plugins.t
+++ b/t/admin/plugins.t
@@ -68,7 +68,6 @@ zipkin
 request-id
 fault-injection
 serverless-pre-function
-batch-requests
 cors
 ip-restriction
 ua-restriction

--- a/t/debug/debug-mode.t
+++ b/t/debug/debug-mode.t
@@ -48,7 +48,6 @@ loaded plugin and sort by priority: 11011 name: zipkin
 loaded plugin and sort by priority: 11010 name: request-id
 loaded plugin and sort by priority: 11000 name: fault-injection
 loaded plugin and sort by priority: 10000 name: serverless-pre-function
-loaded plugin and sort by priority: 4010 name: batch-requests
 loaded plugin and sort by priority: 4000 name: cors
 loaded plugin and sort by priority: 3000 name: ip-restriction
 loaded plugin and sort by priority: 2990 name: referer-restriction


### PR DESCRIPTION
Actually it should be disabled in 0aa97c30f7741eeeb341eed0795c3bd0ef1b7556

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the PR manners:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
7. Only reviewer can click "Resolve conversation" to mark the reviewer's review resolved
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
