### PR TITLE
chore: explain why new injected fields should be under `_meta`

### DIFF
--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -151,6 +151,9 @@ local function load_plugin(name, plugins_list, plugin_type)
 
         properties._meta = plugin_injected_schema._meta
         -- new injected fields should be added under `_meta`
+        -- 1. so we won't break user's code when adding any new injected fields
+        -- 2. the semantics is clear, especially in the doc and in the caller side
+        -- TODO: move the `disable` to `_meta` too
 
         plugin.schema['$comment'] = plugin_injected_schema['$comment']
     end


### PR DESCRIPTION
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

After discussing with @tzssangglass and @membphis, we found it necessary to explain why we need to put new injected fields under `_meta`

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
