### PR TITLE
change: drop support for enable_http2 and listen_port in apisix.ssl

### DIFF
--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -133,10 +133,6 @@ local function path_is_multi_type(path, type_val)
         return true
     end
 
-    if path == "apisix->ssl->listen_port" and type_val == "number" then
-        return true
-    end
-
     return false
 end
 

--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -582,9 +582,6 @@ http {
         {% if proxy_protocol and proxy_protocol.listen_http_port then %}
         listen {* proxy_protocol.listen_http_port *} default_server proxy_protocol;
         {% end %}
-        {% if proxy_protocol and proxy_protocol.listen_https_port then %}
-        listen {* proxy_protocol.listen_https_port *} ssl default_server {% if ssl.enable_http2 then %} http2 {% end %} proxy_protocol;
-        {% end %}
 
         server_name _;
 

--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -582,6 +582,9 @@ http {
         {% if proxy_protocol and proxy_protocol.listen_http_port then %}
         listen {* proxy_protocol.listen_http_port *} default_server proxy_protocol;
         {% end %}
+        {% if proxy_protocol and proxy_protocol.listen_https_port then %}
+        listen {* proxy_protocol.listen_https_port *} ssl default_server proxy_protocol;
+        {% end %}
 
         server_name _;
 

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -428,46 +428,28 @@ Please modify "admin_key" in conf/config.yaml .
     local ssl_listen = {}
     -- listen in https, support multiple ports, support specific IP
     for _, value in ipairs(yaml_conf.apisix.ssl.listen) do
-        if type(value) == "number" then
-            listen_table_insert(ssl_listen, "https", "0.0.0.0", value,
-                    yaml_conf.apisix.ssl.enable_http2, yaml_conf.apisix.enable_ipv6)
-        elseif type(value) == "table" then
-            local ip = value.ip
-            local port = value.port
-            local enable_ipv6 = false
-            local enable_http2 = (value.enable_http2 or yaml_conf.apisix.ssl.enable_http2)
+        local ip = value.ip
+        local port = value.port
+        local enable_ipv6 = false
+        local enable_http2 = value.enable_http2
 
-            if ip == nil then
-                ip = "0.0.0.0"
-                if yaml_conf.apisix.enable_ipv6 then
-                    enable_ipv6 = true
-                end
-            end
-
-            if port == nil then
-                port = 9443
-            end
-
-            if enable_http2 == nil then
-                enable_http2 = false
-            end
-
-            listen_table_insert(ssl_listen, "https", ip, port,
-                    enable_http2, enable_ipv6)
-        end
-    end
-
-    -- listen in https, compatible with the original style
-    if type(yaml_conf.apisix.ssl.listen_port) == "number" then
-        listen_table_insert(ssl_listen, "https", "0.0.0.0", yaml_conf.apisix.ssl.listen_port,
-                yaml_conf.apisix.ssl.enable_http2, yaml_conf.apisix.enable_ipv6)
-    elseif type(yaml_conf.apisix.ssl.listen_port) == "table" then
-        for _, value in ipairs(yaml_conf.apisix.ssl.listen_port) do
-            if type(value) == "number" then
-                listen_table_insert(ssl_listen, "https", "0.0.0.0", value,
-                        yaml_conf.apisix.ssl.enable_http2, yaml_conf.apisix.enable_ipv6)
+        if ip == nil then
+            ip = "0.0.0.0"
+            if yaml_conf.apisix.enable_ipv6 then
+                enable_ipv6 = true
             end
         end
+
+        if port == nil then
+            port = 9443
+        end
+
+        if enable_http2 == nil then
+            enable_http2 = false
+        end
+
+        listen_table_insert(ssl_listen, "https", ip, port,
+                enable_http2, enable_ipv6)
     end
 
     yaml_conf.apisix.ssl.listen = ssl_listen

--- a/apisix/cli/schema.lua
+++ b/apisix/cli/schema.lua
@@ -225,8 +225,7 @@ local config_schema = {
                                     enable_http2 = {
                                         type = "boolean",
                                     }
-                                },
-                                required = {"ip", "port"},
+                                }
                             }
                         }
                     }

