### PR TITLE
ci: revert wildcard rule as it doesn't work

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -48,10 +48,6 @@ github:
           dismiss_stale_reviews: true
           require_code_owner_reviews: true
           required_approving_review_count: 2
-      release/*:
-        required_pull_request_reviews:
-          require_code_owner_reviews: true
-          required_approving_review_count: 2
       release/2.13:
         required_pull_request_reviews:
           require_code_owner_reviews: true


### PR DESCRIPTION
Branch like https://github.com/apache/apisix/tree/release/2.3 is not
protected.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
