### PR TITLE
fix(wolf-rbac):  Return the error code returned by the wolf server

### DIFF
--- a/apisix/plugins/wolf-rbac.lua
+++ b/apisix/plugins/wolf-rbac.lua
@@ -232,7 +232,7 @@ local function check_url_permission(server, appid, action, resName, client_ip, w
         }
     end
 
-    if res.status ~= 200 and res.status ~= 401 then
+    if res.status ~= 200 and res.status >= 500 then
         return {
             status = 500,
             err = 'request to wolf-server failed, status:' .. res.status
@@ -314,7 +314,7 @@ function _M.rewrite(conf, ctx)
         core.response.set_header(prefix .. "UserId", userId)
         core.response.set_header(prefix .. "Username", username)
         core.response.set_header(prefix .. "Nickname", ngx.escape_uri(nickname))
-        core.request.set_header(ctx, prefix .. "UserId", userId, ctx)
+        core.request.set_header(ctx, prefix .. "UserId", userId)
         core.request.set_header(ctx, prefix .. "Username", username)
         core.request.set_header(ctx, prefix .. "Nickname", ngx.escape_uri(nickname))
     end
@@ -324,9 +324,7 @@ function _M.rewrite(conf, ctx)
         core.log.error(" check_url_permission(",
             core.json.delay_encode(perm_item),
             ") failed, res: ",core.json.delay_encode(res))
-        return 403, fail_response("Invalid user permission",
-            { username = username, nickname = nickname }
-        )
+        return res.status, fail_response(res.err, { username = username, nickname = nickname })
     end
     core.log.info("wolf-rbac check permission passed")
 end

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -298,9 +298,15 @@ function _M.wolf_rbac_access_check()
         ngx.say(json_encode({ok=true,
                             data={ userInfo={nickname="administrator",
                                 username="admin", id="100"} }}))
-    else
+    elseif resName == '/hello/500' then
+        ngx.status = 500
+        ngx.say(json_encode({ok=false, reason="ERR_SERVER_ERROR"}))
+    elseif resName == '/hello/401' then
         ngx.status = 401
-        ngx.say(json_encode({ok=false, reason="no permission to access"}))
+        ngx.say(json_encode({ok=false, reason="ERR_TOKEN_INVALID"}))
+    else
+        ngx.status = 403
+        ngx.say(json_encode({ok=false, reason="ERR_ACCESS_DENIED"}))
     end
 end
 

--- a/t/plugin/wolf-rbac.t
+++ b/t/plugin/wolf-rbac.t
@@ -346,13 +346,13 @@ GET /hello1
 --- more_headers
 x-rbac-token: V1#wolf-rbac-app#wolf-rbac-token
 --- response_body
-{"message":"Invalid user permission"}
+{"message":"ERR_ACCESS_DENIED"}
 --- grep_error_log eval
-qr/no permission to access */
+qr/ERR_ACCESS_DENIED */
 --- grep_error_log_out
-no permission to access
-no permission to access
-no permission to access
+ERR_ACCESS_DENIED
+ERR_ACCESS_DENIED
+ERR_ACCESS_DENIED
 
 
 
@@ -545,3 +545,36 @@ location /t {
 }
 --- response_body_like eval
 qr/success to change password/
+
+
+
+=== TEST 29: verify: failed, server internal error
+--- request
+GET /hello/500
+--- error_code: 500
+--- more_headers
+x-rbac-token: V1#wolf-rbac-app#wolf-rbac-token
+--- response_body
+{"message":"request to wolf-server failed, status:500"}
+--- grep_error_log eval
+qr/request to wolf-server failed, status:500 */
+--- grep_error_log_out
+request to wolf-server failed, status:500
+request to wolf-server failed, status:500
+
+
+
+=== TEST 30: verify: failed, token is expired
+--- request
+GET /hello/401
+--- error_code: 401
+--- more_headers
+x-rbac-token: V1#wolf-rbac-app#wolf-rbac-token
+--- response_body
+{"message":"ERR_TOKEN_INVALID"}
+--- grep_error_log eval
+qr/ERR_TOKEN_INVALID */
+--- grep_error_log_out
+ERR_TOKEN_INVALID
+ERR_TOKEN_INVALID
+ERR_TOKEN_INVALID


### PR DESCRIPTION
### Description

Sorry, there were some issue with the last PR. This PR will fix the problem of error code return.
When wolf-rbac checks the permissions, if the wolf server returns an error, it will return the original error code to the client as is.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
