### PR TITLE
change(etcd): the health_check_retry should be named as startup_retry

### DIFF
--- a/apisix/cli/etcd.lua
+++ b/apisix/cli/etcd.lua
@@ -197,8 +197,10 @@ function _M.init(env, args)
         local res, err
         local retry_time = 0
 
-        local health_check_retry = tonumber(yaml_conf.etcd.health_check_retry) or 2
-        while retry_time < health_check_retry do
+        local etcd = yaml_conf.etcd
+        -- TODO: remove deprecated health_check_retry option in APISIX v3
+        local max_retry = tonumber(etcd.startup_retry or etcd.health_check_retry) or 2
+        while retry_time < max_retry do
             res, err = request(version_url, yaml_conf)
             -- In case of failure, request returns nil followed by an error message.
             -- Else the first return value is the response body

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -284,7 +284,7 @@ etcd:
   timeout: 30                     # 30 seconds
   #resync_delay: 5                # when sync failed and a rest is needed, resync after the configured seconds plus 50% random jitter
   #health_check_timeout: 10       # etcd retry the unhealthy nodes after the configured seconds
-  health_check_retry: 2           # etcd retry time that only affects the health check, default 2
+  startup_retry: 2                # the number of retry to etcd during the startup, default to 2
   #user: root                     # root username for etcd
   #password: 5tHkHhYkjr6cQY       # root password for etcd
   tls:


### PR DESCRIPTION
As it only affects the startup.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
