### PR TITLE
fix(opentelemetry): exporter may panic when trace id  is invalid.

### DIFF
--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -73,7 +73,7 @@ dependencies = {
     "inspect == 3.1.1",
     "lualdap = 1.2.6-1",
     "lua-resty-rocketmq = 0.3.0-0",
-    "opentelemetry-lua = 0.1-2",
+    "opentelemetry-lua = 0.1-3",
     "net-url = 0.9-1",
     "xml2lua = 1.5-2",
 }


### PR DESCRIPTION
### What this PR does / why we need it:

Bugfix in `opentelemetry-lua`: spans exporter may panic when traceID is invalid.
