### PR TITLE
docs: fix table garbled

### DIFF
--- a/docs/zh/latest/plugins/forward-auth.md
+++ b/docs/zh/latest/plugins/forward-auth.md
@@ -31,19 +31,20 @@ Forward Auth 巧妙地将认证和授权逻辑移到了一个专门的外部服�
 
 | 名称 | 类型 | 必选项 | 默认值 | 有效值 | 描述 |
 | -- | -- | -- | -- | -- | -- |
-| host | string | 必须 |  |  | 设置 `authorization` 服务的地址 (eg. https://localhost:9188) |
-| ssl_verify | boolean | 可选 | true |   | 是否验证证书 |
-| request_headers | array[string] | 可选 |  |  | 设置需要由 `client` 转发到 `authorization` 服务的请求头。未设置时，只有 Apache APISIX 的(X-Forwarded-XXX)会被转发到 `authorization` 服务。 |
-| upstream_headers | array[string] | 可选 |  |  | 认证通过时，设置 `authorization` 服务转发至 `upstream` 的请求头。如果不设置则不转发任何请求头。
-| client_headers | array[string] | 可选 |  |  | 认证失败时，由 `authorization` 服务向 `client` 发送的响应头。如果不设置则不转发任何响应头。 |
-| timeout | integer | 可选 | 3000ms | [1, 60000]ms | `authorization` 服务请求超时时间 |
-| keepalive | boolean | 可选 | true |  | HTTP 长连接 |
-| keepalive_timeout | integer | 可选 | 60000ms | [1000, ...]ms | 长连接超时时间 |
-| keepalive_pool | integer | 可选 | 5 | [1, ...]ms | 长连接池大小 |
+| host | string | 是 |  |  | 设置 `authorization` 服务的地址 (eg. https://localhost:9188) |
+| ssl_verify | boolean | 否 | true |   | 是否验证证书 |
+| request_headers | array[string] | 是 |  |  | 设置需要由 `client` 转发到 `authorization` 服务的请求头。未设置时，只有 Apache APISIX 的(X-Forwarded-XXX)会被转发到 `authorization` 服务。 |
+| upstream_headers | array[string] | 否 |  |  | 认证通过时，设置 `authorization` 服务转发至 `upstream` 的请求头。如果不设置则不转发任何请求头。
+| client_headers | array[string] | 否 |  |  | 认证失败时，由 `authorization` 服务向 `client` 发送的响应头。如果不设置则不转发任何响应头。 |
+| timeout | integer | 否 | 3000ms | [1, 60000]ms | `authorization` 服务请求超时时间 |
+| keepalive | boolean | 否 | true |  | HTTP 长连接 |
+| keepalive_timeout | integer | 否 | 60000ms | [1000, ...]ms | 长连接超时时间 |
+| keepalive_pool | integer | 否 | 5 | [1, ...]ms | 长连接池大小 |
 
 ## 数据定义
 
 request_headers 属性中转发到 `authorization` 服务中的 Apache APISIX 内容清单
+
 | Scheme | HTTP Method | Host | URI | Source IP |
 | -- | -- | -- | -- | -- |
 | X-Forwarded-Proto | X-Forwarded-Method | X-Forwarded-Host | X-Forwarded-Uri | X-Forwarded-For |

--- a/docs/zh/latest/plugins/forward-auth.md
+++ b/docs/zh/latest/plugins/forward-auth.md
@@ -33,7 +33,7 @@ Forward Auth 巧妙地将认证和授权逻辑移到了一个专门的外部服�
 | -- | -- | -- | -- | -- | -- |
 | host | string | 是 |  |  | 设置 `authorization` 服务的地址 (eg. https://localhost:9188) |
 | ssl_verify | boolean | 否 | true |   | 是否验证证书 |
-| request_headers | array[string] | 是 |  |  | 设置需要由 `client` 转发到 `authorization` 服务的请求头。未设置时，只有 Apache APISIX 的(X-Forwarded-XXX)会被转发到 `authorization` 服务。 |
+| request_headers | array[string] | 否 |  |  | 设置需要由 `client` 转发到 `authorization` 服务的请求头。未设置时，只有 Apache APISIX 的(X-Forwarded-XXX)会被转发到 `authorization` 服务。 |
 | upstream_headers | array[string] | 否 |  |  | 认证通过时，设置 `authorization` 服务转发至 `upstream` 的请求头。如果不设置则不转发任何请求头。
 | client_headers | array[string] | 否 |  |  | 认证失败时，由 `authorization` 服务向 `client` 发送的响应头。如果不设置则不转发任何响应头。 |
 | timeout | integer | 否 | 3000ms | [1, 60000]ms | `authorization` 服务请求超时时间 |


### PR DESCRIPTION
In the Apache APISIX official website, this table format error, because there is no blank line between the table and the text.

![image](https://user-images.githubusercontent.com/97138894/159724425-59e8e46d-e740-48d6-a1a4-c94604c74a0b.png)
