### PR TITLE
feat(promethues): add ngx.shared.DICT status

### DIFF
--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -64,6 +64,13 @@ end
 _M.plugin_attr = plugin_attr
 
 
+local function nginx_config(name)
+    local local_conf = core.config.local_conf()
+    return core.table.try_read_attr(local_conf, "nginx_config", name)
+end
+_M.nginx_config = nginx_config
+
+
 local function sort_plugin(l, r)
     return l.priority > r.priority
 end

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -64,13 +64,6 @@ end
 _M.plugin_attr = plugin_attr
 
 
-local function nginx_config(name)
-    local local_conf = core.config.local_conf()
-    return core.table.try_read_attr(local_conf, "nginx_config", name)
-end
-_M.nginx_config = nginx_config
-
-
 local function sort_plugin(l, r)
     return l.priority > r.priority
 end

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -360,7 +360,7 @@ local key = {}
 local combine_param = {}
 
 local function shared_dict_status()
-    local header_of_shared_dict = ngx.req.get_headers()["shared_dict"]
+    local header_of_shared_dict = core.request.header(ngx.ctx, "shared_dict")
     if not header_of_shared_dict then
         return
     end

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -399,7 +399,7 @@ local function collect(ctx, stream_only)
         return 500, {message = "An unexpected error occurred"}
     end
 
-    --
+    -- collect ngx.shared.DICT status
     shared_dict_status()
 
     -- across all services

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -122,6 +122,10 @@ function _M.http_init(prometheus_enabled_in_stream)
             "Etcd modify index for APISIX keys",
             {"key"})
 
+    metrics.shared_dict = prometheus:gauge("shared_dict",
+            "nginx shared DICT of APISIX",
+            {"key"})
+
     -- per service
 
     -- The consumer label indicates the name of consumer corresponds to the
@@ -395,7 +399,7 @@ local function collect(ctx, stream_only)
         return 500, {message = "An unexpected error occurred"}
     end
 
-    -- 
+    --
     shared_dict_status()
 
     -- across all services

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -33,6 +33,7 @@ local get_services = require("apisix.http.service").services
 local get_consumers = require("apisix.consumer").consumers
 local get_upstreams = require("apisix.upstream").upstreams
 local clear_tab = core.table.clear
+local concat_tab = core.table.concat
 local get_stream_routes = router.stream_routes
 local get_protos = require("apisix.plugins.grpc-transcode.proto").protos
 local service_fetch = require("apisix.http.service").get
@@ -355,14 +356,14 @@ local function etcd_modify_index()
 
 end
 
+local key = {}
+local combine_param = {}
+
 local function shared_dict_status()
     local header_of_shared_dict = ngx.req.get_headers()["shared_dict"]
     if not header_of_shared_dict then
         return
     end
-
-    local key = {}
-    local combine_param = {}
 
     local set_shared_dict_param = function (shared_dict_name)
         if type(shared_dict_name) ~= "string" then
@@ -372,11 +373,11 @@ local function shared_dict_status()
         if share_dict then
             combine_param[1] = shared_dict_name
             combine_param[2] = "capacity"
-            key[1] = table.concat(combine_param, "_")
+            key[1] = concat_tab(combine_param, "_")
             metrics.shared_dict:set(share_dict:capacity(), key)
 
             combine_param[2] = "free_space"
-            key[1] = table.concat(combine_param, "_")
+            key[1] = concat_tab(combine_param, "_")
             metrics.shared_dict:set(share_dict:free_space(), key)
         end
     end

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -364,11 +364,9 @@ end
 local function shared_dict_status()
     local name = {}
     for shared_dict_name, shared_dict in pairs(ngx.shared) do
-        if shared_dict then
-            name[1] = shared_dict_name
-            metrics.shared_dict_capacity_bytes:set(shared_dict:capacity(), name)
-            metrics.shared_dict_free_space_bytes:set(shared_dict:free_space(), name)
-        end
+        name[1] = shared_dict_name
+        metrics.shared_dict_capacity_bytes:set(shared_dict:capacity(), name)
+        metrics.shared_dict_free_space_bytes:set(shared_dict:free_space(), name)
     end
 end
 

--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -207,7 +207,7 @@ The following metrics are exported by the `prometheus` Plugin:
 
 - Shared dict: capacity and free space of ngx.shared.DICT, this param uses the request header `Shared_DICT` to carry the shared memory name to be fetched.
 
-Here are the original metrics from APISIX: 
+Here are the original metrics from APISIX:
 
 ```shell
 curl http://127.0.0.1:9091/apisix/prometheus/metrics

--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -202,6 +202,7 @@ The following metrics are exported by the `prometheus` Plugin:
 
 - Info: Information about the APISIX node.
 - Shared dict: capacity and free space of ngx.shared.DICT, this param uses the configuration file to carry the shared memory name to be fetched, e.g:
+
 ```yaml
 plugin_attr:
   prometheus:

--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -201,15 +201,7 @@ The following metrics are exported by the `prometheus` Plugin:
   | node     | IP address of the Upstream node.                                                                                                    |
 
 - Info: Information about the APISIX node.
-- Shared dict: capacity and free space of ngx.shared.DICT, this param uses the configuration file to carry the shared memory name to be fetched, e.g:
-
-```yaml
-plugin_attr:
-  prometheus:
-    #shared_DICT: internal-status    #config as a string
-    shared_DICT:                     #can also be configured as a table
-      - internal-status
-```
+- Shared dict: The capacity and free space of all nginx.shared.DICT in APISIX.
 
 Here are the original metrics from APISIX:
 
