### PR TITLE
chore: require http_stub_status_module exists

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -82,13 +82,11 @@ http {
             }
         }
 
-        {% if with_module_status then %}
         location = /apisix/nginx_status {
             allow 127.0.0.0/24;
             deny all;
             stub_status;
         }
-        {% end %}
     }
 }
 {% end %}
@@ -503,13 +501,11 @@ http {
             }
         }
 
-        {% if with_module_status then %}
         location = /apisix/nginx_status {
             allow 127.0.0.0/24;
             deny all;
             stub_status;
         }
-        {% end %}
     }
     {% end %}
 
@@ -618,14 +614,12 @@ http {
         {% end %}
         # http server configuration snippet ends
 
-        {% if with_module_status then %}
         location = /apisix/nginx_status {
             allow 127.0.0.0/24;
             deny all;
             access_log off;
             stub_status;
         }
-        {% end %}
 
         {% if enable_admin and not admin_server_addr then %}
         location /apisix/admin {

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -244,12 +244,9 @@ Please modify "admin_key" in conf/config.yaml .
     end
 
     local or_info = util.execute_cmd("openresty -V 2>&1")
-    local with_module_status = true
     if or_info and not or_info:find("http_stub_status_module", 1, true) then
-        stderr:write("'http_stub_status_module' module is missing in ",
-                     "your openresty, please check it out. Without this ",
-                     "module, there will be fewer monitoring indicators.\n")
-        with_module_status = false
+        util.die("'http_stub_status_module' module is missing in ",
+                 "your openresty, please check it out.\n")
     end
 
     local use_apisix_openresty = true
@@ -548,7 +545,6 @@ Please modify "admin_key" in conf/config.yaml .
         lua_cpath = env.pkg_cpath_org,
         os_name = util.trim(util.execute_cmd("uname")),
         apisix_lua_home = env.apisix_home,
-        with_module_status = with_module_status,
         use_apisix_openresty = use_apisix_openresty,
         error_log = {level = "warn"},
         enable_http = enable_http,


### PR DESCRIPTION
The http_stub_status_module is required in fact, as:
1. missing this module will generate "failed to fetch Nginx status" error:
https://github.com/apache/apisix/blob/a99eb64f23737a8796606f48b851e27be52a3e6e/apisix/plugins/prometheus/exporter.lua#L245
2. both OpenResty and APISIX-Base already contains this module

Therefore I decide to remove the additional check to make code simpler.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
