### PR TITLE
docs: fix code block format in jwt-auth doc

### DIFF
--- a/docs/zh/latest/plugins/jwt-auth.md
+++ b/docs/zh/latest/plugins/jwt-auth.md
@@ -170,7 +170,7 @@ curl http://127.0.0.1:9080/apisix/admin/consumers \
 }'
 ```
 
-该插件将在提供的 Vault 路径（<vault.prefix>/consumer/jack/jwt-auth）中查找密钥 `secret`，并将其用于 JWT 身份验证。如果在同一路径中找不到密钥，插件会记录错误并且无法执行 JWT 验证。
+该插件将在提供的 Vault 路径（`<vault.prefix>/consumer/jack/jwt-auth`）中查找密钥 `secret`，并将其用于 JWT 身份验证。如果在同一路径中找不到密钥，插件会记录错误并且无法执行 JWT 验证。
 
 :::note
 


### PR DESCRIPTION
### Description
If '<>' is used in the document, the code block format is required. Otherwise, the official website will fail to build.
As follows:
![error](https://user-images.githubusercontent.com/97138894/165661431-84c07cdb-d68c-4c1b-bd7b-a6c64869644d.jpg)


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
