### PR TITLE
feat: check plugin init type

### DIFF
--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -150,10 +150,13 @@ local function load_plugin(name, plugins_list, plugin_type)
     core.table.insert(plugins_list, plugin)
 
     if plugin.init then
-        plugin.init()
+        if  type(plugin.init) == "function" then
+            plugin.init()
+        else
+            core.log.warn("plugin [", name,
+                           "]: field 'init' is not  a function")
+        end
     end
-
-    return
 end
 
 


### PR DESCRIPTION
### Description
- check  the  type  of  `plugin.init` whether it  is  `function` or  not.   `plugin.init`  may  be defined as  other  data types 
 in custom plugins
-  remove  redundant  code

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->



### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
