### PR TITLE
fix: upstream nodes cant't include ipv6 addr

### DIFF
--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -37,7 +37,7 @@ local id_schema = {
     }
 }
 
-local host_def_pat = "^\\*?[0-9a-zA-Z-._]+$"
+local host_def_pat = "^\\*?[0-9a-zA-Z-._\\[\\]:]+$"
 local host_def = {
     type = "string",
     pattern = host_def_pat,

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -200,7 +200,7 @@ if ($version =~ m/\/apisix-nginx-module/) {
     $a6_ngx_directives = <<_EOC_;
     apisix_delay_client_max_body_check on;
     apisix_mirror_on_demand on;
-    wasm_vm wasmtime;
+    #wasm_vm wasmtime;
 _EOC_
 }
 

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -200,7 +200,7 @@ if ($version =~ m/\/apisix-nginx-module/) {
     $a6_ngx_directives = <<_EOC_;
     apisix_delay_client_max_body_check on;
     apisix_mirror_on_demand on;
-    #wasm_vm wasmtime;
+    wasm_vm wasmtime;
 _EOC_
 }
 

--- a/t/admin/upstream-array-nodes.t
+++ b/t/admin/upstream-array-nodes.t
@@ -476,11 +476,12 @@ GET /t
                 )
 
             ngx.status = code
-            ngx.print(body)
+            ngx.say(body)
         }
     }
 --- request
 GET /t
---- error_code: 201
+--- response_body
+passed
 --- no_error_log
 [error]

--- a/t/admin/upstream-array-nodes.t
+++ b/t/admin/upstream-array-nodes.t
@@ -450,3 +450,37 @@ GET /t
 {"error_msg":"invalid configuration: property \"nodes\" validation failed: object matches none of the required"}
 --- no_error_log
 [error]
+
+
+
+=== TEST 22: nodes host include ipv6 addr
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "upstream": {
+                        "nodes": [
+                            {
+                                "host":"[::1]",
+                                "port":8082,
+                                "weight":1
+                            }
+                        ],
+                        "type": "roundrobin"
+                    },
+                    "uri": "/index.html"
+                }]]
+                )
+
+            ngx.status = code
+            ngx.print(body)
+        }
+    }
+--- request
+GET /t
+--- error_code: 201
+--- no_error_log
+[error]

--- a/t/admin/upstream-array-nodes.t
+++ b/t/admin/upstream-array-nodes.t
@@ -453,7 +453,7 @@ GET /t
 
 
 
-=== TEST 22: nodes host include ipv6 addr
+=== TEST 14: nodes host include ipv6 addr
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/referer-restriction.t
+++ b/t/plugin/referer-restriction.t
@@ -173,7 +173,6 @@ hello world
             local cases = {
                 "x.*",
                 "~y.xn",
-                "::1",
             }
             for _, c in ipairs(cases) do
                 local ok, err = plugin.check_schema({


### PR DESCRIPTION
### Description
Make a simple modification to make the upstream nodes host support ipv6

Fixes #6905 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
