### PR TITLE
动态上游：banlancer.lua -> _M.run() 代码第356行前后，before_proxy 之前，执行ctx.picked_server = server

### DIFF
--- a/apisix/balancer.lua
+++ b/apisix/balancer.lua
@@ -341,6 +341,8 @@ function _M.run(route, ctx, plugin_funcs)
             return core.response.exit(502)
         end
 
+        ctx.picked_server = server
+
         local header_changed
         local pass_host = ctx.pass_host
         if pass_host == "node" and balancer.recreate_request then


### PR DESCRIPTION
service 设置多个上游node， apisix按照设置好的负载均衡策略，选中一个node连接失败时，会重试其他node，这个很赞。
banlancer.lua -> _M.run() 的代码，第356行前后，before_proxy 之前，没有执行 ctx.picked_server = server，自定义插件动态上游，在一些情况下，很不方便， 详细描述如下：

apisix 代码，在执行 before_proxy  之前，都会有 下面几个步骤：
1、server, err = pick_server(route, ctx)
2、ctx.picked_server = serve
3、common_phase("before_proxy")  这个阶段，自定义插件，可以对 ctx.picked_server进行重写，以达到动态上游的目的。

apisix/init.lua -> _M.http_access_phase() 第520行 前后； apisix/init.lua -> _M.stream_preread_phase()  第932行 前后；都是如此。

banlancer.lua -> _M.run() 的代码，调用 before_proxy 前，没有对picked_server进行赋值，因此，做上面改动。

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
