### PR TITLE
docs: sync Chinese benchmark doc and add notes on running the benchmark

### DIFF
--- a/docs/en/latest/benchmark.md
+++ b/docs/en/latest/benchmark.md
@@ -126,3 +126,15 @@ then run wrk:
 ```shell
 wrk -d 60 --latency http://127.0.0.1:9080/hello
 ```
+
+For more reference on how to run the benchmark test, you can see this [PR](https://github.com/apache/apisix/pull/6136) and this [script](https://gist.github.com/membphis/137db97a4bf64d3653aa42f3e016bd01).
+
+**Note**: if you want to run the benchmark with a large number of connections, for example:
+
+```shell
+./wrk -t200 -c5000 -d30s http://127.0.0.1:9080/hello
+```
+
+You may have to update the **keepalive** config in the [conf/config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L242).
+
+Connections exceeding this number will become short connections. For more details you can refer to [Module ngx_http_upstream_module](http://nginx.org/en/docs/http/ngx_http_upstream_module.html).

--- a/docs/en/latest/benchmark.md
+++ b/docs/en/latest/benchmark.md
@@ -129,12 +129,14 @@ wrk -d 60 --latency http://127.0.0.1:9080/hello
 
 For more reference on how to run the benchmark test, you can see this [PR](https://github.com/apache/apisix/pull/6136) and this [script](https://gist.github.com/membphis/137db97a4bf64d3653aa42f3e016bd01).
 
-**Note**: if you want to run the benchmark with a large number of connections, for example:
+:::tip
 
-```shell
-./wrk -t200 -c5000 -d30s http://127.0.0.1:9080/hello
+If you want to run the benchmark with a large number of connections, You may have to update the **keepalive** config in the [conf/config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L242). Connections exceeding this number will become short connections. You can run the following command to test the benchmark with a large number of connections:
+
+```bash
+wrk -t200 -c5000 -d30s http://127.0.0.1:9080/hello
 ```
 
-You may have to update the **keepalive** config in the [conf/config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L242).
+For more details, you can refer to [Module ngx_http_upstream_module](http://nginx.org/en/docs/http/ngx_http_upstream_module.html).
 
-Connections exceeding this number will become short connections. For more details you can refer to [Module ngx_http_upstream_module](http://nginx.org/en/docs/http/ngx_http_upstream_module.html).
+:::

--- a/docs/zh/latest/benchmark.md
+++ b/docs/zh/latest/benchmark.md
@@ -49,6 +49,29 @@ title: 压力测试
 
 ![flamegraph-1](../../assets/images/flamegraph-1.jpg)
 
+如果想在机器上运行基准测试，你应该同时运行另一个 NGINX 来监听 80 端口：
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "methods": ["GET"],
+    "uri": "/hello",
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "127.0.0.1:80": 1,
+            "127.0.0.2:80": 1
+        }
+    }
+}'
+```
+
+然后运行 wrk：
+
+```shell
+wrk -d 60 --latency http://127.0.0.1:9080/hello
+```
+
 ### 测试反向代理，开启 2 个插件
 
 我们把 APISIX 当做反向代理来使用，开启限速和 prometheus 插件，响应体的大小为 1KB。
@@ -69,3 +92,35 @@ title: 压力测试
 
 火焰图的采样结果：
 ![火焰图采样结果](../../assets/images/flamegraph-2.jpg)
+
+如果想在机器上运行基准测试，你应该同时运行另一个 NGINX 来监听 80 端口：
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "methods": ["GET"],
+    "uri": "/hello",
+    "plugins": {
+        "limit-count": {
+            "count": 999999999,
+            "time_window": 60,
+            "rejected_code": 503,
+            "key": "remote_addr"
+        },
+        "prometheus":{}
+    },
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "127.0.0.1:80": 1,
+            "127.0.0.2:80": 1
+        }
+    }
+}'
+```
+
+然后运行 wrk：
+
+```shell
+wrk -d 60 --latency http://127.0.0.1:9080/hello
+```

--- a/docs/zh/latest/benchmark.md
+++ b/docs/zh/latest/benchmark.md
@@ -124,3 +124,15 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
 ```shell
 wrk -d 60 --latency http://127.0.0.1:9080/hello
 ```
+
+有关如何运行基准测试的更多参考，你可以查看此[PR](https://github.com/apache/apisix/pull/6136)和此[脚本](https://gist.github.com/membphis/137db97a4bf64d3653aa42f3e016bd01)。
+
+**注意**: 如果你想运行大量连接的基准测试，例如：
+
+```shell
+./wrk -t200 -c5000 -d30s http://127.0.0.1:9080/hello
+```
+
+你可能需要更新 [conf/config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L242) 中的 **keepalive** 配置项。
+
+超过配置数量的连接将成为短连接。更多文档可以参考：[ngx_http_upstream_module](http://nginx.org/en/docs/http/ngx_http_upstream_module.html)

--- a/docs/zh/latest/benchmark.md
+++ b/docs/zh/latest/benchmark.md
@@ -49,9 +49,9 @@ title: 压力测试
 
 ![flamegraph-1](../../assets/images/flamegraph-1.jpg)
 
-如果想在机器上运行基准测试，你应该同时运行另一个 NGINX 来监听 80 端口：
+如果你需要在本地服务器上运行基准测试，你需要同时运行另一个 NGINX 实例来监听 80 端口：
 
-```shell
+```bash
 curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "methods": ["GET"],
@@ -66,9 +66,9 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
 }'
 ```
 
