### PR TITLE
feat: add hostname config

### DIFF
--- a/apisix/core/utils.lua
+++ b/apisix/core/utils.lua
@@ -253,6 +253,13 @@ function _M.gethostname()
         return hostname
     end
 
+    local local_conf = config_local.local_conf()
+    local config_hostname = table.try_read_attr(local_conf, "apisix", "hostname")
+    if config_hostname then
+        hostname = config_hostname
+        return hostname
+    end
+
     local hd = io_popen("/bin/hostname")
     local data, err = hd:read("*a")
     if err == nil then

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -20,6 +20,7 @@
 #
 
 apisix:
+  # hostname: apisix-node1          # If not set, the default value is server hostname (exec /bin/hostname)
   # node_listen: 9080               # APISIX listening port
   node_listen:                      # This style support multiple ports
     - 9080


### PR DESCRIPTION
hostname use to tag the node
config it in local config file is easy then change server hostname.....
and sometime we can‘t change the server’s hostname