### PR TITLE
ci: ignore releases.hashicorp.com's new certificate which can't be verified in CentOS7

### DIFF
--- a/ci/common.sh
+++ b/ci/common.sh
@@ -63,7 +63,9 @@ install_grpcurl () {
 
 install_vault_cli () {
     VAULT_VERSION="1.9.0"
-    wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip
+    # the certificate can't be verified in CentOS7, see
+    # https://blog.devgenius.io/lets-encrypt-change-affects-openssl-1-0-x-and-centos-7-49bd66016af3
+    wget --no-check-certificate https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip
     unzip vault_${VAULT_VERSION}_linux_amd64.zip && mv ./vault /usr/local/bin
 }
 


### PR DESCRIPTION
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
