### PR TITLE
fix(log-rotate): should rotate logs strictly hourly(or minutely)

### DIFF
--- a/apisix/plugins/log-rotate.lua
+++ b/apisix/plugins/log-rotate.lua
@@ -243,7 +243,7 @@ local function rotate()
     local now_time = ngx_time()
     if not rotate_time then
         -- first init rotate time
-        rotate_time = now_time + interval
+        rotate_time = now_time + interval - (now_time % interval)
         core.log.info("first init rotate time is: ", rotate_time)
         return
     end

--- a/t/plugin/log-rotate2.t
+++ b/t/plugin/log-rotate2.t
@@ -25,17 +25,8 @@ no_root_location();
 add_block_preprocessor(sub {
     my ($block) = @_;
 
-    if ((!defined $block->error_log) && (!defined $block->no_error_log)) {
-        $block->set_value("no_error_log", "[error]");
-    }
-
-    if (!defined $block->request) {
-        $block->set_value("request", "GET /t");
-    }
-
-});
-
-our $yaml_config = <<_EOC_;
+    if (!defined $block->yaml_config) {
+        my $yaml_config = <<_EOC_;
 apisix:
   node_listen: 1984
   admin_key: ~
@@ -48,12 +39,24 @@ plugin_attr:
     enable_compression: true
 _EOC_
 
+        $block->set_value("yaml_config", $yaml_config);
+    }
+
+    if ((!defined $block->error_log) && (!defined $block->no_error_log)) {
+        $block->set_value("no_error_log", "[error]");
+    }
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+});
+
 run_tests;
 
 __DATA__
 
 === TEST 1: log rotate, with enable log file compression
---- yaml_config eval: $::yaml_config
 --- config
     location /t {
         content_by_lua_block {
@@ -99,7 +102,6 @@ start xxxxxx
 
 
 === TEST 3: check file changes (enable compression)
---- yaml_config eval: $::yaml_config
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/log-rotate2.t
+++ b/t/plugin/log-rotate2.t
@@ -25,23 +25,6 @@ no_root_location();
 add_block_preprocessor(sub {
     my ($block) = @_;
 
-    my $user_yaml_config = <<_EOC_;
-apisix:
-  node_listen: 1984
-  admin_key: null
-
-plugins:                          # plugin list
-  - log-rotate
-
-plugin_attr:
-  log-rotate:
-    interval: 1
-    max_kept: 3
-    enable_compression: true
-_EOC_
-
-    $block->set_value("yaml_config", $user_yaml_config);
-
     if ((!defined $block->error_log) && (!defined $block->no_error_log)) {
         $block->set_value("no_error_log", "[error]");
     }
@@ -52,11 +35,25 @@ _EOC_
 
 });
 
+our $yaml_config = <<_EOC_;
+apisix:
+  node_listen: 1984
+  admin_key: ~
+plugins:
+  - log-rotate
+plugin_attr:
+  log-rotate:
+    interval: 1
+    max_kept: 3
+    enable_compression: true
+_EOC_
+
 run_tests;
 
 __DATA__
 
 === TEST 1: log rotate, with enable log file compression
+--- yaml_config eval: $::yaml_config
 --- config
     location /t {
         content_by_lua_block {
@@ -102,6 +99,7 @@ start xxxxxx
 
 
 === TEST 3: check file changes (enable compression)
+--- yaml_config eval: $::yaml_config
 --- config
     location /t {
         content_by_lua_block {
@@ -132,6 +130,45 @@ start xxxxxx
             end
 
             if passed then
+                ngx.say("passed")
+            end
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 4: test rotate time align
+--- yaml_config
+apisix:
+  node_listen: 1984
+  admin_key: ~
+plugins:
+  - log-rotate
+plugin_attr:
+  log-rotate:
+    interval: 3600
+    max_kept: 1
+--- config
+    location /t {
+        content_by_lua_block {
+            local log_file = ngx.config.prefix() .. "logs/error.log"
+            local file = io.open(log_file, "r")
+            local log = file:read("*a")
+
+            local m, err = ngx.re.match(log, [[first init rotate time is: (\d+)]], "jom")
+            if not m then
+                ngx.log(ngx.ERR, "failed to gmatch: ", err)
+                return
+            end
+
+            ngx.sleep(2)
+
+            local now_time = ngx.time()
+            local interval = 3600
+            local rotate_time = now_time + interval - (now_time % interval)
+            if tonumber(m[1]) == tonumber(rotate_time) then
                 ngx.say("passed")
             end
         }


### PR DESCRIPTION
### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bugfix in log-rotate: log-rotate can not rotate logs strictly hourly(or minutely)

FIX #6517

### Pre-submission checklist:

<!--
Please follow the PR manners:
1. Use Draft if the PR is not ready to be reviewed
2. Test is required for the feat/fix PR, unless you have a good reason
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. If you need to resolve merge conflicts after the PR is reviewed, please merge master but do not rebase
6. Use "request review" to notify the reviewer once you have resolved the review
7. Only reviewer can click "Resolve conversation" to mark the reviewer's review resolved
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?
* [ ] Is this PR backward compatible? **If it is not backward compatible, please discuss on the [mailing list](https://github.com/apache/apisix/tree/master#community) first**
