### PR TITLE
change(opentelemetry): the default network port for OTLP/HTTP is changed to 4318

### DIFF
--- a/apisix/plugins/opentelemetry.lua
+++ b/apisix/plugins/opentelemetry.lua
@@ -72,7 +72,7 @@ local attr_schema = {
             type = "object",
             description = "opentelemetry collector",
             properties = {
-                address = {type = "string", description = "host:port", default = "127.0.0.1:4317"},
+                address = {type = "string", description = "host:port", default = "127.0.0.1:4318"},
                 request_timeout = {type = "integer", description = "second uint", default = 3},
                 request_headers = {
                     type = "object",
@@ -82,7 +82,7 @@ local attr_schema = {
                    },
                 }
             },
-            default = {address = "127.0.0.1:4317", request_timeout = 3}
+            default = {address = "127.0.0.1:4318", request_timeout = 3}
         },
         batch_span_processor = {
             type = "object",

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -434,7 +434,7 @@ plugin_attr:
     resource:
       service.name: APISIX
     collector:
-      address: 127.0.0.1:4317
+      address: 127.0.0.1:4318
       request_timeout: 3
       request_headers:
         Authorization: token

--- a/docs/en/latest/plugins/opentelemetry.md
+++ b/docs/en/latest/plugins/opentelemetry.md
@@ -90,8 +90,8 @@ You can set the collecting by specifying the configuration in `conf/config.yaml`
 | ------------ | ------ | -------- | ----------------------------------------------------- |
 | trace_id_source | enum | random | the source of trace id, the valid value is `random` or `x-request-id`. If `x-request-id` is set, the value of `x-request-id` request header will be used as trace id. Please make sure it match regex pattern `[0-9a-f]{32}` |
 | resource | object |   | additional [resource](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md) append to trace |
-| collector | object | {address = "127.0.0.1:4317", request_timeout = 3} | otlp collector |
-| collector.address | string | 127.0.0.1:4317 | collector address |
+| collector | object | {address = "127.0.0.1:4318", request_timeout = 3} | otlp collector |
+| collector.address | string | 127.0.0.1:4318 | collector address |
 | collector.request_timeout | integer | 3 | report request timeout(second) |
 | collector.request_headers | object |  | report request http headers |
 | batch_span_processor | object |  | trace span processor |
@@ -110,7 +110,7 @@ plugin_attr:
       service.name: APISIX
       tenant.id: business_id
     collector:
-      address: 192.168.8.211:4317
+      address: 192.168.8.211:4318
       request_timeout: 3
       request_headers:
         foo: bar

--- a/docs/zh/latest/plugins/opentelemetry.md
+++ b/docs/zh/latest/plugins/opentelemetry.md
@@ -88,8 +88,8 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f1
 | ------------ | ------ | -------- | ----------------------------------------------------- |
 | trace_id_source | enum | random | 合法的取值：`random` 或 `x-request-id`，允许使用当前请求 ID 代替随机 ID 作为新的 TraceID，必须确保当前请求 ID 是符合 TraceID 规范的：`[0-9a-f]{32}` |
 | resource | object |   | 追加到 trace 的额外 [resource](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md) |
-| collector | object | {address = "127.0.0.1:4317", request_timeout = 3} | 数据采集服务 |
-| collector.address | string | 127.0.0.1:4317 | 数据采集服务地址 |
+| collector | object | {address = "127.0.0.1:4318", request_timeout = 3} | 数据采集服务 |
+| collector.address | string | 127.0.0.1:4318 | 数据采集服务地址 |
 | collector.request_timeout | integer | 3 | 数据采集服务上报请求超时时长，单位秒 |
 | collector.request_headers | object |  | 数据采集服务上报请求附加的 HTTP 请求头 |
 | batch_span_processor | object |  | trace span 处理器参数配置 |
@@ -108,7 +108,7 @@ plugin_attr:
       service.name: APISIX
       tenant.id: business_id
     collector:
-      address: 192.168.8.211:4317
+      address: 192.168.8.211:4318
       request_timeout: 3
       request_headers:
         foo: bar


### PR DESCRIPTION
### Description

opentelemetry's default network port for OTLP/HTTP is 4318 not 4317.

The default network port for OTLP/gRPC is 4317.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
