### PR TITLE
chore: set the license location threshold

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -19,6 +19,8 @@ header:
     spdx-id: Apache-2.0
     copyright-owner: Apache Software Foundation
 
+  license-location-threshold: 250
+
   paths-ignore:
     - '.gitignore'
     - 'LICENSE'


### PR DESCRIPTION
Signed-off-by: Navendu Pottekkat <navendupottekkat@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Sets the license location threshold. This _should_ avoid errors thrown in PRs like these https://github.com/apache/apisix/runs/5973924648?check_suite_focus=true

See https://github.com/apache/apisix/pull/6775#discussion_r845818022 for context.