### PR TITLE
backport: update luarocks version to 3.8.0

### DIFF
--- a/utils/linux-install-luarocks.sh
+++ b/utils/linux-install-luarocks.sh
@@ -22,9 +22,11 @@ if [ -z ${OPENRESTY_PREFIX} ]; then
     OPENRESTY_PREFIX="/usr/local/openresty"
 fi
 
-wget https://github.com/luarocks/luarocks/archive/v3.4.0.tar.gz
-tar -xf v3.4.0.tar.gz
-cd luarocks-3.4.0 || exit
+LUAROCKS_VER=3.8.0
+wget https://github.com/luarocks/luarocks/archive/v"$LUAROCKS_VER".tar.gz
+tar -xf v"$LUAROCKS_VER".tar.gz
+rm -f v"$LUAROCKS_VER".tar.gz
+cd luarocks-"$LUAROCKS_VER" || exit
 
 OR_BIN="$OPENRESTY_PREFIX/bin/openresty"
 OR_VER=$($OR_BIN -v 2>&1 | awk -F '/' '{print $2}' | awk -F '.' '{print $1"."$2}')
@@ -41,7 +43,6 @@ fi
 make build > build.log 2>&1 || (cat build.log && exit 1)
 sudo make install > build.log 2>&1 || (cat build.log && exit 1)
 cd .. || exit
-rm -rf luarocks-3.4.0
 
 mkdir ~/.luarocks || true
 

--- a/utils/linux-install-luarocks.sh
+++ b/utils/linux-install-luarocks.sh
@@ -40,13 +40,13 @@ fi
 ./configure $WITH_LUA_OPT \
     > build.log 2>&1 || (cat build.log && exit 1)
 
-rm -rf luarocks-"$LUAROCKS_VER"
-
 make build > build.log 2>&1 || (cat build.log && exit 1)
 sudo make install > build.log 2>&1 || (cat build.log && exit 1)
 cd .. || exit
 
 mkdir ~/.luarocks || true
+
+rm -rf luarocks-"$LUAROCKS_VER"
 
 # OpenResty 1.17.8 or higher version uses openssl111 as the openssl dirname.
 OPENSSL_PREFIX=${OPENRESTY_PREFIX}/openssl

--- a/utils/linux-install-luarocks.sh
+++ b/utils/linux-install-luarocks.sh
@@ -40,6 +40,8 @@ fi
 ./configure $WITH_LUA_OPT \
     > build.log 2>&1 || (cat build.log && exit 1)
 
+rm -rf luarocks-"$LUAROCKS_VER"
+
 make build > build.log 2>&1 || (cat build.log && exit 1)
 sudo make install > build.log 2>&1 || (cat build.log && exit 1)
 cd .. || exit


### PR DESCRIPTION
### Description

luarocks 3.4.0 is out of date, it will cause the follow error:

```
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
```

ref https://github.com/api7/lua-resty-radixtree/issues/107

So we need to update luarocks version to 3.8.0

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
