### PR TITLE
feat: inject kubernetes discovery environment variable

### DIFF
--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -644,6 +644,45 @@ Please modify "admin_key" in conf/config.yaml .
         end
     end
 
+    -- inject kubernetes discovery environment variable
+    if enabled_discoveries["kubernetes"] then
+
+        local kubernetes_conf = yaml_conf.discovery["kubernetes"]
+
+        local keys = {
+            kubernetes_conf.service.host,
+            kubernetes_conf.service.port,
+        }
+
+        if kubernetes_conf.client.token then
+            table_insert(keys, kubernetes_conf.client.token)
+        end
+
+        if kubernetes_conf.client.token_file then
+            table_insert(keys, kubernetes_conf.client.token_file)
+        end
+
+        local envs = {}
+
+        for _, key in ipairs(keys) do
+            if #key > 3 then
+                local first, second = str_byte(key, 1, 2)
+                local last = str_byte(key, #key)
+                if first == str_byte('$') and second == str_byte('{') and last == str_byte('}') then
+                    envs[str_sub(key, 3, #key - 1)] = ""
+                end
+            end
+        end
+
+        if not sys_conf["envs"] then
+            sys_conf["envs"] = {}
+        end
+
+        for item in pairs(envs) do
+            table_insert(sys_conf["envs"], item)
+        end
+    end
+
     -- fix up lua path
     sys_conf["extra_lua_path"] = get_lua_path(yaml_conf.apisix.extra_lua_path)
     sys_conf["extra_lua_cpath"] = get_lua_path(yaml_conf.apisix.extra_lua_cpath)

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -667,9 +667,11 @@ Please modify "admin_key" in conf/config.yaml .
         for _, key in ipairs(keys) do
             if #key > 3 then
                 local first, second = str_byte(key, 1, 2)
-                local last = str_byte(key, #key)
-                if first == str_byte('$') and second == str_byte('{') and last == str_byte('}') then
-                    envs[str_sub(key, 3, #key - 1)] = ""
+                if first == str_byte('$') and second == str_byte('{') then
+                    local last = str_byte(key, #key)
+                    if last == str_byte('}') then
+                        envs[str_sub(key, 3, #key - 1)] = ""
+                    end
                 end
             end
         end

--- a/t/cli/test_kubernetes.sh
+++ b/t/cli/test_kubernetes.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+. ./t/cli/common.sh
+
+exit_if_not_customed_nginx
+
+echo '
+discovery:
+    kubernetes:
+      service:
+        host: ${HOST_ENV}
+      client:
+        token: ${TOKEN_ENV}
+' > conf/config.yaml
+
+make init
+
+if ! grep "env HOST_ENV" conf/nginx.conf; then
+    echo "kubernetes discovery env inject failed"
+    exit 1
+fi
+
+if ! grep "env KUBERNETES_SERVICE_PORT" conf/nginx.conf; then
+    echo "kubernetes discovery env inject failed"
+    exit 1
+fi
+
+if ! grep "env TOKEN_ENV" conf/nginx.conf; then
+    echo "kubernetes discovery env inject failed"
+    exit 1
+fi
+
+echo "kubernetes discovery env inject success"

--- a/t/cli/test_kubernetes.sh
+++ b/t/cli/test_kubernetes.sh
@@ -19,8 +19,6 @@
 
 . ./t/cli/common.sh
 
-exit_if_not_customed_nginx
-
 echo '
 discovery:
     kubernetes:


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fix #6830 

Inject the env variable when k8s service discovery is enabled -> apisix/opt.lua

### Checklist

- [Y] I have explained the need for this PR and the problem it solves
- [Y] I have explained the changes or the new features added to this PR
- [Y] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
