### PR TITLE
fix(DNS): support SRV with port 0

### DIFF
--- a/apisix/discovery/dns/init.lua
+++ b/apisix/discovery/dns/init.lua
@@ -37,7 +37,13 @@ function _M.nodes(service_name)
     local nodes = core.table.new(#records, 0)
     for i, r in ipairs(records) do
         if r.address then
-            nodes[i] = {host = r.address, weight = r.weight or 1, port = r.port or port}
+            local node_port = r.port
+            if not node_port or node_port == 0 then
+                -- if the port is zero, fallback to use the default
+                node_port = port
+            end
+
+            nodes[i] = {host = r.address, weight = r.weight or 1, port = node_port}
             if r.priority then
                 -- for SRV record, nodes with lower priority are chosen first
                 nodes[i].priority = -r.priority

--- a/t/coredns/db.test.local
+++ b/t/coredns/db.test.local
@@ -46,6 +46,8 @@ split-weight.srv   86400 IN    SRV 10      0     1980 C
 priority.srv   86400 IN    SRV 10       60     1979 A
 priority.srv   86400 IN    SRV 20       60     1980 B
 
+zero.srv       86400 IN    SRV 10       60     0    A
+
 ; a domain has both SRV & A records
 srv-a   86400 IN    SRV 10       60     1980 A
 srv-a         IN    A   127.0.0.1

--- a/t/discovery/dns/sanity.t
+++ b/t/discovery/dns/sanity.t
@@ -276,3 +276,20 @@ upstreams:
 proxy request to 127.0.0.1:1980
 --- response_body
 hello world
+
+
+
+=== TEST 14: SRV (port is 0)
+--- apisix_yaml
+upstreams:
+    - service_name: "zero.srv.test.local"
+      discovery_type: dns
+      type: roundrobin
+      id: 1
+--- error_log
+connect() failed
+--- error_code: 502
+--- grep_error_log eval
+qr/proxy request to \S+/
+--- grep_error_log_out
+proxy request to 127.0.0.1:80


### PR DESCRIPTION
rfc2782 allows the port range in [0, 65535] but doesn't mention what
should be done when the port is 0.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #6732

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
