### PR TITLE
chore(jwt-auth): adjust error log level to warn

### DIFF
--- a/apisix/plugins/jwt-auth.lua
+++ b/apisix/plugins/jwt-auth.lua
@@ -361,7 +361,7 @@ function _M.rewrite(conf, ctx)
     local jwt_obj = jwt:load_jwt(jwt_token)
     core.log.info("jwt object: ", core.json.delay_encode(jwt_obj))
     if not jwt_obj.valid then
-        core.log.error("JWT token invalid: ", jwt_obj.reason)
+        core.log.warn("JWT token invalid: ", jwt_obj.reason)
         return 401, {message = "JWT token invalid"}
     end
 
@@ -386,15 +386,15 @@ function _M.rewrite(conf, ctx)
 
     local auth_secret, err = algorithm_handler(consumer)
     if not auth_secret then
-        core.log.error("failed to retrieve secrets, err: ", err)
+        core.log.warn("failed to retrieve secrets, err: ", err)
         return 503, {message = "failed to verify jwt"}
     end
     jwt_obj = jwt:verify_jwt_obj(auth_secret, jwt_obj)
     core.log.info("jwt object: ", core.json.delay_encode(jwt_obj))
 
     if not jwt_obj.verified then
-        core.log.error("JWT token verify failed: ", jwt_obj.reason)
-        return 401, {message = "JWT token verify failed"}
+        core.log.warn("failed to verify jwt: ", jwt_obj.reason)
+        return 401, {message = "failed to verify jwt"}
     end
 
     consumer_mod.attach_consumer(ctx, consumer, consumer_conf)

--- a/apisix/plugins/jwt-auth.lua
+++ b/apisix/plugins/jwt-auth.lua
@@ -386,7 +386,7 @@ function _M.rewrite(conf, ctx)
 
     local auth_secret, err = algorithm_handler(consumer)
     if not auth_secret then
-        core.log.warn("failed to retrieve secrets, err: ", err)
+        core.log.error("failed to retrieve secrets, err: ", err)
         return 503, {message = "failed to verify jwt"}
     end
     jwt_obj = jwt:verify_jwt_obj(auth_secret, jwt_obj)

--- a/t/plugin/jwt-auth.t
+++ b/t/plugin/jwt-auth.t
@@ -217,6 +217,8 @@ GET /hello?jwt=invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtl
 {"message":"JWT token invalid"}
 --- error_log
 JWT token invalid: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
+--- no_error_log
+[error]
 
 
 
@@ -225,9 +227,11 @@ JWT token invalid: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
 GET /hello?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTU2Mzg3MDUwMX0.pPNVvh-TQsdDzorRwa-uuiLYiEBODscp9wv0cwD6c68
 --- error_code: 401
 --- response_body
-{"message":"JWT token verify failed"}
+{"message":"failed to verify jwt"}
 --- error_log
-JWT token verify failed: 'exp' claim expired at Tue, 23 Jul 2019 08:28:21 GMT
+failed to verify jwt: 'exp' claim expired at Tue, 23 Jul 2019 08:28:21 GMT
+--- no_error_log
+[error]
 
 
 
@@ -281,6 +285,8 @@ Authorization: bearer invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c
 {"message":"JWT token invalid"}
 --- error_log
 JWT token invalid: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
+--- no_error_log
+[error]
 
 
 
@@ -434,6 +440,8 @@ GET /hello?jwt=invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtl
 {"message":"JWT token invalid"}
 --- error_log
 JWT token invalid: invalid header: invalid-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
+--- no_error_log
+[error]
 
 
 
@@ -444,9 +452,11 @@ GET /hello
 Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTg3OTMxODU0MX0.fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
 --- error_code: 401
 --- response_body
-{"message":"JWT token verify failed"}
+{"message":"failed to verify jwt"}
 --- error_log
-JWT token verify failed: signature mismatch: fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
+failed to verify jwt: signature mismatch: fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
+--- no_error_log
+[error]
 
 
 


### PR DESCRIPTION
### Description

Adjust the error log level in the `jwt-auth` plugin to warn

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
