### PR TITLE
feat(ops): handle real_ip_from CIDR format

### DIFF
--- a/apisix/cli/ip.lua
+++ b/apisix/cli/ip.lua
@@ -1,0 +1,66 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+--- IP match and verify module.
+--
+-- @module cli.ip
+
+local mediador_ip = require("resty.mediador.ip")
+local setmetatable = setmetatable
+
+
+local _M = {}
+local mt = { __index = _M }
+
+
+---
+-- create a instance of module cli.ip
+--
+-- @function cli.ip:new
+-- @tparam string ip IP or CIDR.
+-- @treturn instance of module if the given ip valid, nil and error message otherwise.
+function _M.new(self, ip)
+    if not mediador_ip.valid(ip) then
+        return nil, "invalid ip"
+    end
+
+    local _ip = mediador_ip.parse(ip)
+
+    return setmetatable({ _ip = _ip }, mt)
+end
+
+
+---
+-- Is that the given ip loopback?
+--
+-- @function cli.ip:is_loopback
+-- @treturn boolean True if the given ip is the loopback, false otherwise.
+function _M.is_loopback(self)
+    return self._ip and "loopback" == self._ip:range()
+end
+
+---
+-- Is that the given ip unspecified?
+--
+-- @function cli.ip:is_unspecified
+-- @treturn boolean True if the given ip is all the unspecified, false otherwise.
+function _M.is_unspecified(self)
+    return self._ip and "unspecified" == self._ip:range()
+end
+
+
+return _M

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -20,6 +20,7 @@ local util = require("apisix.cli.util")
 local file = require("apisix.cli.file")
 local schema = require("apisix.cli.schema")
 local ngx_tpl = require("apisix.cli.ngx_tpl")
+local cli_ip = require("apisix.cli.ip")
 local profile = require("apisix.core.profile")
 local template = require("resty.template")
 local argparse = require("argparse")
@@ -277,16 +278,16 @@ Please modify "admin_key" in conf/config.yaml .
         -- not disabled by the users
         if real_ip_from then
             for _, ip in ipairs(real_ip_from) do
-                -- TODO: handle cidr
-                if ip == "127.0.0.1" or ip == "0.0.0.0/0" then
+                local _ip = cli_ip:new(ip)
+                if _ip:is_loopback() or _ip:is_unspecified() then
                     pass_real_client_ip = true
                 end
             end
         end
 
         if not pass_real_client_ip then
-            util.die("missing '127.0.0.1' in the nginx_config.http.real_ip_from for plugin " ..
-                     "batch-requests\n")
+            util.die("missing loopback or unspecified in the nginx_config.http.real_ip_from" ..
+                     " for plugin batch-requests\n")
         end
     end
 

