### PR TITLE
change: backport server-info to 2.10

### DIFF
--- a/apisix/core/etcd.lua
+++ b/apisix/core/etcd.lua
@@ -207,6 +207,7 @@ local function set(key, value, ttl)
             return nil, grant_err
         end
         res, err = etcd_cli:set(prefix .. key, value, {prev_kv = true, lease = data.body.ID})
+        res.body.lease_id = data.body.ID
     else
         res, err = etcd_cli:set(prefix .. key, value, {prev_kv = true})
     end
@@ -357,6 +358,21 @@ function _M.server_version()
     end
 
     return etcd_cli:version()
+end
+
+
+function _M.keepalive(id)
+    local etcd_cli, _, err = new()
+    if not etcd_cli then
+        return nil, err
+    end
+
+    local res, err = etcd_cli:keepalive(id)
+    if not res then
+        return nil, err
+    end
+
+    return res, nil
 end
 
 

--- a/apisix/core/etcd.lua
+++ b/apisix/core/etcd.lua
@@ -372,7 +372,7 @@ function _M.keepalive(id)
         return nil, err
     end
 
-    return res, nil
+    return res
 end
 
 

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -372,8 +372,7 @@ plugin_attr:
       ip: 127.0.0.1
       port: 9091
   server-info:
-    report_interval: 60  # server info report interval (unit: second)
-    report_ttl: 3600     # live time for server info in etcd (unit: second)
+    report_ttl: 60     # live time for server info in etcd (unit: second)
   dubbo-proxy:
     upstream_multiplex_count: 32
   request-id:

--- a/docs/en/latest/plugins/server-info.md
+++ b/docs/en/latest/plugins/server-info.md
@@ -38,9 +38,7 @@ The meaning of each item in server information is following:
 
 | Name    | Type | Description |
 |---------|------|-------------|
-| up_time | integer | Elapsed time (in seconds) since APISIX instance was launched, value will be reset when you hot updating APISIX but is kept for intact if you just reloading APISIX. |
 | boot_time | integer | Bootstrap time (UNIX timestamp) of the APISIX instance, value will be reset when you hot updating APISIX but is kept for intact if you just reloading APISIX. |
-| last_report_time | integer | Last reporting time (UNIX timestamp). |
 | id | string | APISIX instance id. |
 | etcd_version | string | The etcd cluster version that APISIX is using, value will be `"unknown"` if the network (to etcd) is partitioned. |
 | version | string | APISIX version. |
@@ -75,16 +73,14 @@ We can change the report configurations in the `plugin_attr` section of `conf/co
 
 | Name         | Type   | Default  | Description                                                          |
 | ------------ | ------ | -------- | -------------------------------------------------------------------- |
-| report_interval | integer | 60 | the interval to report server info to etcd (unit: second, maximum: 3600, minimum: 60). |
-| report_ttl | integer | 7200 | the live time for server info in etcd (unit: second, maximum: 86400, minimum: 3600). |
+| report_ttl | integer | 36 | the live time for server info in etcd (unit: second, maximum: 86400, minimum: 3). |
 
-Here is an example, which modifies the `report_interval` to 10 minutes and sets the `report_ttl` to one hour.
+Here is an example, which modifies the `report_ttl` to one minute.
 
 ```yaml
 plugin_attr:
   server-info:
-    report_interval: 600,
-    report_ttl: 3600
+    report_ttl: 60
 ```
 
 ## Test Plugin
@@ -95,8 +91,6 @@ After enabling this plugin, you can access these data through the plugin Control
 $ curl http://127.0.0.1:9090/v1/server_info -s | jq .
 {
   "etcd_version": "3.5.0",
-  "up_time": 9460,
-  "last_report_time": 1608531519,
   "id": "b7ce1c5c-b1aa-4df7-888a-cbe403f3e948",
   "hostname": "fedora32",
   "version": "2.1",

--- a/docs/zh/latest/plugins/server-info.md
+++ b/docs/zh/latest/plugins/server-info.md
@@ -39,14 +39,12 @@ title: server-info
 服务信息中每一项的含义如下：
 
 | 名称             | 类型    | 描述                                                                                                                    |
-| ---------------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
-| up_time          | integer | APISIX 服务实例当前的运行时间（单位：秒）, 如果对 APISIX 进行热更新操作，该值将被重置；普通的 reload 操作不会影响该值。 |
-| boot_time        | integer | APISIX 服务实例的启动时间（UNIX 时间戳），如果对 APIISIX 进行热更新操作，该值将被重置；普通的 reload 操作不会影响该值。 |
-| last_report_time | integer | 最近一次服务信息上报的时间 （UNIX 时间戳）。                                                                            |
+| ---------------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
+| boot_time        | integer | APISIX 服务实例的启动时间（UNIX 时间戳），如果对 APIISIX 进行热更新操作，该值将被重置；普通的 reload 操作不会影响该值。               |
 | id               | string  | APISIX 服务实例 id 。                                                                                                   |
-| etcd_version     | string  | etcd 集群的版本信息，如果 APISIX 和 etcd 集群之间存在网络分区，该值将设置为 `"unknown"`。                               |
+| etcd_version     | string  | etcd 集群的版本信息，如果 APISIX 和 etcd 集群之间存在网络分区，该值将设置为 `"unknown"`。                                       |
 | version          | string  | APISIX 版本信息。                                                                                                       |
-| hostname         | string  | APISIX 所部署的机器或 pod 的主机名信息。                                                                                |
+| hostname         | string  | APISIX 所部署的机器或 pod 的主机名信息。                                                                                   |
 
 ## 插件属性
 
@@ -76,18 +74,15 @@ plugins:                          # plugin list
 我们可以在 `conf/config.yaml` 文件的 `plugin_attr` 一节中修改上报配置。
 
 | 名称            | 类型    | 默认值 | 描述                                                               |
-| --------------- | ------- | ------ | ------------------------------------------------------------------ |
-| report_interval | integer | 60     | 上报服务信息至 etcd 的间隔（单位：秒，最大值：3600，最小值：60）   |
-| report_ttl      | integer | 7200   | etcd 中服务信息保存的 TTL（单位：秒，最大值：86400，最小值：3600） |
+| --------------- | ------- | ------ | --------------------------------------------------------------- |
+| report_ttl      | integer | 36   | etcd 中服务信息保存的 TTL（单位：秒，最大值：86400，最小值：3）            |
 
-下面的例子将 `report_interval` 修改成了 10 分钟，并将 `report_ttl` 修改成了 1
-小时：
+下面的例子将 `report_ttl` 修改成了 1 分钟：
 
 ```yaml
 plugin_attr:
   server-info:
-    report_interval: 600
-    report_ttl: 3600
+    report_ttl: 60
 ```
 
 ## 测试插件
@@ -98,8 +93,6 @@ plugin_attr:
 $ curl http://127.0.0.1:9090/v1/server_info -s | jq .
 {
   "etcd_version": "3.5.0",
-  "up_time": 9460,
-  "last_report_time": 1608531519,
   "id": "b7ce1c5c-b1aa-4df7-888a-cbe403f3e948",
   "hostname": "fedora32",
   "version": "2.1",


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, server-info is refactored, so we should backport to 2.10 release. Because 2.10 is a LTS version.

### Pre-submission checklist:

<!--
Please follow the PR manners:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
7. Only reviewer can click "Resolve conversation" to mark the reviewer's review resolved
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [x] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
