### PR TITLE
fix: `env.lua` should use absolute path

### DIFF
--- a/apisix/cli/env.lua
+++ b/apisix/cli/env.lua
@@ -78,7 +78,14 @@ return function (apisix_home, pkg_cpath_org, pkg_path_org)
         end
     end
 
-    local openresty_args = [[openresty -p ]] .. apisix_home .. [[ -c ]]
+    -- pre-transform openresty path
+    res, err = util.execute_cmd("command -v openresty")
+    if not res then
+        error("failed to exec ulimit cmd \'command -v openresty\', err: " .. err)
+    end
+    local openresty_path_abs = util.trim(res)
+
+    local openresty_args = openresty_path_abs .. [[ -p ]] .. apisix_home .. [[ -c ]]
                            .. apisix_home .. [[/conf/nginx.conf]]
 
     local min_etcd_version = "3.4.0"


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

The current `env.lua` uses CMD `openresty` to launch the service, which causes the master process unable to handle the `USR2` signal properly.

This PR use __absolute__ path CMD to handle it.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
