### PR TITLE
chore: upgrade etcd version to 3.4.18 for ci

### DIFF
--- a/ci/centos7-ci.sh
+++ b/ci/centos7-ci.sh
@@ -35,10 +35,10 @@ install_dependencies() {
     ./utils/linux-install-luarocks.sh
 
     # install etcdctl
-    wget https://github.com/etcd-io/etcd/releases/download/v3.5.2/etcd-v3.5.2-linux-amd64.tar.gz
-    tar xf etcd-v3.5.2-linux-amd64.tar.gz
-    cp ./etcd-v3.5.2-linux-amd64/etcdctl /usr/local/bin/
-    rm -rf etcd-v3.5.2-linux-amd64
+    wget https://github.com/etcd-io/etcd/releases/download/v3.4.18/etcd-v3.4.18-linux-amd64.tar.gz
+    tar xf etcd-v3.4.18-linux-amd64.tar.gz
+    cp ./etcd-v3.4.18-linux-amd64/etcdctl /usr/local/bin/
+    rm -rf etcd-v3.4.18-linux-amd64
 
     # install vault cli capabilities
     install_vault_cli

--- a/ci/centos7-ci.sh
+++ b/ci/centos7-ci.sh
@@ -35,10 +35,10 @@ install_dependencies() {
     ./utils/linux-install-luarocks.sh
 
     # install etcdctl
-    wget https://github.com/etcd-io/etcd/releases/download/v3.4.0/etcd-v3.4.0-linux-amd64.tar.gz
-    tar xf etcd-v3.4.0-linux-amd64.tar.gz
-    cp ./etcd-v3.4.0-linux-amd64/etcdctl /usr/local/bin/
-    rm -rf etcd-v3.4.0-linux-amd64
+    wget https://github.com/etcd-io/etcd/releases/download/v3.5.2/etcd-v3.5.2-linux-amd64.tar.gz
+    tar xf etcd-v3.5.2-linux-amd64.tar.gz
+    cp ./etcd-v3.5.2-linux-amd64/etcdctl /usr/local/bin/
+    rm -rf etcd-v3.5.2-linux-amd64
 
     # install vault cli capabilities
     install_vault_cli

--- a/ci/pod/docker-compose.common.yml
+++ b/ci/pod/docker-compose.common.yml
@@ -31,7 +31,7 @@ services:
       - "3380:2380"
 
   etcd:
-    image: bitnami/etcd:3.4.0
+    image: bitnami/etcd:3.5.2
     restart: unless-stopped
     env_file:
       - ci/pod/etcd/env/common.env
@@ -42,7 +42,7 @@ services:
       - "2380:2380"
 
   etcd_tls:
-    image: bitnami/etcd:3.4.0
+    image: bitnami/etcd:3.5.2
     restart: unless-stopped
     env_file:
       - ci/pod/etcd/env/common.env
@@ -58,7 +58,7 @@ services:
       - ./t/certs:/certs
 
   etcd_mtls:
-    image: bitnami/etcd:3.4.0
+    image: bitnami/etcd:3.5.2
     restart: unless-stopped
     env_file:
       - ci/pod/etcd/env/common.env

--- a/ci/pod/docker-compose.common.yml
+++ b/ci/pod/docker-compose.common.yml
@@ -31,7 +31,7 @@ services:
       - "3380:2380"
 
   etcd:
-    image: bitnami/etcd:3.5.2
+    image: bitnami/etcd:3.4.18
     restart: unless-stopped
     env_file:
       - ci/pod/etcd/env/common.env
@@ -42,7 +42,7 @@ services:
       - "2380:2380"
 
   etcd_tls:
-    image: bitnami/etcd:3.5.2
+    image: bitnami/etcd:3.4.18
     restart: unless-stopped
     env_file:
       - ci/pod/etcd/env/common.env
@@ -58,7 +58,7 @@ services:
       - ./t/certs:/certs
 
   etcd_mtls:
-    image: bitnami/etcd:3.5.2
+    image: bitnami/etcd:3.4.18
     restart: unless-stopped
     env_file:
       - ci/pod/etcd/env/common.env

--- a/docs/en/latest/FAQ.md
+++ b/docs/en/latest/FAQ.md
@@ -302,7 +302,7 @@ apisix:
 Please follow the troubleshooting steps described below:
 
 1. Make sure that there aren't any networking issues between Apache APISIX and your etcd deployment in your cluster.
-2. If your network is healthy, check whether you have enabled the [gRPC gateway](https://etcd.io/docs/v3.4.0/dev-guide/api_grpc_gateway/) for etcd. The default state depends on whether you used command line options or a configuration file to start the etcd server.
+2. If your network is healthy, check whether you have enabled the [gRPC gateway](https://etcd.io/docs/v3.5.2/dev-guide/api_grpc_gateway/) for etcd. The default state depends on whether you used command line options or a configuration file to start the etcd server.
 
    - If you used command line options, gRPC gateway is enabled by default. You can enable it manually as shown below:
 

--- a/docs/en/latest/FAQ.md
+++ b/docs/en/latest/FAQ.md
@@ -302,7 +302,7 @@ apisix:
 Please follow the troubleshooting steps described below:
 
 1. Make sure that there aren't any networking issues between Apache APISIX and your etcd deployment in your cluster.
-2. If your network is healthy, check whether you have enabled the [gRPC gateway](https://etcd.io/docs/v3.5.2/dev-guide/api_grpc_gateway/) for etcd. The default state depends on whether you used command line options or a configuration file to start the etcd server.
+2. If your network is healthy, check whether you have enabled the [gRPC gateway](https://etcd.io/docs/v3.5/dev-guide/api_grpc_gateway/) for etcd. The default state depends on whether you used command line options or a configuration file to start the etcd server.
 
    - If you used command line options, gRPC gateway is enabled by default. You can enable it manually as shown below:
 

--- a/docs/en/latest/FAQ.md
+++ b/docs/en/latest/FAQ.md
@@ -302,7 +302,7 @@ apisix:
 Please follow the troubleshooting steps described below:
 
 1. Make sure that there aren't any networking issues between Apache APISIX and your etcd deployment in your cluster.
-2. If your network is healthy, check whether you have enabled the [gRPC gateway](https://etcd.io/docs/v3.5/dev-guide/api_grpc_gateway/) for etcd. The default state depends on whether you used command line options or a configuration file to start the etcd server.
+2. If your network is healthy, check whether you have enabled the [gRPC gateway](https://etcd.io/docs/v3.4/dev-guide/api_grpc_gateway/) for etcd. The default state depends on whether you used command line options or a configuration file to start the etcd server.
 
    - If you used command line options, gRPC gateway is enabled by default. You can enable it manually as shown below:
 

--- a/docs/en/latest/how-to-build.md
+++ b/docs/en/latest/how-to-build.md
@@ -169,7 +169,7 @@ This step is required only if you haven't installed [etcd](https://github.com/et
 Run the command below to install etcd via the binary in Linux:
 
 ```shell
-ETCD_VERSION='3.4.13'
+ETCD_VERSION='3.5.2'
 wget https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz
 tar -xvf etcd-v${ETCD_VERSION}-linux-amd64.tar.gz && \
   cd etcd-v${ETCD_VERSION}-linux-amd64 && \

--- a/docs/en/latest/how-to-build.md
+++ b/docs/en/latest/how-to-build.md
@@ -169,7 +169,7 @@ This step is required only if you haven't installed [etcd](https://github.com/et
 Run the command below to install etcd via the binary in Linux:
 
 ```shell
-ETCD_VERSION='3.5.2'
+ETCD_VERSION='3.4.18'
 wget https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz
 tar -xvf etcd-v${ETCD_VERSION}-linux-amd64.tar.gz && \
   cd etcd-v${ETCD_VERSION}-linux-amd64 && \

--- a/docs/zh/latest/FAQ.md
+++ b/docs/zh/latest/FAQ.md
@@ -285,7 +285,7 @@ APISIX 主要使用 [etcd.watchdir](https://github.com/api7/lua-resty-etcd/blob/
 
 首先请确保 APISIX 和 etcd 之间不存在网络分区的情况。
 
-如果网络的确是健康的，请检查你的 etcd 集群是否启用了 [gRPC gateway](https://etcd.io/docs/v3.4.0/dev-guide/api_grpc_gateway/) 特性。然而，当你使用命令行参数或配置文件启动 etcd 时，此特性的默认启用情况又是不同的。
+如果网络的确是健康的，请检查你的 etcd 集群是否启用了 [gRPC gateway](https://etcd.io/docs/v3.5.2/dev-guide/api_grpc_gateway/) 特性。然而，当你使用命令行参数或配置文件启动 etcd 时，此特性的默认启用情况又是不同的。
 
 1. 当使用命令行参数启动 etcd，该特性默认被启用，相关选项是 `enable-grpc-gateway`。
 

--- a/docs/zh/latest/FAQ.md
+++ b/docs/zh/latest/FAQ.md
@@ -285,7 +285,7 @@ APISIX 主要使用 [etcd.watchdir](https://github.com/api7/lua-resty-etcd/blob/
 
 首先请确保 APISIX 和 etcd 之间不存在网络分区的情况。
 
-如果网络的确是健康的，请检查你的 etcd 集群是否启用了 [gRPC gateway](https://etcd.io/docs/v3.5.2/dev-guide/api_grpc_gateway/) 特性。然而，当你使用命令行参数或配置文件启动 etcd 时，此特性的默认启用情况又是不同的。
+如果网络的确是健康的，请检查你的 etcd 集群是否启用了 [gRPC gateway](https://etcd.io/docs/v3.5/dev-guide/api_grpc_gateway/) 特性。然而，当你使用命令行参数或配置文件启动 etcd 时，此特性的默认启用情况又是不同的。
 
 1. 当使用命令行参数启动 etcd，该特性默认被启用，相关选项是 `enable-grpc-gateway`。
 

--- a/docs/zh/latest/FAQ.md
+++ b/docs/zh/latest/FAQ.md
@@ -285,7 +285,7 @@ APISIX 主要使用 [etcd.watchdir](https://github.com/api7/lua-resty-etcd/blob/
 
 首先请确保 APISIX 和 etcd 之间不存在网络分区的情况。
 
-如果网络的确是健康的，请检查你的 etcd 集群是否启用了 [gRPC gateway](https://etcd.io/docs/v3.5/dev-guide/api_grpc_gateway/) 特性。然而，当你使用命令行参数或配置文件启动 etcd 时，此特性的默认启用情况又是不同的。
+如果网络的确是健康的，请检查你的 etcd 集群是否启用了 [gRPC gateway](https://etcd.io/docs/v3.4/dev-guide/api_grpc_gateway/) 特性。然而，当你使用命令行参数或配置文件启动 etcd 时，此特性的默认启用情况又是不同的。
 
 1. 当使用命令行参数启动 etcd，该特性默认被启用，相关选项是 `enable-grpc-gateway`。
 

--- a/docs/zh/latest/how-to-build.md
+++ b/docs/zh/latest/how-to-build.md
@@ -163,7 +163,7 @@ sudo yum install ./apisix/*.rpm
 你可以通过 Docker 或者二进制等方式安装 etcd。以下命令通过二进制方式在 Linux 上安装 etcd。
 
 ```shell
-ETCD_VERSION='3.5.2'
+ETCD_VERSION='3.4.18'
 wget https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz
 tar -xvf etcd-v${ETCD_VERSION}-linux-amd64.tar.gz && \
   cd etcd-v${ETCD_VERSION}-linux-amd64 && \

--- a/docs/zh/latest/how-to-build.md
+++ b/docs/zh/latest/how-to-build.md
@@ -163,7 +163,7 @@ sudo yum install ./apisix/*.rpm
 你可以通过 Docker 或者二进制等方式安装 etcd。以下命令通过二进制方式在 Linux 上安装 etcd。
 
 ```shell
-ETCD_VERSION='3.4.13'
+ETCD_VERSION='3.5.2'
 wget https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz
 tar -xvf etcd-v${ETCD_VERSION}-linux-amd64.tar.gz && \
   cd etcd-v${ETCD_VERSION}-linux-amd64 && \

--- a/utils/linux-install-etcd-client.sh
+++ b/utils/linux-install-etcd-client.sh
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-wget https://github.com/etcd-io/etcd/releases/download/v3.4.0/etcd-v3.4.0-linux-amd64.tar.gz
-tar xf etcd-v3.4.0-linux-amd64.tar.gz
-sudo cp etcd-v3.4.0-linux-amd64/etcdctl /usr/local/bin/
-rm -rf etcd-v3.4.0-linux-amd64
+wget https://github.com/etcd-io/etcd/releases/download/v3.5.2/etcd-v3.5.2-linux-amd64.tar.gz
+tar xf etcd-v3.5.2-linux-amd64.tar.gz
+sudo cp etcd-v3.5.2-linux-amd64/etcdctl /usr/local/bin/
+rm -rf etcd-v3.5.2-linux-amd64

--- a/utils/linux-install-etcd-client.sh
+++ b/utils/linux-install-etcd-client.sh
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-wget https://github.com/etcd-io/etcd/releases/download/v3.5.2/etcd-v3.5.2-linux-amd64.tar.gz
-tar xf etcd-v3.5.2-linux-amd64.tar.gz
-sudo cp etcd-v3.5.2-linux-amd64/etcdctl /usr/local/bin/
-rm -rf etcd-v3.5.2-linux-amd64
+wget https://github.com/etcd-io/etcd/releases/download/v3.4.18/etcd-v3.4.18-linux-amd64.tar.gz
+tar xf etcd-v3.4.18-linux-amd64.tar.gz
+sudo cp etcd-v3.4.18-linux-amd64/etcdctl /usr/local/bin/
+rm -rf etcd-v3.4.18-linux-amd64


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

Upgrading etcd version to 3.5.2 for ci. This way we can test the compatibility of apisix with the latest version of etcd
