### PR TITLE
feat: Add support for capturing OIDC refresh tokens

### DIFF
--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -266,7 +266,7 @@ function _M.rewrite(plugin_conf, ctx)
         conf.ssl_verify = "no"
     end
 
-    local response, err, target_url, session
+    local response, err, _, session
 
     if conf.bearer_only or conf.introspection_endpoint or conf.public_key then
         -- An introspection endpoint or a public key has been configured. Try to

--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -96,7 +96,13 @@ local schema = {
                 "header to the request for downstream.",
             type = "boolean",
             default = true
-        }
+        },
+	    set_refresh_token_header = {
+	        description = "Whether the refresh token shoud be added in the X-Refresh-Token " ..
+                "header to the request for downstream.",
+	        type = "boolean",
+	        default = false
+	    }
     },
     required = {"client_id", "client_secret", "discovery"}
 }
@@ -260,7 +266,7 @@ function _M.rewrite(plugin_conf, ctx)
         conf.ssl_verify = "no"
     end
 
-    local response, err
+    local response, err, target_url, session
 
     if conf.bearer_only or conf.introspection_endpoint or conf.public_key then
         -- An introspection endpoint or a public key has been configured. Try to
@@ -298,7 +304,7 @@ function _M.rewrite(plugin_conf, ctx)
         -- provider's authorization endpoint to initiate the Relying Party flow.
         -- This code path also handles when the ID provider then redirects to
         -- the configured redirect URI after successful authentication.
-        response, err = openidc.authenticate(conf)
+        response, err, target_url, session  = openidc.authenticate(conf)
 
         if err then
             core.log.error("OIDC authentication failed: ", err)
@@ -307,7 +313,8 @@ function _M.rewrite(plugin_conf, ctx)
 
         if response then
             -- If the openidc module has returned a response, it may contain,
-            -- respectively, the access token, the ID token, and the userinfo.
+            -- respectively, the access token, the ID token, the refresh token,
+            -- and the userinfo.
             -- Add respective headers to the request, if so configured.
 
             -- Add configured access token header, maybe.
@@ -323,6 +330,11 @@ function _M.rewrite(plugin_conf, ctx)
             if response.user and conf.set_userinfo_header then
                 core.request.set_header(ctx, "X-Userinfo",
                     ngx_encode_base64(core.json.encode(response.user)))
+            end
+
+            -- Add X-Refresh-Token header, maybe.
+            if session.data.refresh_token and conf.set_refresh_token_header then
+                core.request.set_header(ctx, "X-Refresh-Token", session.data.refresh_token)
             end
         end
     end

--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -97,12 +97,12 @@ local schema = {
             type = "boolean",
             default = true
         },
-	    set_refresh_token_header = {
-	        description = "Whether the refresh token should be added in the X-Refresh-Token " ..
+        set_refresh_token_header = {
+            description = "Whether the refresh token should be added in the X-Refresh-Token " ..
                 "header to the request for downstream.",
-	        type = "boolean",
-	        default = false
-	    }
+            type = "boolean",
+            default = false
+        }
     },
     required = {"client_id", "client_secret", "discovery"}
 }

--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -266,7 +266,7 @@ function _M.rewrite(plugin_conf, ctx)
         conf.ssl_verify = "no"
     end
 
-    local response, err, session
+    local response, err, session, _
 
     if conf.bearer_only or conf.introspection_endpoint or conf.public_key then
         -- An introspection endpoint or a public key has been configured. Try to

--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -266,7 +266,7 @@ function _M.rewrite(plugin_conf, ctx)
         conf.ssl_verify = "no"
     end
 
-    local response, err, _, session
+    local response, err, session
 
     if conf.bearer_only or conf.introspection_endpoint or conf.public_key then
         -- An introspection endpoint or a public key has been configured. Try to
@@ -304,7 +304,7 @@ function _M.rewrite(plugin_conf, ctx)
         -- provider's authorization endpoint to initiate the Relying Party flow.
         -- This code path also handles when the ID provider then redirects to
         -- the configured redirect URI after successful authentication.
-        response, err, target_url, session  = openidc.authenticate(conf)
+        response, err, _, session  = openidc.authenticate(conf)
 
         if err then
             core.log.error("OIDC authentication failed: ", err)

