### PR TITLE
test: reduce CI failure caused by flaky tests

### DIFF
--- a/ci/common.sh
+++ b/ci/common.sh
@@ -45,7 +45,7 @@ rerun_flaky_tests() {
     local n_test
     tests="$(awk '/^t\/.*.t\s+\(.+ Failed: .+\)/{ print $1 }' "$1")"
     n_test="$(echo "$tests" | wc -l)"
-    if [ "$n_test" -gt 3 ]; then
+    if [ "$n_test" -gt 10 ]; then
         # too many tests failed
         exit 1
     fi

--- a/t/plugin/file-logger-reopen.t
+++ b/t/plugin/file-logger-reopen.t
@@ -123,6 +123,7 @@ file.log: No such file or directory
             local code = t("/hello", ngx.HTTP_GET)
             assert(io.open("file.log", 'r'))
             os.remove("file.log")
+            ngx.sleep(0.01) -- make sure last reopen file is expired
 
             local process = require "ngx.process"
             local resty_signal = require "resty.signal"
@@ -135,6 +136,7 @@ file.log: No such file or directory
             end
 
             local code = t("/hello", ngx.HTTP_GET)
+            assert(code == 200)
 
             -- file is reopened
             local fd, err = io.open("file.log", 'r')

--- a/t/plugin/prometheus2.t
+++ b/t/plugin/prometheus2.t
@@ -538,7 +538,7 @@ qr/apisix_batch_process_entries\{name="http-logger",route_id="9",server_addr="12
                                 "buffer_duration": 60,
                                 "port": 1000,
                                 "batch_max_size": 1000,
-                                "inactive_timeout": 5,
+                                "inactive_timeout": 60,
                                 "tls": false,
                                 "max_retry_count": 0
                             }

--- a/t/xrpc/redis.t
+++ b/t/xrpc/redis.t
@@ -472,9 +472,9 @@ ok
                         name = "redis",
                         conf = {
                             faults = {
-                                {delay = 0.03, key = "b", commands = {"del"}},
-                                {delay = 0.02, key = "a", commands = {"mset"}},
-                                {delay = 0.01, key = "b", commands = {"mset"}},
+                                {delay = 0.06, key = "b", commands = {"del"}},
+                                {delay = 0.04, key = "a", commands = {"mset"}},
+                                {delay = 0.02, key = "b", commands = {"mset"}},
                             }
                         }
                     },
@@ -517,8 +517,8 @@ passed
                 return
             end
             local now = ngx.now()
-            if math.ceil((now - start) * 1000) < 20 then
-                ngx.say(now, " ", start)
+            if math.ceil((now - start) * 1000) < 40 then
+                ngx.say("mset a ", now, " ", start)
                 return
             end
             start = now
@@ -529,8 +529,8 @@ passed
                 return
             end
             local now = ngx.now()
-            if math.ceil((now - start) * 1000) < 10 or math.ceil((now - start) * 1000) > 15 then
-                ngx.say(now, " ", start)
+            if math.ceil((now - start) * 1000) < 20 or math.ceil((now - start) * 1000) > 35 then
+                ngx.say("mset b ", now, " ", start)
                 return
             end
             start = now
@@ -541,8 +541,8 @@ passed
                 return
             end
             local now = ngx.now()
-            if math.ceil((now - start) * 1000) > 5 then
-                ngx.say(now, " ", start)
+            if math.ceil((now - start) * 1000) > 20 then
+                ngx.say("mset mismatch ", now, " ", start)
                 return
             end
             start = now
@@ -553,8 +553,8 @@ passed
                 return
             end
             local now = ngx.now()
-            if math.ceil((now - start) * 1000) < 30 then
-                ngx.say(now, " ", start)
+            if math.ceil((now - start) * 1000) < 60 then
+                ngx.say("del b ", now, " ", start)
                 return
             end
             start = now


### PR DESCRIPTION
This commit addresses the problem with these actions:
1. increase the rerun limit
2. make sure the last reopen file is expired
3. increase redis delay to reduce the effect of the request latency
4. increase report time so the tcp-logger in prometheus test doesn't
       report to TCP receiver as we don't have such a TCP receiver.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #7037

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