-然后运行 wrk：
+在完成配置并安装 [wrk](https://github.com/wg/wrk/) 之后，可以使用以下命令进行测试：
 
-```shell
+```bash
 wrk -d 60 --latency http://127.0.0.1:9080/hello
 ```
 
@@ -93,9 +93,9 @@ wrk -d 60 --latency http://127.0.0.1:9080/hello
 火焰图的采样结果：
 ![火焰图采样结果](../../assets/images/flamegraph-2.jpg)
 
-如果想在机器上运行基准测试，你应该同时运行另一个 NGINX 来监听 80 端口：
+如果你需要在本地服务器上运行基准测试，你需要同时运行另一个 NGINX 实例来监听 80 端口：
 
-```shell
+```bash
 curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "methods": ["GET"],
@@ -119,20 +119,22 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
 }'
 ```
 
-然后运行 wrk：
+在完成配置并安装 [wrk](https://github.com/wg/wrk/) 之后，可以使用以下命令进行测试：
 
-```shell
+```bash
 wrk -d 60 --latency http://127.0.0.1:9080/hello
 ```
 
 有关如何运行基准测试的更多参考，你可以查看此[PR](https://github.com/apache/apisix/pull/6136)和此[脚本](https://gist.github.com/membphis/137db97a4bf64d3653aa42f3e016bd01)。
 
-**注意**: 如果你想运行大量连接的基准测试，例如：
+:::tip
 
-```shell
-./wrk -t200 -c5000 -d30s http://127.0.0.1:9080/hello
+如果你想测试大量连接的基准测试，你可能需要更新 [`./conf/config-default.yaml`](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L242) 中的 **keepalive** 配置项，否则超过配置数量的连接将成为短连接。你可以使用以下命令运行大量连接的基准测试：
+
+```bash
+wrk -t200 -c5000 -d30s http://127.0.0.1:9080/hello
 ```
 
-你可能需要更新 [conf/config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L242) 中的 **keepalive** 配置项。
+如果你需要了解更多信息，请参考：[ngx_http_upstream_module](http://nginx.org/en/docs/http/ngx_http_upstream_module.html)。
 
-超过配置数量的连接将成为短连接。更多文档可以参考：[ngx_http_upstream_module](http://nginx.org/en/docs/http/ngx_http_upstream_module.html)
+:::


### PR DESCRIPTION
### Description

1. As described in the issue: https://github.com/apache/apisix/issues/5966#issuecomment-1006105454, I added @membphis's comment to the Benchmark page;

2. It seems currently we have both English version and Chinese version doc about benchmark:

   - https://github.com/apache/apisix/blob/master/docs/en/latest/benchmark.md
   - https://github.com/apache/apisix/blob/master/docs/zh/latest/benchmark.md
      but the Chinese doc is missing some parts, so I translated them from the English version;

Fixes #5966

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
