### PR TITLE
fix: add support for multi-header with same key

### DIFF
--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -625,11 +625,17 @@ local rpc_handlers = {
 
             local len = rewrite:RespHeadersLength()
             if len > 0 then
+                local rewrite_resp_headers = {}
                 for i = 1, len do
                     local entry = rewrite:RespHeaders(i)
-                    local name = entry:Name()
-                    if exclude_resp_header[str_lower(name)] == nil then
-                        core.response.set_header(name, entry:Value())
+                    local name = str_lower(entry:Name())
+                    if exclude_resp_header[name] == nil then
+                        if rewrite_resp_headers[name] == nil then
+                            core.response.set_header(name, entry:Value())
+                            rewrite_resp_headers[name] = true
+                        else
+                            core.response.add_header(name, entry:Value())
+                        end
                     end
                 end
             end

--- a/t/lib/ext-plugin.lua
+++ b/t/lib/ext-plugin.lua
@@ -367,12 +367,14 @@ function _M.go(case)
             local action = http_req_call_rewrite.End(builder)
             build_action(action, http_req_call_action.Rewrite)
 
-        elseif case.rewrite_resp_header == true or case.rewrite_vital_resp_header == true then
+        elseif case.rewrite_resp_header == true or case.rewrite_vital_resp_header == true or case.rewrite_same_resp_header then
             local hdrs = {
                 {"X-Resp", "foo"},
                 {"X-Req", "bar"},
                 {"Content-Type", "application/json"},
                 {"Content-Encoding", "deflate"},
+                {"X-Same", "one"},
+                {"X-Same", "two"},
             }
             local len = #hdrs
             local textEntries = {}

--- a/t/lib/ext-plugin.lua
+++ b/t/lib/ext-plugin.lua
@@ -367,12 +367,44 @@ function _M.go(case)
             local action = http_req_call_rewrite.End(builder)
             build_action(action, http_req_call_action.Rewrite)
 
-        elseif case.rewrite_resp_header == true or case.rewrite_vital_resp_header == true or case.rewrite_same_resp_header then
+        elseif case.rewrite_resp_header == true or case.rewrite_vital_resp_header == true then
             local hdrs = {
                 {"X-Resp", "foo"},
                 {"X-Req", "bar"},
                 {"Content-Type", "application/json"},
                 {"Content-Encoding", "deflate"},
+                {"X-Same", "one"},
+                {"X-Same", "two"},
+            }
+            local len = #hdrs
+            local textEntries = {}
+            for i = 1, len do
+                local name = builder:CreateString(hdrs[i][1])
+                local value = builder:CreateString(hdrs[i][2])
+                text_entry.Start(builder)
+                text_entry.AddName(builder, name)
+                text_entry.AddValue(builder, value)
+                local c = text_entry.End(builder)
+                textEntries[i] = c
+            end
+            http_req_call_rewrite.StartRespHeadersVector(builder, len)
+            for i = len, 1, -1 do
+                builder:PrependUOffsetTRelative(textEntries[i])
+            end
+            local vec = builder:EndVector(len)
+
+            local path = builder:CreateString("/plugin_proxy_rewrite_resp_header")
+
+            http_req_call_rewrite.Start(builder)
+            http_req_call_rewrite.AddRespHeaders(builder, vec)
+            http_req_call_rewrite.AddPath(builder, path)
+            local action = http_req_call_rewrite.End(builder)
+            build_action(action, http_req_call_action.Rewrite)
+
+        elseif case.rewrite_same_resp_header == true then
+            local hdrs = {
+                {"X-Resp", "foo"},
+                {"X-Req", "bar"},
                 {"X-Same", "one"},
                 {"X-Same", "two"},
             }

--- a/t/lib/ext-plugin.lua
+++ b/t/lib/ext-plugin.lua
@@ -373,8 +373,6 @@ function _M.go(case)
                 {"X-Req", "bar"},
                 {"Content-Type", "application/json"},
                 {"Content-Encoding", "deflate"},
-                {"X-Same", "one"},
-                {"X-Same", "two"},
             }
             local len = #hdrs
             local textEntries = {}

--- a/t/plugin/ext-plugin/http-req-call.t
+++ b/t/plugin/ext-plugin/http-req-call.t
@@ -727,6 +727,4 @@ plugin_proxy_rewrite_resp_header
 --- response_headers
 X-Resp: foo
 X-Req: bar
-Content-Type: text/plain
-Content-Encoding:
 X-Same: one, two

--- a/t/plugin/ext-plugin/http-req-call.t
+++ b/t/plugin/ext-plugin/http-req-call.t
@@ -707,3 +707,26 @@ PUT /hello?xx=y&xx=z&&y=&&z
             ext.go({check_input = true})
         }
     }
+
+
+
+=== TEST 25: rewrite same response headers and call the upstream service
+--- request
+GET /hello
+--- extra_stream_config
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+
+        content_by_lua_block {
+            local ext = require("lib.ext-plugin")
+            ext.go({rewrite_same_resp_header = true})
+        }
+    }
+--- response_body
+plugin_proxy_rewrite_resp_header
+--- response_headers
+X-Resp: foo
+X-Req: bar
+Content-Type: text/plain
+Content-Encoding:
+X-Same: one, two


### PR DESCRIPTION
### Description

add support for multi-header with same key like `set-cookie`

Fixes # (issue)
https://github.com/apache/apisix-go-plugin-runner/issues/74
### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
