### PR TITLE
perf: don't cache all request headers on critical code path

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -228,14 +228,7 @@ end
 local function set_upstream_headers(api_ctx, picked_server)
     set_upstream_host(api_ctx, picked_server)
 
-    local hdr = core.request.header(api_ctx, "X-Forwarded-Proto")
-    if hdr then
-        if type(hdr) == "table" then
-            api_ctx.var.var_x_forwarded_proto = hdr[1]
-        else
-            api_ctx.var.var_x_forwarded_proto = hdr
-        end
-    end
+    api_ctx.var.var_x_forwarded_proto = api_ctx.var.http_x_forwarded_proto
 end
 
 

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -228,7 +228,10 @@ end
 local function set_upstream_headers(api_ctx, picked_server)
     set_upstream_host(api_ctx, picked_server)
 
-    api_ctx.var.var_x_forwarded_proto = api_ctx.var.http_x_forwarded_proto
+    local proto = api_ctx.var.http_x_forwarded_proto
+    if proto then
+        api_ctx.var.var_x_forwarded_proto = proto
+    end
 end
 
 

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -56,7 +56,6 @@ local str_byte        = string.byte
 local str_sub         = string.sub
 local tonumber        = tonumber
 local pairs           = pairs
-local type            = type
 local control_api_router
 
 local is_http = false

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -330,8 +330,6 @@ graphql:
 
 #ext-plugin:
   #cmd: ["ls", "-l"]
-ext-plugin:
-  path_for_test: /tmp/runner.sock
 
 plugins:                          # plugin list (sorted by priority)
   - real-ip                        # priority: 23000

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -330,6 +330,8 @@ graphql:
 
 #ext-plugin:
   #cmd: ["ls", "-l"]
+ext-plugin:
+  path_for_test: /tmp/runner.sock
 
 plugins:                          # plugin list (sorted by priority)
   - real-ip                        # priority: 23000


### PR DESCRIPTION
### Description

1、`core.request.header` will get all request headers and cache these, we don't need to do this on critical code paths.
2、We can use `api_ctx.var.http_x_forwarded_proto` to get only one header we need

Fixes #7258

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
