### PR TITLE
fix(xRPC): don't keepalive

### DIFF
--- a/apisix/stream/xrpc/protocols/redis/init.lua
+++ b/apisix/stream/xrpc/protocols/redis/init.lua
@@ -250,8 +250,8 @@ function _M.connect_upstream(session, ctx)
 end
 
 
-function _M.disconnect_upstream(session, upstream, upstream_broken)
-    sdk.disconnect_upstream(upstream, session.upstream_conf, upstream_broken)
+function _M.disconnect_upstream(session, upstream)
+    sdk.disconnect_upstream(upstream, session.upstream_conf)
 end
 
 

--- a/apisix/stream/xrpc/runner.lua
+++ b/apisix/stream/xrpc/runner.lua
@@ -43,7 +43,7 @@ local function close_session(session, protocol)
         upstream_ctx.closed = true
 
         local up = upstream_ctx.upstream
-        protocol.disconnect_upstream(session, up, upstream_ctx.broken)
+        protocol.disconnect_upstream(session, up)
     end
 
     local upstream_ctxs = session._upstream_ctxs
@@ -52,7 +52,7 @@ local function close_session(session, protocol)
             upstream_ctx.closed = true
 
             local up = upstream_ctx.upstream
-            protocol.disconnect_upstream(session, up, upstream_ctx.broken)
+            protocol.disconnect_upstream(session, up)
         end
     end
 
@@ -106,7 +106,6 @@ local function open_upstream(protocol, session, ctx)
 
     local up_ctx = {
         upstream = upstream,
-        broken = false,
         closed = false,
     }
     if key then
@@ -183,7 +182,6 @@ function _M.run(protocol, conn_ctx)
             end
 
             if status == DECLINED then
-                up_ctx.broken = true
                 break
             end
 

--- a/apisix/stream/xrpc/sdk.lua
+++ b/apisix/stream/xrpc/sdk.lua
@@ -72,19 +72,13 @@ end
 
 
 ---
--- Returns disconnected xRPC upstream socket according to the configuration
+-- Disconnect xRPC upstream socket according to the configuration
 --
 -- @function xrpc.sdk.disconnect_upstream
 -- @tparam table upstream xRPC upstream socket
 -- @tparam table up_conf upstream configuration
--- @tparam boolean upstream_broken whether the upstream is already broken
-function _M.disconnect_upstream(upstream, up_conf, upstream_broken)
-    if upstream_broken then
-        upstream:close()
-    else
-        -- TODO: support keepalive according to the up_conf
-        upstream:setkeepalive()
-    end
+function _M.disconnect_upstream(upstream, up_conf)
+    return upstream:close()
 end
 
 

--- a/t/xrpc/apisix/stream/xrpc/protocols/pingpong/init.lua
+++ b/t/xrpc/apisix/stream/xrpc/protocols/pingpong/init.lua
@@ -189,11 +189,9 @@ function _M.connect_upstream(session, ctx)
 end
 
 
-function _M.disconnect_upstream(session, upstream, upstream_broken)
+function _M.disconnect_upstream(session, upstream)
     -- disconnect upstream created by connect_upstream
-    -- the upstream_broken flag is used to indicate whether the upstream is
-    -- already broken
-    sdk.disconnect_upstream(upstream, session.upstream_conf, upstream_broken)
+    sdk.disconnect_upstream(upstream, session.upstream_conf)
 end
 
 

--- a/t/xrpc/pingpong.t
+++ b/t/xrpc/pingpong.t
@@ -152,6 +152,9 @@ pp\x01\x00\x00\x00\x00\x00\x00\x00"
 "pp\x02\x00\x00\x00\x00\x00\x00\x03ABC" x 3
 --- response_body eval
 "pp\x02\x00\x00\x00\x00\x00\x00\x03ABC" x 3
+--- log_level: debug
+--- no_error_log
+stream lua tcp socket set keepalive
 --- stream_conf_enable
 
 


### PR DESCRIPTION
We choose not to keepalive the xRPC connection (like Nginx's stream proxy):
1. the TCP connection is probably stateful
2. if there is not downstream, the heartbeat from the upstream is not
   replied, which will cause the connection to close.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
