### PR TITLE
feat: use `command -v` instead of `which` to find the installed path.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ENV_RM                 ?= rm -vf
 ENV_DOCKER             ?= docker
 ENV_DOCKER_COMPOSE     ?= docker-compose --project-directory $(CURDIR) -p $(project_name) -f $(project_compose_ci)
 ENV_NGINX              ?= $(ENV_NGINX_EXEC) -p $(CURDIR) -c $(CURDIR)/conf/nginx.conf
-ENV_NGINX_EXEC         := $(shell which openresty 2>/dev/null || which nginx 2>/dev/null)
+ENV_NGINX_EXEC         := $(shell command -v openresty 2>/dev/null || command -v nginx 2>/dev/null)
 ENV_OPENSSL_PREFIX     ?= $(addprefix $(ENV_NGINX_PREFIX), openssl)
 ENV_LUAROCKS           ?= luarocks
 ## These variables can be injected by luarocks

--- a/bin/apisix
+++ b/bin/apisix
@@ -29,7 +29,7 @@ else
 fi
 
 # find the openresty
-OR_BIN=$(which openresty || exit 1)
+OR_BIN=$(command -v openresty || exit 1)
 OR_EXEC=${OR_BIN:-'/usr/local/openresty-debug/bin/openresty'}
 OR_VER=$(openresty -v 2>&1 | awk -F '/' '{print $2}' | awk -F '.' '{print $1"."$2}')
 LUA_VERSION=$(lua -v 2>&1| grep -E -o  "Lua [0-9]+.[0-9]+")

--- a/ci/centos7-ci.sh
+++ b/ci/centos7-ci.sh
@@ -23,7 +23,7 @@ install_dependencies() {
 
     # install development tools
     yum install -y wget tar gcc automake autoconf libtool make unzip \
-        git which sudo openldap-devel
+        git sudo openldap-devel
 
     # curl with http2
     wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-amd64 -O /usr/bin/curl

--- a/utils/install-dependencies.sh
+++ b/utils/install-dependencies.sh
@@ -20,9 +20,9 @@
 set -ex
 
 function detect_aur_helper() {
-    if [[ $(which yay) ]]; then
+    if [[ $(command -v yay) ]]; then
         AUR_HELPER=yay
-    elif [[ $(which pacaur) ]]; then
+    elif [[ $(command -v pacaur) ]]; then
         AUR_HELPER=pacaur
     else
         echo No available AUR helpers found. Please specify your AUR helper by AUR_HELPER.


### PR DESCRIPTION
Signed-off-by: mango <xu.weiKyrie@foxmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
`command -v` is the builtin shell cmd, the `which` can be replaced so that we don't need an extra dependency.

Fixes #6776 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
