### PR TITLE
fix: duplicate X-Forwarded-Proto will be sent as string

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -55,6 +55,7 @@ local str_byte        = string.byte
 local str_sub         = string.sub
 local tonumber        = tonumber
 local pairs           = pairs
+local type            = type
 local control_api_router
 
 local is_http = false
@@ -277,7 +278,11 @@ local function set_upstream_headers(api_ctx, picked_server)
 
     local hdr = core.request.header(api_ctx, "X-Forwarded-Proto")
     if hdr then
-        api_ctx.var.var_x_forwarded_proto = hdr
+        if type(hdr) == "table" then
+            api_ctx.var.var_x_forwarded_proto = hdr[1]
+        else
+            api_ctx.var.var_x_forwarded_proto = hdr
+        end
     end
 end
 

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -55,7 +55,6 @@ local str_byte        = string.byte
 local str_sub         = string.sub
 local tonumber        = tonumber
 local pairs           = pairs
-local type            = type
 local control_api_router
 
 local is_http = false
@@ -276,13 +275,9 @@ end
 local function set_upstream_headers(api_ctx, picked_server)
     set_upstream_host(api_ctx, picked_server)
 
-    local hdr = core.request.header(api_ctx, "X-Forwarded-Proto")
-    if hdr then
-        if type(hdr) == "table" then
-            api_ctx.var.var_x_forwarded_proto = hdr[1]
-        else
-            api_ctx.var.var_x_forwarded_proto = hdr
-        end
+    local proto = api_ctx.var.http_x_forwarded_proto
+    if proto then
+        api_ctx.var.var_x_forwarded_proto = proto
     end
 end
 

--- a/t/plugin/proxy-rewrite2.t
+++ b/t/plugin/proxy-rewrite2.t
@@ -208,3 +208,27 @@ X-Forwarded-Proto: grpc
 X-Forwarded-Proto: https-rewrite
 --- error_log
 localhost
+
+
+
+=== TEST 7: pass duplicate  X-Forwarded-Proto
+--- apisix_yaml
+routes:
+  -
+    id: 1
+    uri: /echo
+    upstream_id: 1
+upstreams:
+  -
+    id: 1
+    nodes:
+        "127.0.0.1:1980": 1
+    type: roundrobin
+#END
+--- request
+GET /echo
+--- more_headers
+X-Forwarded-Proto: http
+X-Forwarded-Proto: grpc
+--- response_headers
+X-Forwarded-Proto: http


### PR DESCRIPTION
Co-authored-by: soulbird <zhaothree@gmail.com>### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

backport PRs to fix https://github.com/apache/apisix/issues/7215 in branch 2.13

Original PR: 
https://github.com/apache/apisix/pull/7229
https://github.com/apache/apisix/pull/7287


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
