### PR TITLE
fix: recovery old pb state after pubsub.new

### DIFF
--- a/apisix/core/pubsub.lua
+++ b/apisix/core/pubsub.lua
@@ -34,7 +34,7 @@ local mt = { __index = _M }
 local pb_state
 local function init_pb_state()
     -- clear current pb state
-    pb.state(nil)
+    local old_pb_state = pb.state(nil)
 
     -- set int64 rule for pubsub module
     pb.option("int64_as_string")
@@ -49,7 +49,7 @@ local function init_pb_state()
         return "failed to load pubsub protocol: " .. err
     end
 
-    pb_state = pb.state(nil)
+    pb_state = pb.state(old_pb_state)
 end
 
 

--- a/apisix/core/pubsub.lua
+++ b/apisix/core/pubsub.lua
@@ -46,6 +46,7 @@ local function init_pb_state()
     local ok, err = pcall(pubsub_protoc.loadfile, pubsub_protoc, "pubsub.proto")
     if not ok then
         pubsub_protoc:reset()
+        pb.state(old_pb_state)
         return "failed to load pubsub protocol: " .. err
     end
 


### PR DESCRIPTION
### Description

recovery old pb state after pubsub.new, so that it won't affect other module who use pb state.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

