### PR TITLE
feat: add default handler for pubsub ping command

### DIFF
--- a/apisix/core/pubsub.lua
+++ b/apisix/core/pubsub.lua
@@ -123,6 +123,11 @@ function _M.new()
         cmd_handler = {},
     }, mt)
 
+    -- add default ping handler
+    obj:on("cmd_ping", function (params)
+        return { pong_resp = params }
+    end)
+
     return obj
 end
 

--- a/apisix/include/apisix/model/pubsub.proto
+++ b/apisix/include/apisix/model/pubsub.proto
@@ -73,8 +73,8 @@ message CmdKafkaFetch {
 message PubSubReq {
     int64 sequence = 1;
     oneof req {
-        CmdEmpty cmd_empty                       = 31;
-        CmdPing cmd_ping                         = 32;
+        CmdEmpty           cmd_empty             = 31;
+        CmdPing            cmd_ping              = 32;
         CmdKafkaFetch      cmd_kafka_fetch       = 33;
         CmdKafkaListOffset cmd_kafka_list_offset = 34;
     };
@@ -135,9 +135,9 @@ message KafkaListOffsetResp {
 message PubSubResp {
     int64 sequence = 1;
     oneof resp {
-        ErrorResp error_resp                       = 31;
-        PongResp pong_resp                         = 32;
-        KafkaFetchResp kafka_fetch_resp            = 33;
+        ErrorResp           error_resp             = 31;
+        PongResp            pong_resp              = 32;
+        KafkaFetchResp      kafka_fetch_resp       = 33;
         KafkaListOffsetResp kafka_list_offset_resp = 34;
     };
 }


### PR DESCRIPTION
### Description

Add the default ping handler, which will be overridden when the user re-calls the on function to set the `cmd_ping` handler. There are already test cases for `cmd_ping` in the original tests.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
