### PR TITLE
ci: enable rebase in some situation

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,8 +39,10 @@ github:
 
     enabled_merge_buttons:
       squash:  true
+      # **WARNING**: rebase should only be used
+      # when backport multiple commits to the `release/xx` branch
+      rebase:  true
       merge:   false
-      rebase:  false
 
     protected_branches:
       master:


### PR DESCRIPTION
As discussed, now we decide to allow using rebase only when backport
multiple commits to the `release/xx` branch. Therefore we can preserve
the commit message.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
