### PR TITLE
feat(prometheus): extra labels from nginx var for http request metrics

### DIFF
--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -78,13 +78,13 @@ local function extra_labels(name, ctx)
     if metrics and metrics[name] and metrics[name].extra_labels then
         local labels = metrics[name].extra_labels
         for _, kv in ipairs(labels) do
-			local val, v = next(kv)
-			if ctx then
-				val = ctx.var[v:sub(2)]
-				if val == nil then
-					val = ""
-				end
-			end
+            local val, v = next(kv)
+            if ctx then
+                val = ctx.var[v:sub(2)]
+                if val == nil then
+                    val = ""
+                end
+            end
             core.table.insert(extra_labels_tbl, val)
         end
     end
@@ -166,7 +166,7 @@ function _M.http_init(prometheus_enabled_in_stream)
     metrics.status = prometheus:counter("http_status",
             "HTTP status codes per service in APISIX",
             {"code", "route", "matched_uri", "matched_host", "service", "consumer", "node",
-			unpack(extra_labels("http_status"))})
+            unpack(extra_labels("http_status"))})
 
     metrics.latency = prometheus:histogram("http_latency",
         "HTTP request latency in milliseconds per service in APISIX",

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -40,6 +40,7 @@ local service_fetch = require("apisix.http.service").get
 local latency_details = require("apisix.utils.log-util").latency_details_in_ms
 local xrpc = require("apisix.stream.xrpc")
 local unpack = unpack
+local next = next
 
 
 local ngx_capture

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -73,10 +73,10 @@ local function ngx_var_label_values(ctx, name)
     clear_tab(ngx_var_label_values_tbl)
 
     local attr = plugin.plugin_attr("prometheus")
-    local ngx_var_labels = attr.ngx_var_labels
+    local custom_labels = attr.custom_labels
 
-    if ngx_var_labels and ngx_var_labels[name] then
-        local labels = ngx_var_labels[name]
+    if custom_labels and custom_labels[name] then
+        local labels = custom_labels[name]
         for _, name in ipairs(labels) do
             local val = ctx.var[name]
             if val == nil then
@@ -126,7 +126,7 @@ function _M.http_init(prometheus_enabled_in_stream)
         metric_prefix = attr.metric_prefix
     end
 
-    local ngx_var_labels = attr.ngx_var_labels
+    local custom_labels = attr.custom_labels
 
     prometheus = base_prometheus.init("prometheus-metrics", metric_prefix)
 
@@ -163,24 +163,24 @@ function _M.http_init(prometheus_enabled_in_stream)
     -- request to the route/service, it will be an empty string if there is
     -- no consumer in request.
     local labels = {"code", "route", "matched_uri", "matched_host", "service", "consumer", "node"}
-    if ngx_var_labels and ngx_var_labels.http_status then
-        tab_insert_tail(labels, unpack(ngx_var_labels.http_status))
+    if custom_labels and custom_labels.http_status then
+        tab_insert_tail(labels, unpack(custom_labels.http_status))
     end
     metrics.status = prometheus:counter("http_status",
             "HTTP status codes per service in APISIX",
             labels)
 
     local labels = {"type", "route", "service", "consumer", "node"}
-    if ngx_var_labels and ngx_var_labels.http_latency then
-        tab_insert_tail(labels, unpack(ngx_var_labels.http_latency))
+    if custom_labels and custom_labels.http_latency then
+        tab_insert_tail(labels, unpack(custom_labels.http_latency))
     end
     metrics.latency = prometheus:histogram("http_latency",
         "HTTP request latency in milliseconds per service in APISIX",
         labels, DEFAULT_BUCKETS)
 
     local labels = {"type", "route", "service", "consumer", "node"}
-    if ngx_var_labels and ngx_var_labels.bandwidth then
-        tab_insert_tail(labels, unpack(ngx_var_labels.bandwidth))
+    if custom_labels and custom_labels.bandwidth then
+        tab_insert_tail(labels, unpack(custom_labels.bandwidth))
     end
     metrics.bandwidth = prometheus:counter("bandwidth",
             "Total bandwidth in bytes consumed per service in APISIX",

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -40,6 +40,7 @@ local get_protos = require("apisix.plugins.grpc-transcode.proto").protos
 local service_fetch = require("apisix.http.service").get
 local latency_details = require("apisix.utils.log-util").latency_details_in_ms
 local xrpc = require("apisix.stream.xrpc")
+local unapck = unpack
 
 
 local ngx_capture

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -40,7 +40,7 @@ local get_protos = require("apisix.plugins.grpc-transcode.proto").protos
 local service_fetch = require("apisix.http.service").get
 local latency_details = require("apisix.utils.log-util").latency_details_in_ms
 local xrpc = require("apisix.stream.xrpc")
-local unapck = unpack
+local unpack = unpack
 
 
 local ngx_capture

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -522,7 +522,7 @@ plugin_attr:
     export_addr:
       ip: 127.0.0.1
       port: 9091
-    # ngx_var_labels:
+    # custom_labels:
     #   http_status:
     #     - upstream_addr
     #     - upstream_status

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -522,6 +522,14 @@ plugin_attr:
     export_addr:
       ip: 127.0.0.1
       port: 9091
+    # ngx_var_labels:
+    #   http_status:
+    #     - upstream_addr
+    #     - upstream_status
+    #   http_latency:
+    #     - upstream_addr
+    #   bandwidth:
+    #     - upstream_addr
   server-info:
     report_ttl: 60   # live time for server info in etcd (unit: second)
   dubbo-proxy:

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -522,14 +522,20 @@ plugin_attr:
     export_addr:
       ip: 127.0.0.1
       port: 9091
-    # custom_labels:
-    #   http_status:
-    #     - upstream_addr
-    #     - upstream_status
-    #   http_latency:
-    #     - upstream_addr
-    #   bandwidth:
-    #     - upstream_addr
+    #metrics:
+    #  http_status:
+    #    # extra labels from nginx variables
+    #    extra_labels:
+    #      # the label name doesn't need to be the same as variable name
+    #      # below labels are only examples, you could add any valid variables as you need
+    #      - upstream_addr: $upstream_addr
+    #      - upstream_status: $upstream_status
+    #  http_latency:
+    #    extra_labels:
+    #      - upstream_addr: $upstream_addr
+    #  bandwidth:
+    #    extra_labels:
+    #      - upstream_addr: $upstream_addr
   server-info:
     report_ttl: 60   # live time for server info in etcd (unit: second)
   dubbo-proxy:

--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -53,7 +53,7 @@ plugin_attr:
     export_uri: /apisix/metrics
 ```
 
-### Specifying `custom_labels`
+### Specifying `metrics`
 
 For http request related metrics, you could specify extra labels, which match the nginx variables.
 
@@ -71,10 +71,11 @@ Here is a configuration example:
 ```yaml title="conf/config.yaml"
 plugin_attr:
   prometheus:
-    custom_labels:
+    metrics:
         http_status:
-            - upstream_addr
-            - upstream_status
+            extra_labels:
+                - upstream_addr: $upstream_addr
+                - upstream_status: $upstream_status
 
 ## API
 

--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -65,7 +65,6 @@ Currently, only below metrics are supported:
 * http_latency
 * bandwidth
 
-
 Here is a configuration example:
 
 ```yaml title="conf/config.yaml"

--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -53,7 +53,7 @@ plugin_attr:
     export_uri: /apisix/metrics
 ```
 
-### Specifying `ngx_var_labels`
+### Specifying `custom_labels`
 
 For http request related metrics, you could specify extra labels, which match the nginx variables.
 
@@ -71,7 +71,7 @@ Here is a configuration example:
 ```yaml title="conf/config.yaml"
 plugin_attr:
   prometheus:
-    ngx_var_labels:
+    custom_labels:
         http_status:
             - upstream_addr
             - upstream_status

--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -55,9 +55,9 @@ plugin_attr:
 
 ### Specifying `metrics`
 
-For http request related metrics, you could specify extra labels, which match the nginx variables.
+For http request related metrics, you could specify extra labels, which match the APISIX variables.
 
-If you specify label for nonexist nginx variable, the label value would be "".
+If you specify label for nonexist APISIX variable, the label value would be "".
 
 Currently, only below metrics are supported:
 

--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -57,7 +57,7 @@ plugin_attr:
 
 For http request related metrics, you could specify extra labels, which match the nginx variables.
 
-If you specify label for nonexist nginx variable, the label value would be "nil".
+If you specify label for nonexist nginx variable, the label value would be "".
 
 Currently, only below metrics are supported:
 

--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -53,6 +53,29 @@ plugin_attr:
     export_uri: /apisix/metrics
 ```
 
+### Specifying `ngx_var_labels`
+
+For http request related metrics, you could specify extra labels, which match the nginx variables.
+
+If you specify label for nonexist nginx variable, the label value would be "nil".
+
+Currently, only below metrics are supported:
+
+* http_status
+* http_latency
+* bandwidth
+
+
+Here is a configuration example:
+
+```yaml title="conf/config.yaml"
+plugin_attr:
+  prometheus:
+    ngx_var_labels:
+        http_status:
+            - upstream_addr
+            - upstream_status
+
 ## API
 
 This Plugin will add the API endpoint `/apisix/prometheus/metrics` or your custom export URI for exposing the metrics.

--- a/t/plugin/prometheus4.t
+++ b/t/plugin/prometheus4.t
@@ -1,0 +1,144 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+BEGIN {
+    if ($ENV{TEST_NGINX_CHECK_LEAK}) {
+        $SkipReason = "unavailable for the hup tests";
+
+    } else {
+        $ENV{TEST_NGINX_USE_HUP} = 1;
+        undef $ENV{TEST_NGINX_USE_STAP};
+    }
+}
+
+use t::APISIX 'no_plan';
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if ((!defined $block->error_log) && (!defined $block->no_error_log)) {
+        $block->set_value("no_error_log", "[error]");
+    }
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: pre-create public API route
+--- config
+    location /t {
+        content_by_lua_block {
+
+            local t = require("lib.test_admin").test
+            local code = t('/apisix/admin/routes/metrics',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "public-api": {}
+                    },
+                    "uri": "/apisix/prometheus/metrics"
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+                return
+            end
+        }
+    }
+--- error_code: 200
+
+
+
+=== TEST 2: set route
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/10',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "prometheus": {}
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 3: client request
+--- yaml_config
+plugin_attr:
+    prometheus:
+        ngx_var_labels:
+            bandwidth:
+                - upstream_addr
+                - upstream_status
+--- request
+GET /hello
+--- error_code: 200
+
+
+
+=== TEST 4: fetch the prometheus metric data
+--- request
+GET /apisix/prometheus/metrics
+--- response_body eval
+qr/apisix_bandwidth\{type="egress",route="10",service="",consumer="",node="127.0.0.1",upstream_addr="127.0.0.1:1980",upstream_status="200"\} \d+/
+
+
+
+=== TEST 5: client request, label with nonexist ngx variable
+--- yaml_config
+plugin_attr:
+    prometheus:
+        ngx_var_labels:
+            http_status:
+                - dummy
+            bandwidth:
+                - upstream_addr
+                - upstream_status
+--- request
+GET /hello
+--- error_code: 200
+
+
+
+=== TEST 6: fetch the prometheus metric data, with nil label
+--- request
+GET /apisix/prometheus/metrics
+--- response_body eval
+qr/apisix_http_status\{code="200",route="10",matched_uri="\/hello",matched_host="",service="",consumer="",node="127.0.0.1",dummy="nil"\} \d+/

--- a/t/plugin/prometheus4.t
+++ b/t/plugin/prometheus4.t
@@ -103,7 +103,7 @@ passed
 --- yaml_config
 plugin_attr:
     prometheus:
-        ngx_var_labels:
+        custom_labels:
             bandwidth:
                 - upstream_addr
                 - upstream_status
@@ -125,7 +125,7 @@ qr/apisix_bandwidth\{type="egress",route="10",service="",consumer="",node="127.0
 --- yaml_config
 plugin_attr:
     prometheus:
-        ngx_var_labels:
+        custom_labels:
             http_status:
                 - dummy
             bandwidth:

--- a/t/plugin/prometheus4.t
+++ b/t/plugin/prometheus4.t
@@ -63,7 +63,6 @@ __DATA__
             end
         }
     }
---- error_code: 200
 
 
 
@@ -103,10 +102,11 @@ passed
 --- yaml_config
 plugin_attr:
     prometheus:
-        custom_labels:
+        metrics:
             bandwidth:
-                - upstream_addr
-                - upstream_status
+                extra_labels:
+                    - upstream_addr: $upstream_addr
+                    - upstream_status: $upstream_status
 --- request
 GET /hello
 --- error_code: 200
@@ -125,12 +125,10 @@ qr/apisix_bandwidth\{type="egress",route="10",service="",consumer="",node="127.0
 --- yaml_config
 plugin_attr:
     prometheus:
-        custom_labels:
+        metrics:
             http_status:
-                - dummy
-            bandwidth:
-                - upstream_addr
-                - upstream_status
+                extra_labels:
+                    - dummy: $dummy
 --- request
 GET /hello
 --- error_code: 200
@@ -141,4 +139,4 @@ GET /hello
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_http_status\{code="200",route="10",matched_uri="\/hello",matched_host="",service="",consumer="",node="127.0.0.1",dummy="nil"\} \d+/
+qr/apisix_http_status\{code="200",route="10",matched_uri="\/hello",matched_host="",service="",consumer="",node="127.0.0.1",dummy=""\} \d+/

--- a/t/plugin/prometheus4.t
+++ b/t/plugin/prometheus4.t
@@ -109,7 +109,6 @@ plugin_attr:
                     - upstream_status: $upstream_status
 --- request
 GET /hello
---- error_code: 200
 
 
 
@@ -131,11 +130,10 @@ plugin_attr:
                     - dummy: $dummy
 --- request
 GET /hello
---- error_code: 200
 
 
 
-=== TEST 6: fetch the prometheus metric data, with nil label
+=== TEST 6: fetch the prometheus metric data, with nonexist ngx variable
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval


### PR DESCRIPTION
close #4273

### Description

Add extra labels from nginx variables for http request metrics.

Fixes #4273

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
