### PR TITLE
build: purge all the dependent rocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,14 @@ deps: runtime
 	fi
 
 
+### undeps : Uninstallation dependencies
+.PHONY: undeps
+undeps:
+	@$(call func_echo_status, "$@ -> [ Start ]")
+	$(ENV_LUAROCKS) purge --tree=deps
+	@$(call func_echo_success_status, "$@ -> [ Done ]")
+
+
 ### utils : Installation tools
 .PHONY: utils
 utils:

--- a/docs/en/latest/how-to-build.md
+++ b/docs/en/latest/how-to-build.md
@@ -122,6 +122,8 @@ Please refer to: [Installing Apache APISIX with Helm Chart](https://github.com/a
 ```shell
   # Uninstall apisix command
   $ make uninstall
+  # Purge dependencies
+  $ make undeps
 ```
 
   Attention please, this operation will totally **remove** the related files.

--- a/docs/zh/latest/how-to-build.md
+++ b/docs/zh/latest/how-to-build.md
@@ -122,6 +122,8 @@ $ sudo yum install ./apisix/*.rpm
 ```shell
   # 卸载 apisix 命令
   $ make uninstall
+  # 卸载依赖
+  $ make undeps
 ```
 
   请注意，该操作将完整**删除**相关文件。


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
`make undeps` supports to uninstall dependent rocks.

use it in some cases:

- failed rocks after installed partial, clear then reinstall
- modify some rocks source codes, recover them, so purge and reinstall

<!--- If it fixes an open issue, please link to the issue here. -->
#6226 
### Pre-submission checklist:

<!--
Please follow the PR manners:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
7. Only reviewer can click "Resolve conversation" to mark the reviewer's review resolved
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
