### PR TITLE
feat: support to use plugin_config_id for consumer object

### DIFF
--- a/apisix/balancer.lua
+++ b/apisix/balancer.lua
@@ -305,8 +305,6 @@ do
             pool_opt.pool_size = size
             local ok, err = balancer.set_current_peer(server.host, server.port,
                                                       pool_opt)
-            require("lualib.mobdebug").start("127.0.0.1", 8172)
-
             if not ok then
                 return ok, err
             end

--- a/apisix/balancer.lua
+++ b/apisix/balancer.lua
@@ -305,6 +305,8 @@ do
             pool_opt.pool_size = size
             local ok, err = balancer.set_current_peer(server.host, server.port,
                                                       pool_opt)
+            require("lualib.mobdebug").start("127.0.0.1", 8172)
+
             if not ok then
                 return ok, err
             end

--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -54,6 +54,7 @@ local function plugin_consumer()
                 local new_consumer = core.table.clone(consumer.value)
                 -- Note: the id here is the key of consumer data, which
                 -- is 'username' field in admin
+                new_consumer.plugin_config_id = consumer.value.plugin_config_id
                 new_consumer.consumer_name = new_consumer.id
                 new_consumer.auth_conf = config
                 core.log.info("consumer:", core.json.delay_encode(new_consumer))

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -444,13 +444,20 @@ function _M.http_access_phase()
         local plugins = plugin.filter(api_ctx, route)
         api_ctx.plugins = plugins
 
+        local conf = plugin_config.get(route.value.plugin_config_id)
+        if conf == nil then
+            core.log.error("failed to fetch plugin config by ",
+                    "id: ", route.value.plugin_config_id)
+            return core.response.exit(503)
+        end
         plugin.run_plugin("rewrite", plugins, api_ctx)
         if api_ctx.consumer then
             local changed
             route, changed = plugin.merge_consumer_route(
                 route,
                 api_ctx.consumer,
-                api_ctx
+                api_ctx,
+                conf
             )
 
             core.log.info("find consumer ", api_ctx.consumer.username,

--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -699,6 +699,7 @@ _M.consumer = {
         create_time = timestamp_def,
         update_time = timestamp_def,
         desc = desc_def,
+        plugin_config_id = id_schema,
     },
     required = {"username"},
 }


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

related to [ISSUE#5800](https://github.com/apache/apisix/issues/5800)

Currently, ```router.lua``` supports forwarding to the corresponding ```upstream``` instance after loading the ```plugin_config_id```, but the consumer does not support it. Currently, the ```modifiedIndex``` is passed according to the ```plugin_conf``` provided by the route, representing ```plugin_config_id```


This is my first contribution. Currently writing unit tests with reference to [test-framework](https://github.com/apache/apisix/blob/master/docs/en/latest/internal/testing-framework.md)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
