### PR TITLE
chore: replace ngx.req.get_post_args to core.request.get_post_args

### DIFF
--- a/apisix/plugins/wolf-rbac.lua
+++ b/apisix/plugins/wolf-rbac.lua
@@ -29,7 +29,6 @@ local setmetatable = setmetatable
 local type     = type
 local string   = string
 local req_read_body = ngx.req.read_body
-local req_get_post_args = ngx.req.get_post_args
 local req_get_body_data = ngx.req.get_body_data
 
 local plugin_name = "wolf-rbac"

--- a/apisix/plugins/wolf-rbac.lua
+++ b/apisix/plugins/wolf-rbac.lua
@@ -344,7 +344,7 @@ local function get_args()
             core.log.error("json.decode(", req_body, ") failed! ", err)
         end
     else
-        args = req_get_post_args()
+        args = core.request.get_post_args(ctx)
     end
 
     return args


### PR DESCRIPTION
### Description

Replace ngx.req.get_post_args to core.request.get_post_args, so that we can support more than 100 post args.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
