### PR TITLE
chore: replace ngx.decode_args to core.string.decode_args

### DIFF
--- a/apisix/core/string.lua
+++ b/apisix/core/string.lua
@@ -105,6 +105,15 @@ function _M.compress_script(s)
 end
 
 
+---
+-- Decodes a URI encoded query-string into a Lua table.
+-- All request arguments received will be decoded by default.
+--
+-- @function core.string.decode_args
+-- @tparam string args A URI encoded query-string.
+-- @treturn table the value of decoded query-string.
+-- @usage
+-- local args, err = core.string.decode_args("a=1&b=2") -- {a=1, b=2}
 function _M.decode_args(args)
     -- use 0 to avoid truncated result and keep the behavior as the
     -- same as other platforms
@@ -112,6 +121,14 @@ function _M.decode_args(args)
 end
 
 
+---
+-- Encode the Lua table to a query args string according to the URI encoded rules.
+--
+-- @function core.string.encode_args
+-- @tparam table args The query args Lua table.
+-- @treturn string the value of query args string.
+-- @usage
+-- local str = core.string.encode_args({a=1, b=2}) -- "a=1&b=2"
 function _M.encode_args(args)
     return ngx_encode_args(args)
 end

--- a/apisix/core/string.lua
+++ b/apisix/core/string.lua
@@ -27,6 +27,8 @@ local ffi         = require("ffi")
 local C           = ffi.C
 local ffi_cast    = ffi.cast
 local ngx         = ngx
+local ngx_decode_args  = ngx.decode_args
+local ngx_encode_args  = ngx.encode_args
 
 
 ffi.cdef[[
@@ -102,5 +104,16 @@ function _M.compress_script(s)
     return s
 end
 
+
+function _M.decode_args(args)
+    -- use 0 to avoid truncated result and keep the behavior as the
+    -- same as other platforms
+    return ngx_decode_args(args, 0)
+end
+
+
+function _M.encode_args(args)
+    return ngx_encode_args(args)
+end
 
 return _M

--- a/apisix/plugins/authz-keycloak.lua
+++ b/apisix/plugins/authz-keycloak.lua
@@ -714,7 +714,7 @@ local function generate_token_using_password_grant(conf,ctx)
         log.error("Failed to get request body: ", err)
         return 503
     end
-    local parameters = ngx.decode_args(body)
+    local parameters = core.string.decode_args(body)
 
     local username = parameters["username"]
     local password = parameters["password"]


### PR DESCRIPTION
### Description

Replace replace ngx.decode_args to core.string.decode_args, so that we can support more than 100 raw args.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
