### PR TITLE
docs:update "plugin-develop"(#6743)

### DIFF
--- a/docs/en/latest/plugin-develop.md
+++ b/docs/en/latest/plugin-develop.md
@@ -42,6 +42,7 @@ For example, you can create a directory structure like this:
 │           └── plugins
 │               └── 3rd-party.lua
 ```
+**Note：custom plugin root directory must exists `/apisix/plugins` subdirectory**
 
 Then add this configuration into your `conf/config.yaml`:
 

--- a/docs/en/latest/plugin-develop.md
+++ b/docs/en/latest/plugin-develop.md
@@ -42,6 +42,7 @@ For example, you can create a directory structure like this:
 │           └── plugins
 │               └── 3rd-party.lua
 ```
+
 :::note
 
 If you need to customize the directory of plugin, please create a subdirectory of `/apisix/plugins` under this directory.

--- a/docs/en/latest/plugin-develop.md
+++ b/docs/en/latest/plugin-develop.md
@@ -42,7 +42,11 @@ For example, you can create a directory structure like this:
 │           └── plugins
 │               └── 3rd-party.lua
 ```
-**Note：custom plugin root directory must exists `/apisix/plugins` subdirectory**
+:::note
+
+custom plugin root directory must exists `/apisix/plugins` subdirectory**
+
+:::
 
 Then add this configuration into your `conf/config.yaml`:
 

--- a/docs/en/latest/plugin-develop.md
+++ b/docs/en/latest/plugin-develop.md
@@ -44,7 +44,7 @@ For example, you can create a directory structure like this:
 ```
 :::note
 
-custom plugin root directory must exists `/apisix/plugins` subdirectory**
+If you need to customize the directory of plugin, please create a subdirectory of `/apisix/plugins` under this directory.
 
 :::
 

--- a/docs/zh/latest/plugin-develop.md
+++ b/docs/zh/latest/plugin-develop.md
@@ -41,7 +41,11 @@ Apache APISIX 提供了两种方式来添加新的功能。
 │           └── plugins
 │               └── 3rd-party.lua
 ```
-**注意：自定义插件根目录下必须存在 `/apisix/plugins` 的子目录**
+:::note
+
+自定义插件根目录下必须存在 `/apisix/plugins` 的子目录。
+
+:::
 
 接着，在 `conf/config.yaml` 文件中添加如下的配置：
 

--- a/docs/zh/latest/plugin-develop.md
+++ b/docs/zh/latest/plugin-develop.md
@@ -41,6 +41,7 @@ Apache APISIX 提供了两种方式来添加新的功能。
 │           └── plugins
 │               └── 3rd-party.lua
 ```
+
 :::note
 
 如果你需要自定义插件的目录，请在该目录下创建 `/apisix/plugins` 的子目录。

--- a/docs/zh/latest/plugin-develop.md
+++ b/docs/zh/latest/plugin-develop.md
@@ -41,6 +41,7 @@ Apache APISIX 提供了两种方式来添加新的功能。
 │           └── plugins
 │               └── 3rd-party.lua
 ```
+**注意：自定义插件根目录下必须存在 `/apisix/plugins` 的子目录**
 
 接着，在 `conf/config.yaml` 文件中添加如下的配置：
 

--- a/docs/zh/latest/plugin-develop.md
+++ b/docs/zh/latest/plugin-develop.md
@@ -43,7 +43,7 @@ Apache APISIX 提供了两种方式来添加新的功能。
 ```
 :::note
 
-自定义插件根目录下必须存在 `/apisix/plugins` 的子目录。
+如果你需要自定义插件的目录，请在该目录下创建 `/apisix/plugins` 的子目录。
 
 :::
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

When developing plug-ins, I didn't pay attention to the user-defined path of plug-ins, resulting in no plug-ins found during testing. The original document didn't clearly remind this directory structure.

The modified content is to add a path prompt description to the document file

Fixes #6743

### Checklist

- [✅] I have explained the need for this PR and the problem it solves
- [✅] I have explained the changes or the new features added to this PR
- [✅ ] I have added tests corresponding to this change
- [✅ ] I have updated the documentation to reflect this change
- [✅] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
