### PR TITLE
bugfix: when both route and global rules setted proxy-rewrite plugin,…

### DIFF
--- a/apisix/plugins/proxy-rewrite.lua
+++ b/apisix/plugins/proxy-rewrite.lua
@@ -185,6 +185,7 @@ function _M.rewrite(conf, ctx)
         upstream_uri = core.utils.uri_safe_encode(upstream_uri)
     end
 
+    ctx.var.upstream_uri = nil
     if ctx.var.is_args == "?" then
         if index then
             ctx.var.upstream_uri = upstream_uri .. "&" .. (ctx.var.args or "")


### PR DESCRIPTION
when proxy-rewrite plugin is both set in route and global rule, uri rewrite won't work, cause `ctx.var.upstream_uri` will only sync once to `ngx.var.upstream_uri`

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)
How to reproduce it?
```bash
# create a global_rules
curl 127.0.0.1:8081/apisix/admin/global_rules/proxy_set_header -H 'x-api-key: xxx' -XPUT \
	-d '{"plugins":{"proxy-rewrite":{"headers":{"bb": "cc"}}}}'

# create a route for debug
curl 127.0.0.1:8081/apisix/admin/routes/proxy-rewrite-test -H 'x-api-key: xxx'  -XPUT -d '{
	"uri": "/server/*",
	"host": "apisix.debug",
	"plugins": {
		"proxy-rewrite":{
			"regex_uri": [
			    "/server/(.*)",
                             "/$1"
			]
		}
	},
	"upstream": {
		"type": "roundrobin",
		"nodes": {
			"127.0.0.1:7777": 1
		}
	}
}'

# run an http server
python -m SimpleHTTPServer 7777 &

# send a requests
curl 127.0.0.1/server/123123 -H 'host: apisix.debug'
```

```bash
# expect access log
/123123

# actual log
/server/123123
```

```bash
# remove global rules, everything works fine
curl 127.0.0.1:8081/apisix/admin/global_rules/proxy_set_header -H 'x-api-key: xxx' -DELETE
curl 127.0.0.1/server/123123 -H 'host: apisix.debug'
```

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
