### PR TITLE
test(openwhisk): ensure the request sent to a wrong host

### DIFF
--- a/t/plugin/openwhisk.t
+++ b/t/plugin/openwhisk.t
@@ -244,7 +244,7 @@ qr/"error":"The requested resource does not exist."/
                  [[{
                         "plugins": {
                             "openwhisk": {
-                                "api_host": "http://127.0.0.0:3233",
+                                "api_host": "http://127.0.0.1:1979",
                                 "service_token": "23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP",
                                 "namespace": "guest",
                                 "action": "non-existent"


### PR DESCRIPTION
Avoid test failures:
Failed test 't/plugin/openwhisk.t TEST 12: hit route (with wrong api_host) -
pattern "failed to process openwhisk action, err:" should match a line
in error.log
happened in CentOS 7 test.

Look like 127.0.0.0 is connectable in some environment.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