--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -76,7 +76,8 @@ dependencies = {
     "opentelemetry-lua = 0.1-3",
     "net-url = 0.9-1",
     "xml2lua = 1.5-2",
-    "nanoid = 0.1-1"
+    "nanoid = 0.1-1",
+    "lua-resty-mediador = 0.1.2-1"
 }
 
 build = {

--- a/t/cli/test_validate_config.sh
+++ b/t/cli/test_validate_config.sh
@@ -161,6 +161,7 @@ fi
 
 echo "passed: apisix test(failure scenario)"
 
+# apisix plugin batch-requests real_ip_from invalid - failure scenario
 echo '
 plugins:
 - batch-requests
@@ -176,8 +177,9 @@ if ! echo "$out" | grep "missing loopback or unspecified in the nginx_config.htt
     exit 1
 fi
 
-echo "passed: check the realip configuration for batch-requests"
+echo "passed: apisix plugin batch-requests real_ip_from(failure scenario)"
 
+# apisix plugin batch-requests real_ip_from valid
 echo '
 plugins:
 - batch-requests
@@ -185,57 +187,11 @@ nginx_config:
     http:
         real_ip_from:
         - "127.0.0.1"
-' > conf/config.yaml
-
-out=$(make init 2>&1 || true)
-if echo "$out" | grep "missing loopback or unspecified in the nginx_config.http.real_ip_from for plugin batch-requests"; then
-    echo "failed: should check the realip configuration for batch-requests"
-    exit 1
-fi
-
-echo "passed: check the realip configuration for batch-requests"
-
-echo '
-plugins:
-- batch-requests
-nginx_config:
-    http:
-        real_ip_from:
-        - "127.0.0.1/8"
-' > conf/config.yaml
-
-out=$(make init 2>&1 || true)
-if echo "$out" | grep "missing loopback or unspecified in the nginx_config.http.real_ip_from for plugin batch-requests"; then
-    echo "failed: should check the realip configuration for batch-requests"
-    exit 1
-fi
-
-echo "passed: check the realip configuration for batch-requests"
-
-echo '
-plugins:
-- batch-requests
-nginx_config:
-    http:
-        real_ip_from:
+        - "127.0.0.2/8"
+        - "0.0.0.0"
         - "0.0.0.0/0"
-' > conf/config.yaml
-
-out=$(make init 2>&1 || true)
-if echo "$out" | grep "missing loopback or unspecified in the nginx_config.http.real_ip_from for plugin batch-requests"; then
-    echo "failed: should check the realip configuration for batch-requests"
-    exit 1
-fi
-
-echo "passed: check the realip configuration for batch-requests"
-
-echo '
-plugins:
-- batch-requests
-nginx_config:
-    http:
-        real_ip_from:
         - "::"
+        - "::/0"
 ' > conf/config.yaml
 
 out=$(make init 2>&1 || true)

--- a/t/cli/test_validate_config.sh
+++ b/t/cli/test_validate_config.sh
@@ -167,11 +167,79 @@ plugins:
 nginx_config:
     http:
         real_ip_from:
-        - "127.0.0.2"
+        - "128.0.0.2"
 ' > conf/config.yaml
 
 out=$(make init 2>&1 || true)
-if ! echo "$out" | grep "missing '127.0.0.1' in the nginx_config.http.real_ip_from for plugin batch-requests"; then
+if ! echo "$out" | grep "missing loopback or unspecified in the nginx_config.http.real_ip_from for plugin batch-requests"; then
+    echo "failed: should check the realip configuration for batch-requests"
+    exit 1
+fi
+
+echo "passed: check the realip configuration for batch-requests"
+
+echo '
+plugins:
+- batch-requests
+nginx_config:
+    http:
+        real_ip_from:
+        - "127.0.0.1"
+' > conf/config.yaml
+
+out=$(make init 2>&1 || true)
+if echo "$out" | grep "missing loopback or unspecified in the nginx_config.http.real_ip_from for plugin batch-requests"; then
+    echo "failed: should check the realip configuration for batch-requests"
+    exit 1
+fi
+
+echo "passed: check the realip configuration for batch-requests"
+
+echo '
+plugins:
+- batch-requests
+nginx_config:
+    http:
+        real_ip_from:
+        - "127.0.0.1/8"
+' > conf/config.yaml
+
+out=$(make init 2>&1 || true)
+if echo "$out" | grep "missing loopback or unspecified in the nginx_config.http.real_ip_from for plugin batch-requests"; then
+    echo "failed: should check the realip configuration for batch-requests"
+    exit 1
+fi
+
+echo "passed: check the realip configuration for batch-requests"
+
+echo '
+plugins:
+- batch-requests
+nginx_config:
+    http:
+        real_ip_from:
+        - "0.0.0.0/0"
+' > conf/config.yaml
+
+out=$(make init 2>&1 || true)
+if echo "$out" | grep "missing loopback or unspecified in the nginx_config.http.real_ip_from for plugin batch-requests"; then
+    echo "failed: should check the realip configuration for batch-requests"
+    exit 1
+fi
+
+echo "passed: check the realip configuration for batch-requests"
+
+echo '
+plugins:
+- batch-requests
+nginx_config:
+    http:
+        real_ip_from:
+        - "::"
+' > conf/config.yaml
+
+out=$(make init 2>&1 || true)
+if echo "$out" | grep "missing loopback or unspecified in the nginx_config.http.real_ip_from for plugin batch-requests"; then
     echo "failed: should check the realip configuration for batch-requests"
     exit 1
 fi


### PR DESCRIPTION
### Description
Handle `real_ip_from` CIDR format on plugin batch-requests when APISIX init.

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
* Add `cli.ip` module with lua-resty-mediador/ip.lua to verify
* Support loopback and unspecified(zeros) ip address
* Support IPv4 and IPv6

Fixes # (issue)
https://github.com/apache/apisix/blob/cc88a8db0ba64e1cb351e389ca5ec64c516073d6/apisix/cli/ops.lua#L279-L281

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
