### PR TITLE
test: test in TEST_NGINX_USE_HUP mode can't run after the standalone mode

### DIFF
--- a/t/plugin/prometheus.t
+++ b/t/plugin/prometheus.t
@@ -632,14 +632,3 @@ GET /apisix/prometheus/metrics
 qr/apisix_/
 --- response_body_unlike eval
 qr/etcd/
-
-
-
-=== TEST 42: fetch the prometheus shared dict internal-status data
---- http_config
-lua_shared_dict test-shared-dict 10m;
---- request
-GET /apisix/prometheus/metrics
---- response_body_like
-.*apisix_shared_dict_capacity_bytes{name="test-shared-dict"} 10485760(?:.|\n)*
-apisix_shared_dict_free_space_bytes{name="test-shared-dict"} \d+.*

--- a/t/plugin/prometheus2.t
+++ b/t/plugin/prometheus2.t
@@ -914,3 +914,14 @@ GET /hello
 GET /apisix/prometheus/metrics
 --- response_body eval
 qr/apisix_bandwidth\{type="egress",route="1",service="service_name",consumer="",node="127.0.0.1"\} \d+/
+
+
+
+=== TEST 50: fetch the prometheus shared dict data
+--- http_config
+lua_shared_dict test-shared-dict 10m;
+--- request
+GET /apisix/prometheus/metrics
+--- response_body_like
+.*apisix_shared_dict_capacity_bytes{name="test-shared-dict"} 10485760(?:.|\n)*
+apisix_shared_dict_free_space_bytes{name="test-shared-dict"} \d+.*


### PR DESCRIPTION
Otherwise, there will be `failed to fetch /apisix/t/servroot/conf/apisix.yaml attributes:
cannot obtain information from file '/apisix/t/servroot/conf/apisix.yaml': No such file or directory`
error occasionally.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
