### PR TITLE
docs: optimization curl command

### DIFF
--- a/docs/en/latest/getting-started.md
+++ b/docs/en/latest/getting-started.md
@@ -111,7 +111,7 @@ Once the download is complete, execute the `curl` command on the host running Do
 
 ```bash
 # Note: Please execute the curl command on the host where you are running Docker.
-curl "http://127.0.0.1:9080/apisix/admin/services/" -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1'
+curl "http://127.0.0.1:9080/apisix/admin/services/" -H "X-API-KEY: edd1c9f034335f136f87ad84b625c8f1"
 ```
 
 The following data is returned to indicate that Apache APISIX was successfully started:

--- a/docs/zh/latest/getting-started.md
+++ b/docs/zh/latest/getting-started.md
@@ -109,7 +109,7 @@ docker-compose -p docker-apisix up -d
 
 ```bash
 # 注意：请在运行 Docker 的宿主机上执行 curl 命令。
-curl "http://127.0.0.1:9080/apisix/admin/services/" -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1'
+curl "http://127.0.0.1:9080/apisix/admin/services/" -H "X-API-KEY: edd1c9f034335f136f87ad84b625c8f1"
 ```
 
 返回数据如下所示，表示 Apache APISIX 成功启动：


### PR DESCRIPTION



### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In some special env. the test curl command may get the error result.
optimization the command in docs.
``` sh
# curl "http://127.0.0.1:9080/apisix/admin/services/" -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1'
{"error_msg":"failed to check token"}
curl: (6) Could not resolve host: edd1c9f034335f136f87ad84b625c8f1'
```
references： https://blog.csdn.net/u011035397/article/details/109452045


### Pre-submission checklist:

<!--
Please follow the PR manners:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
7. Only reviewer can click "Resolve conversation" to mark the reviewer's review resolved
-->

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
