### PR TITLE
chore: remove useless judge in pubsub init

### DIFF
--- a/apisix/core/pubsub.lua
+++ b/apisix/core/pubsub.lua
@@ -42,16 +42,11 @@ local function init_pb_state()
     -- initialize protoc compiler
     protoc.reload()
     local pubsub_protoc = protoc.new()
-
-    -- compile the protobuf file on initial load module
-    -- ensure that each worker is loaded once
-    if not pubsub_protoc.loaded["pubsub.proto"] then
-        pubsub_protoc:addpath("apisix/include/apisix/model")
-        local ok, err = pcall(pubsub_protoc.loadfile, pubsub_protoc, "pubsub.proto")
-        if not ok then
-            pubsub_protoc:reset()
-            return "failed to load pubsub protocol: " .. err
-        end
+    pubsub_protoc:addpath("apisix/include/apisix/model")
+    local ok, err = pcall(pubsub_protoc.loadfile, pubsub_protoc, "pubsub.proto")
+    if not ok then
+        pubsub_protoc:reset()
+        return "failed to load pubsub protocol: " .. err
     end
 
     pb_state = pb.state(nil)


### PR DESCRIPTION
### Description

remove useless judge in pubsub init, the `loaded`  table is empty after `new`
https://github.com/starwing/lua-protobuf/blob/master/protoc.lua#L301


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

