### PR TITLE
refactor(ops): penlight path instead of shell command mkdir

### DIFF
--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -713,15 +713,14 @@ local function start(env, ...)
         util.die("Error: It is forbidden to run APISIX in the /root directory.\n")
     end
 
-    local logs = env.apisix_home .. "/logs"
-    local logs_path = pl_path.exists(logs)
-    if not logs_path then
-        local _, err = pl_path.mkdir(logs)
+    local logs_path = env.apisix_home .. "/logs"
+    if not pl_path.exists(logs_path) then
+        local _, err = pl_path.mkdir(logs_path)
         if err ~= nil then
-            util.die("failed to mkdir" .. logs .. ", error: ", err)
+            util.die("failed to mkdir ", logs_path, ", error: ", err)
         end
     elseif not pl_path.isdir(logs_path) and not pl_path.islink(logs_path) then
-        util.die(logs .. " is not directory nor symbol link")
+        util.die(logs_path, " is not directory nor symbol link")
     end
 
     -- check running

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -713,8 +713,16 @@ local function start(env, ...)
         util.die("Error: It is forbidden to run APISIX in the /root directory.\n")
     end
 
-    local cmd_logs = "mkdir -p " .. env.apisix_home .. "/logs"
-    util.execute_cmd(cmd_logs)
+    local logs = env.apisix_home .. "/logs"
+    local logs_path = pl_path.exists(logs)
+    if not logs_path then
+        local _, err = pl_path.mkdir(logs)
+        if err ~= nil then
+            util.die("failed to mkdir" .. logs .. ", error: ", err)
+        end
+    elseif not pl_path.isdir(logs_path) and not pl_path.islink(logs_path) then
+        util.die(logs .. " is not directory nor symbol link")
+    end
 
     -- check running
     local pid_path = env.apisix_home .. "/logs/nginx.pid"


### PR DESCRIPTION

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
Using Lua library(penlight, luafilesystem) to do file system related operations.
<!-- Please also include relevant motivation and context. -->
* If shell command mkdir not exist, command `mkdir -p path` will failed.
* Avoid `mkdir` dependency, use penlight path library, it's a dependent library of APISIX.

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