--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -98,7 +98,7 @@ local schema = {
             default = true
         },
 	    set_refresh_token_header = {
-	        description = "Whether the refresh token shoud be added in the X-Refresh-Token " ..
+	        description = "Whether the refresh token should be added in the X-Refresh-Token " ..
                 "header to the request for downstream.",
 	        type = "boolean",
 	        default = false

--- a/docs/en/latest/plugins/openid-connect.md
+++ b/docs/en/latest/plugins/openid-connect.md
@@ -55,6 +55,7 @@ The `openid-connect` Plugin provides authentication and introspection capability
 | access_token_in_authorization_header | boolean | False    | false                 |              | When set to true, sets the access token in the `Authorization` header. Otherwise, set the `X-Access-Token` header. |
 | set_id_token_header                  | boolean | False    | true                  |              | When set to true and the ID token is available, sets the ID token in the `X-ID-Token` request header.              |
 | set_userinfo_header                  | boolean | False    | true                  |              | When set to true and the UserInfo object is available, sets it in the `X-Userinfo` request header.                 |
+| set_refresh_token_header                  | boolean | False    | false                  |              | When set to true and a refresh token object is available, sets it in the `X-Refresh-Token` request header.                 |
 
 ## Modes of operation
 

--- a/t/plugin/openid-connect.t
+++ b/t/plugin/openid-connect.t
@@ -918,7 +918,7 @@ OIDC introspection failed: invalid token
 --- request
 GET /t
 --- response_body
-{"access_token_in_authorization_header":false,"bearer_only":false,"client_id":"kbyuFDidLLm280LIwVFiazOqjO3ty8KH","client_secret":"60Op4HFM0I8ajz0WdiStAbziZ-VFQttXuxixHHs2R7r7-CW8GR79l-mmLqMhc-Sa","discovery":"http://127.0.0.1:1980/.well-known/openid-configuration","introspection_endpoint_auth_method":"client_secret_basic","logout_path":"/logout","realm":"apisix","scope":"openid","set_access_token_header":true,"set_id_token_header":true,"set_userinfo_header":true,"ssl_verify":false,"timeout":3}
+{"access_token_in_authorization_header":false,"bearer_only":false,"client_id":"kbyuFDidLLm280LIwVFiazOqjO3ty8KH","client_secret":"60Op4HFM0I8ajz0WdiStAbziZ-VFQttXuxixHHs2R7r7-CW8GR79l-mmLqMhc-Sa","discovery":"http://127.0.0.1:1980/.well-known/openid-configuration","introspection_endpoint_auth_method":"client_secret_basic","logout_path":"/logout","realm":"apisix","scope":"openid","set_access_token_header":true,"set_id_token_header":true,"set_refresh_token_header":false,"set_userinfo_header":true,"ssl_verify":false,"timeout":3}
 --- no_error_log
 [error]
 

--- a/t/plugin/openid-connect.t
+++ b/t/plugin/openid-connect.t
@@ -189,7 +189,8 @@ true
                                 "set_access_token_header": true,
                                 "access_token_in_authorization_header": false,
                                 "set_id_token_header": true,
-                                "set_userinfo_header": true
+                                "set_userinfo_header": true,
+                                "set_refresh_token_header": true
                             }
                         },
                         "upstream": {

--- a/t/plugin/openid-connect.t
+++ b/t/plugin/openid-connect.t
@@ -273,6 +273,7 @@ x-access-token: ey.*
 x-id-token: ey.*
 x-real-ip: 127.0.0.1
 x-userinfo: ey.*
+x-refresh-token: ey.*
 --- no_error_log
 [error]
 

--- a/t/plugin/openid-connect.t
+++ b/t/plugin/openid-connect.t
@@ -273,8 +273,8 @@ user-agent: .*
 x-access-token: ey.*
 x-id-token: ey.*
 x-real-ip: 127.0.0.1
-x-userinfo: ey.*
 x-refresh-token: ey.*
+x-userinfo: ey.*
 --- no_error_log
 [error]
 


### PR DESCRIPTION
Add support for capturing OIDC refresh tokens in RP scenario. This is an important feature for people implementing BFF designs, especially considering refreshing the access token using previous techniques (such as hidden iframe) will, soon, not be available (Safari already blocks it).

This addition has been discussed in Slack and was implemented according to Zexuan Luo's recommendations:
https://the-asf.slack.com/archives/CUC5MN17A/p1654178597713989

The relevant English documentation is also updated.