### PR TITLE
docs(Wasm): use official name

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,15 +142,15 @@ A/B testing, canary release, blue-green deployment, limit rate, defense against 
 - **Highly scalable**
   - [Custom plugins](docs/en/latest/plugin-develop.md): Allows hooking of common phases, such as `rewrite`, `access`, `header filter`, `body filter` and `log`, also allows to hook the `balancer` stage.
   - [Plugin can be written in Java/Go/Python](docs/en/latest/external-plugin.md)
-  - [Plugin can be written with Proxy WASM SDK](docs/en/latest/wasm.md)
+  - [Plugin can be written with Proxy Wasm SDK](docs/en/latest/wasm.md)
   - Custom load balancing algorithms: You can use custom load balancing algorithms during the `balancer` phase.
   - Custom routing: Support users to implement routing algorithms themselves.
 
 - **Multi-Language support**
-  - Apache APISIX is a multi-language gateway for plugin development and provides support via `RPC` and `WASM`.
+  - Apache APISIX is a multi-language gateway for plugin development and provides support via `RPC` and `Wasm`.
   ![Multi Language Support into Apache APISIX](docs/assets/images/apisix-multi-lang-support.png)
   - The RPC way, is the current way. Developers can choose the language according to their needs and after starting an independent process with the RPC, it exchanges data with APISIX through local RPC communication. Till this moment, APISIX has support for [Java](https://github.com/apache/apisix-java-plugin-runner), [Golang](https://github.com/apache/apisix-go-plugin-runner), [Python](https://github.com/apache/apisix-python-plugin-runner) and Node.js.
-  - The WASM or WebAssembly, is an experimental way. APISIX can load and run WASM bytecode via APISIX [wasm plugin](https://github.com/apache/apisix/blob/master/docs/en/latest/wasm.md) written with the [Proxy WASM SDK](https://github.com/proxy-wasm/spec#sdks). Developers only need to write the code according to the SDK and then compile it into a WASM bytecode that runs on WASM VM with APISIX.
+  - The Wasm or WebAssembly, is an experimental way. APISIX can load and run Wasm bytecode via APISIX [wasm plugin](https://github.com/apache/apisix/blob/master/docs/en/latest/wasm.md) written with the [Proxy Wasm SDK](https://github.com/proxy-wasm/spec#sdks). Developers only need to write the code according to the SDK and then compile it into a Wasm bytecode that runs on Wasm VM with APISIX.
 
 - **Serverless**
   - [Lua functions](docs/en/latest/plugins/serverless.md): Invoke functions in each phase in APISIX.

--- a/docs/en/latest/wasm.md
+++ b/docs/en/latest/wasm.md
@@ -1,5 +1,5 @@
 ---
-title: WASM
+title: Wasm
 ---
 
 <!--
@@ -21,14 +21,14 @@ title: WASM
 #
 -->
 
-APISIX supports WASM plugins written with [Proxy WASM SDK](https://github.com/proxy-wasm/spec#sdks).
+APISIX supports Wasm plugins written with [Proxy Wasm SDK](https://github.com/proxy-wasm/spec#sdks).
 
 This plugin requires APISIX to run on [APISIX-OpenResty](../how-to-build.md#step-6-build-openresty-for-apache-apisix), and is under construction.
 Currently, only a few APIs are implemented. Please follow [wasm-nginx-module](https://github.com/api7/wasm-nginx-module) to know the progress.
 
 ## Programming model
 
-The plugin supports the following concepts from Proxy WASM:
+The plugin supports the following concepts from Proxy Wasm:
 
 ```
                     Wasm Virtual Machine
@@ -45,10 +45,10 @@ The plugin supports the following concepts from Proxy WASM:
 └────────────────────────────────────────────────────────────────┘
 ```
 
-* All plugins run in the same WASM VM, like the Lua plugin in the Lua VM
+* All plugins run in the same Wasm VM, like the Lua plugin in the Lua VM
 * Each plugin has its own VMContext (the root ctx)
 * Each configured route/global rules has its own PluginContext (the plugin ctx).
-For example, if we have a service configuring with WASM plugin, and two routes inherit from it,
+For example, if we have a service configuring with Wasm plugin, and two routes inherit from it,
 there will be two plugin ctxs.
 * Each HTTP request which hits the configuration will have its own HttpContext (the HTTP ctx).
 For example, if we configure both global rules and route, the HTTP request will
@@ -94,12 +94,12 @@ Attributes below can be configured in the plugin:
 
 | Name           | Type                 | Requirement | Default        | Valid                                                                      | Description                                                                                                                                         |
 | --------------------------------------| ------------| -------------- | -------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-|  conf         | string | required |   |  != ""      | the plugin ctx configuration which can be fetched via Proxy WASM SDK |
+|  conf         | string | required |   |  != ""      | the plugin ctx configuration which can be fetched via Proxy Wasm SDK |
 
-Here is the mapping between Proxy WASM callbacks and APISIX's phases:
+Here is the mapping between Proxy Wasm callbacks and APISIX's phases:
 
 * `proxy_on_configure`: run once there is not PluginContext for the new configuration.
-For example, when the first request hits the route which has WASM plugin configured.
+For example, when the first request hits the route which has Wasm plugin configured.
 * `proxy_on_http_request_headers`: run in the access/rewrite phase, depends on the configuration of `http_request_phase`.
 * `proxy_on_http_request_body`: run in the same phase of `proxy_on_http_request_headers`. To run this callback, we need to set property `wasm_process_req_body` to non-empty value in `proxy_on_http_request_headers`. See `t/wasm/request-body/main.go` as an example.
 * `proxy_on_http_response_headers`: run in the header_filter phase.

--- a/docs/zh/latest/README.md
+++ b/docs/zh/latest/README.md
@@ -146,10 +146,10 @@ A/B 测试、金丝雀发布(灰度发布)、蓝绿部署、限流限速、抵�
   - 自定义路由: 支持用户自己实现路由算法。
 
 - **多语言支持**
-- Apache APISIX 是一个通过 `RPC` 和 `WASM` 支持不同语言来进行插件开发的网关.
+- Apache APISIX 是一个通过 `RPC` 和 `Wasm` 支持不同语言来进行插件开发的网关.
   ![Multi Language Support into Apache APISIX](../../../docs/assets/images/apisix-multi-lang-support.png)
   - RPC 是当前采用的开发方式。开发者可以使用他们需要的语言来进行 RPC 服务的开发，该 RPC 通过本地通讯来跟 APISIX 进行数据交换。到目前为止，APISIX 已支持[Java](https://github.com/apache/apisix-java-plugin-runner), [Golang](https://github.com/apache/apisix-go-plugin-runner), [Python](https://github.com/apache/apisix-python-plugin-runner) 和 Node.js。
-  - WASM 或 WebAssembly 是实验性的开发方式。 APISIX 能加载运行使用[Proxy WASM SDK](https://github.com/proxy-wasm/spec#sdks)编译的 WASM 字节码。开发者仅需要使用该 SDK 编写代码，然后编译成 WASM 字节码，即可运行在 APISIX 中的 WASM 虚拟机中。
+  - Wasm 或 WebAssembly 是实验性的开发方式。 APISIX 能加载运行使用[Proxy Wasm SDK](https://github.com/proxy-wasm/spec#sdks)编译的 Wasm 字节码。开发者仅需要使用该 SDK 编写代码，然后编译成 Wasm 字节码，即可运行在 APISIX 中的 Wasm 虚拟机中。
 
 - **Serverless**
   - [Lua functions](plugins/serverless.md): 能在 APISIX 每个阶段调用 lua 函数.


### PR DESCRIPTION
Like iOS, WebAssembly is often called as Wasm but not WASM.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the PR manners:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
7. Only reviewer can click "Resolve conversation" to mark the reviewer's review resolved
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
