### PR TITLE
fix: improve fetch_api_router

### DIFF
--- a/apisix/api_router.lua
+++ b/apisix/api_router.lua
@@ -43,7 +43,8 @@ function fetch_api_router()
                            core.json.delay_encode(api_routes, true))
             for _, route in ipairs(api_routes) do
                 if route.uri == nil then
-                    core.log.error("got nil uri in api route: ", core.json.delay_encode(route, true))
+                    core.log.error("got nil uri in api route: ",
+                                   core.json.delay_encode(route, true))
                     break
                 end
 

--- a/apisix/api_router.lua
+++ b/apisix/api_router.lua
@@ -42,6 +42,10 @@ function fetch_api_router()
             core.log.debug("fetched api routes: ",
                            core.json.delay_encode(api_routes, true))
             for _, route in ipairs(api_routes) do
+                if route.uri == nil then
+                    break
+                end
+
                 local typ_uri = type(route.uri)
                 if not has_route_not_under_apisix then
                     if typ_uri == "string" then

--- a/apisix/api_router.lua
+++ b/apisix/api_router.lua
@@ -43,6 +43,7 @@ function fetch_api_router()
                            core.json.delay_encode(api_routes, true))
             for _, route in ipairs(api_routes) do
                 if route.uri == nil then
+                    core.log.error("got nil uri in api route: ", core.json.delay_encode(route, true))
                     break
                 end
 


### PR DESCRIPTION
### Description
As the issue described in #6620 , if I there is one plugin with wrong api routes info, the function fetch_api_router in api_router.lua would always report exception, and lead to internal error for the normal http request. This PR is to avoid such embarrassing situation.


Fixes #6620 (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added in this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backwards compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark PR as draft until its ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after you make changes.
7. Only a reviewer can mark a conversation as resolved.

-->
