### PR TITLE
fix:When the token in the configuration file is a numeric type, the verification fails due to the inconsistency of the types. The reasons are as follows: the requested type (req_token) = string, the configured type (token) = number

### DIFF
--- a/apisix/admin/init.lua
+++ b/apisix/admin/init.lua
@@ -76,7 +76,7 @@ local function check_token(ctx)
 
     local admin
     for i, row in ipairs(local_conf.apisix.admin_key) do
-        if req_token == row.key then
+        if req_token == tostring(row.key) then
             admin = row
             break
         end


### PR DESCRIPTION
### Description

fix:When the token in the configuration file is a numeric type, the verification fails due to the inconsistency of the types. The reasons are as follows: the requested type (req_token) = string, the configured type (token) = number

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
