### PR TITLE
chore: disable etcd dir init operation in DP mode

### DIFF
--- a/apisix/cli/etcd.lua
+++ b/apisix/cli/etcd.lua
@@ -241,6 +241,11 @@ function _M.init(env, args)
         util.die("the etcd cluster needs at least 50% and above healthy nodes\n")
     end
 
+    if not yaml_conf.apisix.enable_admin then
+        print("skip etcd dir init operation as DP enabled")
+        return
+    end
+
     local etcd_ok = false
     for index, host in ipairs(etcd_healthy_hosts) do
         local is_success = true

--- a/t/cli/test_admin.sh
+++ b/t/cli/test_admin.sh
@@ -376,3 +376,21 @@ fi
 make stop
 
 echo "pass: accept changes to /apisix/plugins successfully"
+
+
+# Skip the write dir operation in init_etcd
+git checkout conf/config.yaml
+
+# Check etcd dir init skip
+echo '
+apisix:
+  enable_admin: false
+' > conf/config.yaml
+
+out=$(make init 2>&1 || true)
+if ! echo "$out" | grep "skip etcd dir init operation as DP enabled"; then
+    echo "failed: unable to skip etcd dir init operation"
+    exit 1
+fi
+
+echo "pass: skip etcd dir init operation"


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #6735

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
