### PR TITLE
docs: update "getting started" and "how to build" guides

### DIFF
--- a/docs/en/latest/getting-started.md
+++ b/docs/en/latest/getting-started.md
@@ -31,7 +31,7 @@ The guide is divided into these three steps:
 2. Creating a Route and binding it with an Upstream
 3. Verifying the results after binding with `curl`
 
-This docs also introduces some of the advanced features and operations in Apache APISIX like authentication, prefixing a Route, using the APISIX Dashboard, and troubleshooting.
+This document also introduces some of the advanced features and operations in Apache APISIX like authentication, prefixing a Route, using the APISIX Dashboard, and troubleshooting.
 
 The following `echo` endpoint is used as an example here. This endpoint will return the parameters we pass.
 
@@ -76,7 +76,7 @@ We receive a JSON response when we send the request:
 
 ## Pre-Requisites
 
-Before you jump head, make sure that you have your machine setup with these tools.
+Before you jump ahead, make sure that you have your machine setup with these tools.
 
 - [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/).
 
@@ -118,11 +118,11 @@ Please remain patient as it will take some time to download the files and spin u
 Once Apache APISIX is running, you can use `curl` to access the Admin API. You can also check if Apache APISIX is running properly by running this command and checking the response.
 
 ```bash
-# Execute in your host machine (machine running Docker)
+# Execute on your host machine (machine running Docker)
 curl "http://127.0.0.1:9080/apisix/admin/services/" -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1'
 ```
 
-This response indicate that Apache APISIX is running successfully.
+This response indicates that Apache APISIX is running successfully.
 
 ```json
 {
@@ -138,7 +138,7 @@ This response indicate that Apache APISIX is running successfully.
 
 ## Step 2: Create a Route
 
-[Routes](./architecture-design/route.md) matches to clients requests based on defined rules, loads and executes the corresponding plugins, and forwards the request to the specified upstream.
+[Routes](./architecture-design/route.md) matches the client's requests based on defined rules, loads and executes the corresponding plugins, and forwards the request to the specified upstream.
 
 From the previous step, we have a running instance of Apache APISIX in Docker. Now let's create a Route.
 
@@ -161,7 +161,7 @@ curl "http://127.0.0.1:9080/apisix/admin/routes/1" -H "X-API-KEY: edd1c9f034335f
 }'
 ```
 
-This configuration basically means that it will forward all matching inbound requests to the upstream service (`httpbin.org:80`) if they meet these specified criterions.
+This configuration means that it will forward all matching inbound requests to the upstream service (`httpbin.org:80`) if they meet these specified criterion.
 
 - The HTTP method of the request is `GET`.
 - The request header contains the `host` field, and its value is `example.com`.
@@ -191,7 +191,7 @@ curl "http://127.0.0.1:9080/apisix/admin/upstreams/1" -H "X-API-KEY: edd1c9f0343
 }'
 ```
 
-We use `roundrobin` as the load balancing mechanism, and set `httpbin.org:80` as our Upstream service with an ID of `1`. See [Admin API](./admin-api.md) for more information about the fields.
+We use `roundrobin` as the load balancing mechanism and set `httpbin.org:80` as our Upstream service with an ID of `1`. See [Admin API](./admin-api.md) for more information about the fields.
 
 <!--
 #
@@ -326,7 +326,7 @@ You can try these troubleshooting steps if you are unable to proceed as suggeste
 
 Please [open an issue](/docs/general/contributor-guide#submit-an-issue) if you run into any bugs or if there are any missing troubleshooting steps.
 
-- Make sure that all required ports (**default 9080/9443/2379**) are available and is not used by other systems or processes.
+- Make sure that all required ports (**default 9080/9443/2379**) are available (not used by other systems or processes).
 
     You can run the command below to terminate the processes that are listening on a specific port (on Unix-based systems).
 

--- a/docs/en/latest/getting-started.md
+++ b/docs/en/latest/getting-started.md
@@ -23,35 +23,39 @@ title: Getting Started
 
 ## Summary
 
-This documentation is a quick start guide for Apache APISIX. The Quick Start is divided into the following three steps:
+This guide walks through how you can get up and running with Apache APISIX.
 
-1. Install Apache APISIX via [Docker Compose](https://docs.docker.com/compose/).
-1. Create a route and bind it with a Upstream.
-1. Use `curl` command to verify that the results returned after binding are as expected.
+The guide is divided into these three steps:
 
-In addition, this documentation provides some advanced operations on how to use Apache APISIX, including adding authentication, prefixing Route, using the APISIX Dashboard, and troubleshooting.
+1. Installing Apache APISIX
+2. Creating a Route and binding it with an Upstream
+3. Verifying the results after binding with `curl`
 
-We will use the following `echo` endpoint as an example, which will return the parameters we passed.
+This docs also introduces some of the advanced features and operations in Apache APISIX like authentication, prefixing a Route, using the APISIX Dashboard, and troubleshooting.
+
+The following `echo` endpoint is used as an example here. This endpoint will return the parameters we pass.
 
 **Request**
 
-The request URL consists of these components:
+The components of the request URL are shown and explained below:
 
 ![RequestURL](../../assets/images/requesturl.jpg)
 
-- Protocol: the network transport protocol, `HTTP` protocol is used in our example.
-- Port: The port, `80` is used in our example.
-- Host: The host, `httpbin.org` is used in our example.
-- Path: The path, `/get` is used in our example.
-- Query Parameters: the query string, two strings `foo1` and `foo2` are listed in our example.
+- Protocol: The network transport protocol. `HTTP` protocol is used for this example.
+- Port: The port. `80` is used for this example.
+- Host: The host. `httpbin.org` is used for this example.
+- Path: The path. `/get` is used for this example.
+- Query Parameters: The query string. Two strings `foo1` and `foo2` are used for this example.
 
-Run the following command to send the request:
+We can use the `curl` command to send the request:
 
 ```bash
 curl --location --request GET "http://httpbin.org/get?foo1=bar1&foo2=bar2"
 ```
 
 **Response**
+
+We receive a JSON response when we send the request:
 
 ```json
 {
@@ -70,11 +74,13 @@ curl --location --request GET "http://httpbin.org/get?foo1=bar1&foo2=bar2"
 }
 ```
 
-## Pre-requisites
+## Pre-Requisites
 
-- Installed [Docker](https://www.docker.com/) and [Docker Compose component](https://docs.docker.com/compose/).
+Before you jump head, make sure that you have your machine setup with these tools.
 
-- We use the [curl](https://curl.se/docs/manpage.html) command for API testing. You can also use other tools such as [Postman](https://www.postman.com/) for testing.
+- [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/).
+
+- [curl](https://curl.se/docs/manpage.html) for testing the API. Alternatively, you can use tools like [Hoppscotch](https://hoppscotch.io/) or [Postman](https://www.postman.com/).
 
 <!--
 #
@@ -92,29 +98,31 @@ If you already have Apache APISIX installed, please skip Step 1, and go to [Step
 
 ## Step 1: Install Apache APISIX
 
-Thanks to Docker, we can start Apache APISIX and enable it by enabling [Admin API](./admin-api.md).
+You can check out [Building Apache APISIX](./how-to-build.md) for different installation methods.
+
+To get started quickly, we will install Apache APISIX with Docker and enable the [Admin API](./admin-api.md).
 
 ```bash