--- a/apisix/cli/schema.lua
+++ b/apisix/cli/schema.lua
@@ -225,7 +225,8 @@ local config_schema = {
                                     enable_http2 = {
                                         type = "boolean",
                                     }
-                                }
+                                },
+                                required = {"ip", "port"},
                             }
                         }
                     }

--- a/apisix/cli/schema.lua
+++ b/apisix/cli/schema.lua
@@ -208,6 +208,22 @@ local config_schema = {
                     properties = {
                         ssl_trusted_certificate = {
                             type = "string",
+                        },
+                        listen = {
+                            type = "object",
+                            properties = {
+                                ip = {
+                                    type = "string",
+                                },
+                                port = {
+                                    type = "integer",
+                                    minimum = 1,
+                                    maximum = 65535
+                                },
+                                enable_http2 = {
+                                    type = "boolean",
+                                }
+                            },
                         }
                     }
                 },

--- a/apisix/cli/schema.lua
+++ b/apisix/cli/schema.lua
@@ -210,20 +210,23 @@ local config_schema = {
                             type = "string",
                         },
                         listen = {
-                            type = "object",
-                            properties = {
-                                ip = {
-                                    type = "string",
-                                },
-                                port = {
-                                    type = "integer",
-                                    minimum = 1,
-                                    maximum = 65535
-                                },
-                                enable_http2 = {
-                                    type = "boolean",
+                            type = "array",
+                            items = {
+                                type = "object",
+                                properties = {
+                                    ip = {
+                                        type = "string",
+                                    },
+                                    port = {
+                                        type = "integer",
+                                        minimum = 1,
+                                        maximum = 65535
+                                    },
+                                    enable_http2 = {
+                                        type = "boolean",
+                                    }
                                 }
-                            },
+                            }
                         }
                     }
                 },

--- a/apisix/plugins/redirect.lua
+++ b/apisix/plugins/redirect.lua
@@ -166,11 +166,6 @@ local function get_port(attr)
         return port
     end
 
