### PR TITLE
ci: enforce request review on the final state

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -45,6 +45,7 @@ github:
     protected_branches:
       master:
         required_pull_request_reviews:
+          dismiss_stale_reviews: true
           require_code_owner_reviews: true
           required_approving_review_count: 2
       release/2.12:


### PR DESCRIPTION
In https://github.com/apache/apisix/pull/5940#discussion_r802593858,
during solving the merge conflict,
a bug which is fixed in https://github.com/apache/apisix/pull/6204 is
reintroduced.
The test is also changed so it can't catch up the regression.

That PR is approved before merging the master. Luckily, I am cautious
enough to start another turn of review.

We should not rely on the lucky or someone else's caution.
To prevent that from happening again, here we enforce the approval
should be applied with the final state.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the PR manners:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
7. Only reviewer can click "Resolve conversation" to mark the reviewer's review resolved
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
