### PR TITLE
test: make sure the nginx.pid is written

### DIFF
--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -699,16 +699,15 @@ echo "-1" > logs/nginx.pid
 out=$(./bin/apisix start 2>&1 || true)
 if echo "$out" | grep "APISIX is running"; then
     rm logs/nginx.pid
-    echo "failed: should ignore stale nginx.pid"
+    echo "failed: should reject bad nginx.pid"
     exit 1
 fi
 
 ./bin/apisix stop
-echo "pass: ignore stale nginx.pid"
+sleep 0.5
 
 # check no corresponding process
 make run
-sleep 0.5
 oldpid=$(< logs/nginx.pid)
 make stop
 sleep 0.5

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -708,6 +708,7 @@ echo "pass: ignore stale nginx.pid"
 
 # check no corresponding process
 make run
+sleep 0.5
 oldpid=$(< logs/nginx.pid)
 make stop
 sleep 0.5


### PR DESCRIPTION
This should avoid "logs/nginx.pid: No such file or directory" error
which causes ci failures in:
https://github.com/apache/apisix/runs/6585253041?check_suite_focus=true
https://github.com/apache/apisix/runs/6565320107?check_suite_focus=true

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