-    port = ssl["listen_port"]
-    if port then
-        return port
-    end
-
     local ports = ssl["listen"]
     if ports and #ports > 0 then
         local idx = math_random(1, #ports)

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -133,14 +133,13 @@ apisix:
   ssl:
     enable: true
     listen:                       # APISIX listening port in https.
-      - 9443
+      - port: 9443
+        enable_http2: true
     #   - port: 9444
     #     enable_http2: true      # If not set, the default value is `false`.
     #   - ip: 127.0.0.3           # Specific IP, If not set, the default value is `0.0.0.0`.
     #     port: 9445
     #     enable_http2: true
-    enable_http2: true            # Not recommend: This parameter should be set via the `listen`.
-    # listen_port: 9443           # Not recommend: This parameter should be set via the `listen`.
     #ssl_trusted_certificate: /path/to/ca-cert  # Specifies a file path with trusted CA certificates in the PEM format
                                                 # used to verify the certificate when APISIX needs to do SSL/TLS handshaking
                                                 # with external services (e.g. etcd)

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -135,8 +135,6 @@ apisix:
     listen:                       # APISIX listening port in https.
       - port: 9443
         enable_http2: true
-    #   - port: 9444
-    #     enable_http2: true      # If not set, the default value is `false`.
     #   - ip: 127.0.0.3           # Specific IP, If not set, the default value is `0.0.0.0`.
     #     port: 9445
     #     enable_http2: true

--- a/docs/en/latest/FAQ.md
+++ b/docs/en/latest/FAQ.md
@@ -267,15 +267,16 @@ To configure Apache APISIX to listen on multiple ports, you can:
         - 9082
    ```
 
-   Similarly for HTTPS requests, modify the parameter `ssl.listen_port` in `conf/config.yaml`:
+   Similarly for HTTPS requests, modify the parameter `ssl.listen` in `conf/config.yaml`:
 
    ```
    apisix:
      ssl:
-       listen_port:
-         - 9443
-         - 9444
-         - 9445
+       enable: true
+       listen:
+         - port: 9443
+         - port: 9444
+         - port: 9445
    ```
 
 2. Reload or restart Apache APISIX.

--- a/docs/en/latest/plugins/redirect.md
+++ b/docs/en/latest/plugins/redirect.md
@@ -47,7 +47,7 @@ The `redirect` Plugin can be used to configure redirects.
 * Only one of `http_to_https` and `append_query_string` can be configured.
 * When enabling `http_to_https`, the ports in the redirect URL will pick a value in the following order (in descending order of priority)
   * Read `plugin_attr.redirect.https_port` from the configuration file (`conf/config.yaml`).
-  * If `apisix.ssl` is enabled, read `apisix.ssl.listen_port` first, and if it does not exist, read `apisix.ssl.listen` and select a port randomly from it.
+  * If `apisix.ssl` is enabled, read `apisix.ssl.listen` and select a port randomly from it.
   * Use 443 as the default https port.
 
 :::

--- a/docs/zh/latest/FAQ.md
+++ b/docs/zh/latest/FAQ.md
@@ -270,15 +270,16 @@ nginx_config:
        - 9082
    ```
 
-   处理 HTTPS 请求也类似，修改 `conf/config.yaml` 中 HTTPS 端口监听的参数 `ssl.listen_port`，示例：
+   处理 HTTPS 请求也类似，修改 `conf/config.yaml` 中 HTTPS 端口监听的参数 `ssl.listen`，示例：
 
    ```
    apisix:
      ssl:
-       listen_port:
-         - 9443
-         - 9444
-         - 9445
+       enable: true
+       listen:
+         - port: 9443
+         - port: 9444
+         - port: 9445
    ```
 
 2. 重启或者重新加载 APISIX。

--- a/docs/zh/latest/plugins/redirect.md
+++ b/docs/zh/latest/plugins/redirect.md
@@ -47,7 +47,7 @@ description: 本文介绍了关于 Apache APISIX `redirect` 插件的基本信�
 * `http_to_https`、和 `append_query_string` 只能配置其中一个属性。
 * 当开启 `http_to_https` 时，重定向 URL 中的端口将按如下顺序选取一个值（按优先级从高到低排列）
   * 从配置文件（`conf/config.yaml`）中读取 `plugin_attr.redirect.https_port`。
-  * 如果 `apisix.ssl` 处于开启状态，先读取 `apisix.ssl.listen_port`，如果没有，再读取 `apisix.ssl.listen` 并从中随机选一个 `port`。
+  * 如果 `apisix.ssl` 处于开启状态，读取 `apisix.ssl.listen` 并从中随机选一个 `port`。
   * 使用 443 作为默认 `https port`。
 
 :::

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -59,7 +59,9 @@ echo "passed: nginx.conf file contains reuseport configuration"
 echo "
 apisix:
     ssl:
-        listen_port: 8443
+        listen:
+            - port: 8443
+
 " > conf/config.yaml
 
 make init
@@ -87,10 +89,11 @@ apisix:
     - 9081
     - 9082
   ssl:
-    listen_port:
-      - 9443
-      - 9444
-      - 9445
+    enable: true
+    listen:
+        - port: 9443
+        - port: 9444
+        - port: 9445
 " > conf/config.yaml
 
 make init

--- a/t/plugin/redirect.t
+++ b/t/plugin/redirect.t
@@ -443,12 +443,13 @@ Location: https://foo.com:8443/hello
 
 
 
-=== TEST 19: redirect(port using `apisix.ssl.listen_port`)
+=== TEST 19: redirect(port using `apisix.ssl.listen`)
 --- yaml_config
 apisix:
     ssl:
         enable: true
-        listen_port: 9445
+        listen:
+            - port: 9445
 --- request
 GET /hello
 --- more_headers


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #7482

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
