### PR TITLE
api-breaker plugin returns default response body

### DIFF
--- a/apisix/plugins/api-breaker.lua
+++ b/apisix/plugins/api-breaker.lua
@@ -46,10 +46,12 @@ local schema = {
                 type = "object",
                 properties = {
                     key = {
-                        type = "string"
+                        type = "string",
+                        minLength = 1
                     },
                     value = {
-                        type = "string"
+                        type = "string",
+                        minLength = 1
                     }
                 }
             }
@@ -178,8 +180,8 @@ function _M.access(conf, ctx)
     -- breaker
     if lasttime + breaker_time >= ngx.time() then
         if conf.break_response_body then
-            if conf.headers then
-                for _, value in ipairs(conf.headers) do
+            if conf.break_response_headers then
+                for _, value in ipairs(conf.break_response_headers) do
                     local val = core.utils.resolve_var(value.value, ctx.var)
                     core.response.add_header(value.key, val)
                 end

--- a/apisix/plugins/api-breaker.lua
+++ b/apisix/plugins/api-breaker.lua
@@ -40,7 +40,7 @@ local schema = {
         break_response_body = {
             type = "string"
         },
-        headers = {
+        break_response_headers = {
             type = "array",
             items = {
                 type = "object",

--- a/apisix/plugins/api-breaker.lua
+++ b/apisix/plugins/api-breaker.lua
@@ -132,12 +132,7 @@ local _M = {
 
 
 function _M.check_schema(conf)
-    local ok, err = core.schema.check(schema, conf)
-    if not ok then
-        return false, err
-    end
-
-    return true
+    return core.schema.check(schema, conf)
 end
 
 

--- a/apisix/plugins/api-breaker.lua
+++ b/apisix/plugins/api-breaker.lua
@@ -35,6 +35,13 @@ local schema = {
             minimum = 200,
             maximum = 599,
         },
+        break_response_body = {
+            type = "string"
+        },
+        break_response_content_type = {
+            type = "string",
+            default = "application/json"
+        },
         max_breaker_sec = {
             type = "integer",
             minimum = 3,
@@ -158,6 +165,11 @@ function _M.access(conf, ctx)
 
     -- breaker
     if lasttime + breaker_time >= ngx.time() then
+        if conf.break_response_body then
+            core.response.clear_header_as_body_modified()
+            ngx.header["Content-Type"] = conf.break_response_content_type
+            return conf.break_response_code, conf.break_response_body
+        end
         return conf.break_response_code
     end
 

--- a/apisix/plugins/api-breaker.lua
+++ b/apisix/plugins/api-breaker.lua
@@ -167,7 +167,9 @@ function _M.access(conf, ctx)
     if lasttime + breaker_time >= ngx.time() then
         if conf.break_response_body then
             core.response.clear_header_as_body_modified()
-            ngx.header["Content-Type"] = conf.break_response_content_type
+            if conf.break_response_content_type then
+                core.response.set_header("Content-Type", conf.break_response_content_type)
+            end
             return conf.break_response_code, conf.break_response_body
         end
         return conf.break_response_code

--- a/docs/en/latest/plugins/api-breaker.md
+++ b/docs/en/latest/plugins/api-breaker.md
@@ -45,7 +45,7 @@ In an unhealthy state, when a request is forwarded to an upstream service and th
 | ----------------------- | ------------- | ----------- | -------- | --------------- | --------------------------------------------------------------------------- |
 | break_response_code     | integer        | required |            | [200, ..., 599] | Return error code when unhealthy |
 | break_response_body     | string         | optional |            |                 | Return response body when unhealthy |
-| break_response_content_type     | string        | optional | application/json |    | Return body's content type when unhealthy |
+| break_response_content_type     | string        | optional | application/json |    | Return body's content type when unhealthy. This field is in effective only if `break_response_body` is configured. |
 | max_breaker_sec         | integer        | optional | 300        | >=3             | Maximum breaker time(seconds) |
 | unhealthy.http_statuses | array[integer] | optional | {500}      | [500, ..., 599] | Status codes when unhealthy |
 | unhealthy.failures      | integer        | optional | 3          | >=1             | Number of consecutive error requests that triggered an unhealthy state |

--- a/docs/en/latest/plugins/api-breaker.md
+++ b/docs/en/latest/plugins/api-breaker.md
@@ -45,7 +45,7 @@ In an unhealthy state, when a request is forwarded to an upstream service and th
 | ----------------------- | ------------- | ----------- | -------- | --------------- | --------------------------------------------------------------------------- |
 | break_response_code     | integer        | required |            | [200, ..., 599] | Return error code when unhealthy |
 | break_response_body     | string         | optional |            |                 | Return response body when unhealthy |
-| break_response_content_type     | string        | optional | application/json |    | Return body's content type when unhealthy. This field is in effective only if `break_response_body` is configured. |
+| headers                 | array[object]  | optional |            |                 | New headers for the response. The values in the header can contain Nginx variables like `$remote_addr` and `$balancer_ip`. This field is in effective only if `break_response_body` is configured. |
 | max_breaker_sec         | integer        | optional | 300        | >=3             | Maximum breaker time(seconds) |
 | unhealthy.http_statuses | array[integer] | optional | {500}      | [500, ..., 599] | Status codes when unhealthy |
 | unhealthy.failures      | integer        | optional | 3          | >=1             | Number of consecutive error requests that triggered an unhealthy state |

--- a/docs/en/latest/plugins/api-breaker.md
+++ b/docs/en/latest/plugins/api-breaker.md
@@ -45,7 +45,7 @@ In an unhealthy state, when a request is forwarded to an upstream service and th
 | ----------------------- | ------------- | ----------- | -------- | --------------- | --------------------------------------------------------------------------- |
 | break_response_code     | integer        | required |            | [200, ..., 599] | Return error code when unhealthy |
 | break_response_body     | string         | optional |            |                 | Return response body when unhealthy |
-| headers                 | array[object]  | optional |            |                 | New headers for the response. The values in the header can contain Nginx variables like `$remote_addr` and `$balancer_ip`. This field is in effective only if `break_response_body` is configured. |
+| break_response_headers  | array[object]  | optional |            |                 | New headers for the response. The values in the header can contain Nginx variables like `$remote_addr` and `$balancer_ip`. This field is in effective only if `break_response_body` is configured. |
 | max_breaker_sec         | integer        | optional | 300        | >=3             | Maximum breaker time(seconds) |
 | unhealthy.http_statuses | array[integer] | optional | {500}      | [500, ..., 599] | Status codes when unhealthy |
 | unhealthy.failures      | integer        | optional | 3          | >=1             | Number of consecutive error requests that triggered an unhealthy state |

--- a/docs/en/latest/plugins/api-breaker.md
+++ b/docs/en/latest/plugins/api-breaker.md
@@ -44,7 +44,7 @@ In an unhealthy state, when a request is forwarded to an upstream service and th
 | Name                    | Type          | Requirement | Default | Valid            | Description                                                                 |
 | ----------------------- | ------------- | ----------- | -------- | --------------- | --------------------------------------------------------------------------- |
 | break_response_code     | integer        | required |            | [200, ..., 599] | Return error code when unhealthy |
-| break_response_body     | string         | optional |            |                 | Return reponse body when unhealthy |
+| break_response_body     | string         | optional |            |                 | Return response body when unhealthy |
 | break_response_content_type     | string        | optional | application/json |    | Return body's content type when unhealthy |
 | max_breaker_sec         | integer        | optional | 300        | >=3             | Maximum breaker time(seconds) |
 | unhealthy.http_statuses | array[integer] | optional | {500}      | [500, ..., 599] | Status codes when unhealthy |

--- a/docs/en/latest/plugins/api-breaker.md
+++ b/docs/en/latest/plugins/api-breaker.md
@@ -44,6 +44,8 @@ In an unhealthy state, when a request is forwarded to an upstream service and th
 | Name                    | Type          | Requirement | Default | Valid            | Description                                                                 |
 | ----------------------- | ------------- | ----------- | -------- | --------------- | --------------------------------------------------------------------------- |
 | break_response_code     | integer        | required |            | [200, ..., 599] | Return error code when unhealthy |
+| break_response_body     | string         | optional |            |                 | Return reponse body when unhealthy |
+| break_response_content_type     | string        | optional | application/json |    | Return body's content type when unhealthy |
 | max_breaker_sec         | integer        | optional | 300        | >=3             | Maximum breaker time(seconds) |
 | unhealthy.http_statuses | array[integer] | optional | {500}      | [500, ..., 599] | Status codes when unhealthy |
 | unhealthy.failures      | integer        | optional | 3          | >=1             | Number of consecutive error requests that triggered an unhealthy state |

--- a/docs/zh/latest/plugins/api-breaker.md
+++ b/docs/zh/latest/plugins/api-breaker.md
@@ -45,7 +45,7 @@ title: api-breaker
 | ----------------------- | -------------- | ------ | ---------- | --------------- | -------------------------------- |
 | break_response_code     | integer        | 必须   | 无         | [200, ..., 599] | 不健康返回错误码                 |
 | break_response_body     | string         | 可选   | 无         |                 | 不健康返回报文                   |
-| break_response_content_type     | string | 可选   | application/json |           | 不健康返回报文的内容类型，该字段仅在 `break_response_body` 被配置时生效 |
+| headers                 | array[object]  | 可选   | 无         |                 | 不健康返回报文头，这里可以设置多个。这个值能够以 `$var` 的格式包含 Nginx 变量，比如 `$remote_addr $balancer_ip`。该字段仅在 `break_response_body` 被配置时生效 |
 | max_breaker_sec         | integer        | 可选   | 300        | >=3             | 最大熔断持续时间                 |
 | unhealthy.http_statuses | array[integer] | 可选   | {500}      | [500, ..., 599] | 不健康时候的状态码               |
 | unhealthy.failures      | integer        | 可选   | 3          | >=1             | 触发不健康状态的连续错误请求次数 |

--- a/docs/zh/latest/plugins/api-breaker.md
+++ b/docs/zh/latest/plugins/api-breaker.md
@@ -45,7 +45,7 @@ title: api-breaker
 | ----------------------- | -------------- | ------ | ---------- | --------------- | -------------------------------- |
 | break_response_code     | integer        | 必须   | 无         | [200, ..., 599] | 不健康返回错误码                 |
 | break_response_body     | string         | 可选   | 无         |                 | 不健康返回报文                   |
-| break_response_content_type     | string | 可选   | application/json |           | 不健康返回 Content-Type          |
+| break_response_content_type     | string | 可选   | application/json |           | 不健康返回报文的内容类型，该字段仅在 `break_response_body` 被配置时生效 |
 | max_breaker_sec         | integer        | 可选   | 300        | >=3             | 最大熔断持续时间                 |
 | unhealthy.http_statuses | array[integer] | 可选   | {500}      | [500, ..., 599] | 不健康时候的状态码               |
 | unhealthy.failures      | integer        | 可选   | 3          | >=1             | 触发不健康状态的连续错误请求次数 |

--- a/docs/zh/latest/plugins/api-breaker.md
+++ b/docs/zh/latest/plugins/api-breaker.md
@@ -45,7 +45,7 @@ title: api-breaker
 | ----------------------- | -------------- | ------ | ---------- | --------------- | -------------------------------- |
 | break_response_code     | integer        | 必须   | 无         | [200, ..., 599] | 不健康返回错误码                 |
 | break_response_body     | string         | 可选   | 无         |                 | 不健康返回报文                   |
-| headers                 | array[object]  | 可选   | 无         |                 | 不健康返回报文头，这里可以设置多个。这个值能够以 `$var` 的格式包含 Nginx 变量，比如 `$remote_addr $balancer_ip`。该字段仅在 `break_response_body` 被配置时生效 |
+| break_response_headers  | array[object]  | 可选   | 无         |                 | 不健康返回报文头，这里可以设置多个。这个值能够以 `$var` 的格式包含 Nginx 变量，比如 `$remote_addr $balancer_ip`。该字段仅在 `break_response_body` 被配置时生效 |
 | max_breaker_sec         | integer        | 可选   | 300        | >=3             | 最大熔断持续时间                 |
 | unhealthy.http_statuses | array[integer] | 可选   | {500}      | [500, ..., 599] | 不健康时候的状态码               |
 | unhealthy.failures      | integer        | 可选   | 3          | >=1             | 触发不健康状态的连续错误请求次数 |

--- a/docs/zh/latest/plugins/api-breaker.md
+++ b/docs/zh/latest/plugins/api-breaker.md
@@ -45,7 +45,7 @@ title: api-breaker
 | ----------------------- | -------------- | ------ | ---------- | --------------- | -------------------------------- |
 | break_response_code     | integer        | 必须   | 无         | [200, ..., 599] | 不健康返回错误码                 |
 | break_response_body     | string         | 可选   | 无         |                 | 不健康返回报文                   |
-| break_response_content_type     | string | 可选   | application/json |           | 不健康返回Content-Type          |
+| break_response_content_type     | string | 可选   | application/json |           | 不健康返回 Content-Type          |
 | max_breaker_sec         | integer        | 可选   | 300        | >=3             | 最大熔断持续时间                 |
 | unhealthy.http_statuses | array[integer] | 可选   | {500}      | [500, ..., 599] | 不健康时候的状态码               |
 | unhealthy.failures      | integer        | 可选   | 3          | >=1             | 触发不健康状态的连续错误请求次数 |

--- a/docs/zh/latest/plugins/api-breaker.md
+++ b/docs/zh/latest/plugins/api-breaker.md
@@ -44,6 +44,8 @@ title: api-breaker
 | 名称                    | 类型           | 必选项 | 默认值     | 有效值          | 描述                             |
 | ----------------------- | -------------- | ------ | ---------- | --------------- | -------------------------------- |
 | break_response_code     | integer        | 必须   | 无         | [200, ..., 599] | 不健康返回错误码                 |
+| break_response_body     | string         | 可选   | 无         |                 | 不健康返回报文                   |
+| break_response_content_type     | string | 可选   | application/json |           | 不健康返回Content-Type          |
 | max_breaker_sec         | integer        | 可选   | 300        | >=3             | 最大熔断持续时间                 |
 | unhealthy.http_statuses | array[integer] | 可选   | {500}      | [500, ..., 599] | 不健康时候的状态码               |
 | unhealthy.failures      | integer        | 可选   | 3          | >=1             | 触发不健康状态的连续错误请求次数 |

--- a/t/plugin/api-breaker.t
+++ b/t/plugin/api-breaker.t
@@ -459,7 +459,7 @@ breaker_time: 2
                         "api-breaker": {
                             "break_response_code": 502,
                             "break_response_body": "{\"message\":\"breaker opened.\"}",
-                            "headers": [{"key":"Content-Type","value":"application/json"},{"key":"Content-Type","value":"application/json+v1"}],
+                            "break_response_headers": [{"key":"Content-Type","value":"application/json"},{"key":"Content-Type","value":"application/json+v1"}],
                             "unhealthy": {
                                 "failures": 3
                             },

--- a/t/plugin/api-breaker.t
+++ b/t/plugin/api-breaker.t
@@ -511,7 +511,7 @@ GET /api_breaker?code=500
 --- error_code eval
 [200, 500, 503, 500, 500, 502]
 --- response_body_like eval
-[".*", ".*", ".*", ".*", ".*", "{\"message\":\"breaker opened\"}"]
+[".*", ".*", ".*", ".*", ".*", "{\"message\":\"breaker opened.\"}"]
 --- no_error_log
 [error]
 

--- a/t/plugin/api-breaker.t
+++ b/t/plugin/api-breaker.t
@@ -77,7 +77,7 @@ done
 --- request
 GET /t
 --- response_body
-{"break_response_code":502,"break_response_content_type":"application/json","healthy":{"http_statuses":[200],"successes":3},"max_breaker_sec":300,"unhealthy":{"failures":3,"http_statuses":[500]}}
+{"break_response_code":502,"healthy":{"http_statuses":[200],"successes":3},"max_breaker_sec":300,"unhealthy":{"failures":3,"http_statuses":[500]}}
 --- no_error_log
 [error]
 
@@ -104,7 +104,7 @@ GET /t
 --- request
 GET /t
 --- response_body
-{"break_response_code":502,"break_response_content_type":"application/json","healthy":{"http_statuses":[200],"successes":3},"max_breaker_sec":300,"unhealthy":{"failures":3,"http_statuses":[500]}}
+{"break_response_code":502,"healthy":{"http_statuses":[200],"successes":3},"max_breaker_sec":300,"unhealthy":{"failures":3,"http_statuses":[500]}}
 --- no_error_log
 [error]
 
@@ -131,7 +131,7 @@ GET /t
 --- request
 GET /t
 --- response_body
-{"break_response_code":502,"break_response_content_type":"application/json","healthy":{"http_statuses":[200],"successes":3},"max_breaker_sec":300,"unhealthy":{"failures":3,"http_statuses":[500]}}
+{"break_response_code":502,"healthy":{"http_statuses":[200],"successes":3},"max_breaker_sec":300,"unhealthy":{"failures":3,"http_statuses":[500]}}
 --- no_error_log
 [error]
 
@@ -459,7 +459,7 @@ breaker_time: 2
                         "api-breaker": {
                             "break_response_code": 502,
                             "break_response_body": "{\"message\":\"breaker opened.\"}",
-                            "break_response_content_type": "application/json+v1",
+                            "headers": [{"key":"Content-Type","value":"application/json"},{"key":"Content-Type","value":"application/json+v1"}],
                             "unhealthy": {
                                 "failures": 3
                             },

--- a/t/plugin/api-breaker.t
+++ b/t/plugin/api-breaker.t
@@ -459,6 +459,7 @@ breaker_time: 2
                         "api-breaker": {
                             "break_response_code": 502,
                             "break_response_body": "{\"message\":\"breaker opened.\"}",
+                            "break_response_content_type": "application/json+v1",
                             "unhealthy": {
                                 "failures": 3
                             },
@@ -510,6 +511,8 @@ GET /api_breaker?code=500
 ]
 --- error_code eval
 [200, 500, 503, 500, 500, 502]
+--- response_headers eval
+["Content-Type: text/plain", "Content-Type: text/html", "Content-Type: text/html", "Content-Type: text/html", "Content-Type: text/html", "Content-Type: application/json+v1"]
 --- response_body_like eval
 [".*", ".*", ".*", ".*", ".*", "{\"message\":\"breaker opened.\"}"]
 --- no_error_log

--- a/t/plugin/api-breaker.t
+++ b/t/plugin/api-breaker.t
@@ -77,7 +77,7 @@ done
 --- request
 GET /t
 --- response_body
-{"break_response_code":502,"healthy":{"http_statuses":[200],"successes":3},"max_breaker_sec":300,"unhealthy":{"failures":3,"http_statuses":[500]}}
+{"break_response_code":502,"break_response_content_type":"application/json","healthy":{"http_statuses":[200],"successes":3},"max_breaker_sec":300,"unhealthy":{"failures":3,"http_statuses":[500]}}
 --- no_error_log
 [error]
 
@@ -104,7 +104,7 @@ GET /t
 --- request
 GET /t
 --- response_body
-{"break_response_code":502,"healthy":{"http_statuses":[200],"successes":3},"max_breaker_sec":300,"unhealthy":{"failures":3,"http_statuses":[500]}}
+{"break_response_code":502,"break_response_content_type":"application/json","healthy":{"http_statuses":[200],"successes":3},"max_breaker_sec":300,"unhealthy":{"failures":3,"http_statuses":[500]}}
 --- no_error_log
 [error]
 
@@ -131,7 +131,7 @@ GET /t
 --- request
 GET /t
 --- response_body
-{"break_response_code":502,"healthy":{"http_statuses":[200],"successes":3},"max_breaker_sec":300,"unhealthy":{"failures":3,"http_statuses":[500]}}
+{"break_response_code":502,"break_response_content_type":"application/json","healthy":{"http_statuses":[200],"successes":3},"max_breaker_sec":300,"unhealthy":{"failures":3,"http_statuses":[500]}}
 --- no_error_log
 [error]
 
@@ -458,6 +458,7 @@ breaker_time: 2
                     "plugins": {
                         "api-breaker": {
                             "break_response_code": 502,
+                            "break_response_body": "{\"message\":\"breaker opened.\"}",
                             "unhealthy": {
                                 "failures": 3
                             },
@@ -509,6 +510,8 @@ GET /api_breaker?code=500
 ]
 --- error_code eval
 [200, 500, 503, 500, 500, 502]
+--- response_body_like eval
+[".*", ".*", ".*", ".*", ".*", "{\"message\":\"breaker opened\"}"]
 --- no_error_log
 [error]
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
When upstream is in the unhealthy state, the api-breaker returns unhealthy.http_statuses only, without a response body.
In order to be more compatible to the client, return a default response body is useful.

Fixes #6923

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
