### PR TITLE
fix(ext-plugin): append resp header when multiple headers with the same name is given

### DIFF
--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -577,9 +577,16 @@ local rpc_handlers = {
 
             local len = stop:HeadersLength()
             if len > 0 then
+                local stop_resp_headers = {}
                 for i = 1, len do
                     local entry = stop:Headers(i)
-                    core.response.set_header(entry:Name(), entry:Value())
+                    local name = str_lower(entry:Name())
+                    if stop_resp_headers[name] == nil then
+                        core.response.set_header(name, entry:Value())
+                        stop_resp_headers[name] = true
+                    else
+                        core.response.add_header(name, entry:Value())
+                    end
                 end
             end
 

--- a/t/lib/ext-plugin.lua
+++ b/t/lib/ext-plugin.lua
@@ -251,6 +251,8 @@ function _M.go(case)
             local hdrs = {
                 {"X-Resp", "foo"},
                 {"X-Req", "bar"},
+                {"X-Same", "one"},
+                {"X-Same", "two"},
             }
             local len = #hdrs
             local textEntries = {}

--- a/t/plugin/ext-plugin/http-req-call.t
+++ b/t/plugin/ext-plugin/http-req-call.t
@@ -728,3 +728,25 @@ plugin_proxy_rewrite_resp_header
 X-Resp: foo
 X-Req: bar
 X-Same: one, two
+
+
+
+=== TEST 26: stop with modify same response headers
+--- request
+GET /hello
+--- response_body chomp
+cat
+--- extra_stream_config
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+
+        content_by_lua_block {
+            local ext = require("lib.ext-plugin")
+            ext.go({stop = true})
+        }
+    }
+--- error_code: 405
+--- response_headers
+X-Resp: foo
+X-Req: bar
+X-Same: one, two


### PR DESCRIPTION
### Description
The same fix to other headers.
I only found one place to fix and I think request headers not to fix. What else?

@spacewander 
Fixes # (issue)

https://github.com/apache/apisix/pull/6811#issuecomment-1096463034

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)