### PR TITLE
feat: just change uri args or headers when hiding credentials

### DIFF
--- a/apisix/plugins/key-auth.lua
+++ b/apisix/plugins/key-auth.lua
@@ -89,13 +89,13 @@ end
 
 
 function _M.rewrite(conf, ctx)
-    local hide_header = true
+    local from_header = true
     local key = core.request.header(ctx, conf.header)
 
     if not key then
         local uri_args = core.request.get_uri_args(ctx) or {}
         key = uri_args[conf.query]
-        hide_header = false
+        from_header = false
     end
 
     if not key then
@@ -117,7 +117,7 @@ function _M.rewrite(conf, ctx)
     core.log.info("consumer: ", core.json.delay_encode(consumer))
 
     if conf.hide_credentials then
-        if hide_header then
+        if from_header then
             core.request.set_header(ctx, conf.header, nil)
         else
             local args = core.request.get_uri_args(ctx)

--- a/apisix/plugins/key-auth.lua
+++ b/apisix/plugins/key-auth.lua
@@ -89,11 +89,13 @@ end
 
 
 function _M.rewrite(conf, ctx)
+    local hide_header = true
     local key = core.request.header(ctx, conf.header)
 
     if not key then
         local uri_args = core.request.get_uri_args(ctx) or {}
         key = uri_args[conf.query]
+        hide_header = false
     end
 
     if not key then
@@ -115,10 +117,13 @@ function _M.rewrite(conf, ctx)
     core.log.info("consumer: ", core.json.delay_encode(consumer))
 
     if conf.hide_credentials then
-        core.request.set_header(ctx, conf.header, nil)
-        local args = core.request.get_uri_args(ctx)
-        args[conf.query] = nil
-        core.request.set_uri_args(ctx, args)
+        if hide_header then
+            core.request.set_header(ctx, conf.header, nil)
+        else
+            local args = core.request.get_uri_args(ctx)
+            args[conf.query] = nil
+            core.request.set_uri_args(ctx, args)
+        end
     end
 
     consumer_mod.attach_consumer(ctx, consumer, consumer_conf)

--- a/docs/en/latest/plugins/key-auth.md
+++ b/docs/en/latest/plugins/key-auth.md
@@ -43,11 +43,11 @@ For Consumer:
 
 For Route:
 
-| Name   | Type   | Requirement | Default | Valid | Description                                                       |
-|--------|--------|-------------|---------|-------|-------------------------------------------------------------------|
-| header | string | optional    | apikey  |       | The header to get the key from.                                   |
-| query  | string | optional    | apikey  |       | The query string to get the key from. Lower priority than header. |
-| hide_credentials   | bool | optional    | false        |       | When set to `false` passes the request header containing authentication information to the Upstream. |
+| Name   | Type   | Requirement | Default | Valid | Description                                                                                                                                                                                                                                                                   |
+|--------|--------|-------------|---------|-------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header | string | optional    | apikey  |       | The header to get the key from.                                                                                                                                                                                                                                               |
+| query  | string | optional    | apikey  |       | The query string to get the key from. Lower priority than header.                                                                                                                                                                                                             |
+| hide_credentials   | bool | optional    | false        |       | When set to `false` passes the request header or query string containing authentication information to the Upstream. If `true`, the corresponding header or query string will be deleted, depending on whether the key is obtained from the header or from the query string.  |
 
 ## Enabling the Plugin
 

--- a/docs/en/latest/plugins/key-auth.md
+++ b/docs/en/latest/plugins/key-auth.md
@@ -47,7 +47,7 @@ For Route:
 |--------|--------|-------------|---------|-------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | header | string | optional    | apikey  |       | The header to get the key from.                                                                                                                                                                                                                                               |
 | query  | string | optional    | apikey  |       | The query string to get the key from. Lower priority than header.                                                                                                                                                                                                             |
-| hide_credentials   | bool | optional    | false        |       | When set to `false` passes the request header or query string containing authentication information to the Upstream. If `true`, the corresponding header or query string will be deleted, depending on whether the key is obtained from the header or from the query string.  |
+| hide_credentials   | bool | optional    | false        |       | Apache APISIX will pass the request header or query string that contains the authentication information to the Upstream if `hide_credentials` is `false`. Otherwise the authentication information will be removed before proxying.|
 
 ## Enabling the Plugin
 

--- a/docs/zh/latest/plugins/key-auth.md
+++ b/docs/zh/latest/plugins/key-auth.md
@@ -43,11 +43,11 @@ Consumer 端：
 
 Router 端：
 
