### PR TITLE
chore: the second returned value of ngx.thread.wait is execution result but not err

### DIFF
--- a/apisix/timers.lua
+++ b/apisix/timers.lua
@@ -49,9 +49,9 @@ local function background_timer()
 ::continue::
     end
 
-    local ok, err = thread_wait(unpack(threads))
+    local ok = thread_wait(unpack(threads))
     if not ok then
-        core.log.error("failed to wait threads: ", err)
+        core.log.error("failed to wait threads")
     end
 end
 


### PR DESCRIPTION
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
