### PR TITLE
fix(wolf-rbac): Return 403 error code when the user does not have per…

### DIFF
--- a/apisix/plugins/wolf-rbac.lua
+++ b/apisix/plugins/wolf-rbac.lua
@@ -324,7 +324,7 @@ function _M.rewrite(conf, ctx)
         core.log.error(" check_url_permission(",
             core.json.delay_encode(perm_item),
             ") failed, res: ",core.json.delay_encode(res))
-        return 401, fail_response("Invalid user permission",
+        return 403, fail_response("Invalid user permission",
             { username = username, nickname = nickname }
         )
     end

--- a/t/plugin/wolf-rbac.t
+++ b/t/plugin/wolf-rbac.t
@@ -115,12 +115,12 @@ done
 
             for _, data in ipairs(data) do
                 local code, body = t(data.url, ngx.HTTP_PUT, data.data)
-                ngx.say(code..body)
+                ngx.say(body)
             end
         }
     }
 --- response_body eval
-"201passed\n" x 3
+"passed\n" x 3
 
 
 
@@ -342,7 +342,7 @@ x-rbac-token: V1#invalid-appid#rbac-token
 === TEST 16: verify: failed
 --- request
 GET /hello1
---- error_code: 401
+--- error_code: 403
 --- more_headers
 x-rbac-token: V1#wolf-rbac-app#wolf-rbac-token
 --- response_body


### PR DESCRIPTION
…mission.

### Description

Return 403 error code when the user does not have permission.
It is more reasonable to return 401 error code when user does not have permission

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
