### PR TITLE
fix: add unzip into ubuntu dependency install script

### DIFF
--- a/utils/install-dependencies.sh
+++ b/utils/install-dependencies.sh
@@ -79,7 +79,7 @@ function install_dependencies_with_apt() {
     sudo apt-get update
 
     # install OpenResty and some compilation tools
-    sudo apt-get install -y git openresty curl openresty-openssl111-dev make gcc libpcre3 libpcre3-dev libldap2-dev
+    sudo apt-get install -y git openresty curl openresty-openssl111-dev make gcc libpcre3 libpcre3-dev libldap2-dev unzip
 }
 
 # Install dependencies on mac osx


### PR DESCRIPTION
### What this PR does / why we need it:
In `ubuntu:18.04` docker image, I executed  `install-dependencies.sh` and then executed `linux-install-luarocks.sh` , but got an error saying unable to find unzip.
```
Configuring LuaRocks version 3.8.0...

Lua version detected: 5.1
Lua interpreter found: /usr/local/openresty/luajit/bin/luajit
lua.h found: /usr/local/openresty/luajit/include/luajit-2.1/lua.h
Could not find 'unzip'.
Make sure it is installed and available in your PATH.

configure failed.
```
So I want to add `unzip` into `install-dependencies.sh` script.
### Pre-submission checklist:

<!--
Please follow the PR manners:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
7. Only reviewer can click "Resolve conversation" to mark the reviewer's review resolved
-->

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [X] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
