### PR TITLE
fix(batch-requests): ignore "unix:" in the configuration

### DIFF
--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -279,8 +279,10 @@ Please modify "admin_key" in conf/config.yaml .
         if real_ip_from then
             for _, ip in ipairs(real_ip_from) do
                 local _ip = cli_ip:new(ip)
-                if _ip and _ip:is_loopback() or _ip:is_unspecified() then
-                    pass_real_client_ip = true
+                if _ip then
+                    if _ip:is_loopback() or _ip:is_unspecified() then
+                        pass_real_client_ip = true
+                    end
                 end
             end
         end

--- a/t/cli/test_validate_config.sh
+++ b/t/cli/test_validate_config.sh
@@ -195,7 +195,7 @@ nginx_config:
         - "unix:"
 ' > conf/config.yaml
 
-out=$(make init 2>&1 || true)
+out=$(make init 2>&1)
 if echo "$out" | grep "missing loopback or unspecified in the nginx_config.http.real_ip_from for plugin batch-requests"; then
     echo "failed: should check the realip configuration for batch-requests"
     exit 1


### PR DESCRIPTION
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
