### PR TITLE
fix: allow apisix start when open file descriptors unlimited

### DIFF
--- a/apisix/cli/env.lua
+++ b/apisix/cli/env.lua
@@ -33,7 +33,8 @@ return function (apisix_home, pkg_cpath_org, pkg_path_org)
     if not res then
         error("failed to exec ulimit cmd \'ulimit -n \', err: " .. err)
     end
-    local ulimit = tonumber(util.trim(res))
+    local trimed_res = util.trim(res)
+    local ulimit = trimed_res == "unlimited" and trimed_res or tonumber(trimed_res)
     if not ulimit then
         error("failed to fetch current maximum number of open file descriptors")
     end

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -155,7 +155,7 @@ local function init(env)
     end
 
     local min_ulimit = 1024
-    if env.ulimit <= min_ulimit then
+    if env.ulimit ~= "unlimited" and env.ulimit <= min_ulimit then
         print(str_format("Warning! Current maximum number of open file "
                 .. "descriptors [%d] is not greater than %d, please increase user limits by "
                 .. "execute \'ulimit -n <new user limits>\' , otherwise the performance"


### PR DESCRIPTION
### Description

Allow apisix start when open file descriptors unlimited

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
