### PR TITLE
fix(request-validation): should not limit the urlencoded post args number

### DIFF
--- a/apisix/plugins/request-validation.lua
+++ b/apisix/plugins/request-validation.lua
@@ -88,7 +88,9 @@ function _M.rewrite(conf, ctx)
         end
 
         if headers["content-type"] == "application/x-www-form-urlencoded" then
-            req_body, err = ngx.decode_args(body)
+            -- use 0 to avoid truncated result and keep the behavior as the
+            -- same as other platforms
+            req_body, err = ngx.decode_args(body, 0)
         else -- JSON as default
             req_body, err = core.json.decode(body)
         end


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR allows the [request-validation](https://github.com/apache/apisix/blob/42e84e437f/docs/en/latest/plugins/request-validation.md) to validate more than 100 parameters in a request.

### Pre-submission checklist:

<!--
Please follow the PR manners:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
7. Only reviewer can click "Resolve conversation" to mark the reviewer's review resolved
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
