### PR TITLE
fix: remove the restriction of etcd prefix

### DIFF
--- a/apisix/cli/schema.lua
+++ b/apisix/cli/schema.lua
@@ -47,7 +47,6 @@ local etcd_schema = {
         },
         prefix = {
             type = "string",
-            pattern = [[^/[^/]+$]]
         },
         host = {
             type = "array",

--- a/t/cli/test_validate_config.sh
+++ b/t/cli/test_validate_config.sh
@@ -215,17 +215,4 @@ if ! echo "$out" | grep 'property "host" validation failed'; then
     exit 1
 fi
 
-echo '
-etcd:
-    prefix: "/apisix/"
-    host:
-        - https://127.0.0.1
-' > conf/config.yaml
-
-out=$(make init 2>&1 || true)
-if ! echo "$out" | grep 'property "prefix" validation failed'; then
-    echo "failed: should check etcd schema during init"
-    exit 1
-fi
-
 echo "passed: check etcd schema during init"


### PR DESCRIPTION
The validation is introduced in https://github.com/apache/apisix/commit/fc0dc15fcc430fe255cceab007e33ee03ce7025b
Several people complain this change breaks their code.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
