### PR TITLE
fix(proxy-cache): bypass when method mismatch cache_method under disk strategy

### DIFF
--- a/apisix/plugins/proxy-cache/disk_handler.lua
+++ b/apisix/plugins/proxy-cache/disk_handler.lua
@@ -55,6 +55,11 @@ function _M.access(conf, ctx)
         ctx.var.upstream_cache_bypass = value
         core.log.info("proxy-cache cache bypass value:", value)
     end
+
+    if not util.match_method(conf, ctx) then
+        ctx.var.upstream_cache_bypass = "1"
+        core.log.info("proxy-cache cache bypass method: ", ctx.var.request_method)
+    end
 end
 
 

--- a/t/plugin/proxy-cache/disk.t
+++ b/t/plugin/proxy-cache/disk.t
@@ -451,21 +451,22 @@ Apisix-Cache-Status: MISS
 
 
 
-=== TEST 17: hit route (HEAD method)
+=== TEST 17: hit route (will be cached)
 --- request
-HEAD /hello-world
+GET /hello
+--- response_body chop
+hello world!
+--- response_headers
+Apisix-Cache-Status: HIT
+
+
+
+=== TEST 18: hit route (HEAD method mismatch cache_method)
+--- request
+HEAD /hello
 --- error_code: 200
 --- response_headers
-Apisix-Cache-Status: MISS
-
-
-
-=== TEST 18: hit route (HEAD method there's no cache)
---- request
-HEAD /hello-world
---- error_code: 200
---- response_headers
-Apisix-Cache-Status: MISS
+Apisix-Cache-Status: BYPASS
 
 
 


### PR DESCRIPTION
### Description

When request method mismatch `cache_method`, it will also bypass instread of reading cached data.

Fixes #7096

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
