### PR TITLE
fix: jwt-auth error may leak secret

### DIFF
--- a/apisix/plugins/jwt-auth.lua
+++ b/apisix/plugins/jwt-auth.lua
@@ -361,7 +361,8 @@ function _M.rewrite(conf, ctx)
     local jwt_obj = jwt:load_jwt(jwt_token)
     core.log.info("jwt object: ", core.json.delay_encode(jwt_obj))
     if not jwt_obj.valid then
-        return 401, {message = jwt_obj.reason}
+        core.log.error("JWT validate fail: " .. jwt_obj.reason)
+        return 401
     end
 
     local user_key = jwt_obj.payload and jwt_obj.payload.key
@@ -392,7 +393,8 @@ function _M.rewrite(conf, ctx)
     core.log.info("jwt object: ", core.json.delay_encode(jwt_obj))
 
     if not jwt_obj.verified then
-        return 401, {message = jwt_obj.reason}
+        core.log.error("JWT verify fail: " .. jwt_obj.reason)
+        return 401
     end
 
     consumer_mod.attach_consumer(ctx, consumer, consumer_conf)

--- a/apisix/plugins/jwt-auth.lua
+++ b/apisix/plugins/jwt-auth.lua
@@ -361,7 +361,7 @@ function _M.rewrite(conf, ctx)
     local jwt_obj = jwt:load_jwt(jwt_token)
     core.log.info("jwt object: ", core.json.delay_encode(jwt_obj))
     if not jwt_obj.valid then
-        core.log.error("JWT invalid: ", jwt_obj.reason)
+        core.log.error("JWT token invalid: ", jwt_obj.reason)
         return 401, {message = "JWT token invalid"}
     end
 
@@ -393,7 +393,7 @@ function _M.rewrite(conf, ctx)
     core.log.info("jwt object: ", core.json.delay_encode(jwt_obj))
 
     if not jwt_obj.verified then
-        core.log.error("JWT verify failed: ", jwt_obj.reason)
+        core.log.error("JWT token verify failed: ", jwt_obj.reason)
         return 401, {message = "JWT token verify failed"}
     end
 

--- a/apisix/plugins/jwt-auth.lua
+++ b/apisix/plugins/jwt-auth.lua
@@ -361,8 +361,8 @@ function _M.rewrite(conf, ctx)
     local jwt_obj = jwt:load_jwt(jwt_token)
     core.log.info("jwt object: ", core.json.delay_encode(jwt_obj))
     if not jwt_obj.valid then
-        core.log.error("JWT validate fail: " .. jwt_obj.reason)
-        return 401
+        core.log.error("JWT invalid: ", jwt_obj.reason)
+        return 401, {message = "JWT token invalid"}
     end
 
     local user_key = jwt_obj.payload and jwt_obj.payload.key
@@ -393,8 +393,8 @@ function _M.rewrite(conf, ctx)
     core.log.info("jwt object: ", core.json.delay_encode(jwt_obj))
 
     if not jwt_obj.verified then
-        core.log.error("JWT verify fail: " .. jwt_obj.reason)
-        return 401
+        core.log.error("JWT verify failed: ", jwt_obj.reason)
+        return 401, {message = "JWT token verify failed"}
     end
 
     consumer_mod.attach_consumer(ctx, consumer, consumer_conf)

--- a/t/plugin/jwt-auth.t
+++ b/t/plugin/jwt-auth.t
@@ -213,8 +213,8 @@ GET /hello
 --- request
 GET /hello?jwt=invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTU2Mzg3MDUwMX0.pPNVvh-TQsdDzorRwa-uuiLYiEBODscp9wv0cwD6c68
 --- error_code: 401
---- response_body
-{"message":"invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"}
+--- error_log
+JWT validate fail: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
 
 
 
@@ -222,8 +222,8 @@ GET /hello?jwt=invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtl
 --- request
 GET /hello?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTU2Mzg3MDUwMX0.pPNVvh-TQsdDzorRwa-uuiLYiEBODscp9wv0cwD6c68
 --- error_code: 401
---- response_body
-{"message":"'exp' claim expired at Tue, 23 Jul 2019 08:28:21 GMT"}
+--- error_log
+JWT verify fail: 'exp' claim expired at Tue, 23 Jul 2019 08:28:21 GMT
 
 
 
@@ -273,8 +273,8 @@ GET /hello
 --- more_headers
 Authorization: bearer invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTg3OTMxODU0MX0.fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
 --- error_code: 401
