### PR TITLE
fix(make): make reload doesn't call apisix reload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ clean:
 .PHONY: reload
 reload: runtime
 	@$(call func_echo_status, "$@ -> [ Start ]")
-	$(ENV_NGINX) -s reload
+	$(ENV_APISIX) reload
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
 
 

--- a/t/cli/test_makefile.sh
+++ b/t/cli/test_makefile.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+. ./t/cli/common.sh
+
+make run
+
+echo "
+apisix:
+  enable_admin: true
+  admin_listen:
+    ip: 127.0.0.2
+    port: 9181
+" > conf/config.yaml
+
+make reload
+make stop
+
+if ! grep "listen 127.0.0.2:9181;" conf/nginx.conf > /dev/null; then
+    echo "failed: regenerate nginx conf in 'make reload'"
+    exit 1
+fi
+
+echo "passed: regenerate nginx conf in 'make reload'"


### PR DESCRIPTION
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #7376

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
