### PR TITLE
build(install-deps): noops on installed yum-utils

### DIFF
--- a/utils/install-dependencies.sh
+++ b/utils/install-dependencies.sh
@@ -44,7 +44,7 @@ function install_dependencies_with_aur() {
 
 # Install dependencies on centos and fedora
 function install_dependencies_with_yum() {
-    sudo yum install -y yum-utils
+    rpm -q --quiet yum-utils || sudo yum install -y yum-utils
 
     local common_dep="curl git gcc openresty-openssl111-devel unzip pcre pcre-devel openldap-devel"
     if [ "${1}" == "centos" ]; then


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
1. no repeatedly install `yum-utils`, install only when not found it.
2. more quickly complete `utils/install-dependencies.sh multi_distro_installation`

on my env, it shows that noops maybe complete 30% quickly than nocheck

- noops takes 4.149s

```bash
[vagrant@lvs apisix]$ time ./utils/install-dependencies.sh multi_distro_installation
+ main multi_distro_installation
++ uname -s
++ tr '[:upper:]' '[:lower:]'
+ OS_NAME=linux
+ [[ 1 == 0 ]]
+ case_opt=multi_distro_installation
+ case "${case_opt}" in
+ multi_distro_installation
+ grep -Eqi CentOS /etc/issue
+ grep -Eq CentOS /etc/centos-release /etc/os-release /etc/redhat-release /etc/system-release
+ install_dependencies_with_yum centos
+ rpm -q --quiet yum-utils
+ local 'common_dep=curl git gcc openresty-openssl111-devel unzip pcre pcre-devel openldap-devel'
+ '[' centos == centos ']'
+ local apisix_pkg=apache-apisix-repo-1.0-1.noarch
+ rpm -q --quiet apache-apisix-repo-1.0-1.noarch
+ sudo yum install -y apisix-base curl git gcc openresty-openssl111-devel unzip pcre pcre-devel openldap-devel
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
Package apisix-base-1.19.9.1.3-0.el7.x86_64 already installed and latest version
Package curl-7.29.0-59.el7_9.1.x86_64 already installed and latest version
Package git-1.8.3.1-23.el7_8.x86_64 already installed and latest version
Package gcc-4.8.5-44.el7.x86_64 already installed and latest version
Package openresty-openssl111-devel-1.1.1l-1.el7.x86_64 already installed and latest version
Package unzip-6.0-24.el7_9.x86_64 already installed and latest version
Package pcre-8.32-17.el7.x86_64 already installed and latest version
Package pcre-devel-8.32-17.el7.x86_64 already installed and latest version
Package openldap-devel-2.4.44-24.el7_9.x86_64 already installed and latest version
Nothing to do

real	0m4.149s
user	0m1.275s
sys	0m1.397s
```

- nocheck takes 6.402s

```bash
[vagrant@lvs apisix]$ time ./utils/install-dependencies.sh multi_distro_installation
+ main multi_distro_installation
++ uname -s
++ tr '[:upper:]' '[:lower:]'
+ OS_NAME=linux
+ [[ 1 == 0 ]]
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
+ case_opt=multi_distro_installation
+ case "${case_opt}" in
+ multi_distro_installation
+ grep -Eqi CentOS /etc/issue
+ grep -Eq CentOS /etc/centos-release /etc/os-release /etc/redhat-release /etc/system-release
+ install_dependencies_with_yum centos
+ sudo yum install -y yum-utils
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
Package yum-utils-1.1.31-54.el7_8.noarch already installed and latest version
Nothing to do
+ local 'common_dep=curl git gcc openresty-openssl111-devel unzip pcre pcre-devel openldap-devel'
+ '[' centos == centos ']'
+ local apisix_pkg=apache-apisix-repo-1.0-1.noarch
+ rpm -q --quiet apache-apisix-repo-1.0-1.noarch
+ sudo yum install -y apisix-base curl git gcc openresty-openssl111-devel unzip pcre pcre-devel openldap-devel
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
Package apisix-base-1.19.9.1.3-0.el7.x86_64 already installed and latest version
Package curl-7.29.0-59.el7_9.1.x86_64 already installed and latest version
Package git-1.8.3.1-23.el7_8.x86_64 already installed and latest version
Package gcc-4.8.5-44.el7.x86_64 already installed and latest version
Package openresty-openssl111-devel-1.1.1l-1.el7.x86_64 already installed and latest version
Package unzip-6.0-24.el7_9.x86_64 already installed and latest version
Package pcre-8.32-17.el7.x86_64 already installed and latest version
Package pcre-devel-8.32-17.el7.x86_64 already installed and latest version
Package openldap-devel-2.4.44-24.el7_9.x86_64 already installed and latest version
Nothing to do

real	0m6.402s
user	0m2.064s
sys	0m1.932s
```
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the PR manners:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
7. Only reviewer can click "Resolve conversation" to mark the reviewer's review resolved
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