@@ -281,14 +273,46 @@ apisix_http_latency_bucket{type="upstream",route="1",service="",consumer="",node
 # HELP apisix_node_info Info of APISIX node
 # TYPE apisix_node_info gauge
 apisix_node_info{hostname="desktop-2022q8f-wsl"} 1
-# HELP apisix_shared_dict_capacity_bytes capacity every moment of nginx shared DICT since APISIX start
+# HELP apisix_shared_dict_capacity_bytes The capacity of each nginx shared DICT since APISIX start
 # TYPE apisix_shared_dict_capacity_bytes gauge
+apisix_shared_dict_capacity_bytes{name="access-tokens"} 1048576
+apisix_shared_dict_capacity_bytes{name="balancer-ewma"} 10485760
+apisix_shared_dict_capacity_bytes{name="balancer-ewma-last-touched-at"} 10485760
+apisix_shared_dict_capacity_bytes{name="balancer-ewma-locks"} 10485760
+apisix_shared_dict_capacity_bytes{name="discovery"} 1048576
+apisix_shared_dict_capacity_bytes{name="etcd-cluster-health-check"} 10485760
+apisix_shared_dict_capacity_bytes{name="ext-plugin"} 1048576
 apisix_shared_dict_capacity_bytes{name="internal-status"} 10485760
+apisix_shared_dict_capacity_bytes{name="introspection"} 10485760
+apisix_shared_dict_capacity_bytes{name="jwks"} 1048576
+apisix_shared_dict_capacity_bytes{name="lrucache-lock"} 10485760
+apisix_shared_dict_capacity_bytes{name="plugin-api-breaker"} 10485760
+apisix_shared_dict_capacity_bytes{name="plugin-limit-conn"} 10485760
+apisix_shared_dict_capacity_bytes{name="plugin-limit-count"} 10485760
+apisix_shared_dict_capacity_bytes{name="plugin-limit-count-redis-cluster-slot-lock"} 1048576
+apisix_shared_dict_capacity_bytes{name="plugin-limit-req"} 10485760
+apisix_shared_dict_capacity_bytes{name="prometheus-metrics"} 10485760
 apisix_shared_dict_capacity_bytes{name="upstream-healthcheck"} 10485760
 apisix_shared_dict_capacity_bytes{name="worker-events"} 10485760
-# HELP apisix_shared_dict_free_space_bytes the current free space for nginx shared DICT in APISIX
+# HELP apisix_shared_dict_free_space_bytes The free space of each nginx shared DICT since APISIX start
 # TYPE apisix_shared_dict_free_space_bytes gauge
+apisix_shared_dict_free_space_bytes{name="access-tokens"} 1032192
+apisix_shared_dict_free_space_bytes{name="balancer-ewma"} 10412032
+apisix_shared_dict_free_space_bytes{name="balancer-ewma-last-touched-at"} 10412032
+apisix_shared_dict_free_space_bytes{name="balancer-ewma-locks"} 10412032
+apisix_shared_dict_free_space_bytes{name="discovery"} 1032192
+apisix_shared_dict_free_space_bytes{name="etcd-cluster-health-check"} 10412032
+apisix_shared_dict_free_space_bytes{name="ext-plugin"} 1032192
 apisix_shared_dict_free_space_bytes{name="internal-status"} 10412032
+apisix_shared_dict_free_space_bytes{name="introspection"} 10412032
+apisix_shared_dict_free_space_bytes{name="jwks"} 1032192
+apisix_shared_dict_free_space_bytes{name="lrucache-lock"} 10412032
+apisix_shared_dict_free_space_bytes{name="plugin-api-breaker"} 10412032
+apisix_shared_dict_free_space_bytes{name="plugin-limit-conn"} 10412032
+apisix_shared_dict_free_space_bytes{name="plugin-limit-count"} 10412032
+apisix_shared_dict_free_space_bytes{name="plugin-limit-count-redis-cluster-slot-lock"} 1036288
+apisix_shared_dict_free_space_bytes{name="plugin-limit-req"} 10412032
+apisix_shared_dict_free_space_bytes{name="prometheus-metrics"} 10399744
 apisix_shared_dict_free_space_bytes{name="upstream-healthcheck"} 10412032
 apisix_shared_dict_free_space_bytes{name="worker-events"} 10407936
 ```

--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -281,19 +281,7 @@ apisix_shared_dict_capacity_bytes{name="balancer-ewma-last-touched-at"} 10485760
 apisix_shared_dict_capacity_bytes{name="balancer-ewma-locks"} 10485760
 apisix_shared_dict_capacity_bytes{name="discovery"} 1048576
 apisix_shared_dict_capacity_bytes{name="etcd-cluster-health-check"} 10485760
-apisix_shared_dict_capacity_bytes{name="ext-plugin"} 1048576
-apisix_shared_dict_capacity_bytes{name="internal-status"} 10485760
-apisix_shared_dict_capacity_bytes{name="introspection"} 10485760
-apisix_shared_dict_capacity_bytes{name="jwks"} 1048576
-apisix_shared_dict_capacity_bytes{name="lrucache-lock"} 10485760
-apisix_shared_dict_capacity_bytes{name="plugin-api-breaker"} 10485760
-apisix_shared_dict_capacity_bytes{name="plugin-limit-conn"} 10485760
-apisix_shared_dict_capacity_bytes{name="plugin-limit-count"} 10485760
-apisix_shared_dict_capacity_bytes{name="plugin-limit-count-redis-cluster-slot-lock"} 1048576
-apisix_shared_dict_capacity_bytes{name="plugin-limit-req"} 10485760
-apisix_shared_dict_capacity_bytes{name="prometheus-metrics"} 10485760
-apisix_shared_dict_capacity_bytes{name="upstream-healthcheck"} 10485760
-apisix_shared_dict_capacity_bytes{name="worker-events"} 10485760
+...
 # HELP apisix_shared_dict_free_space_bytes The free space of each nginx shared DICT since APISIX start
 # TYPE apisix_shared_dict_free_space_bytes gauge
 apisix_shared_dict_free_space_bytes{name="access-tokens"} 1032192
@@ -302,19 +290,7 @@ apisix_shared_dict_free_space_bytes{name="balancer-ewma-last-touched-at"} 104120
 apisix_shared_dict_free_space_bytes{name="balancer-ewma-locks"} 10412032
 apisix_shared_dict_free_space_bytes{name="discovery"} 1032192
 apisix_shared_dict_free_space_bytes{name="etcd-cluster-health-check"} 10412032
-apisix_shared_dict_free_space_bytes{name="ext-plugin"} 1032192
-apisix_shared_dict_free_space_bytes{name="internal-status"} 10412032
-apisix_shared_dict_free_space_bytes{name="introspection"} 10412032
-apisix_shared_dict_free_space_bytes{name="jwks"} 1032192
-apisix_shared_dict_free_space_bytes{name="lrucache-lock"} 10412032
-apisix_shared_dict_free_space_bytes{name="plugin-api-breaker"} 10412032
-apisix_shared_dict_free_space_bytes{name="plugin-limit-conn"} 10412032
-apisix_shared_dict_free_space_bytes{name="plugin-limit-count"} 10412032
-apisix_shared_dict_free_space_bytes{name="plugin-limit-count-redis-cluster-slot-lock"} 1036288
-apisix_shared_dict_free_space_bytes{name="plugin-limit-req"} 10412032
-apisix_shared_dict_free_space_bytes{name="prometheus-metrics"} 10399744
-apisix_shared_dict_free_space_bytes{name="upstream-healthcheck"} 10412032
-apisix_shared_dict_free_space_bytes{name="worker-events"} 10407936
+...
 ```
 
 ## Disable Plugin

--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -187,8 +187,11 @@ The following metrics are exported by the `prometheus` Plugin:
   | node     | IP address of the Upstream node.                                                                                              |
 
 - etcd reachability: A gauge type representing whether etcd can be reached by APISIX. A value of `1` represents reachable and `0` represents unreachable.
+
 - Connections: Nginx connection metrics like active, reading, writing, and number of accepted connections.
+
 - Batch process entries: A gauge type useful when Plugins like [syslog](./syslog.md), [http-logger](./http-logger.md), [tcp-logger](./tcp-logger.md), [udp-logger](./udp-logger.md), and [zipkin](./zipkin.md) use batch process to send data. Entries that hasn't been sent in batch process will be counted in the metrics.
+
 - Latency: Histogram of the request time per service in different dimensions.
 
   The available attributes are:
@@ -202,7 +205,9 @@ The following metrics are exported by the `prometheus` Plugin:
 
 - Info: Information about the APISIX node.
 
-Here are the original metrics from APISIX:
+- Shared dict: capacity and free space of ngx.shared.DICT, this param uses the request header `Shared_DICT` to carry the shared memory name to be fetched.
+
+Here are the original metrics from APISIX: 
 
 ```shell
 curl http://127.0.0.1:9091/apisix/prometheus/metrics
@@ -272,6 +277,10 @@ apisix_http_latency_bucket{type="upstream",route="1",service="",consumer="",node
 # HELP apisix_node_info Info of APISIX node
 # TYPE apisix_node_info gauge
 apisix_node_info{hostname="desktop-2022q8f-wsl"} 1
+# HELP apisix_shared_dict nginx shared DICT of APISIX
+# TYPE apisix_shared_dict gauge
+apisix_shared_dict{key="internal-status_capacity"} 10485760
+apisix_shared_dict{key="internal-status_free_space"} 10407936
 ```
 
 ## Disable Plugin

--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -187,11 +187,8 @@ The following metrics are exported by the `prometheus` Plugin:
   | node     | IP address of the Upstream node.                                                                                              |
 
 - etcd reachability: A gauge type representing whether etcd can be reached by APISIX. A value of `1` represents reachable and `0` represents unreachable.
-
 - Connections: Nginx connection metrics like active, reading, writing, and number of accepted connections.
-
 - Batch process entries: A gauge type useful when Plugins like [syslog](./syslog.md), [http-logger](./http-logger.md), [tcp-logger](./tcp-logger.md), [udp-logger](./udp-logger.md), and [zipkin](./zipkin.md) use batch process to send data. Entries that hasn't been sent in batch process will be counted in the metrics.
-
 - Latency: Histogram of the request time per service in different dimensions.
 
   The available attributes are:
@@ -204,7 +201,6 @@ The following metrics are exported by the `prometheus` Plugin:
   | node     | IP address of the Upstream node.                                                                                                    |
 
 - Info: Information about the APISIX node.
-
 - Shared dict: capacity and free space of ngx.shared.DICT, this param uses the request header `Shared_DICT` to carry the shared memory name to be fetched.
 
 Here are the original metrics from APISIX:

--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -201,7 +201,14 @@ The following metrics are exported by the `prometheus` Plugin:
   | node     | IP address of the Upstream node.                                                                                                    |
 
 - Info: Information about the APISIX node.
-- Shared dict: capacity and free space of ngx.shared.DICT, this param uses the request header `Shared_DICT` to carry the shared memory name to be fetched.
+- Shared dict: capacity and free space of ngx.shared.DICT, this param uses the configuration file to carry the shared memory name to be fetched, e.g:
+```yaml
+plugin_attr:
+  prometheus:
+    #shared_DICT: internal-status    #config as a string
+    shared_DICT:                     #can also be configured as a table
+      - internal-status
+```
 
 Here are the original metrics from APISIX:
 
@@ -273,10 +280,16 @@ apisix_http_latency_bucket{type="upstream",route="1",service="",consumer="",node
 # HELP apisix_node_info Info of APISIX node
 # TYPE apisix_node_info gauge
 apisix_node_info{hostname="desktop-2022q8f-wsl"} 1
-# HELP apisix_shared_dict nginx shared DICT of APISIX
-# TYPE apisix_shared_dict gauge
-apisix_shared_dict{key="internal-status_capacity"} 10485760
-apisix_shared_dict{key="internal-status_free_space"} 10407936
+# HELP apisix_shared_dict_capacity_bytes capacity every moment of nginx shared DICT since APISIX start
+# TYPE apisix_shared_dict_capacity_bytes gauge
+apisix_shared_dict_capacity_bytes{name="internal-status"} 10485760
+apisix_shared_dict_capacity_bytes{name="upstream-healthcheck"} 10485760
+apisix_shared_dict_capacity_bytes{name="worker-events"} 10485760
+# HELP apisix_shared_dict_free_space_bytes the current free space for nginx shared DICT in APISIX
+# TYPE apisix_shared_dict_free_space_bytes gauge
+apisix_shared_dict_free_space_bytes{name="internal-status"} 10412032
+apisix_shared_dict_free_space_bytes{name="upstream-healthcheck"} 10412032
+apisix_shared_dict_free_space_bytes{name="worker-events"} 10407936
 ```
 
 ## Disable Plugin

--- a/docs/zh/latest/plugins/prometheus.md
+++ b/docs/zh/latest/plugins/prometheus.md
@@ -186,11 +186,8 @@ scrape_configs:
     | node         | 消费者节点 IP 地址。 |
 
 - etcd reachability: APISIX 连接 etcd 的可用性，用 0 和 1 来表示，`1` 表示可用，`0` 表示不可用。
-
 - Connections: 各种的 NGINX 连接指标，如 `active`（正处理的活动连接数），`reading`（NGINX 读取到客户端的 Header 信息数），writing（NGINX 返回给客户端的 Header 信息数），已建立的连接数。
-
 - Batch process entries: 批处理未发送数据计数器，当你使用了批处理发送插件，比如：[syslog](./syslog.md), [http-logger](./http-logger.md), [tcp-logger](./tcp-logger.md), [udp-logger](./udp-logger.md), and [zipkin](./zipkin.md)，那么你将会在此指标中看到批处理当前尚未发送的数据的数量。
-
 - Latency: 每个服务的请求用时和 APISIX 处理耗时的直方图。属性如下所示：
 
     | 名称          |    描述                                                                                 |
@@ -201,7 +198,6 @@ scrape_configs:
     | node         | 上游节点的 IP 地址。                                                                      |
 
 - Info: 当前 APISIX 节点信息。
-
 - Shared dict: 共享内存的大小以及剩余可用空间，该指标使用请求头 `Shared_DICT` 携带需要查询的共享内存名称。
 
 以下是 APISIX 的原始的指标数据集：

--- a/docs/zh/latest/plugins/prometheus.md
+++ b/docs/zh/latest/plugins/prometheus.md
@@ -199,13 +199,14 @@ scrape_configs:
 
 - Info: 当前 APISIX 节点信息。
 - Shared dict: 共享内存的大小以及剩余可用空间，该指标使用配置文件进行配置，示例如下：
-    ```yaml
-    plugin_attr:
-      prometheus:
-        #shared_DICT: internal-status    #可配置为单个字符串
-        shared_DICT:					 #也可以数组的形式进行配置
-          - internal-status
-    ```
+
+```yaml
+plugin_attr:
+    prometheus:
+    #shared_DICT: internal-status    #可配置为单个字符串
+    shared_DICT:					 #也可以数组的形式进行配置
+        - internal-status
+```
 
 以下是 APISIX 的原始的指标数据集：
 

--- a/docs/zh/latest/plugins/prometheus.md
+++ b/docs/zh/latest/plugins/prometheus.md
@@ -198,7 +198,7 @@ scrape_configs:
     | node         | 上游节点的 IP 地址。                                                                      |
 
 - Info: 当前 APISIX 节点信息。
-- Shared dict: APISIX中所有共享内存的容量以及剩余可用空间。
+- Shared dict: APISIX 中所有共享内存的容量以及剩余可用空间。
 
 以下是 APISIX 的原始的指标数据集：
 

--- a/docs/zh/latest/plugins/prometheus.md
+++ b/docs/zh/latest/plugins/prometheus.md
@@ -186,8 +186,11 @@ scrape_configs:
     | node         | 消费者节点 IP 地址。 |
 
 - etcd reachability: APISIX 连接 etcd 的可用性，用 0 和 1 来表示，`1` 表示可用，`0` 表示不可用。
+
 - Connections: 各种的 NGINX 连接指标，如 `active`（正处理的活动连接数），`reading`（NGINX 读取到客户端的 Header 信息数），writing（NGINX 返回给客户端的 Header 信息数），已建立的连接数。
+
 - Batch process entries: 批处理未发送数据计数器，当你使用了批处理发送插件，比如：[syslog](./syslog.md), [http-logger](./http-logger.md), [tcp-logger](./tcp-logger.md), [udp-logger](./udp-logger.md), and [zipkin](./zipkin.md)，那么你将会在此指标中看到批处理当前尚未发送的数据的数量。
+
 - Latency: 每个服务的请求用时和 APISIX 处理耗时的直方图。属性如下所示：
 
     | 名称          |    描述                                                                                 |
@@ -199,13 +202,15 @@ scrape_configs:
 
 - Info: 当前 APISIX 节点信息。
 
+- Shared dict: 共享内存的大小以及剩余可用空间，该指标使用请求头 `Shared_DICT` 携带需要查询的共享内存名称。
+
 以下是 APISIX 的原始的指标数据集：
 
 ```shell
-curl http://127.0.0.1:9091/apisix/prometheus/metrics
+curl http://127.0.0.1:9091/apisix/prometheus/metrics -H "Shared_DICT:internal-status"
 ```
 
-```
+```shell
 # HELP apisix_bandwidth Total bandwidth in bytes consumed per service in Apisix
 # TYPE apisix_bandwidth counter
 apisix_bandwidth{type="egress",route="",service="",consumer="",node=""} 8417
@@ -269,6 +274,10 @@ apisix_http_latency_bucket{type="upstream",route="1",service="",consumer="",node
 # HELP apisix_node_info Info of APISIX node
 # TYPE apisix_node_info gauge
 apisix_node_info{hostname="APISIX"} 1
+# HELP apisix_shared_dict nginx shared DICT of APISIX
+# TYPE apisix_shared_dict gauge
+apisix_shared_dict{key="internal-status_capacity"} 10485760
+apisix_shared_dict{key="internal-status_free_space"} 10407936
 ```
 
 ## 禁用插件

--- a/docs/zh/latest/plugins/prometheus.md
+++ b/docs/zh/latest/plugins/prometheus.md
@@ -198,15 +198,7 @@ scrape_configs:
     | node         | 上游节点的 IP 地址。                                                                      |
 
 - Info: 当前 APISIX 节点信息。
-- Shared dict: 共享内存的大小以及剩余可用空间，该指标使用配置文件进行配置，示例如下：
-
-```yaml
-plugin_attr:
-    prometheus:
-    #shared_DICT: internal-status    #可配置为单个字符串
-    shared_DICT:					 #也可以数组的形式进行配置
-        - internal-status
-```
+- Shared dict: APISIX中所有共享内存的容量以及剩余可用空间。
 
 以下是 APISIX 的原始的指标数据集：
 
@@ -278,14 +270,46 @@ apisix_http_latency_bucket{type="upstream",route="1",service="",consumer="",node
 # HELP apisix_node_info Info of APISIX node
 # TYPE apisix_node_info gauge
 apisix_node_info{hostname="APISIX"} 1
-# HELP apisix_shared_dict_capacity_bytes capacity every moment of nginx shared DICT since APISIX start
+# HELP apisix_shared_dict_capacity_bytes The capacity of each nginx shared DICT since APISIX start
 # TYPE apisix_shared_dict_capacity_bytes gauge
+apisix_shared_dict_capacity_bytes{name="access-tokens"} 1048576
+apisix_shared_dict_capacity_bytes{name="balancer-ewma"} 10485760
+apisix_shared_dict_capacity_bytes{name="balancer-ewma-last-touched-at"} 10485760
+apisix_shared_dict_capacity_bytes{name="balancer-ewma-locks"} 10485760
+apisix_shared_dict_capacity_bytes{name="discovery"} 1048576
+apisix_shared_dict_capacity_bytes{name="etcd-cluster-health-check"} 10485760
+apisix_shared_dict_capacity_bytes{name="ext-plugin"} 1048576
 apisix_shared_dict_capacity_bytes{name="internal-status"} 10485760
+apisix_shared_dict_capacity_bytes{name="introspection"} 10485760
+apisix_shared_dict_capacity_bytes{name="jwks"} 1048576
+apisix_shared_dict_capacity_bytes{name="lrucache-lock"} 10485760
+apisix_shared_dict_capacity_bytes{name="plugin-api-breaker"} 10485760
+apisix_shared_dict_capacity_bytes{name="plugin-limit-conn"} 10485760
+apisix_shared_dict_capacity_bytes{name="plugin-limit-count"} 10485760
+apisix_shared_dict_capacity_bytes{name="plugin-limit-count-redis-cluster-slot-lock"} 1048576
+apisix_shared_dict_capacity_bytes{name="plugin-limit-req"} 10485760
+apisix_shared_dict_capacity_bytes{name="prometheus-metrics"} 10485760
 apisix_shared_dict_capacity_bytes{name="upstream-healthcheck"} 10485760
 apisix_shared_dict_capacity_bytes{name="worker-events"} 10485760
-# HELP apisix_shared_dict_free_space_bytes the current free space for nginx shared DICT in APISIX
+# HELP apisix_shared_dict_free_space_bytes The free space of each nginx shared DICT since APISIX start
 # TYPE apisix_shared_dict_free_space_bytes gauge
+apisix_shared_dict_free_space_bytes{name="access-tokens"} 1032192
+apisix_shared_dict_free_space_bytes{name="balancer-ewma"} 10412032
+apisix_shared_dict_free_space_bytes{name="balancer-ewma-last-touched-at"} 10412032
+apisix_shared_dict_free_space_bytes{name="balancer-ewma-locks"} 10412032
+apisix_shared_dict_free_space_bytes{name="discovery"} 1032192
+apisix_shared_dict_free_space_bytes{name="etcd-cluster-health-check"} 10412032
+apisix_shared_dict_free_space_bytes{name="ext-plugin"} 1032192
 apisix_shared_dict_free_space_bytes{name="internal-status"} 10412032
+apisix_shared_dict_free_space_bytes{name="introspection"} 10412032
+apisix_shared_dict_free_space_bytes{name="jwks"} 1032192
+apisix_shared_dict_free_space_bytes{name="lrucache-lock"} 10412032
+apisix_shared_dict_free_space_bytes{name="plugin-api-breaker"} 10412032
+apisix_shared_dict_free_space_bytes{name="plugin-limit-conn"} 10412032
+apisix_shared_dict_free_space_bytes{name="plugin-limit-count"} 10412032
+apisix_shared_dict_free_space_bytes{name="plugin-limit-count-redis-cluster-slot-lock"} 1036288
+apisix_shared_dict_free_space_bytes{name="plugin-limit-req"} 10412032
+apisix_shared_dict_free_space_bytes{name="prometheus-metrics"} 10399744
 apisix_shared_dict_free_space_bytes{name="upstream-healthcheck"} 10412032
 apisix_shared_dict_free_space_bytes{name="worker-events"} 10407936
 ```

--- a/docs/zh/latest/plugins/prometheus.md
+++ b/docs/zh/latest/plugins/prometheus.md
@@ -198,12 +198,19 @@ scrape_configs:
     | node         | 上游节点的 IP 地址。                                                                      |
 
 - Info: 当前 APISIX 节点信息。
-- Shared dict: 共享内存的大小以及剩余可用空间，该指标使用请求头 `Shared_DICT` 携带需要查询的共享内存名称。
+- Shared dict: 共享内存的大小以及剩余可用空间，该指标使用配置文件进行配置，示例如下：
+    ```yaml
+    plugin_attr:
+      prometheus:
+        #shared_DICT: internal-status    #可配置为单个字符串
+        shared_DICT:					 #也可以数组的形式进行配置
+          - internal-status
+    ```
 
 以下是 APISIX 的原始的指标数据集：
 
 ```shell
-curl http://127.0.0.1:9091/apisix/prometheus/metrics -H "Shared_DICT:internal-status"
+curl http://127.0.0.1:9091/apisix/prometheus/metrics
 ```
 
 ```shell
@@ -270,10 +277,16 @@ apisix_http_latency_bucket{type="upstream",route="1",service="",consumer="",node
 # HELP apisix_node_info Info of APISIX node
 # TYPE apisix_node_info gauge
 apisix_node_info{hostname="APISIX"} 1
-# HELP apisix_shared_dict nginx shared DICT of APISIX
-# TYPE apisix_shared_dict gauge
-apisix_shared_dict{key="internal-status_capacity"} 10485760
-apisix_shared_dict{key="internal-status_free_space"} 10407936
+# HELP apisix_shared_dict_capacity_bytes capacity every moment of nginx shared DICT since APISIX start
+# TYPE apisix_shared_dict_capacity_bytes gauge
+apisix_shared_dict_capacity_bytes{name="internal-status"} 10485760
+apisix_shared_dict_capacity_bytes{name="upstream-healthcheck"} 10485760
+apisix_shared_dict_capacity_bytes{name="worker-events"} 10485760
+# HELP apisix_shared_dict_free_space_bytes the current free space for nginx shared DICT in APISIX
+# TYPE apisix_shared_dict_free_space_bytes gauge
+apisix_shared_dict_free_space_bytes{name="internal-status"} 10412032
+apisix_shared_dict_free_space_bytes{name="upstream-healthcheck"} 10412032
+apisix_shared_dict_free_space_bytes{name="worker-events"} 10407936
 ```
 
 ## 禁用插件

--- a/docs/zh/latest/plugins/prometheus.md
+++ b/docs/zh/latest/plugins/prometheus.md
@@ -278,19 +278,7 @@ apisix_shared_dict_capacity_bytes{name="balancer-ewma-last-touched-at"} 10485760
 apisix_shared_dict_capacity_bytes{name="balancer-ewma-locks"} 10485760
 apisix_shared_dict_capacity_bytes{name="discovery"} 1048576
 apisix_shared_dict_capacity_bytes{name="etcd-cluster-health-check"} 10485760
-apisix_shared_dict_capacity_bytes{name="ext-plugin"} 1048576
-apisix_shared_dict_capacity_bytes{name="internal-status"} 10485760
-apisix_shared_dict_capacity_bytes{name="introspection"} 10485760
-apisix_shared_dict_capacity_bytes{name="jwks"} 1048576
-apisix_shared_dict_capacity_bytes{name="lrucache-lock"} 10485760
-apisix_shared_dict_capacity_bytes{name="plugin-api-breaker"} 10485760
-apisix_shared_dict_capacity_bytes{name="plugin-limit-conn"} 10485760
-apisix_shared_dict_capacity_bytes{name="plugin-limit-count"} 10485760
-apisix_shared_dict_capacity_bytes{name="plugin-limit-count-redis-cluster-slot-lock"} 1048576
-apisix_shared_dict_capacity_bytes{name="plugin-limit-req"} 10485760
-apisix_shared_dict_capacity_bytes{name="prometheus-metrics"} 10485760
-apisix_shared_dict_capacity_bytes{name="upstream-healthcheck"} 10485760
-apisix_shared_dict_capacity_bytes{name="worker-events"} 10485760
+...
 # HELP apisix_shared_dict_free_space_bytes The free space of each nginx shared DICT since APISIX start
 # TYPE apisix_shared_dict_free_space_bytes gauge
 apisix_shared_dict_free_space_bytes{name="access-tokens"} 1032192
@@ -299,19 +287,7 @@ apisix_shared_dict_free_space_bytes{name="balancer-ewma-last-touched-at"} 104120
 apisix_shared_dict_free_space_bytes{name="balancer-ewma-locks"} 10412032
 apisix_shared_dict_free_space_bytes{name="discovery"} 1032192
 apisix_shared_dict_free_space_bytes{name="etcd-cluster-health-check"} 10412032
-apisix_shared_dict_free_space_bytes{name="ext-plugin"} 1032192
-apisix_shared_dict_free_space_bytes{name="internal-status"} 10412032
-apisix_shared_dict_free_space_bytes{name="introspection"} 10412032
-apisix_shared_dict_free_space_bytes{name="jwks"} 1032192
-apisix_shared_dict_free_space_bytes{name="lrucache-lock"} 10412032
-apisix_shared_dict_free_space_bytes{name="plugin-api-breaker"} 10412032
-apisix_shared_dict_free_space_bytes{name="plugin-limit-conn"} 10412032
-apisix_shared_dict_free_space_bytes{name="plugin-limit-count"} 10412032
-apisix_shared_dict_free_space_bytes{name="plugin-limit-count-redis-cluster-slot-lock"} 1036288
-apisix_shared_dict_free_space_bytes{name="plugin-limit-req"} 10412032
-apisix_shared_dict_free_space_bytes{name="prometheus-metrics"} 10399744
-apisix_shared_dict_free_space_bytes{name="upstream-healthcheck"} 10412032
-apisix_shared_dict_free_space_bytes{name="worker-events"} 10407936
+...
 ```
 
 ## 禁用插件

--- a/t/plugin/prometheus.t
+++ b/t/plugin/prometheus.t
@@ -635,30 +635,11 @@ qr/etcd/
 
 
 
-=== TEST 42: fetch the prometheus multiple shared dict data
---- request eval
-["GET /apisix/prometheus/metrics",
-"GET /apisix/prometheus/metrics",
-"GET /apisix/prometheus/metrics",
-"GET /apisix/prometheus/metrics",
-"GET /apisix/prometheus/metrics",
-"GET /apisix/prometheus/metrics",
-"GET /apisix/prometheus/metrics",
-"GET /apisix/prometheus/metrics"]
---- response_body_like eval
-[qr/.*apisix_shared_dict_capacity_bytes{name="internal-status"} \d+(?:.|\n)*
-apisix_shared_dict_free_space_bytes{name="internal-status"} \d+.*/,
-qr/.*apisix_shared_dict_capacity_bytes{name="upstream-healthcheck"} \d+(?:.|\n)*
-apisix_shared_dict_free_space_bytes{name="upstream-healthcheck"} \d+.*/,
-qr/.*apisix_shared_dict_capacity_bytes{name="worker-events"} \d+(?:.|\n)*
-apisix_shared_dict_free_space_bytes{name="worker-events"} \d+.*/,
-qr/.*apisix_shared_dict_capacity_bytes{name="lrucache-lock"} \d+(?:.|\n)*
-apisix_shared_dict_free_space_bytes{name="lrucache-lock"} \d+.*/,
-qr/.*apisix_shared_dict_capacity_bytes{name="balancer-ewma"} \d+(?:.|\n)*
-apisix_shared_dict_free_space_bytes{name="balancer-ewma"} \d+.*/,
-qr/.*apisix_shared_dict_capacity_bytes{name="balancer-ewma-locks"} \d+(?:.|\n)*
-apisix_shared_dict_free_space_bytes{name="balancer-ewma-locks"} \d+.*/,
-qr/.*apisix_shared_dict_capacity_bytes{name="balancer-ewma-last-touched-at"} \d+(?:.|\n)*
-apisix_shared_dict_free_space_bytes{name="balancer-ewma-last-touched-at"} \d+.*/,
-qr/.*apisix_shared_dict_capacity_bytes{name="etcd-cluster-health-check"} \d+(?:.|\n)*
-apisix_shared_dict_free_space_bytes{name="etcd-cluster-health-check"} \d+.*/]
+=== TEST 42: fetch the prometheus shared dict internal-status data
+--- http_config
+lua_shared_dict test-shared-dict 10m;
+--- request
+GET /apisix/prometheus/metrics
+--- response_body_like
+.*apisix_shared_dict_capacity_bytes{name="test-shared-dict"} \d+(?:.|\n)*
+apisix_shared_dict_free_space_bytes{name="test-shared-dict"} \d+.*

--- a/t/plugin/prometheus.t
+++ b/t/plugin/prometheus.t
@@ -637,9 +637,10 @@ qr/etcd/
 
 === TEST 42: fetch the prometheus one shared dict data storage with string
 --- yaml_config
-plugin_attr:
-  prometheus:
-    shared_DICT: internal-status
+nginx_config:
+  http:
+    lua_shared_dict:
+      internal-status: 10m
 --- request
 GET /apisix/prometheus/metrics
 --- response_body_like eval
@@ -648,28 +649,14 @@ apisix_shared_dict_free_space_bytes{name="internal-status"} \d+.*/
 
 
 
-=== TEST 43: fetch the prometheus one shared dict data storage with table
+=== TEST 43: fetch the prometheus multiple shared dict data
 --- yaml_config
-plugin_attr:
-  prometheus:
-    shared_DICT:
-      - internal-status
---- request
-GET /apisix/prometheus/metrics
---- response_body_like eval
-qr/.*apisix_shared_dict_capacity_bytes{name="internal-status"} \d+(?:.|\n)*
-apisix_shared_dict_free_space_bytes{name="internal-status"} \d+.*/
-
-
-
-=== TEST 44: fetch the prometheus multiple shared dict data
---- yaml_config
-plugin_attr:
-  prometheus:
-    shared_DICT:
-      - worker-events
-      - upstream-healthcheck
-      - internal-status
+nginx_config:
+  http:
+    lua_shared_dict:
+      worker-events: 10m
+      upstream-healthcheck: 10m
+      internal-status: 10m
 --- request eval
 ["GET /apisix/prometheus/metrics", "GET /apisix/prometheus/metrics", "GET /apisix/prometheus/metrics"]
 --- response_body_like eval
@@ -682,14 +669,14 @@ apisix_shared_dict_free_space_bytes{name="internal-status"} \d+.*/]
 
 
 
-=== TEST 45: fetch the prometheus multiple shared dict data contain not exist shared dict
+=== TEST 44: fetch the prometheus multiple shared dict data contain not exist shared dict
 --- yaml_config
-plugin_attr:
-  prometheus:
-    shared_DICT:
-      - worker-events
-      - upstream-healthcheck
-      - not-exist-shared-dict
+nginx_config:
+  http:
+    lua_shared_dict:
+      worker-events: 10m
+      upstream-healthcheck: 10m
+      not-exist-shared-dict: 10m
 --- request
 GET /apisix/prometheus/metrics
 --- response_body_unlike

--- a/t/plugin/prometheus.t
+++ b/t/plugin/prometheus.t
@@ -634,6 +634,7 @@ qr/apisix_/
 qr/etcd/
 
 
+
 === TEST 42: fetch the prometheus one shared dict data
 --- request
 GET /apisix/prometheus/metrics
@@ -641,6 +642,7 @@ GET /apisix/prometheus/metrics
 Shared_DICT: worker-events
 --- response_body_like
 .*TYPE apisix_shared_dict gauge.*worker-events_capacity.*worker-events_free_space.*
+
 
 
 === TEST 43: fetch the prometheus multiple shared dict data
@@ -654,6 +656,7 @@ Shared_DICT: internal-status
 .*TYPE apisix_shared_dict gauge.*worker-events_capacity.*worker-events_free_space.*
 
 
+
 === TEST 44: fetch the prometheus multiple shared dict data
 --- request
 GET /apisix/prometheus/metrics
@@ -663,6 +666,7 @@ Shared_DICT: upstream-healthcheck
 Shared_DICT: internal-status
 --- response_body_like
 .*TYPE apisix_shared_dict gauge.*upstream-healthcheck_capacity.*upstream-healthcheck_free_space.*
+
 
 
 === TEST 45: fetch the prometheus multiple shared dict data
@@ -676,6 +680,7 @@ Shared_DICT: internal-status
 .*TYPE apisix_shared_dict gauge.*internal-status_capacity.*internal-status_free_space.*
 
 
+
 === TEST 46: fetch the prometheus multiple shared dict data contain not exist shared dict
 --- request
 GET /apisix/prometheus/metrics
@@ -685,4 +690,3 @@ Shared_DICT: upstream-healthcheck
 Shared_DICT: not-exist-shared-dict
 --- response_body_unlike
 .*TYPE apisix_shared_dict gauge.*not-exist-shared-dict_capacity.*not-exist-shared-dict_free_space.*
-

--- a/t/plugin/prometheus.t
+++ b/t/plugin/prometheus.t
@@ -641,5 +641,5 @@ lua_shared_dict test-shared-dict 10m;
 --- request
 GET /apisix/prometheus/metrics
 --- response_body_like
-.*apisix_shared_dict_capacity_bytes{name="test-shared-dict"} \d+(?:.|\n)*
+.*apisix_shared_dict_capacity_bytes{name="test-shared-dict"} 10485760(?:.|\n)*
 apisix_shared_dict_free_space_bytes{name="test-shared-dict"} \d+.*

--- a/t/plugin/prometheus.t
+++ b/t/plugin/prometheus.t
@@ -635,50 +635,30 @@ qr/etcd/
 
 
 
-=== TEST 42: fetch the prometheus one shared dict data storage with string
---- yaml_config
-nginx_config:
-  http:
-    lua_shared_dict:
-      internal-status: 10m
---- request
-GET /apisix/prometheus/metrics
---- response_body_like eval
-qr/.*apisix_shared_dict_capacity_bytes{name="internal-status"} \d+(?:.|\n)*
-apisix_shared_dict_free_space_bytes{name="internal-status"} \d+.*/
-
-
-
 === TEST 43: fetch the prometheus multiple shared dict data
---- yaml_config
-nginx_config:
-  http:
-    lua_shared_dict:
-      worker-events: 10m
-      upstream-healthcheck: 10m
-      internal-status: 10m
 --- request eval
-["GET /apisix/prometheus/metrics", "GET /apisix/prometheus/metrics", "GET /apisix/prometheus/metrics"]
+["GET /apisix/prometheus/metrics",
+"GET /apisix/prometheus/metrics",
+"GET /apisix/prometheus/metrics",
+"GET /apisix/prometheus/metrics",
+"GET /apisix/prometheus/metrics",
+"GET /apisix/prometheus/metrics",
+"GET /apisix/prometheus/metrics",
+"GET /apisix/prometheus/metrics"]
 --- response_body_like eval
-[qr/.*apisix_shared_dict_capacity_bytes{name="worker-events"} \d+(?:.|\n)*
-apisix_shared_dict_free_space_bytes{name="worker-events"} \d+.*/,
+[qr/.*apisix_shared_dict_capacity_bytes{name="internal-status"} \d+(?:.|\n)*
+apisix_shared_dict_free_space_bytes{name="internal-status"} \d+.*/,
 qr/.*apisix_shared_dict_capacity_bytes{name="upstream-healthcheck"} \d+(?:.|\n)*
 apisix_shared_dict_free_space_bytes{name="upstream-healthcheck"} \d+.*/,
-qr/.*apisix_shared_dict_capacity_bytes{name="internal-status"} \d+(?:.|\n)*
-apisix_shared_dict_free_space_bytes{name="internal-status"} \d+.*/]
-
-
-
-=== TEST 44: fetch the prometheus multiple shared dict data contain not exist shared dict
---- yaml_config
-nginx_config:
-  http:
-    lua_shared_dict:
-      worker-events: 10m
-      upstream-healthcheck: 10m
-      not-exist-shared-dict: 10m
---- request
-GET /apisix/prometheus/metrics
---- response_body_unlike
-qr/.*apisix_shared_dict_capacity_bytes{name="not-exist-shared-dict"} \d+(?:.|\n)*
-apisix_shared_dict_free_space_bytes{name="not-exist-shared-dict"} \d+.*/
+qr/.*apisix_shared_dict_capacity_bytes{name="worker-events"} \d+(?:.|\n)*
+apisix_shared_dict_free_space_bytes{name="worker-events"} \d+.*/,
+qr/.*apisix_shared_dict_capacity_bytes{name="lrucache-lock"} \d+(?:.|\n)*
+apisix_shared_dict_free_space_bytes{name="lrucache-lock"} \d+.*/,
+qr/.*apisix_shared_dict_capacity_bytes{name="balancer-ewma"} \d+(?:.|\n)*
+apisix_shared_dict_free_space_bytes{name="balancer-ewma"} \d+.*/,
+qr/.*apisix_shared_dict_capacity_bytes{name="balancer-ewma-locks"} \d+(?:.|\n)*
+apisix_shared_dict_free_space_bytes{name="balancer-ewma-locks"} \d+.*/,
+qr/.*apisix_shared_dict_capacity_bytes{name="balancer-ewma-last-touched-at"} \d+(?:.|\n)*
+apisix_shared_dict_free_space_bytes{name="balancer-ewma-last-touched-at"} \d+.*/,
+qr/.*apisix_shared_dict_capacity_bytes{name="etcd-cluster-health-check"} \d+(?:.|\n)*
+apisix_shared_dict_free_space_bytes{name="etcd-cluster-health-check"} \d+.*/]

--- a/t/plugin/prometheus.t
+++ b/t/plugin/prometheus.t
@@ -646,42 +646,20 @@ Shared_DICT: worker-events
 
 
 === TEST 43: fetch the prometheus multiple shared dict data
---- request
-GET /apisix/prometheus/metrics
+--- request eval
+["GET /apisix/prometheus/metrics", "GET /apisix/prometheus/metrics", "GET /apisix/prometheus/metrics"]
 --- more_headers
 Shared_DICT: worker-events
 Shared_DICT: upstream-healthcheck
 Shared_DICT: internal-status
---- response_body_like
-.*TYPE apisix_shared_dict gauge.*worker-events_capacity.*worker-events_free_space.*
+--- response_body_like eval
+[".*TYPE apisix_shared_dict gauge.*upstream-healthcheck_capacity.*upstream-healthcheck_free_space.*",
+".*TYPE apisix_shared_dict gauge.*internal-status_capacity.*internal-status_free_space.*",
+".*TYPE apisix_shared_dict gauge.*worker-events_capacity.*worker-events_free_space.*"]
 
 
 
-=== TEST 44: fetch the prometheus multiple shared dict data
---- request
-GET /apisix/prometheus/metrics
---- more_headers
-Shared_DICT: worker-events
-Shared_DICT: upstream-healthcheck
-Shared_DICT: internal-status
---- response_body_like
-.*TYPE apisix_shared_dict gauge.*upstream-healthcheck_capacity.*upstream-healthcheck_free_space.*
-
-
-
-=== TEST 45: fetch the prometheus multiple shared dict data
---- request
-GET /apisix/prometheus/metrics
---- more_headers
-Shared_DICT: worker-events
-Shared_DICT: upstream-healthcheck
-Shared_DICT: internal-status
---- response_body_like
-.*TYPE apisix_shared_dict gauge.*internal-status_capacity.*internal-status_free_space.*
-
-
-
-=== TEST 46: fetch the prometheus multiple shared dict data contain not exist shared dict
+=== TEST 44: fetch the prometheus multiple shared dict data contain not exist shared dict
 --- request
 GET /apisix/prometheus/metrics
 --- more_headers

--- a/t/plugin/prometheus.t
+++ b/t/plugin/prometheus.t
@@ -635,7 +635,7 @@ qr/etcd/
 
 
 
-=== TEST 43: fetch the prometheus multiple shared dict data
+=== TEST 42: fetch the prometheus multiple shared dict data
 --- request eval
 ["GET /apisix/prometheus/metrics",
 "GET /apisix/prometheus/metrics",

--- a/t/plugin/prometheus.t
+++ b/t/plugin/prometheus.t
@@ -632,3 +632,57 @@ GET /apisix/prometheus/metrics
 qr/apisix_/
 --- response_body_unlike eval
 qr/etcd/
+
+
+=== TEST 42: fetch the prometheus one shared dict data
+--- request
+GET /apisix/prometheus/metrics
+--- more_headers
+Shared_DICT: worker-events
+--- response_body_like
+.*TYPE apisix_shared_dict gauge.*worker-events_capacity.*worker-events_free_space.*
+
+
+=== TEST 43: fetch the prometheus multiple shared dict data
+--- request
+GET /apisix/prometheus/metrics
+--- more_headers
+Shared_DICT: worker-events
+Shared_DICT: upstream-healthcheck
+Shared_DICT: internal-status
+--- response_body_like
+.*TYPE apisix_shared_dict gauge.*worker-events_capacity.*worker-events_free_space.*
+
+
+=== TEST 44: fetch the prometheus multiple shared dict data
+--- request
+GET /apisix/prometheus/metrics
+--- more_headers
+Shared_DICT: worker-events
+Shared_DICT: upstream-healthcheck
+Shared_DICT: internal-status
+--- response_body_like
+.*TYPE apisix_shared_dict gauge.*upstream-healthcheck_capacity.*upstream-healthcheck_free_space.*
+
+
+=== TEST 45: fetch the prometheus multiple shared dict data
+--- request
+GET /apisix/prometheus/metrics
+--- more_headers
+Shared_DICT: worker-events
+Shared_DICT: upstream-healthcheck
+Shared_DICT: internal-status
+--- response_body_like
+.*TYPE apisix_shared_dict gauge.*internal-status_capacity.*internal-status_free_space.*
+
+
+=== TEST 46: fetch the prometheus multiple shared dict data contain not exist shared dict
+--- request
+GET /apisix/prometheus/metrics
+--- more_headers
+Shared_DICT: worker-events
+Shared_DICT: upstream-healthcheck
+Shared_DICT: not-exist-shared-dict
+--- response_body_unlike
+.*TYPE apisix_shared_dict gauge.*not-exist-shared-dict_capacity.*not-exist-shared-dict_free_space.*
+


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #5837 
Use the request header to carry the name of ngx.shared.DICT that needs to be fetched, use `ngx.shared.DICT.capacity` and `ngx.shared.DICT.free_space` to get the current status of `ngx.shared.DICT`, and use `gauge` to store the status
### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
