### PR TITLE
feat: add `rewrite:RespHeaders` and modify the upstream response headers via `request` implementation

### DIFF
--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -611,13 +611,13 @@ local rpc_handlers = {
                 end
             end
 
-			local len = rewrite:RespHeadersLength()
-			if len > 0 then
+            local len = rewrite:RespHeadersLength()
+            if len > 0 then
                 for i = 1, len do
                     local entry = rewrite:RespHeaders(i)
                     core.response.set_header(entry:Name(), entry:Value())
                 end
-			end
+            end
 
             local len = rewrite:ArgsLength()
             if len > 0 then

--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -612,7 +612,7 @@ local rpc_handlers = {
             end
 
             local len = rewrite:RespHeadersLength()
-            local excludeRespHeader = {
+            local exclude_resp_header = {
                 ["connection"] = true,
                 ["content-length"] = true,
                 ["transfer-encoding"] = true,
@@ -628,7 +628,7 @@ local rpc_handlers = {
                 for i = 1, len do
                     local entry = rewrite:RespHeaders(i)
                     local name = entry:Name()
-                    if excludeRespHeader[str_lower(name)] == nil then
+                    if exclude_resp_header[str_lower(name)] == nil then
                         core.response.set_header(name, entry:Value())
                     end
                 end

--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -613,25 +613,23 @@ local rpc_handlers = {
 
             local len = rewrite:RespHeadersLength()
             local excludeRespHeader = {
-                "Connection",
-                "Content-Length",
-                "Transfer-Encoding",
-                "Location",
-                "Server",
-                "WWW-Authenticate",
-                "Content-Encoding",
-                "Content-Type",
-                "Content-Location",
-                "Content-Type",
-                "Content-Language"
+                ["connection"] = true,
+                ["content-length"] = true,
+                ["transfer-encoding"] = true,
+                ["location"] = true,
+                ["server"] = true,
+                ["www-authenticate"] = true,
+                ["content-encoding"] = true,
+                ["content-type"] = true,
+                ["content-location"] = true,
+                ["content-language"] = true,
             }
             if len > 0 then
                 for i = 1, len do
                     local entry = rewrite:RespHeaders(i)
-                    for j = 1, #excludeRespHeader do
-                        if str_lower(entry:Name()) ~= str_lower(excludeRespHeader(j)) then
-                        core.response.set_header(entry:Name(), entry:Value())
-                        end
+                    local name = entry:Name()
+                    if excludeRespHeader[str_lower(name)] == nil then
+                        core.response.set_header(name, entry:Value())
                     end
                 end
             end

--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -612,10 +612,27 @@ local rpc_handlers = {
             end
 
             local len = rewrite:RespHeadersLength()
+            local excludeRespHeader = {
+                "Connection",
+                "Content-Length",
+                "Transfer-Encoding",
+                "Location",
+                "Server",
+                "WWW-Authenticate",
+                "Content-Encoding",
+                "Content-Type",
+                "Content-Location",
+                "Content-Type",
+                "Content-Language"
+            }
             if len > 0 then
                 for i = 1, len do
                     local entry = rewrite:RespHeaders(i)
-                    core.response.set_header(entry:Name(), entry:Value())
+                    for j = 1, #excludeRespHeader do
+                        if str_lower(entry:Name()) ~= str_lower(excludeRespHeader(j)) then
+                        core.response.set_header(entry:Name(), entry:Value())
+                        end
+                    end
                 end
             end
 

--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -611,6 +611,14 @@ local rpc_handlers = {
                 end
             end
 
+			local len = rewrite:RespHeadersLength()
+			if len > 0 then
+                for i = 1, len do
+                    local entry = rewrite:RespHeaders(i)
+                    core.response.set_header(entry:Name(), entry:Value())
+                end
+			end
+
             local len = rewrite:ArgsLength()
             if len > 0 then
                 local changed = {}

--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -65,6 +65,18 @@ local type = type
 
 
 local events_list
+local exclude_resp_header = {
+    ["connection"] = true,
+    ["content-length"] = true,
+    ["transfer-encoding"] = true,
+    ["location"] = true,
+    ["server"] = true,
+    ["www-authenticate"] = true,
+    ["content-encoding"] = true,
+    ["content-type"] = true,
+    ["content-location"] = true,
+    ["content-language"] = true,
+}
 
 local function new_lrucache()
     return core.lrucache.new({
@@ -612,18 +624,6 @@ local rpc_handlers = {
             end
 
             local len = rewrite:RespHeadersLength()
-            local exclude_resp_header = {
-                ["connection"] = true,
-                ["content-length"] = true,
-                ["transfer-encoding"] = true,
-                ["location"] = true,
-                ["server"] = true,
-                ["www-authenticate"] = true,
-                ["content-encoding"] = true,
-                ["content-type"] = true,
-                ["content-location"] = true,
-                ["content-language"] = true,
-            }
             if len > 0 then
                 for i = 1, len do
                     local entry = rewrite:RespHeaders(i)

--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -67,7 +67,7 @@ dependencies = {
     "luasec = 0.9-1",
     "lua-resty-consul = 0.3-2",
     "penlight = 1.9.2-1",
-    "ext-plugin-proto = 0.3.0",
+    "ext-plugin-proto = 0.4.0",
     "casbin = 1.26.0",
     "api7-snowflake = 2.0-1",
     "inspect == 3.1.1",

--- a/t/lib/ext-plugin.lua
+++ b/t/lib/ext-plugin.lua
@@ -367,10 +367,12 @@ function _M.go(case)
             local action = http_req_call_rewrite.End(builder)
             build_action(action, http_req_call_action.Rewrite)
 
-        elseif case.rewrite_resp_header == true then
+        elseif case.rewrite_resp_header == true or case.rewrite_vital_resp_header == true then
             local hdrs = {
                 {"X-Resp", "foo"},
                 {"X-Req", "bar"},
+                {"Content-Type", "application/json"},
+                {"Content-Encoding", "deflate"},
             }
             local len = #hdrs
             local textEntries = {}
@@ -389,8 +391,11 @@ function _M.go(case)
             end
             local vec = builder:EndVector(len)
 
+            local path = builder:CreateString("/plugin_proxy_rewrite_resp_header")
+
             http_req_call_rewrite.Start(builder)
             http_req_call_rewrite.AddRespHeaders(builder, vec)
+            http_req_call_rewrite.AddPath(builder, path)
             local action = http_req_call_rewrite.End(builder)
             build_action(action, http_req_call_action.Rewrite)
 

--- a/t/lib/ext-plugin.lua
+++ b/t/lib/ext-plugin.lua
@@ -390,10 +390,7 @@ function _M.go(case)
             local vec = builder:EndVector(len)
 
             http_req_call_rewrite.Start(builder)
-            if case.check_default_status ~= true then
-                http_req_call_rewrite.AddStatus(builder, 405)
-            end
-            http_req_call_rewrite.AddHeaders(builder, vec)
+            http_req_call_rewrite.AddRespHeaders(builder, vec)
             local action = http_req_call_rewrite.End(builder)
             build_action(action, http_req_call_action.Rewrite)
 

--- a/t/lib/ext-plugin.lua
+++ b/t/lib/ext-plugin.lua
@@ -67,7 +67,7 @@ function _M.go(case)
             ty = constants.RPC_ERROR
             err_resp.Start(builder)
             err_resp.AddCode(builder, err_code.BAD_REQUEST)
-                local req = prepare_conf_req.End(builder)
+            local req = prepare_conf_req.End(builder)
             builder:Finish(req)
             data = builder:Output()
 

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -524,7 +524,12 @@ function _M.google_logging_entries()
     ngx.say(data)
 end
 
-
+function _M.plugin_proxy_rewrite_resp_header()
+    ngx.req.read_body()
+    local s = "plugin_proxy_rewrite_resp_header"
+    ngx.header['Content-Length'] = #s + 1
+    ngx.say(s)
+end
 
 -- Please add your fake upstream above
 function _M.go()
@@ -537,13 +542,5 @@ function _M.go()
     inject_headers()
     return _M[action]()
 end
-
-function _M.plugin_proxy_rewrite_resp_header()
-    ngx.req.read_body()
-    local s = "plugin_proxy_rewrite_resp_header"
-    ngx.header['Content-Length'] = #s + 1
-    ngx.say(s)
-end
-
 
 return _M

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -524,6 +524,8 @@ function _M.google_logging_entries()
     ngx.say(data)
 end
 
+
+
 -- Please add your fake upstream above
 function _M.go()
     local action = string.sub(ngx.var.uri, 2)
@@ -534,6 +536,13 @@ function _M.go()
 
     inject_headers()
     return _M[action]()
+end
+
+function _M.plugin_proxy_rewrite_resp_header()
+    ngx.req.read_body()
+    local s = "plugin_proxy_rewrite_resp_header"
+    ngx.header['Content-Length'] = #s + 1
+    ngx.say(s)
 end
 
 

--- a/t/plugin/ext-plugin/http-req-call.t
+++ b/t/plugin/ext-plugin/http-req-call.t
@@ -539,9 +539,10 @@ X-Resp: foo
 X-Req: bar
 
 
-=== TEST 19: rewrite resp_header
+
+=== TEST 19: rewrite response header and call the upstream service
 --- request
-GET /plugin_proxy_rewrite_resp_header
+GET /hello
 --- extra_stream_config
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
@@ -556,3 +557,25 @@ plugin_proxy_rewrite_resp_header
 --- response_headers
 X-Resp: foo
 X-Req: bar
+
+
+
+=== TEST 20: rewrite non-important response headers and call the upstream service
+--- request
+GET /hello
+--- extra_stream_config
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+
+        content_by_lua_block {
+            local ext = require("lib.ext-plugin")
+            ext.go({rewrite_vital_resp_header = true})
+        }
+    }
+--- response_body
+plugin_proxy_rewrite_resp_header
+--- response_headers
+X-Resp: foo
+X-Req: bar
+Content-Type: text/plain
+Content-Encoding:

--- a/t/plugin/ext-plugin/http-req-call.t
+++ b/t/plugin/ext-plugin/http-req-call.t
@@ -537,3 +537,22 @@ cat
 --- response_headers
 X-Resp: foo
 X-Req: bar
+
+
+=== TEST 19: rewrite resp_header
+--- request
+GET /plugin_proxy_rewrite_resp_header
+--- extra_stream_config
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+
+        content_by_lua_block {
+            local ext = require("lib.ext-plugin")
+            ext.go({rewrite_resp_header = true})
+        }
+    }
+--- response_body
+plugin_proxy_rewrite_resp_header
+--- response_headers
+X-Resp: foo
+X-Req: bar


### PR DESCRIPTION
### What this PR does / why we need it:
This PR add the ability to call upstream server when change the response header. 
When we implement SSO, we can set and modify cookie in APISIX plugin layer and also call upstream at the same time.

This is refer to https://github.com/apache/apisix-go-plugin-runner/issues/67

ext-plugin-proto : https://github.com/api7/ext-plugin-proto/pull/26
apisix-go-plugin-runner : https://github.com/apache/apisix-go-plugin-runner/pull/68

### Pre-submission checklist:

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
