### PR TITLE
feat: add version header for Admin API

### DIFF
--- a/apisix/admin/init.lua
+++ b/apisix/admin/init.lua
@@ -18,6 +18,7 @@ local require = require
 local core = require("apisix.core")
 local route = require("apisix.utils.router")
 local plugin = require("apisix.plugin")
+local v3_adapter = require("apisix.admin.v3_adapter")
 local ngx = ngx
 local get_method = ngx.req.get_method
 local ngx_time = ngx.time
@@ -188,6 +189,11 @@ local function run()
     local code, data = resource[method](seg_id, req_body, seg_sub_path,
                                         uri_args)
     if code then
+        if v3_adapter.enable_v3() then
+            core.response.set_header("X-API-VERSION", "v3")
+        else
+            core.response.set_header("X-API-VERSION", "v2")
+        end
         data = strip_etcd_resp(data)
         core.response.exit(code, data)
     end

--- a/apisix/admin/init.lua
+++ b/apisix/admin/init.lua
@@ -190,9 +190,9 @@ local function run()
                                         uri_args)
     if code then
         if v3_adapter.enable_v3() then
-            core.response.set_header("X-API-VERSION", "v3")
+            core.response.set_header("X-API-VERSION", "3")
         else
-            core.response.set_header("X-API-VERSION", "v2")
+            core.response.set_header("X-API-VERSION", "2")
         end
         data = strip_etcd_resp(data)
         core.response.exit(code, data)

--- a/apisix/admin/init.lua
+++ b/apisix/admin/init.lua
@@ -190,9 +190,9 @@ local function run()
                                         uri_args)
     if code then
         if v3_adapter.enable_v3() then
-            core.response.set_header("X-API-VERSION", "3")
+            core.response.set_header("X-API-VERSION", "v3")
         else
-            core.response.set_header("X-API-VERSION", "2")
+            core.response.set_header("X-API-VERSION", "v2")
         end
         data = strip_etcd_resp(data)
         core.response.exit(code, data)

--- a/t/admin/api.t
+++ b/t/admin/api.t
@@ -70,7 +70,7 @@ apisix:
 --- more_headers
 X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
 --- response_headers
-X-API-VERSION: 2
+X-API-VERSION: v2
 
 
 
@@ -81,4 +81,4 @@ apisix:
 --- more_headers
 X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
 --- response_headers
-X-API-VERSION: 3
+X-API-VERSION: v3

--- a/t/admin/api.t
+++ b/t/admin/api.t
@@ -24,7 +24,7 @@ add_block_preprocessor(sub {
     my ($block) = @_;
 
     if (!$block->request) {
-        $block->set_value("request", "GET /t");
+        $block->set_value("request", "GET /apisix/admin/routes");
     }
 
     if (!$block->no_error_log && !$block->error_log) {
@@ -37,19 +37,8 @@ run_tests;
 __DATA__
 
 === TEST 1: Server header for admin API
---- config
-    location /t {
-        content_by_lua_block {
-            local http = require("resty.http")
-            local httpc = http.new()
-            uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
-                  .. ":" .. ngx.var.server_port .. "/apisix/admin/routes"
-            local res, err = httpc:request_uri(uri)
-            ngx.say(res.headers["Server"])
-        }
-    }
---- response_body eval
-qr/APISIX\//
+--- response_headers_like
+Server: APISIX/(.*)
 
 
 
@@ -58,16 +47,38 @@ qr/APISIX\//
 apisix:
   node_listen: 1984
   enable_server_tokens: false
---- config
-    location /t {
-        content_by_lua_block {
-            local http = require("resty.http")
-            local httpc = http.new()
-            uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
-                  .. ":" .. ngx.var.server_port .. "/apisix/admin/routes"
-            local res, err = httpc:request_uri(uri)
-            ngx.say(res.headers["Server"])
-        }
-    }
---- response_body
-APISIX
+--- error_code: 401
+--- response_headers
+Server: APISIX
+
+
+
+=== TEST 3: Version header for admin API (without apikey)
+--- yaml_config
+apisix:
+  admin_api_version: default
+--- error_code: 401
+--- response_headers
+! X-API-VERSION
+
+
+
+=== TEST 4: Version header for admin API (v2)
+--- yaml_config
+apisix:
+  admin_api_version: v2 # default may change
+--- more_headers
+X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
+--- response_headers
+X-API-VERSION: 2
+
+
+
+=== TEST 5: Version header for admin API (v3)
+--- yaml_config
+apisix:
+  admin_api_version: v3
+--- more_headers
+X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
+--- response_headers
+X-API-VERSION: 3


### PR DESCRIPTION
### Description

We designed a new Admin API data format for APISIX v3 that is not compatible with what was once v2. We now lack the means to distinguish which version of the Admin API is currently in use, so I will add a default response header for Admin APIia that contains its version number information.

No issue was created.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
