### PR TITLE
fix(opentelemetry): batch_span_processor export zero length spans

### DIFF
--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -73,7 +73,7 @@ dependencies = {
     "inspect == 3.1.1",
     "lualdap = 1.2.6-1",
     "lua-resty-rocketmq = 0.3.0-0",
-    "opentelemetry-lua = 0.1-1",
+    "opentelemetry-lua = 0.1-2",
 }
 
 build = {


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #6329 
