### PR TITLE
fix(balancer): Add test cases  when setting upstream doesn't specify priority

### DIFF
--- a/apisix/balancer.lua
+++ b/apisix/balancer.lua
@@ -50,12 +50,17 @@ local function transform_node(new_nodes, node)
         new_nodes._priority_index = {}
     end
 
-    if not new_nodes[node.priority] then
-        new_nodes[node.priority] = {}
-        core.table.insert(new_nodes._priority_index, node.priority)
+    local node_priority = 0   -- if nodes don't specify priority using default
+    if node.priority then
+        node_priority = node.priority
     end
 
-    new_nodes[node.priority][node.host .. ":" .. node.port] = node.weight
+    if not new_nodes[node_priority] then
+        new_nodes[node_priority] = {}
+        core.table.insert(new_nodes._priority_index, node_priority)
+    end
+
+    new_nodes[node_priority][node.host .. ":" .. node.port] = node.weight
     return new_nodes
 end
 

--- a/t/admin/balancer.t
+++ b/t/admin/balancer.t
@@ -251,3 +251,118 @@ host: 39.97.63.217 count: 4
 host: 39.97.63.218 count: 12
 --- no_error_log
 [error]
+
+
+
+=== TEST 6: don't specify the priority
+--- config
+    location /t {
+        content_by_lua_block {
+            local up_conf = {
+                type = "roundrobin",
+                nodes = {
+                    {host = "39.97.63.215", port = 80, weight = 1},
+                    {host = "39.97.63.216", port = 81, weight = 1, priority = 0},
+                    {host = "39.97.63.217", port = 82, weight = 1, priority = 0},
+                }
+            }
+            local ctx = {conf_version = 1}
+            ctx.upstream_conf = up_conf
+            ctx.upstream_version = "ver"
+            ctx.upstream_key = up_conf.type .. "#route_" .. "id"
+
+            test(route, ctx)
+        }
+    }
+--- request
+GET /t
+--- response_body
+host: 39.97.63.215 count: 4
+host: 39.97.63.216 count: 4
+host: 39.97.63.217 count: 4
+--- no_error_log
+[error]
+
+
+
+=== TEST 7: don't specify the priority, then use one node
+--- config
+    location /t {
+        content_by_lua_block {
+            local up_conf = {
+                type = "roundrobin",
+                nodes = {
+                    {host = "39.97.63.215", port = 80, weight = 1},
+                    {host = "39.97.63.216", port = 81, weight = 1},
+                    {host = "39.97.63.217", port = 82, weight = 1, priority = 0},
+                }
+            }
+            local ctx = {}
+            ctx.upstream_conf = up_conf
+            ctx.upstream_version = 1
+            ctx.upstream_key = up_conf.type .. "#route_" .. "id"
+
+            test(route, ctx)
+
+            -- one item in nodes, return it directly
+            up_conf.nodes = {
+                {host = "39.97.63.218", port = 80, weight = 1},
+            }
+            test(route, ctx)
+        }
+    }
+--- request
+GET /t
+--- response_body
+host: 39.97.63.215 count: 4
+host: 39.97.63.216 count: 4
+host: 39.97.63.217 count: 4
+host: 39.97.63.218 count: 12
+--- no_error_log
+[error]
+
+
+
+=== TEST 8: don't specify the priority and cached version
+--- config
+    location /t {
+        content_by_lua_block {
+            local up_conf = {
+                type = "roundrobin",
+                nodes = {
+                    {host = "39.97.63.215", port = 80, weight = 1, priority = 0},
+                    {host = "39.97.63.216", port = 81, weight = 1, priority = 0},
+                    {host = "39.97.63.217", port = 82, weight = 1},
+                }
+            }
+            local ctx = {}
+            ctx.upstream_conf = up_conf
+            ctx.upstream_version = 1
+            ctx.upstream_key = up_conf.type .. "#route_" .. "id"
+
+            test(route, ctx)
+
+            -- cached by version
+            up_conf.nodes = {
+                {host = "39.97.63.218", port = 80, weight = 1},
+                {host = "39.97.63.219", port = 80, weight = 0, priority = 0},
+            }
+            test(route, ctx)
+
+            -- update, version changed
+            ctx.upstream_version = 2
+            test(route, ctx)
+        }
+    }
+--- request
+GET /t
+--- response_body
+host: 39.97.63.215 count: 4
+host: 39.97.63.216 count: 4
+host: 39.97.63.217 count: 4
+host: 39.97.63.215 count: 4
+host: 39.97.63.216 count: 4
+host: 39.97.63.217 count: 4
+host: 39.97.63.218 count: 12
+--- no_error_log
+[error]


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

The `transform_node` function doesn't check the priority. If the priority is `nil`, apisix will print a error.

![image](https://user-images.githubusercontent.com/88528414/165246304-4509b67f-af3d-4a2f-b1af-d92a6e28c825.png)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
