### PR TITLE
fix: hidding real message when password or username is error

### DIFF
--- a/apisix/plugins/basic-auth.lua
+++ b/apisix/plugins/basic-auth.lua
@@ -167,14 +167,14 @@ function _M.rewrite(conf, ctx)
     -- 3. check user exists
     local cur_consumer = consumers[username]
     if not cur_consumer then
-        return 401, { message = "Invalid user key in authorization" }
+        return 401, { message = "Invalid password or username" }
     end
     core.log.info("consumer: ", core.json.delay_encode(cur_consumer))
 
 
     -- 4. check the password is correct
     if cur_consumer.auth_conf.password ~= password then
-        return 401, { message = "Password is error" }
+        return 401, { message = "Invalid password or username" }
     end
 
     -- 5. hide `Authorization` request header if `hide_credentials` is `true`

--- a/apisix/plugins/basic-auth.lua
+++ b/apisix/plugins/basic-auth.lua
@@ -167,14 +167,14 @@ function _M.rewrite(conf, ctx)
     -- 3. check user exists
     local cur_consumer = consumers[username]
     if not cur_consumer then
-        return 401, { message = "Invalid password or username" }
+        return 401, { message = "Invalid user authorization" }
     end
     core.log.info("consumer: ", core.json.delay_encode(cur_consumer))
 
 
     -- 4. check the password is correct
     if cur_consumer.auth_conf.password ~= password then
-        return 401, { message = "Invalid password or username" }
+        return 401, { message = "Invalid user authorization" }
     end
 
     -- 5. hide `Authorization` request header if `hide_credentials` is `true`

--- a/apisix/plugins/ldap-auth.lua
+++ b/apisix/plugins/ldap-auth.lua
@@ -140,7 +140,7 @@ function _M.rewrite(conf, ctx)
     local userdn =  uid .. "=" .. user.username .. "," .. conf.base_dn
     local ld = lualdap.open_simple (conf.ldap_uri, userdn, user.password, conf.use_tls)
     if not ld then
-        return 401, { message = "Invalid password or username" }
+        return 401, { message = "Invalid user authorization" }
     end
 
     -- 3. Retrieve consumer for authorization plugin
@@ -152,7 +152,7 @@ function _M.rewrite(conf, ctx)
         create_consumer_cache, consumer_conf)
     local consumer = consumers[userdn]
     if not consumer then
-        return 401, {message = "Invalid password or username"}
+        return 401, {message = "Invalid user authorization"}
     end
     consumer_mod.attach_consumer(ctx, consumer, consumer_conf)
 

--- a/apisix/plugins/ldap-auth.lua
+++ b/apisix/plugins/ldap-auth.lua
@@ -140,7 +140,7 @@ function _M.rewrite(conf, ctx)
     local userdn =  uid .. "=" .. user.username .. "," .. conf.base_dn
     local ld = lualdap.open_simple (conf.ldap_uri, userdn, user.password, conf.use_tls)
     if not ld then
-        return 401, { message = "Invalid user authorization" }
+        return 401, { message = "Invalid password or username" }
     end
 
     -- 3. Retrieve consumer for authorization plugin
@@ -152,7 +152,7 @@ function _M.rewrite(conf, ctx)
         create_consumer_cache, consumer_conf)
     local consumer = consumers[userdn]
     if not consumer then
-        return 401, {message = "Invalid API key in request"}
+        return 401, {message = "Invalid password or username"}
     end
     consumer_mod.attach_consumer(ctx, consumer, consumer_conf)
 

--- a/docs/en/latest/plugins/basic-auth.md
+++ b/docs/en/latest/plugins/basic-auth.md
@@ -105,7 +105,7 @@ HTTP/1.1 401 Unauthorized
 $ curl -i -ubar:bar http://127.0.0.1:9080/hello
 HTTP/1.1 401 Unauthorized
 ...
-{"message":"Invalid user key in authorization"}
+{"message":"Invalid password or username"}
 ```
 
 - password is invalid:
@@ -114,7 +114,7 @@ HTTP/1.1 401 Unauthorized
 $ curl -i -ufoo:foo http://127.0.0.1:9080/hello
 HTTP/1.1 401 Unauthorized
 ...
-{"message":"Password is error"}
+{"message":"Invalid password or username"}
 ```
 
 - success:

--- a/docs/en/latest/plugins/basic-auth.md
+++ b/docs/en/latest/plugins/basic-auth.md
@@ -105,7 +105,7 @@ HTTP/1.1 401 Unauthorized
 $ curl -i -ubar:bar http://127.0.0.1:9080/hello
 HTTP/1.1 401 Unauthorized
 ...
-{"message":"Invalid password or username"}
+{"message":"Invalid user authorization"}
 ```
 
 - password is invalid:
@@ -114,7 +114,7 @@ HTTP/1.1 401 Unauthorized
 $ curl -i -ufoo:foo http://127.0.0.1:9080/hello
 HTTP/1.1 401 Unauthorized
 ...
-{"message":"Invalid password or username"}
+{"message":"Invalid user authorization"}
 ```
 
 - success:

