### PR TITLE
fix(benchmark): write worker_processes into config.yaml

### DIFF
--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -35,12 +35,15 @@ mkdir -p benchmark/fake-apisix/logs
 
 make init
 
+fake_apisix_cmd="openresty -p $PWD/benchmark/fake-apisix -c $PWD/benchmark/fake-apisix/conf/nginx.conf"
+server_cmd="openresty -p $PWD/benchmark/server -c $PWD/benchmark/server/conf/nginx.conf"
+
 trap 'onCtrlC' INT
 function onCtrlC () {
     sudo killall wrk
     sudo killall openresty
-    sudo openresty -p $PWD/benchmark/fake-apisix -s stop || exit 1
-    sudo openresty -p $PWD/benchmark/server -s stop || exit 1
+    sudo ${fake_apisix_cmd} -s stop || exit 1
+    sudo ${server_cmd} -s stop || exit 1
 }
 
 for up_cnt in $(seq 1 $upstream_cnt);
@@ -55,14 +58,22 @@ do
 done
 
 if [[ "$(uname)" == "Darwin" ]]; then
-    sed  -i "" "s/worker_processes .*/worker_processes $worker_cnt;/g" conf/nginx.conf
     sed  -i "" "s/listen .*;/$nginx_listen/g" benchmark/server/conf/nginx.conf
 else
-    sed  -i "s/worker_processes .*/worker_processes $worker_cnt;/g" conf/nginx.conf
     sed  -i "s/listen .*;/$nginx_listen/g" benchmark/server/conf/nginx.conf
 fi
 
-sudo openresty -p $PWD/benchmark/server || exit 1
+echo "
+apisix:
+  admin_key:
+    - name: admin
+      key: edd1c9f034335f136f87ad84b625c8f1
+      role: admin
+nginx_config:
+  worker_processes: ${worker_cnt}
+" > conf/config.yaml
+
+sudo ${server_cmd} || exit 1
 
 make run
 
@@ -140,7 +151,7 @@ else
     sed  -i "s/worker_processes [0-9]*/worker_processes $worker_cnt/g" benchmark/fake-apisix/conf/nginx.conf
 fi
 
-sudo openresty -p $PWD/benchmark/fake-apisix || exit 1
+sudo ${fake_apisix_cmd} || exit 1
 
 sleep 1
 
@@ -150,6 +161,6 @@ sleep 1
 
 wrk -d 5 -c 16 http://127.0.0.1:9080/hello
 
-sudo openresty -p $PWD/benchmark/fake-apisix -s stop || exit 1
+sudo ${fake_apisix_cmd} -s stop || exit 1
 
-sudo openresty -p $PWD/benchmark/server -s stop || exit 1
+sudo ${server_cmd} -s stop || exit 1

--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -58,8 +58,12 @@ do
 done
 
 if [[ "$(uname)" == "Darwin" ]]; then
+    sed  -i "" "s/\- proxy-mirror .*/#\- proxy-mirror/g" conf/config-default.yaml
+    sed  -i "" "s/\- proxy-cache .*/#\- proxy-cache/g" conf/config-default.yaml
     sed  -i "" "s/listen .*;/$nginx_listen/g" benchmark/server/conf/nginx.conf
 else
+    sed  -i "s/\- proxy-mirror/#\- proxy-mirror/g" conf/config-default.yaml
+    sed  -i "s/\- proxy-cache/#\- proxy-cache/g" conf/config-default.yaml
     sed  -i "s/listen .*;/$nginx_listen/g" benchmark/server/conf/nginx.conf
 fi
 


### PR DESCRIPTION
### Description

1. Write worker_processes into config.yaml instead of nginx.conf
2. Improve script compatibility
3. Disable  `proxy-cache` and `proxy-mirror` plugins

Fixes #7205 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
4. Always update the documentation to reflect the changes made in the PR.
5. Make a new commit to resolve conversations instead of `push -f`.
6. To resolve merge conflicts, merge master instead of rebasing.
7. Use "request review" to notify the reviewer after making changes.
8. Only a reviewer can mark a conversation as resolved.

-->
