### PR TITLE
ci: runner shell sudo doesn't affect redirects SC2024

### DIFF
--- a/ci/linux_apisix_current_luarocks_runner.sh
+++ b/ci/linux_apisix_current_luarocks_runner.sh
@@ -33,8 +33,8 @@ script() {
     sudo rm -rf /usr/local/share/lua/5.1/apisix
 
     # install APISIX with local version
-    sudo luarocks install rockspec/apisix-master-0.rockspec --only-deps | sudo tee build.log > /dev/null 2>&1 || (cat build.log && exit 1)
-    sudo luarocks make rockspec/apisix-master-0.rockspec | sudo tee build.log > /dev/null 2>&1 || (cat build.log && exit 1)
+    sudo luarocks install rockspec/apisix-master-0.rockspec --only-deps | tee build.log > /dev/null 2>&1 || (cat build.log && exit 1)
+    sudo luarocks make rockspec/apisix-master-0.rockspec | tee build.log > /dev/null 2>&1 || (cat build.log && exit 1)
     # ensure all files under apisix is installed
     diff -rq apisix /usr/local/share/lua/5.1/apisix
 

--- a/ci/linux_apisix_current_luarocks_runner.sh
+++ b/ci/linux_apisix_current_luarocks_runner.sh
@@ -33,8 +33,8 @@ script() {
     sudo rm -rf /usr/local/share/lua/5.1/apisix
 
     # install APISIX with local version
-    sudo luarocks install rockspec/apisix-master-0.rockspec --only-deps > build.log 2>&1 || (cat build.log && exit 1)
-    sudo luarocks make rockspec/apisix-master-0.rockspec > build.log 2>&1 || (cat build.log && exit 1)
+    sudo luarocks install rockspec/apisix-master-0.rockspec --only-deps | sudo tee build.log > /dev/null 2>&1 || (cat build.log && exit 1)
+    sudo luarocks make rockspec/apisix-master-0.rockspec | sudo tee build.log > /dev/null 2>&1 || (cat build.log && exit 1)
     # ensure all files under apisix is installed
     diff -rq apisix /usr/local/share/lua/5.1/apisix
 

--- a/ci/linux_apisix_master_luarocks_runner.sh
+++ b/ci/linux_apisix_master_luarocks_runner.sh
@@ -37,7 +37,7 @@ script() {
     cp -r ../utils ./
 
     # install APISIX by luarocks
-    sudo luarocks install $APISIX_MAIN > build.log 2>&1 || (cat build.log && exit 1)
+    sudo luarocks install $APISIX_MAIN | sudo tee build.log > /dev/null 2>&1 || (cat build.log && exit 1)
     cp ../bin/apisix /usr/local/bin/apisix
 
     # show install files

--- a/ci/linux_apisix_master_luarocks_runner.sh
+++ b/ci/linux_apisix_master_luarocks_runner.sh
@@ -37,7 +37,7 @@ script() {
     cp -r ../utils ./
 
     # install APISIX by luarocks
-    sudo luarocks install $APISIX_MAIN | sudo tee build.log > /dev/null 2>&1 || (cat build.log && exit 1)
+    sudo luarocks install $APISIX_MAIN | tee build.log > /dev/null 2>&1 || (cat build.log && exit 1)
     cp ../bin/apisix /usr/local/bin/apisix
 
     # show install files

--- a/ci/linux_openresty_common_runner.sh
+++ b/ci/linux_openresty_common_runner.sh
@@ -19,7 +19,7 @@
 . ./ci/common.sh
 
 before_install() {
-    sudo cpanm --notest Test::Nginx | sudo tee build.log > /dev/null 2>&1 || (cat build.log && exit 1)
+    sudo cpanm --notest Test::Nginx | tee build.log > /dev/null 2>&1 || (cat build.log && exit 1)
 
     # launch deps env
     make ci-env-up

--- a/ci/linux_openresty_common_runner.sh
+++ b/ci/linux_openresty_common_runner.sh
@@ -19,7 +19,7 @@
 . ./ci/common.sh
 
 before_install() {
-    sudo cpanm --notest Test::Nginx >build.log 2>&1 || (cat build.log && exit 1)
+    sudo cpanm --notest Test::Nginx | sudo tee build.log > /dev/null 2>&1 || (cat build.log && exit 1)
 
     # launch deps env
     make ci-env-up


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
fix ci shell scripts warning `sudo` doesn't affect redirects [SC2024](https://github.com/koalaman/shellcheck/wiki/SC2024)

- use `tee` copies standard input to standard output, instead of `>` to write

<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the PR manners:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
7. Only reviewer can click "Resolve conversation" to mark the reviewer's review resolved
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