--- a/docs/en/latest/plugins/ldap-auth.md
+++ b/docs/en/latest/plugins/ldap-auth.md
@@ -104,7 +104,7 @@ HTTP/1.1 401 Unauthorized
 $ curl -i -uuser:password1 http://127.0.0.1:9080/hello
 HTTP/1.1 401 Unauthorized
 ...
-{"message":"Invalid user key in authorization"}
+{"message":"Invalid password or username"}
 ```
 
 - password is invalid:
@@ -113,7 +113,7 @@ HTTP/1.1 401 Unauthorized
 $ curl -i -uuser01:passwordfalse http://127.0.0.1:9080/hello
 HTTP/1.1 401 Unauthorized
 ...
-{"message":"Password is error"}
+{"message":"Invalid password or username"}
 ```
 
 - success:

--- a/docs/en/latest/plugins/ldap-auth.md
+++ b/docs/en/latest/plugins/ldap-auth.md
@@ -104,7 +104,7 @@ HTTP/1.1 401 Unauthorized
 $ curl -i -uuser:password1 http://127.0.0.1:9080/hello
 HTTP/1.1 401 Unauthorized
 ...
-{"message":"Invalid password or username"}
+{"message":"Invalid user authorization"}
 ```
 
 - password is invalid:
@@ -113,7 +113,7 @@ HTTP/1.1 401 Unauthorized
 $ curl -i -uuser01:passwordfalse http://127.0.0.1:9080/hello
 HTTP/1.1 401 Unauthorized
 ...
-{"message":"Invalid password or username"}
+{"message":"Invalid user authorization"}
 ```
 
 - success:

--- a/docs/zh/latest/plugins/basic-auth.md
+++ b/docs/zh/latest/plugins/basic-auth.md
@@ -105,7 +105,7 @@ HTTP/1.1 401 Unauthorized
 $ curl -i -ubar:bar http://127.0.0.1:9080/hello
 HTTP/1.1 401 Unauthorized
 ...
-{"message":"Invalid password or username"}
+{"message":"Invalid user authorization"}
 ```
 
 - 密码错误：
@@ -114,7 +114,7 @@ HTTP/1.1 401 Unauthorized
 $ curl -i -ufoo:foo http://127.0.0.1:9080/hello
 HTTP/1.1 401 Unauthorized
 ...
-{"message":"Invalid password or username"}
+{"message":"Invalid user authorization"}
 ...
 ```
 

--- a/docs/zh/latest/plugins/basic-auth.md
+++ b/docs/zh/latest/plugins/basic-auth.md
@@ -105,7 +105,7 @@ HTTP/1.1 401 Unauthorized
 $ curl -i -ubar:bar http://127.0.0.1:9080/hello
 HTTP/1.1 401 Unauthorized
 ...
-{"message":"Invalid user key in authorization"}
+{"message":"Invalid password or username"}
 ```
 
 - 密码错误：
@@ -114,7 +114,7 @@ HTTP/1.1 401 Unauthorized
 $ curl -i -ufoo:foo http://127.0.0.1:9080/hello
 HTTP/1.1 401 Unauthorized
 ...
-{"message":"Password is error"}
+{"message":"Invalid password or username"}
 ...
 ```
 

--- a/t/plugin/basic-auth.t
+++ b/t/plugin/basic-auth.t
@@ -196,7 +196,7 @@ GET /hello
 Authorization: Basic YmFyOmJhcgo=
 --- error_code: 401
 --- response_body
-{"message":"Invalid user key in authorization"}
+{"message":"Invalid password or username"}
 --- no_error_log
 [error]
 
@@ -209,7 +209,7 @@ GET /hello
 Authorization: Basic Zm9vOmZvbwo=
 --- error_code: 401
 --- response_body
-{"message":"Password is error"}
+{"message":"Invalid password or username"}
 --- no_error_log
 [error]
 

--- a/t/plugin/basic-auth.t
+++ b/t/plugin/basic-auth.t
@@ -196,7 +196,7 @@ GET /hello
 Authorization: Basic YmFyOmJhcgo=
 --- error_code: 401
 --- response_body
-{"message":"Invalid password or username"}
+{"message":"Invalid user authorization"}
 --- no_error_log
 [error]
 
@@ -209,7 +209,7 @@ GET /hello
 Authorization: Basic Zm9vOmZvbwo=
 --- error_code: 401
 --- response_body
-{"message":"Invalid password or username"}
+{"message":"Invalid user authorization"}
 --- no_error_log
 [error]
 

--- a/t/plugin/ldap-auth.t
+++ b/t/plugin/ldap-auth.t
@@ -189,7 +189,7 @@ GET /hello
 Authorization: Basic Zm9vOmZvbwo=
 --- error_code: 401
 --- response_body
-{"message":"Invalid user authorization"}
+{"message":"Invalid password or username"}
 
 
 

--- a/t/plugin/ldap-auth.t
+++ b/t/plugin/ldap-auth.t
@@ -189,7 +189,7 @@ GET /hello
 Authorization: Basic Zm9vOmZvbwo=
 --- error_code: 401
 --- response_body
-{"message":"Invalid password or username"}
+{"message":"Invalid user authorization"}
 
 
 


### PR DESCRIPTION
### Description
about auth-plugin when have password and username hidding real message when password or username is not match

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes https://github.com/apache/apisix/issues/6703

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
