### PR TITLE
chore: remove stale todo at plugin redirect

### DIFF
--- a/apisix/plugins/redirect.lua
+++ b/apisix/plugins/redirect.lua
@@ -194,8 +194,6 @@ function _M.rewrite(conf, ctx)
     local proxy_proto = core.request.header(ctx, "X-Forwarded-Proto")
     local _scheme = proxy_proto or core.request.get_scheme(ctx)
     if conf.http_to_https and _scheme == "http" then
-        -- TODO： add test case
-        -- PR: https://github.com/apache/apisix/pull/1958
         if ret_port == nil or ret_port == 443 or ret_port <= 0 or ret_port > 65535  then
             uri = "https://$host$request_uri"
         else


### PR DESCRIPTION
- there're test cases at `t/plugin/redirect.t`

so we can remove this stale TODO, and avoid developers working on repeated.

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