-# Download the Docker image of Apache APISIX
+# Download the docker-compose file of Apache APISIX
 git clone https://github.com/apache/apisix-docker.git
-# Switch the current directory to the apisix-docker/example path
+# Switch the current directory to the apisix-docker/example
 cd apisix-docker/example
-# Run the docker-compose command to install Apache APISIX
+# Start Apache APISIX with docker-compose
 docker-compose -p docker-apisix up -d
 ```
 
-> Apache APISIX has already supported ARM64 architecture. For ARM64 users, please use `docker-compose -p docker-apisix -f docker-compose-arm64.yml up -d` instead in the last step.
+> Apache APISIX already supports ARM64 architecture. To run Apache APISIX on ARM64, run: `docker-compose -p docker-apisix -f docker-compose-arm64.yml up -d` instead of the last step above.
 
-It will take some time to download all required files, please be patient.
+Please remain patient as it will take some time to download the files and spin up the containers.
 
-Once the download is complete, execute the `curl` command on the host running Docker to access the Admin API, and determine if Apache APISIX was successfully started based on the returned data.
+Once Apache APISIX is running, you can use `curl` to access the Admin API. You can also check if Apache APISIX is running properly by running this command and checking the response.
 
 ```bash
-# Note: Please execute the curl command on the host where you are running Docker.
+# Execute in your host machine (machine running Docker)
 curl "http://127.0.0.1:9080/apisix/admin/services/" -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1'
 ```
 
-The following data is returned to indicate that Apache APISIX was successfully started:
+This response indicate that Apache APISIX is running successfully.
 
 ```json
 {
@@ -130,15 +138,13 @@ The following data is returned to indicate that Apache APISIX was successfully s
 
 ## Step 2: Create a Route
 
-Now we have a running instance of Apache APISIX! Next, let's create a Route.
+[Routes](./architecture-design/route.md) matches to clients requests based on defined rules, loads and executes the corresponding plugins, and forwards the request to the specified upstream.
 
-### How it works
+From the previous step, we have a running instance of Apache APISIX in Docker. Now let's create a Route.
 
-Apache APISIX provides users with a powerful [Admin API](./admin-api.md) and [APISIX Dashboard](https://github.com/apache/apisix-dashboard). In this documentation, we use the Admin API to walk you through the procedures of creating a Route.
+Apache APISIX provides a powerful [Admin API](./admin-api.md) and [APISIX Dashboard](https://github.com/apache/apisix-dashboard). Here, we will use the Admin API to create a Route and connect it to an [Upstream](./architecture-design/upstream.md) service. When a request arrives, Apache APISIX will forward the request to the specified Upstream service.
 
-We can create a [Route](./architecture-design/route.md) and connect it to an Upstream service(also known as the [Upstream](./architecture-design/upstream.md)). When a `Request` arrives at Apache APISIX, Apache APISIX knows which Upstream the request should be forwarded to.
-
-Because we have configured matching rules for the Route object, Apache APISIX can forward the request to the corresponding Upstream service. The following code creates a sample configuration of Route:
+We will create a sample configuration for our Route object so that Apache APISIX can forward the request to the corresponding Upstream service.
 
 ```bash
 curl "http://127.0.0.1:9080/apisix/admin/routes/1" -H "X-API-KEY: edd1c9f034335f136f87ad84b625c8f1" -X PUT -d '
@@ -155,23 +161,25 @@ curl "http://127.0.0.1:9080/apisix/admin/routes/1" -H "X-API-KEY: edd1c9f034335f
 }'
 ```
 
-This routing configuration means that all matching inbound requests will be forwarded to the Upstream service `httpbin.org:80` when they meet **all** the rules listed below:
+This configuration basically means that it will forward all matching inbound requests to the upstream service (`httpbin.org:80`) if they meet these specified criterions.
 
 - The HTTP method of the request is `GET`.
 - The request header contains the `host` field, and its value is `example.com`.
-- The request path matches `/anything/*`, `*` means any subpath, for example `/anything/foo?arg=10`.
+- The request path matches `/anything/*`. `*` means any sub path. For example `/anything/foo?arg=10`.
 
-Once this route is created, we can access the Upstream service using the address exposed by Apache APISIX.
+Now that the Route has been created, we can access the Upstream service from the address exposed by Apache APISIX.
 
 ```bash
 curl -i -X GET "http://127.0.0.1:9080/anything/foo?arg=10" -H "Host: example.com"
 ```
 
-This will be forwarded to `http://httpbin.org:80/anything/foo?arg=10` by Apache APISIX.
+This request will be forwarded to `http://httpbin.org:80/anything/foo?arg=10` by Apache APISIX.
 
 ### Create an Upstream
 
-After reading the previous section, we know that we must set up an `Upstream` for  the `Route`. An Upstream can be created by simply executing the following command:
+In the previous session we discussed setting up a Route and an Upstream for the Route.
+
+To create an Upstream, we can execute the following command.
 
 ```bash
 curl "http://127.0.0.1:9080/apisix/admin/upstreams/1" -H "X-API-KEY: edd1c9f034335f136f87ad84b625c8f1" -X PUT -d '
@@ -183,7 +191,7 @@ curl "http://127.0.0.1:9080/apisix/admin/upstreams/1" -H "X-API-KEY: edd1c9f0343
 }'
 ```
 
-We use `roundrobin` as the load balancing mechanism, and set `httpbin.org:80` as our upstream target (Upstream service) with an ID of `1`. For more information on the fields, see [Admin API](./admin-api.md).
+We use `roundrobin` as the load balancing mechanism, and set `httpbin.org:80` as our Upstream service with an ID of `1`. See [Admin API](./admin-api.md) for more information about the fields.
 
 <!--
 #
@@ -196,12 +204,12 @@ We use `roundrobin` as the load balancing mechanism, and set `httpbin.org:80` as
 -->
 
 :::note Note
-Creating an Upstream service is not actually necessary, as we can use [Plugin](./architecture-design/plugin.md) to intercept the request and then respond directly. However, for the purposes of this guide, we assume that at least one Upstream service needs to be set up.
+Creating an Upstream service is not mandatory as we can use a [Plugin](./architecture-design/plugin.md) to intercept the request and then respond directly. However, for the purposes of this guide, we assume that at least one Upstream service needs to be set up.
 :::
 
-### Bind the Route to the Upstream
+### Binding the Route to the Upstream
 
-We've just created an Upstream service (referencing our backend service), now let's bind a Route for it!
+We can now bind a Route to the Upstream service we just created.
 
 ```bash
 curl "http://127.0.0.1:9080/apisix/admin/routes/1" -H "X-API-KEY: edd1c9f034335f136f87ad84b625c8f1" -X PUT -d '
@@ -212,27 +220,31 @@ curl "http://127.0.0.1:9080/apisix/admin/routes/1" -H "X-API-KEY: edd1c9f034335f
 }'
 ```
 
-## Step 3: Validation
+## Step 3: Validating the Route
 
-We have created the route and the Upstream service and bound them. Now let's access Apache APISIX to test this route.
+We will now access Apache APISIX to test the Route and the bounded Upstream service.
 
 ```bash
 curl -i -X GET "http://127.0.0.1:9080/get?foo1=bar1&foo2=bar2" -H "Host: httpbin.org"
 ```
 
-It returns data from our Upstream service (actually `httpbin.org`) and the result is as expected.
+This will return the data from the Upstream service we configured in our route (`httpbin.org`).
 
-## Advanced Operations
+## Advanced Features and Operations
 
-This section provides some advanced operations such as adding authentication, prefixing Route, using the APISIX Dashboard, and troubleshooting.
+This section looks at some of the advanced features and operations available in Apache APISIX like [authentication](#authentication), [prefixing a Route](#prefixing-a-route), using the [APISIX Dashboard](#apisix-dashboard), and [troubleshooting](#troubleshooting).
 
-### Add Authentication
+### Authentication
 
-The route we created in step 2 is public. Thus, **anyone** can access this Upstream service as long as they know the address that Apache APISIX exposes to the outside world. This is unsafe, it creates certain security risks. In a practical application scenario, we need to add authentication to the route.
+The Route we created in [step 2](#step-2-create-a-route) is public. This means that anyone knowing the address exposed by Apache APISIX can access the Upstream service.
 
-Now we want only a specific user `John` to have access to this Upstream service, and we need to use [Consumer](./architecture-design/consumer.md) and [Plugin](./architecture-design/plugin.md) to implement authentication.
+This is unsafe and amounts to security risks. So, in practical applications, we generally add authentication to the Route to enhance security.
 
-First, let's use [key-auth](./plugins/key-auth.md) plugin to create a [Consumer](./architecture-design/consumer.md) `John`, we need to provide a specified key.
+Let's assume for our scenario that we only want a specific user `John` to have access to the Upstream service.
+
+We will use [Consumer](./architecture-design/consumer.md) a [Plugin](./architecture-design/plugin.md) to implement authentication to handle this scenario.
+
+First, we will use the [key-auth](./plugins/key-auth.md) plugin to create a [Consumer](./architecture-design/consumer.md) `John`. We also need to provide the specified key for `John`.
 
 ```bash
 curl "http://127.0.0.1:9080/apisix/admin/consumers" -H "X-API-KEY: edd1c9f034335f136f87ad84b625c8f1" -X PUT -d '
@@ -246,7 +258,7 @@ curl "http://127.0.0.1:9080/apisix/admin/consumers" -H "X-API-KEY: edd1c9f034335
 }'
 ```
 
-Next, let's bind `consumer (John)` to the route, we just need to **enable** the [key-auth](./plugins/key-auth.md) plugin.
+We can now bind `consumer(John)` to the Route. For this, we just need to enable the [key-auth](./plugins/key-auth.md) plugin as shown below.
 
 ```bash
 curl "http://127.0.0.1:9080/apisix/admin/routes/1" -H "X-API-KEY: edd1c9f034335f136f87ad84b625c8f1" -X PUT -d '
@@ -260,9 +272,9 @@ curl "http://127.0.0.1:9080/apisix/admin/routes/1" -H "X-API-KEY: edd1c9f034335f
 }'
 ```
 
-Now when we access the route created in step 2, an **Unauthorized Error** will be triggered.
+Now with the authentication added, when we try to access the Route we created in [step 2](#step-2-create-a-route) it will trigger an "Unauthorized Error".
 
-The correct way to access that route is to add a `Header` named `apikey` with the correct key, as shown in the code below:
+To access the Route, we need to add a `Header` named `apikey` with John's key.
 
 ```bash
 curl -i -X GET http://127.0.0.1:9080/get -H "Host: httpbin.org" -H "apikey: key-of-john"
@@ -270,7 +282,7 @@ curl -i -X GET http://127.0.0.1:9080/get -H "Host: httpbin.org" -H "apikey: key-
 
 ### Prefixing a Route
 
-Now, suppose you want to add a prefix to a route (e.g. samplePrefix) and don't want to use the `host` header, then you can use the `proxy-rewrite` plugin to do so.
+When you want to add a prefix to your Route but don't want to use the `Host` header, you can use the `proxy-rewrite` Plugin.
 
 ```bash
 curl "http://127.0.0.1:9080/apisix/admin/routes/1" -H "X-API-KEY: edd1c9f034335f136f87ad84b625c8f1" -X PUT -d '
@@ -286,7 +298,7 @@ curl "http://127.0.0.1:9080/apisix/admin/routes/1" -H "X-API-KEY: edd1c9f034335f
 }'
 ```
 
-You can now use the following command to invoke the route:
+Then to invoke the Route you can run:
 
 ```bash
 curl -i -X GET "http://127.0.0.1:9080/samplePrefix/get?param1=foo&param2=bar" -H "apikey: key-of-john"
@@ -294,7 +306,7 @@ curl -i -X GET "http://127.0.0.1:9080/samplePrefix/get?param1=foo&param2=bar" -H
 
 ### APISIX Dashboard
 
-Apache APISIX provides a [Dashboard](https://github.com/apache/apisix-dashboard) to make our operation more intuitive and easier.
+Apache APISIX comes with an intuitive [Dashboard](https://github.com/apache/apisix-dashboard) to make it easy to configure and perform operations.
 
 ![Dashboard](../../assets/images/dashboard.jpeg)
 
@@ -310,15 +322,19 @@ Apache APISIX provides a [Dashboard](https://github.com/apache/apisix-dashboard)
 
 ### Troubleshooting
 
-- Make sure that all required ports (**default 9080/9443/2379**) are not used by other systems or processes.
+You can try these troubleshooting steps if you are unable to proceed as suggested in the docs above.
 
-    The following are commands to terminate a process that is listening on a specific port (on unix-based systems).
+Please [open an issue](/docs/general/contributor-guide#submit-an-issue) if you run into any bugs or if there are any missing troubleshooting steps.
+
+- Make sure that all required ports (**default 9080/9443/2379**) are available and is not used by other systems or processes.
+
+    You can run the command below to terminate the processes that are listening on a specific port (on Unix-based systems).
 
     ```bash
     sudo fuser -k 9443/tcp
     ```
 
-- If the Docker container keeps restarting or failing, log in to the container and observe the logs to diagnose the problem.
+- If the Docker container keeps restarting or IS failing, log in to the container and observe the logs to diagnose the problem.
 
     ```bash
     docker logs -f --tail container_id

--- a/docs/en/latest/how-to-build.md
+++ b/docs/en/latest/how-to-build.md
@@ -1,5 +1,5 @@
 ---
-title: Building Apache APISIX
+title: Installing Apache APISIX
 ---
 
 <!--
@@ -31,7 +31,7 @@ Apache APISIX can be installed via the [RPM package](#installation-via-rpm-repos
 
 This installation method is suitable for CentOS 7.
 
-If the official OpenResty repository is **not installed yet**, the following command will help you automatically install both the repositories—OpenResty and Apache APISIX.
+If the official OpenResty repository is **not installed yet**, the following command will help you automatically install both OpenResty and Apache APISIX repositories.
 
 ```shell
 sudo yum install -y https://repos.apiseven.com/packages/centos/apache-apisix-repo-1.0-1.noarch.rpm
@@ -92,13 +92,13 @@ Follow the steps below to install Apache APISIX via the source release package.
   mkdir apisix-${APISIX_VERSION}
   ```
 
-2. Download the [Apache APISIX source release package](https://downloads.apache.org/apisix/APISIX_VERSION/apache-apisix-APISIX_VERSION-src.tgz).
+2. Download the Apache APISIX source release package.
 
   ```shell
   wget https://downloads.apache.org/apisix/${APISIX_VERSION}/apache-apisix-${APISIX_VERSION}-src.tgz
   ```
 
-  You can also download the Apache APISIX source release package from the [Apache APISIX website](https://apisix.apache.org/downloads/). The website also provides source packages for Apache APISIX, APISIX Dashboard and APISIX Ingress Controller.
+  You can also download the Apache APISIX source release package from the [Apache APISIX website](https://apisix.apache.org/downloads/). The website also provides source packages for Apache APISIX, APISIX Dashboard, and APISIX Ingress Controller.
 
 3. Unzip the Apache APISIX source release package.
 
@@ -134,11 +134,11 @@ Follow the steps below to install Apache APISIX via the source release package.
 
 ### LTS version installation via Source Release Package
 
-The [current LTS version](https://apisix.apache.org/downloads/) of Apache APISIX is `2.10.4`. 
+The [current LTS version](https://apisix.apache.org/downloads/) of Apache APISIX is `2.10.4`.
 
-To install this version, set `APISIX _VERSION`
+To install this version, set `APISIX_VERSION`
 
-Set `APISIX VERSION` in [Installation via Source Release Package](#installation-via-source-release-package) to `2.10.4` and continue with the other steps.
+Set `APISIX_VERSION` in [Installation via Source Release Package](#installation-via-source-release-package) to `2.10.4` and continue with the other steps.
 
 ## Step 2: Install etcd
 
@@ -190,7 +190,7 @@ apisix start
 
 Both `apisix quit` and `apisix stop` can stop Apache APISIX. The main difference is that `apisix quit` stops Apache APISIX gracefully, while `apisix stop` stops Apache APISIX immediately.
 
-It is recommended to use gracefully stop command `apisix quit` because it ensures that Apache APISIX will complete all the requests it has received before stopping. On the other hand, `apisix stop` will trigger a forced shutdown and will stop Apache APISIX immediately. This will cause the pending incoming requests to not be processed before shutdown.
+It is recommended to use the "gracefully stop" command `apisix quit` because it ensures that Apache APISIX will complete all the requests it has received before stopping. On the other hand, `apisix stop` will trigger a forced shutdown and will stop Apache APISIX immediately. This will cause the pending incoming requests to not be processed before shutdown.
 
 To perform a graceful shutdown, run:
 
@@ -309,7 +309,7 @@ Content-Type: text/plain
 {"node":{...},"action":"get"}
 ```
 
-If the key you enter does not match the value of `apisix.admin_key` in `conf/config.yaml`, a response with a status code 401 will indicate that the access failed.
+If the key you entered does not match the value of `apisix.admin_key` in `conf/config.yaml`, a response with a status code 401 will indicate that the access failed.
 
 ```shell
 curl http://127.0.0.1:9080/apisix/admin/routes?api_key=wrong-key -i

--- a/docs/en/latest/how-to-build.md
+++ b/docs/en/latest/how-to-build.md
@@ -1,5 +1,5 @@
 ---
-title: How to build Apache APISIX
+title: Building Apache APISIX
 ---
 
 <!--
@@ -21,27 +21,29 @@ title: How to build Apache APISIX
 #
 -->
 
+This guide walks you through how you can build and get Apache APISIX running on your environment. Please refer the [Getting Started](./getting-started.md) guide for a quick walkthrough on running Apache APISIX.
+
 ## Step 1: Install Apache APISIX
 
-You can install Apache APISIX via RPM Repository, Docker, Helm Chart, source release package, and source release package ( LTS version ). Please choose one from the following options.
+Apache APISIX can be installed via the [RPM package](#installation-via-rpm-repository-centos-7), [Docker image](#installation-via-docker), [Helm Chart](#installation-via-helm-chart) or the [source release package](#installation-via-source-release-package). You can install via any one of these options.
 
-### Installation via RPM Repository(CentOS 7)
+### Installation via RPM Repository (CentOS 7)
 
 This installation method is suitable for CentOS 7.
 
-If the official OpenResty repository is not installed yet, the following command will help you automatically install both the repositories of OpenResty and Apache APISIX.
+If the official OpenResty repository is **not installed yet**, the following command will help you automatically install both the repositories—OpenResty and Apache APISIX.
 
 ```shell
 sudo yum install -y https://repos.apiseven.com/packages/centos/apache-apisix-repo-1.0-1.noarch.rpm
 ```
 
-If the official OpenResty repository is installed, the following command will help you automatically install the repositories of Apache APISIX.
+If the official OpenResty repository **is installed**, the following command will help you automatically install the repositories of Apache APISIX.
 
 ```shell
 sudo yum-config-manager --add-repo https://repos.apiseven.com/packages/centos/apache-apisix.repo
 ```
 
-Please run the following commands to install the repository and Apache APISIX.
+Run the following commands to install the repository and Apache APISIX.
 
 ```shell
 # View the information of the latest apisix package
@@ -54,9 +56,9 @@ sudo yum --showduplicates list apisix
 sudo yum install apisix
 ```
 
-### Installation via RPM Offline Package(CentOS 7)
+### Installation via RPM Offline Package (CentOS 7)
 
-Download APISIX offline RPM package to `./apisix` folder
+First, download Apache APISIX offline RPM package to `./apisix` folder.
 
 ```shell
 sudo mkdir -p apisix
@@ -65,7 +67,7 @@ sudo yum clean all && yum makecache
 sudo yum install -y --downloadonly --downloaddir=./apisix apisix
 ```
 
-Copy `./apisix` folder to the target host, run the following command to install Apache APISIX.
+Then copy `./apisix` folder to the target host and run the following command to install.
 
 ```shell
 sudo yum install ./apisix/*.rpm
@@ -73,13 +75,15 @@ sudo yum install ./apisix/*.rpm
 
 ### Installation via Docker
 
-Please refer to: [Installing Apache APISIX with Docker](https://hub.docker.com/r/apache/apisix).
+Please refer to [Installing Apache APISIX with Docker](https://hub.docker.com/r/apache/apisix).
 
 ### Installation via Helm Chart
 
-Please refer to: [Installing Apache APISIX with Helm Chart](https://github.com/apache/apisix-helm-chart).
+Please refer to [Installing Apache APISIX with Helm Chart](https://github.com/apache/apisix-helm-chart).
 
 ### Installation via Source Release Package
+
+Follow the steps below to install Apache APISIX via the source release package.
 
 1. Create a directory named `apisix-2.12.0`.
 
@@ -88,15 +92,15 @@ Please refer to: [Installing Apache APISIX with Helm Chart](https://github.com/a
   mkdir apisix-${APISIX_VERSION}
   ```
 
-2. Download Apache APISIX Release source package.
+2. Download the [Apache APISIX source release package](https://downloads.apache.org/apisix/APISIX_VERSION/apache-apisix-APISIX_VERSION-src.tgz).
 
   ```shell
   wget https://downloads.apache.org/apisix/${APISIX_VERSION}/apache-apisix-${APISIX_VERSION}-src.tgz
   ```
 
-  You can also download the Apache APISIX Release source package from the Apache APISIX website. The [Apache APISIX Official Website - Download Page](https://apisix.apache.org/downloads/) also provides source packages for Apache APISIX, APISIX Dashboard and APISIX Ingress Controller.
+  You can also download the Apache APISIX source release package from the [Apache APISIX website](https://apisix.apache.org/downloads/). The website also provides source packages for Apache APISIX, APISIX Dashboard and APISIX Ingress Controller.
 
-3. Unzip the Apache APISIX Release source package.
+3. Unzip the Apache APISIX source release package.
 
   ```shell
   tar zxvf apache-apisix-${APISIX_VERSION}-src.tgz -C apisix-${APISIX_VERSION}
@@ -113,30 +117,34 @@ Please refer to: [Installing Apache APISIX with Helm Chart](https://github.com/a
   make install
   ```
 
-  - 4.1 `make deps` install `lualdap` failed, error like: `Could not find header file for LDAP`
+  **Note**: If `make deps` fails with "install `lualdap` failed" with an error like `Could not find header file for LDAP` try the solution below.
 
-        Solution: set `LDAP_DIR` with `luarocks config` manually, for example `luarocks config variables.LDAP_DIR /usr/local/opt/openldap/`
+  Solution: Set `LDAP_DIR` with `luarocks config` manually. For example `luarocks config variables.LDAP_DIR /usr/local/opt/openldap/`.
 
-5. If you have no more need for the Apache APISIX runtime, you could uninstall it like this.
+5. To uninstall the Apache APISIX runtime, run:
 
-```shell
-  # Uninstall apisix command
-  make uninstall
-  # Purge dependencies
-  make undeps
-```
+   ```shell
+   # Uninstall apisix command
+   make uninstall
+   # Purge dependencies
+   make undeps
+   ```
 
-  Attention please, this operation will totally **remove** the related files.
+   **Note**: This operation will remove the files completely.
 
-### LTS version Installation via Source Release Package
+### LTS version installation via Source Release Package
 
-The current LTS VERSION of Apache APISIX is `2.10.3`. Set `APISIX VERSION` in [install by source package](# Install by source package) to `2.10.3` and follow the other steps.
+The [current LTS version](https://apisix.apache.org/downloads/) of Apache APISIX is `2.10.4`. 
 
-## Step 2: Install ETCD
+To install this version, set `APISIX _VERSION`
 
-This step is required if you have installed only Apache APISIX via RPM, Docker or source code but not ETCD.
+Set `APISIX VERSION` in [Installation via Source Release Package](#installation-via-source-release-package) to `2.10.4` and continue with the other steps.
 
-You can install ETCD via Docker or binary etc. The following command installs ETCD via binary.
+## Step 2: Install etcd
+
+This step is required only if you haven't installed [etcd](https://github.com/etcd-io/etcd).
+
+Run the command below to install etcd via the binary.
 
 ```shell
 ETCD_VERSION='3.4.13'
@@ -149,9 +157,9 @@ nohup etcd >/tmp/etcd.log 2>&1 &
 
 ## Step 3: Manage Apache APISIX Server
 
-We can initialize dependencies, start service, and stop service with commands in the Apache APISIX directory, we can also view all commands and their corresponding functions with the `apisix help` command.
+In the Apache APISIX directory, you can initialize dependencies, start service and stop service with commands. Run `apisix help` to get a full list of available commands.
 
-### Initializing Dependencies
+### Initializing dependencies
 
 Run the following command to initialize the NGINX configuration file and etcd.
 
@@ -160,7 +168,7 @@ Run the following command to initialize the NGINX configuration file and etcd.
 apisix init
 ```
 
-### Test configuration file
+### Test the configuration file
 
 Run the following command to test the configuration file. APISIX will generate `nginx.conf` from `config.yaml` and check whether the syntax of `nginx.conf` is correct.
 
@@ -182,54 +190,54 @@ apisix start
 
 Both `apisix quit` and `apisix stop` can stop Apache APISIX. The main difference is that `apisix quit` stops Apache APISIX gracefully, while `apisix stop` stops Apache APISIX immediately.
 
-It is recommended to use gracefully stop command `apisix quit` because it ensures that Apache APISIX will complete all the requests it has received before stopping down. In contrast, `apisix stop` will trigger a forced shutdown, it stops Apache APISIX immediately, in which case the incoming requests will not be processed before the shutdown.
+It is recommended to use gracefully stop command `apisix quit` because it ensures that Apache APISIX will complete all the requests it has received before stopping. On the other hand, `apisix stop` will trigger a forced shutdown and will stop Apache APISIX immediately. This will cause the pending incoming requests to not be processed before shutdown.
 
-The command to perform a graceful shutdown is shown below.
+To perform a graceful shutdown, run:
 
 ```shell
 # stop Apache APISIX server gracefully
 apisix quit
 ```
 
-The command to perform a forced shutdown is shown below.
+To perform a forced shutdown, run:
 
 ```shell
 # stop Apache APISIX server immediately
 apisix stop
 ```
 
-### View Other Operations
+### Other operations
 
-Run the `apisix help` command to see the returned results and get commands and descriptions of other operations.
+You can get help and learn more about all the available operations in Apache APISIX by running the `help` command as shown below.
 
 ```shell
-# more actions find by `help`
+# show a list of available operations
 apisix help
 ```
 
 ## Step 4: Run Test Cases
 
-1. Install `cpanminus`, the package manager for `perl`.
+To run the test cases, run the steps outlined below.
 
-Please refer to: [Installing package manager `cpanminus`](https://metacpan.org/pod/App::cpanminus#INSTALLATION).
+1. [Install `cpanminus`](https://metacpan.org/pod/App::cpanminus#INSTALLATION), the package manager for `perl`.
 
-2. Then install the test-nginx dependencies via `cpanm`:
+2. Install the test-nginx dependencies via `cpanm` as shown below.
 
   ```shell
   sudo cpanm --notest Test::Nginx IPC::Run > build.log 2>&1 || (cat build.log && exit 1)
   ```
 
-3. Run the `git clone` command to clone the latest source code locally, please use the version we forked out：
+3. Clone the latest source code locally by using the forked out version.
 
   ```shell
   git clone https://github.com/iresty/test-nginx.git
   ```
 
-4. Here are two ways of running tests:
+4. There are two ways to run the tests.
 
-  - Append the current directory to the perl module directory: `export PERL5LIB=.:$PERL5LIB`, then run `make test` command.
+  1. Append the current directory to the perl module directory: `export PERL5LIB=.:$PERL5LIB` and then run `make test` command.
 
-  - Or you can specify the NGINX binary path by running this command: `TEST_NGINX_BINARY=/usr/local/bin/openresty prove -Itest-nginx/lib -r t`.
+  2. Specify the NGINX binary path by running `TEST_NGINX_BINARY=/usr/local/bin/openresty prove -Itest-nginx/lib -r t`.
 
   <!--
   #
@@ -245,9 +253,9 @@ Please refer to: [Installing package manager `cpanminus`](https://metacpan.org/p
   Some of the tests rely on external services and system configuration modification. For a complete test environment build, you can refer to `ci/linux_openresty_common_runner.sh`.
   :::
 
-### Troubleshoot Testing
+### Troubleshoot testing
 
-**Configuring NGINX Path**
+#### Configuring NGINX path
 
 The solution to the `Error unknown directive "lua_package_path" in /API_ASPIX/apisix/t/servroot/conf/nginx.conf` error is as shown below.
 
@@ -259,21 +267,21 @@ Ensure that OpenResty is set to the default NGINX, and export the path as follow
   * MacOS default installation path via homebrew:
     * `export PATH=/usr/local/opt/openresty/nginx/sbin:$PATH`
 
-**Run a Single Test Case**
+#### Running a single test case
 
-Run the specified test case using the following command.
+To run a specific test case, use the command below.
 
 ```shell
 prove -Itest-nginx/lib -r t/plugin/openid-connect.t
 ```
 
-For more details on the test cases, see the [testing framework](https://github.com/apache/apisix/blob/master/docs/en/latest/internal/testing-framework.md).
+For more details on the test cases, see the [testing framework](https://github.com/apache/apisix/blob/master/docs/en/latest/internal/testing-framework.md) document.
 
-## Step 5: Update Admin API token to Protect Apache APISIX
+## Step 5: Update Admin API token to Secure Apache APISIX
 
-You need to modify the Admin API key to protect Apache APISIX.
+You can modify the Admin API key to secure your Apache APISIX deployment.
 
-Please modify `apisix.admin_key` in `conf/config.yaml` and restart the service as shown below.
+This can be done by modifying the `apisix.admin_key` in `conf/config.yaml` and restarting the service.
 
 ```yaml
 apisix:
@@ -285,13 +293,13 @@ apisix:
       role: admin
 ```
 
-When we need to access the Admin API, we can use the key above, as shown below.
+Then to access the Admin API, you can use the above key.
 
 ```shell
 curl http://127.0.0.1:9080/apisix/admin/routes?api_key=abcdefghabcdefgh -i
 ```
 
-The status code 200 in the returned result indicates that the access was successful, as shown below.
+A status code of 200 in the returned result will indicate that the access was successful.
 
 ```shell
 HTTP/1.1 200 OK
@@ -301,13 +309,11 @@ Content-Type: text/plain
 {"node":{...},"action":"get"}
 ```
 
-At this point, if the key you enter does not match the value of `apisix.admin_key` in `conf/config.yaml`, for example, we know that the correct key is `abcdefghabcdefgh`, but we enter an incorrect key, such as `wrong-key`, as shown below.
+If the key you enter does not match the value of `apisix.admin_key` in `conf/config.yaml`, a response with a status code 401 will indicate that the access failed.
 
 ```shell
 curl http://127.0.0.1:9080/apisix/admin/routes?api_key=wrong-key -i
 ```
-
-The status code `401` in the returned result indicates that the access failed because the `key` entered was incorrect and did not pass authentication, triggering an `Unauthorized` error, as shown below.
 
 ```shell
 HTTP/1.1 401 Unauthorized
@@ -320,16 +326,16 @@ Content-Type: text/html
 ## Step 6: Build OpenResty for Apache APISIX
 
 Some features require additional NGINX modules to be introduced into OpenResty.
-If you need these features, you can build the APISIX OpenResty.
-You can refer to the source of [api7/apisix-build-tools](https://github.com/api7/apisix-build-tools) for how to set up the build environment and build the APISIX OpenResty.
 
-## Step 7: Add Systemd Unit File for Apache APISIX
+If you need these features, you can build APISIX OpenResty. You can refer to the source of [api7/apisix-build-tools](https://github.com/api7/apisix-build-tools) for setting up your build environment and building APISIX OpenResty.
 
-If you are using CentOS 7 and you installed Apache APISIX via the RPM package in step 2, the configuration file is already in place automatically and you can run the following command directly.
+## Step 7: Add Systemd unit file for Apache APISIX
+
+If you are using CentOS 7 and you installed [Apache APISIX via the RPM package](#installation-via-rpm-repository-centos-7), the configuration file will already be in place and you can run the following command directly.
 
 ```shell
 systemctl start apisix
 systemctl stop apisix
 ```
 
-If you installed Apache APISIX by other methods, you can refer to the [configuration file template](https://github.com/api7/apisix-build-tools/blob/master/usr/lib/systemd/system/apisix.service) for modification and put it in the `/usr/lib/systemd/system/apisix.service` path.
+If you installed Apache APISIX by other methods, please refer to the [configuration file template](https://github.com/api7/apisix-build-tools/blob/master/usr/lib/systemd/system/apisix.service) for a modification guide and copy it to the `/usr/lib/systemd/system/apisix.service` path.


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #6380 

This PR fixes issues in the "Getting Started" and "Building Apache APISIX" pages.

- Adds internal hyperlinks
- Fixes typos
- Enhances readability and usability