### PR TITLE
docs: opentelemetry plugin update to prose

### DIFF
--- a/docs/en/latest/plugins/opentelemetry.md
+++ b/docs/en/latest/plugins/opentelemetry.md
@@ -23,9 +23,11 @@ title: opentelemetry
 
 ## Description
 
-[OpenTelemetry](https://opentelemetry.io/) report Tracing data according to [OpenTelemetry specification](https://opentelemetry.io/docs/reference/specification/).
+[OpenTelemetry](https://opentelemetry.io) report Tracing data according to [OpenTelemetry specification](https://opentelemetry.io/docs/reference/specification/).
 
-Just support reporting in `HTTP` with `Content-Type=application/x-protobuf`, the specification: [OTLP/HTTP Request](https://opentelemetry.io/docs/reference/specification/protocol/otlp/#otlphttp-request).
+The plugin currently only supports binary-encoded OTLP over HTTP. For details, see [OTLP/HTTP].
+
+[OTLP/HTTP]: https://opentelemetry.io/docs/reference/specification/protocol/otlp/#otlphttp
 
 ## Attributes
 


### PR DESCRIPTION
- This PR is in support of https://github.com/open-telemetry/opentelemetry.io/pull/1185.
- It is a followup to https://github.com/apache/apisix/pull/6711#discussion_r834869409.
- Note that I did my best to figure out the intent of the original paragraph was based on a translation of the zh version of the page. Hopefully you see this as a correct improvement.

/cc @leslie-tsang @austinlparker @SergeyKanzhelev