### PR TITLE
chore: tweak conf_server unstable test cases

### DIFF
--- a/t/deployment/conf_server.t
+++ b/t/deployment/conf_server.t
@@ -310,8 +310,6 @@ deployment:
             verify: false
 --- error_log
 Receive SNI: localhost
---- no_error_log
-[error]
 
 
 
@@ -357,8 +355,6 @@ deployment:
             sni: "x.com"
 --- error_log
 Receive SNI: x.com
---- no_error_log
-[error]
 
 
 


### PR DESCRIPTION
### Description

In tests 6&7 of `t/deployment/conf_server.t`, two separate instances of etcd are actually used: 127.0.0.1:12379 and 127.0.0.1:2379. 

The `balancer` phase in `conf_server` will choose one of them based on the load balancing policy.

If select one of the instances through the `balancer` of `conf_server` when granting lease, and select another instance through the `balancer` of `conf_server` when writing data with lease, the `requested lease not found` error will occur. Because the lease is not issued by the etcd instance that selected to  write the data.

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #7476

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
