### PR TITLE
fix(batch-requests): read trailers

### DIFF
--- a/apisix/plugins/batch-requests.lua
+++ b/apisix/plugins/batch-requests.lua
@@ -277,6 +277,9 @@ local function batch_requests(ctx)
         if resp.has_body then
             sub_resp.body = resp:read_body()
         end
+        if resp.trailer_reader then
+            sub_resp.trailers = resp:read_trailers()
+        end
         core.table.insert(aggregated_resp, sub_resp)
     end
     return 200, aggregated_resp


### PR DESCRIPTION
### Description

当使用batch-requests插件，上游服务器返回的报文包含Transfer-Encoding: chunked时，只有第一个请求正常，其他请求返回
{"reason":"upstream timeout","status":504}。
查询源码后， 定位到deps/share/lua/5.1/resty/http.lua文件中的_chunked_body_reader方法，并未处理trailers。

 if length > 0 then
                local str, err = sock:receive(length)
                if not str then
                    co_yield(nil, err)
                end

                max_chunk_size = co_yield(str) or default_chunk_size

                -- If we're finished with this chunk, read the carriage return.
                if remaining == 0 then
                    sock:receive(2) -- read \r\n
                end
            else
                -- Read the last (zero length) chunk's carriage return
                -- !!! 此处未处理trailers，在有trailers的时候会读取到trailer的前两个字符
                sock:receive(2) -- read \r\n
            end

但此文件未包含在apisix的源码中，所以只在batch-requests.lua中做了修改。

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