-| 名称              | 类型   | 必选项 | 默认值 | 描述                                                                                                          |
-| ----------------- | ------ | ----- | ------ |------------------------------------------------------------------------------------------------------------- |
-| header            | string | 否    | apikey | 设置我们从哪个 header 获取 key。 |
-| query             | string | 否    | apikey | 设置我们从哪个 query string 获取 key，优先级低于 `header`。 |
-| hide_credentials  | bool   | 否    | false  | 当设置为 `false` 时将含有认证信息的请求头传递给 Upstream。 |
+| 名称              | 类型   | 必选项 | 默认值 | 描述                                                                                                                                                    |
+| ----------------- | ------ | ----- | ------ |-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header            | string | 否    | apikey | 设置我们从哪个 header 获取 key。                                                                                                                                |
+| query             | string | 否    | apikey | 设置我们从哪个 query string 获取 key，优先级低于 `header`。                                                                                                           |
+| hide_credentials  | bool   | 否    | false  | 当设置为 `false` 时将含有认证信息的 header 或 query string 传递给 Upstream。 如果为 `true` 时将删除对应的header 或 query string，具体删除哪一个取决于是从header 获取 key 还是从query string  获取 key。 |
 
 ## 启用插件
 

--- a/docs/zh/latest/plugins/key-auth.md
+++ b/docs/zh/latest/plugins/key-auth.md
@@ -43,11 +43,11 @@ Consumer 端：
 
 Router 端：
 
-| 名称              | 类型   | 必选项 | 默认值 | 描述                                                                                                                                                    |
-| ----------------- | ------ | ----- | ------ |-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| header            | string | 否    | apikey | 设置我们从哪个 header 获取 key。                                                                                                                                |
-| query             | string | 否    | apikey | 设置我们从哪个 query string 获取 key，优先级低于 `header`。                                                                                                           |
-| hide_credentials  | bool   | 否    | false  | 当设置为 `false` 时将含有认证信息的 header 或 query string 传递给 Upstream。 如果为 `true` 时将删除对应的header 或 query string，具体删除哪一个取决于是从header 获取 key 还是从query string  获取 key。 |
+| 名称              | 类型   | 必选项 | 默认值 | 描述                                                                                                                                                       |
+| ----------------- | ------ | ----- | ------ |----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| header            | string | 否    | apikey | 设置我们从哪个 header 获取 key。                                                                                                                                   |
+| query             | string | 否    | apikey | 设置我们从哪个 query string 获取 key，优先级低于 `header`。                                                                                                              |
+| hide_credentials  | bool   | 否    | false  | 当设置为 `false` 时将含有认证信息的 header 或 query string 传递给 Upstream。 如果为 `true` 时将删除对应的 header 或 query string，具体删除哪一个取决于是从 header 获取 key 还是从 query string  获取 key。 |
 
 ## 启用插件
 

--- a/t/plugin/key-auth.t
+++ b/t/plugin/key-auth.t
@@ -451,7 +451,21 @@ test: auth-two
 
 
 
-=== TEST 19: customize query string, set hide_credentials = true
+=== TEST 19: when apikey both in header and query string, verify apikey request header is hidden but request args is not hidden
+--- request
+GET /echo?apikey=auth-one
+--- more_headers
+apikey: auth-one
+--- response_headers
+!apikey
+--- response_args
+apikey: auth-one
+--- no_error_log
+[error]
+
+
+
+=== TEST 20: customize query string, set hide_credentials = true
 --- config
     location /t {
         content_by_lua_block {
@@ -471,7 +485,7 @@ test: auth-two
                         },
                         "type": "roundrobin"
                     },
-                    "uri": "/hello"
+                    "uri": "/echo"
                 }]]
                 )
 
@@ -490,9 +504,9 @@ passed
 
 
 
-=== TEST 20: verify auth request args is hidden
+=== TEST 21: verify auth request args is hidden
 --- request
-GET /hello?auth=auth-one
+GET /echo?auth=auth-one
 --- response_args
 !auth
 --- no_error_log
@@ -500,9 +514,9 @@ GET /hello?auth=auth-one
 
 
 
-=== TEST 21: verify that only the keys in the query parameters are deleted
+=== TEST 22: verify that only the keys in the query parameters are deleted
 --- request
-GET /hello?auth=auth-one&test=auth-two
+GET /echo?auth=auth-one&test=auth-two
 --- response_args
 !auth
 test: auth-two
@@ -511,7 +525,21 @@ test: auth-two
 
 
 
-=== TEST 22: customize query string, set hide_credentials = false
+=== TEST 23: when auth both in header and query string, verify auth request args is hidden but request header is not hidden
+--- request
+GET /echo?auth=auth-one
+--- more_headers
+auth: auth-one
+--- response_headers
+auth: auth-one
+--- response_args
+!auth
+--- no_error_log
+[error]
+
+
+
+=== TEST 24: customize query string, set hide_credentials = false
 --- config
     location /t {
         content_by_lua_block {
@@ -550,7 +578,7 @@ passed
 
 
 
-=== TEST 23: verify auth request args should not hidden
+=== TEST 25: verify auth request args should not hidden
 --- request
 GET /hello?auth=auth-one
 --- response_args


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

As a user, I want to only change uri args or headers when hiding credentials in the `key-auth` plugin

When `hide_credentials` is set to `false` passes the request header or query string containing authentication information to the Upstream. If `true`, the corresponding header or query string will be deleted, depending on whether the key is obtained from the header or the query string.

Fixes #6940 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
