### PR TITLE
docs(style): fix json code block syntax

### DIFF
--- a/docs/en/latest/admin-api.md
+++ b/docs/en/latest/admin-api.md
@@ -105,7 +105,7 @@ There are two points that need special attention:
 
 Config Example:
 
-```json
+```shell
 {
     "id": "1",                            # id, unnecessary.
     "uris": ["/a","/b"],                  # A set of uri.
@@ -330,7 +330,7 @@ Return response from etcd currently.
 
 Config Example:
 
-```json
+```shell
 {
     "id": "1",                # id
     "plugins": {},            # Bound plugin
@@ -474,7 +474,7 @@ Return response from etcd currently.
 
 Config Example:
 
-```json
+```shell
 {
     "plugins": {},          # Bound plugin
     "username": "name",     # Consumer name
@@ -594,7 +594,7 @@ Its children fields, like `requests`, can be used to configure the upstream keep
 
 **Config Example:**
 
-```json
+```shell
 {
     "id": "1",                  # id
     "retries": 1,               # retry times
@@ -815,7 +815,7 @@ Return response from etcd currently.
 
 Config Example:
 
-```json
+```shell
 {
     "id": "1",           # id
     "cert": "cert",      # Certificate

--- a/docs/en/latest/admin-api.md
+++ b/docs/en/latest/admin-api.md
@@ -112,8 +112,7 @@ Config Example:
     "methods": ["GET","POST"],            # Can fill multiple methods
     "hosts": ["a.com","b.com"],           # A set of host.
     "plugins": {},                        # Bound plugin
-    "priority": 0,                        # If different routes contain the same `uri`, 
-    determine which route is matched first based on the attribute` priority`, the default value is 0.
+    "priority": 0,                        # If different routes contain the same `uri`, determine which route is matched first based on the attribute` priority`, the default value is 0.
     "name": "route-xxx",
     "desc": "hello world",
     "remote_addrs": ["127.0.0.1"],        # A set of Client IP.

--- a/docs/en/latest/admin-api.md
+++ b/docs/en/latest/admin-api.md
@@ -105,26 +105,27 @@ There are two points that need special attention:
 
 Config Example:
 
-```shell
+```json
 {
-    "id": "1",                  # id, unnecessary.
-    "uris": ["/a","/b"],        # A set of uri.
-    "methods": ["GET","POST"],  # Can fill multiple methods
-    "hosts": ["a.com","b.com"], # A set of host.
-    "plugins": {},              # Bound plugin
-    "priority": 0,              # If different routes contain the same `uri`, determine which route is matched first based on the attribute` priority`, the default value is 0.
+    "id": "1",                            # id, unnecessary.
+    "uris": ["/a","/b"],                  # A set of uri.
+    "methods": ["GET","POST"],            # Can fill multiple methods
+    "hosts": ["a.com","b.com"],           # A set of host.
+    "plugins": {},                        # Bound plugin
+    "priority": 0,                        # If different routes contain the same `uri`, 
+    determine which route is matched first based on the attribute` priority`, the default value is 0.
     "name": "route-xxx",
     "desc": "hello world",
-    "remote_addrs": ["127.0.0.1"], # A set of Client IP.
+    "remote_addrs": ["127.0.0.1"],        # A set of Client IP.
     "vars": [["http_user", "==", "ios"]], # A list of one or more `[var, operator, val]` elements
-    "upstream_id": "1",         # upstream id, recommended
-    "upstream": {},             # upstream, not recommended
-    "timeout": {                # Set the upstream timeout for connecting, sending and receiving messages of the route.
+    "upstream_id": "1",                   # upstream id, recommended
+    "upstream": {},                       # upstream, not recommended
+    "timeout": {                          # Set the upstream timeout for connecting, sending and receiving messages of the route.
         "connect": 3,
         "send": 3,
         "read": 3
     },
-    "filter_func": "",          # User-defined filtering function
+    "filter_func": "",                    # User-defined filtering function
 }
 ```
 
@@ -331,10 +332,10 @@ Config Example:
 
 ```json
 {
-    "id": "1",          # id
-    "plugins": {},      # Bound plugin
-    "upstream_id": "1", # upstream id, recommended
-    "upstream": {},     # upstream, not recommended
+    "id": "1",                # id
+    "plugins": {},            # Bound plugin
+    "upstream_id": "1",       # upstream id, recommended
+    "upstream": {},           # upstream, not recommended
     "name": "service-test",
     "desc": "hello world",
     "enable_websocket": true,
@@ -473,7 +474,7 @@ Return response from etcd currently.
 
 Config Example:
 
-```shell
+```json
 {
     "plugins": {},          # Bound plugin
     "username": "name",     # Consumer name
@@ -593,7 +594,7 @@ Its children fields, like `requests`, can be used to configure the upstream keep
 
 **Config Example:**
 
-```shell
+```json
 {
     "id": "1",                  # id
     "retries": 1,               # retry times
@@ -603,7 +604,7 @@ Its children fields, like `requests`, can be used to configure the upstream keep
         "read":15,
     },
     "nodes": {"host:80": 100},  # Upstream machine address list, the format is `Address + Port`
-    # is the same as "nodes": [ {"host": "host", "port": 80, "weight": 100} ],
+                                # is the same as "nodes": [ {"host": "host", "port": 80, "weight": 100} ],
     "type":"roundrobin",
     "checks": {},               # Health check parameters
     "hash_on": "",
@@ -814,11 +815,11 @@ Return response from etcd currently.
 
 Config Example:
 
-```shell
+```json
 {
-    "id": "1",      # id
-    "cert": "cert", # Certificate
-    "key": "key",   # Private key
+    "id": "1",           # id
+    "cert": "cert",      # Certificate
+    "key": "key",        # Private key
     "snis": ["t.com"]    # https SNI
 }
 ```

--- a/docs/zh/latest/admin-api.md
+++ b/docs/zh/latest/admin-api.md
@@ -336,7 +336,7 @@ service 对象 json 配置内容：
     "plugins": {},            # 指定 service 绑定的插件
     "upstream_id": "1",       # upstream 对象在 etcd 中的 id ，建议使用此值
     "upstream": {},           # upstream 信息对象，不建议使用
-    "name": "测试svc",         # service 名称
+    "name": "test svc",       # service 名称
     "desc": "hello world",    # service 描述
     "enable_websocket": true, # 启动 websocket 功能
     "hosts": ["foo.com"]

--- a/docs/zh/latest/admin-api.md
+++ b/docs/zh/latest/admin-api.md
@@ -105,26 +105,26 @@ Admin API 是为 Apache APISIX 服务的一组 API，我们可以将参数传递
 
 route 对象 json 配置内容：
 
-```shell
+```json
 {
-    "id": "1",                  # id，非必填
-    "uris": ["/a","/b"],        # 一组 URL 路径
-    "methods": ["GET","POST"],  # 可以填多个方法
-    "hosts": ["a.com","b.com"], # 一组 host 域名
-    "plugins": {},              # 指定 route 绑定的插件
-    "priority": 0,              # apisix 支持多种匹配方式，可能会在一次匹配中同时匹配到多条路由，此时优先级高的优先匹配中
+    "id": "1",                            # id，非必填
+    "uris": ["/a","/b"],                  # 一组 URL 路径
+    "methods": ["GET","POST"],            # 可以填多个方法
+    "hosts": ["a.com","b.com"],           # 一组 host 域名
+    "plugins": {},                        # 指定 route 绑定的插件
+    "priority": 0,                        # apisix 支持多种匹配方式，可能会在一次匹配中同时匹配到多条路由，此时优先级高的优先匹配中
     "name": "路由xxx",
     "desc": "hello world",
-    "remote_addrs": ["127.0.0.1"],  # 一组客户端请求 IP 地址
+    "remote_addrs": ["127.0.0.1"],        # 一组客户端请求 IP 地址
     "vars": [["http_user", "==", "ios"]], # 由一个或多个 [var, operator, val] 元素组成的列表
-    "upstream_id": "1",         # upstream 对象在 etcd 中的 id ，建议使用此值
-    "upstream": {},             # upstream 信息对象，建议尽量不要使用
-    "timeout": {                # 为 route 设置 upstream 的连接、发送消息、接收消息的超时时间。
+    "upstream_id": "1",                   # upstream 对象在 etcd 中的 id ，建议使用此值
+    "upstream": {},                       # upstream 信息对象，建议尽量不要使用
+    "timeout": {                          # 为 route 设置 upstream 的连接、发送消息、接收消息的超时时间。
         "connect": 3,
         "send": 3,
         "read": 3
     },
-    "filter_func": "",          # 用户自定义的过滤函数，非必填
+    "filter_func": "",                    # 用户自定义的过滤函数，非必填
 }
 ```
 
@@ -817,7 +817,7 @@ $ curl http://127.0.0.1:9080/get
 
 ssl 对象 json 配置内容：
 
-```shell
+```json
 {
     "id": "1",          # id
     "cert": "cert",     # 证书

--- a/docs/zh/latest/admin-api.md
+++ b/docs/zh/latest/admin-api.md
@@ -332,12 +332,12 @@ service 对象 json 配置内容：
 
 ```json
 {
-    "id": "1",              # id
-    "plugins": {},          # 指定 service 绑定的插件
-    "upstream_id": "1",     # upstream 对象在 etcd 中的 id ，建议使用此值
-    "upstream": {},         # upstream 信息对象，不建议使用
-    "name": "测试svc",  # service 名称
-    "desc": "hello world",  # service 描述
+    "id": "1",                # id
+    "plugins": {},            # 指定 service 绑定的插件
+    "upstream_id": "1",       # upstream 对象在 etcd 中的 id ，建议使用此值
+    "upstream": {},           # upstream 信息对象，不建议使用
+    "name": "测试svc",         # service 名称
+    "desc": "hello world",    # service 描述
     "enable_websocket": true, #启动 websocket 功能
     "hosts": ["foo.com"]
 }
@@ -598,7 +598,7 @@ APISIX 的 Upstream 除了基本的负载均衡算法选择外，还支持对上
 
 **upstream 对象 json 配置内容：**
 
-```shell
+```json
 {
     "id": "1",                  # id
     "retries": 1,               # 请求重试次数
@@ -608,7 +608,7 @@ APISIX 的 Upstream 除了基本的负载均衡算法选择外，还支持对上
         "read":15,
     },
     "nodes": {"host:80": 100},  # 上游机器地址列表，格式为`地址 + 端口`
-    # 等价于 "nodes": [ {"host":"host", "port":80, "weight": 100} ],
+                                # 等价于 "nodes": [ {"host":"host", "port":80, "weight": 100} ],
     "type":"roundrobin",
     "checks": {},               # 配置健康检查的参数
     "hash_on": "",

--- a/docs/zh/latest/admin-api.md
+++ b/docs/zh/latest/admin-api.md
@@ -105,7 +105,7 @@ Admin API 是为 Apache APISIX 服务的一组 API，我们可以将参数传递
 
 route 对象 json 配置内容：
 
-```json
+```shell
 {
     "id": "1",                            # id，非必填
     "uris": ["/a","/b"],                  # 一组 URL 路径
@@ -330,7 +330,7 @@ HTTP/1.1 200 OK
 
 service 对象 json 配置内容：
 
-```json
+```shell
 {
     "id": "1",                # id
     "plugins": {},            # 指定 service 绑定的插件
@@ -338,7 +338,7 @@ service 对象 json 配置内容：
     "upstream": {},           # upstream 信息对象，不建议使用
     "name": "测试svc",         # service 名称
     "desc": "hello world",    # service 描述
-    "enable_websocket": true, #启动 websocket 功能
+    "enable_websocket": true, # 启动 websocket 功能
     "hosts": ["foo.com"]
 }
 ```
@@ -598,7 +598,7 @@ APISIX 的 Upstream 除了基本的负载均衡算法选择外，还支持对上
 
 **upstream 对象 json 配置内容：**
 
-```json
+```shell
 {
     "id": "1",                  # id
     "retries": 1,               # 请求重试次数
@@ -817,7 +817,7 @@ $ curl http://127.0.0.1:9080/get
 
 ssl 对象 json 配置内容：
 
-```json
+```shell
 {
     "id": "1",          # id
     "cert": "cert",     # 证书


### PR DESCRIPTION
1、The tag of the json code block in markdown should be 'json' instead of 'shell'
2、Adjusting file alignment to make the document more formal