---- response_body
-{"message":"invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"}
+--- error_log
+JWT validate fail: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
 
 
 
@@ -424,8 +424,8 @@ hello world
 --- request
 GET /hello?jwt=invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTU2Mzg3MDUwMX0.pPNVvh-TQsdDzorRwa-uuiLYiEBODscp9wv0cwD6c68
 --- error_code: 401
---- response_body
-{"message":"invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"}
+--- error_log
+JWT validate fail: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
 
 
 
@@ -435,8 +435,8 @@ GET /hello
 --- more_headers
 Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTg3OTMxODU0MX0.fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
 --- error_code: 401
---- response_body
-{"message":"signature mismatch: fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs"}
+--- error_log
+JWT verify fail: signature mismatch: fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
 
 
 

--- a/t/plugin/jwt-auth.t
+++ b/t/plugin/jwt-auth.t
@@ -216,7 +216,7 @@ GET /hello?jwt=invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtl
 --- response_body
 {"message":"JWT token invalid"}
 --- error_log
-JWT invalid: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
+JWT token invalid: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
 
 
 
@@ -227,7 +227,7 @@ GET /hello?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4
 --- response_body
 {"message":"JWT token verify failed"}
 --- error_log
-JWT verify failed: 'exp' claim expired at Tue, 23 Jul 2019 08:28:21 GMT
+JWT token verify failed: 'exp' claim expired at Tue, 23 Jul 2019 08:28:21 GMT
 
 
 
@@ -280,7 +280,7 @@ Authorization: bearer invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c
 --- response_body
 {"message":"JWT token invalid"}
 --- error_log
-JWT invalid: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
+JWT token invalid: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
 
 
 
@@ -433,7 +433,7 @@ GET /hello?jwt=invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtl
 --- response_body
 {"message":"JWT token invalid"}
 --- error_log
-JWT invalid: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
+JWT token invalid: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
 
 
 
@@ -446,7 +446,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtle
 --- response_body
 {"message":"JWT token verify failed"}
 --- error_log
-JWT verify failed: signature mismatch: fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
+JWT token verify failed: signature mismatch: fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
 
 
 

--- a/t/plugin/jwt-auth.t
+++ b/t/plugin/jwt-auth.t
@@ -213,8 +213,10 @@ GET /hello
 --- request
 GET /hello?jwt=invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTU2Mzg3MDUwMX0.pPNVvh-TQsdDzorRwa-uuiLYiEBODscp9wv0cwD6c68
 --- error_code: 401
+--- response_body
+{"message":"JWT token invalid"}
 --- error_log
-JWT validate fail: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
+JWT invalid: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
 
 
 
@@ -222,8 +224,10 @@ JWT validate fail: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
 --- request
 GET /hello?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTU2Mzg3MDUwMX0.pPNVvh-TQsdDzorRwa-uuiLYiEBODscp9wv0cwD6c68
 --- error_code: 401
+--- response_body
+{"message":"JWT token verify failed"}
 --- error_log
-JWT verify fail: 'exp' claim expired at Tue, 23 Jul 2019 08:28:21 GMT
+JWT verify failed: 'exp' claim expired at Tue, 23 Jul 2019 08:28:21 GMT
 
 
 
@@ -273,8 +277,10 @@ GET /hello
 --- more_headers
 Authorization: bearer invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTg3OTMxODU0MX0.fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
 --- error_code: 401
+--- response_body
+{"message":"JWT token invalid"}
 --- error_log
-JWT validate fail: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
+JWT invalid: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
 
 
 
@@ -424,8 +430,10 @@ hello world
 --- request
 GET /hello?jwt=invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTU2Mzg3MDUwMX0.pPNVvh-TQsdDzorRwa-uuiLYiEBODscp9wv0cwD6c68
 --- error_code: 401
+--- response_body
+{"message":"JWT token invalid"}
 --- error_log
-JWT validate fail: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
+JWT invalid: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
 
 
 
@@ -435,8 +443,10 @@ GET /hello
 --- more_headers
 Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTg3OTMxODU0MX0.fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
 --- error_code: 401
+--- response_body
+{"message":"JWT token verify failed"}
 --- error_log
-JWT verify fail: signature mismatch: fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
+JWT verify failed: signature mismatch: fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
 
 
 


### PR DESCRIPTION
### Description

The jwt-auth plugin's response body may leak secrets in error message

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
