### PR TITLE
ci(traffic-split): improve ci stability

### DIFF
--- a/t/plugin/traffic-split.t
+++ b/t/plugin/traffic-split.t
@@ -696,7 +696,7 @@ GET /t
             local json = require("toolkit.json")
             local t = require("lib.test_admin").test
             local data = {
-              uri = "/server_port",
+              uri = "/",
               plugins = {
                 ["traffic-split"] = {
                   rules = { {
@@ -704,8 +704,10 @@ GET /t
                       upstream = {
                         name = "upstream_A",
                         type = "roundrobin",
+                        pass_host = "rewrite",
+                        upstream_host = "www.apiseven.com",
                         nodes = {
-                          ["apiseven.com:80"] = 0
+                          ["www.apiseven.com:80"] = 0
                         }
                       },
                       weight = 100000
@@ -743,10 +745,10 @@ passed
 
 === TEST 19: domain name resolved successfully
 --- request
-GET /server_port
---- error_code: 502
+GET /
+--- error_code: 200
 --- error_log eval
-qr/dns resolver domain: apiseven.com to \d+.\d+.\d+.\d+/
+qr/dns resolver domain: www.apiseven.com to \d+.\d+.\d+.\d+/
 
 
 


### PR DESCRIPTION
### Description

Improve ci(traffic-split) stability. HTTP status code check 200 instead of 502

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
