### PR TITLE
fix: should not limit the header number

### DIFF
--- a/apisix/core/request.lua
+++ b/apisix/core/request.lua
@@ -43,7 +43,7 @@ local function _headers(ctx)
     end
     local headers = ctx.headers
     if not headers then
-        headers = get_headers()
+        headers = get_headers(0)
         ctx.headers = headers
     end
 

--- a/apisix/plugins/request-validation.lua
+++ b/apisix/plugins/request-validation.lua
@@ -66,8 +66,8 @@ function _M.check_schema(conf)
 end
 
 
-function _M.rewrite(conf)
-    local headers = ngx.req.get_headers()
+function _M.rewrite(conf, ctx)
+    local headers = core.request.headers(ctx)
 
     if conf.header_schema then
         local ok, err = core.schema.check(conf.header_schema, headers)

--- a/t/core/request.t
+++ b/t/core/request.t
@@ -422,3 +422,24 @@ the post form is too large: request body in temp file not supported
 POST /t
 --- response_body
 POST
+
+
+
+=== TEST 14: get header
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            ngx.say(core.request.header(ngx.ctx, "X-101"))
+        }
+    }
+--- more_headers eval
+my $i = 1;
+my $s;
+while ($i <= 101) {
+    $s .= "X-$i:$i\n";
+    $i++;
+}
+$s
+--- response_body
+101


### PR DESCRIPTION
TODO: convert the remain `ngx.req.get_headers()[XXX]` to core.request.header(...)
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the PR manners:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
7. Only reviewer can click "Resolve conversation" to mark the reviewer's review resolved
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
