### PR TITLE
fix: the client verify flag might not be set

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -313,8 +313,8 @@ end
 
 
 local function verify_tls_client(ctx)
-    if ctx and ctx.ssl_client_verified then
-        local res = ngx_var.ssl_client_verify
+    local res = ngx_var.ssl_client_verify
+    if res ~= nil then
         if res ~= "SUCCESS" then
             if res == "NONE" then
                 core.log.error("client certificate was not present")

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -314,7 +314,7 @@ end
 
 
 local function verify_tls_client(ctx)
-    local matched = router.router_ssl.match_and_set(ctx)
+    local matched = router.router_ssl.match_and_set(ctx, true)
     if not matched then
         return true
     end

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -361,7 +361,7 @@ function _M.http_access_phase()
     local api_ctx = core.tablepool.fetch("api_ctx", 0, 32)
     ngx_ctx.api_ctx = api_ctx
 
-    if not verify_tls_client(ngx_ctx.api_ctx) then
+    if not verify_tls_client(api_ctx) then
         return core.response.exit(400)
     end
 
@@ -882,7 +882,7 @@ function _M.stream_preread_phase()
         ngx_ctx.api_ctx = api_ctx
     end
 
-    if not verify_tls_client(ngx_ctx.api_ctx) then
+    if not verify_tls_client(api_ctx) then
         return ngx_exit(1)
     end
 

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -36,6 +36,7 @@ local get_var         = require("resty.ngxvar").fetch
 local router          = require("apisix.router")
 local apisix_upstream = require("apisix.upstream")
 local set_upstream    = apisix_upstream.set_by_route
+local apisix_ssl      = require("apisix.ssl")
 local upstream_util   = require("apisix.utils.upstream")
 local xrpc            = require("apisix.stream.xrpc")
 local ctxdump         = require("resty.ctxdump")
@@ -313,8 +314,14 @@ end
 
 
 local function verify_tls_client(ctx)
-    local res = ngx_var.ssl_client_verify
-    if res ~= nil then
+    local matched = router.router_ssl.match_and_set(ctx)
+    if not matched then
+        return true
+    end
+
+    local matched_ssl = ctx.matched_ssl
+    if matched_ssl.value.client and apisix_ssl.support_client_verification() then
+        local res = ngx_var.ssl_client_verify
         if res ~= "SUCCESS" then
             if res == "NONE" then
                 core.log.error("client certificate was not present")
@@ -350,13 +357,13 @@ end
 function _M.http_access_phase()
     local ngx_ctx = ngx.ctx
 
-    if not verify_tls_client(ngx_ctx.api_ctx) then
-        return core.response.exit(400)
-    end
-
     -- always fetch table from the table pool, we don't need a reused api_ctx
     local api_ctx = core.tablepool.fetch("api_ctx", 0, 32)
     ngx_ctx.api_ctx = api_ctx
+
+    if not verify_tls_client(ngx_ctx.api_ctx) then
+        return core.response.exit(400)
+    end
 
     core.ctx.set_vars_meta(api_ctx)
 
@@ -870,13 +877,13 @@ function _M.stream_preread_phase()
     local ngx_ctx = ngx.ctx
     local api_ctx = ngx_ctx.api_ctx
 
-    if not verify_tls_client(ngx_ctx.api_ctx) then
-        return ngx_exit(1)
-    end
-
     if not api_ctx then
         api_ctx = core.tablepool.fetch("api_ctx", 0, 32)
         ngx_ctx.api_ctx = api_ctx
+    end
+
+    if not verify_tls_client(ngx_ctx.api_ctx) then
+        return ngx_exit(1)
     end
 
     core.ctx.set_vars_meta(api_ctx)

--- a/apisix/ssl/router/radixtree_sni.lua
+++ b/apisix/ssl/router/radixtree_sni.lua
@@ -209,8 +209,6 @@ function _M.match_and_set(api_ctx)
             if not ok then
                 return false, err
             end
-
-            api_ctx.ssl_client_verified = true
         end
     end
 

--- a/apisix/ssl/router/radixtree_sni.lua
+++ b/apisix/ssl/router/radixtree_sni.lua
@@ -117,7 +117,7 @@ local function set_pem_ssl_key(sni, cert, pkey)
 end
 
 
-function _M.match_and_set(api_ctx)
+function _M.match_and_set(api_ctx, match_only)
     local err
     if not radixtree_router or
        radixtree_router_ver ~= ssl_certificates.conf_version then
@@ -174,6 +174,10 @@ function _M.match_and_set(api_ctx)
 
     local matched_ssl = api_ctx.matched_ssl
     core.log.info("debug - matched: ", core.json.delay_encode(matched_ssl, true))
+
+    if match_only then
+        return true
+    end
 
     ngx_ssl.clear_certs()
 


### PR DESCRIPTION
A more suitable way is to reject client TLS handshake directly, just
like what Go has done.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #6896

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
