### PR TITLE
fix: `make deps` should check PCRE header in openresty-pcre-devel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ ENV_DOCKER_COMPOSE     ?= docker-compose --project-directory $(CURDIR) -p $(proj
 ENV_NGINX              ?= $(ENV_NGINX_EXEC) -p $(CURDIR) -c $(CURDIR)/conf/nginx.conf
 ENV_NGINX_EXEC         := $(shell command -v openresty 2>/dev/null || command -v nginx 2>/dev/null)
 ENV_OPENSSL_PREFIX     ?= $(addprefix $(ENV_NGINX_PREFIX), openssl)
+ENV_PCRE_PREFIX        ?= $(addprefix $(ENV_NGINX_PREFIX), pcre)
 ENV_LUAROCKS           ?= luarocks
 ## These variables can be injected by luarocks
 ENV_INST_PREFIX        ?= /usr
@@ -61,6 +62,9 @@ ifneq ($(ENV_NGINX_EXEC), )
 	# OpenResty 1.17.8 or higher version uses openssl111 as the openssl dirname.
 	ifeq ($(shell test -d $(addprefix $(ENV_NGINX_PREFIX), openssl111) && echo -n yes), yes)
 		ENV_OPENSSL_PREFIX := $(addprefix $(ENV_NGINX_PREFIX), openssl111)
+	endif
+	ifeq ($(shell test -d $(addprefix $(ENV_NGINX_PREFIX), pcre) && echo -n yes), yes)
+		ENV_PCRE_PREFIX := $(addprefix $(ENV_NGINX_PREFIX), pcre)
 	endif
 endif
 
@@ -153,6 +157,8 @@ deps: runtime
 		mkdir -p ~/.luarocks; \
 		$(ENV_LUAROCKS) config $(ENV_LUAROCKS_FLAG_LOCAL) variables.OPENSSL_LIBDIR $(addprefix $(ENV_OPENSSL_PREFIX), /lib); \
 		$(ENV_LUAROCKS) config $(ENV_LUAROCKS_FLAG_LOCAL) variables.OPENSSL_INCDIR $(addprefix $(ENV_OPENSSL_PREFIX), /include); \
+		$(ENV_LUAROCKS) config $(ENV_LUAROCKS_FLAG_LOCAL) variables.PCRE_LIBDIR $(addprefix $(ENV_PCRE_PREFIX), /lib); \
+		$(ENV_LUAROCKS) config $(ENV_LUAROCKS_FLAG_LOCAL) variables.PCRE_INCDIR $(addprefix $(ENV_PCRE_PREFIX), /include); \
 		$(ENV_LUAROCKS) install rockspec/apisix-master-0.rockspec --tree=deps --only-deps --local $(ENV_LUAROCKS_SERVER_OPT); \
 	else \
 		$(call func_echo_warn_status, "WARNING: You're not using LuaRocks 3.x; please remove the luarocks and reinstall it via https://raw.githubusercontent.com/apache/apisix/master/utils/linux-install-luarocks.sh"); \

--- a/ci/centos7-ci.sh
+++ b/ci/centos7-ci.sh
@@ -29,7 +29,7 @@ install_dependencies() {
     wget https://github.com/moparisthebest/static-curl/releases/download/v7.79.1/curl-amd64 -O /usr/bin/curl
     # install openresty to make apisix's rpm test work
     yum install -y yum-utils && yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
-    yum install -y openresty openresty-debug openresty-openssl111-debug-devel pcre pcre-devel
+    yum install -y openresty openresty-debug openresty-openssl111-debug-devel pcre openresty-pcre-devel
 
     # install luarocks
     ./utils/linux-install-luarocks.sh

--- a/utils/install-dependencies.sh
+++ b/utils/install-dependencies.sh
@@ -46,7 +46,7 @@ function install_dependencies_with_aur() {
 function install_dependencies_with_yum() {
     sudo yum install -y yum-utils
 
-    local common_dep="curl wget git gcc openresty-openssl111-devel unzip pcre pcre-devel openldap-devel"
+    local common_dep="curl wget git gcc openresty-openssl111-devel unzip openresty-pcre-devel openldap-devel"
     if [ "${1}" == "centos" ]; then
         # add APISIX source
         local apisix_pkg=apache-apisix-repo-1.0-1.noarch

--- a/utils/linux-install-luarocks.sh
+++ b/utils/linux-install-luarocks.sh
@@ -61,3 +61,7 @@ fi
 
 luarocks config variables.OPENSSL_LIBDIR ${OPENSSL_PREFIX}/lib
 luarocks config variables.OPENSSL_INCDIR ${OPENSSL_PREFIX}/include
+
+PCRE_PREFIX=${OPENRESTY_PREFIX}/pcre
+luarocks config variables.PCRE_LIBDIR ${PCRE_PREFIX}/lib
+luarocks config variables.PCRE_INCDIR ${PCRE_PREFIX}/include


### PR DESCRIPTION
### Description

Already header file for OpenSSL (openresty-openssl111-devel) is
checked, so do same thing for PCRE.

Without this fix, even though openresty-pcre-devel is installed, make
deps fails like this:

  Error: Failed installing dependency: https://luarocks.org/jsonschema-0.9.8-0.src.rock - Failed installing dependency: https://luarocks.org/lrexlib-pcre-2.9.1-1.src.rock - Could not find header file for PCRE
    No file pcre.h in /usr/local/include
    No file pcre.h in /usr/include
    No file pcre.h in /include
  You may have to install PCRE in your system and/or pass PCRE_DIR or PCRE_INCDIR to the luarocks command.
  Example: luarocks install lrexlib-pcre PCRE_DIR=/usr/local


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

NOTE: utils/install-dependencies.sh or ci/centos7-ci.sh explicitly installs pcre-devel instead
of openresty-pcre-devel, does it intentional?

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
