### PR TITLE
feat(consumer_groups): add consumer_groups resource

### DIFF
--- a/apisix/admin/consumer_group.lua
+++ b/apisix/admin/consumer_group.lua
@@ -15,13 +15,10 @@
 -- limitations under the License.
 --
 local core = require("apisix.core")
-local get_routes = require("apisix.router").http_routes
 local utils = require("apisix.admin.utils")
 local schema_plugin = require("apisix.admin.plugins").check_schema
 local v3_adapter = require("apisix.admin.v3_adapter")
-local type = type
 local tostring = tostring
-local ipairs = ipairs
 
 
 local _M = {

--- a/apisix/admin/consumer_group.lua
+++ b/apisix/admin/consumer_group.lua
@@ -1,0 +1,102 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+local core = require("apisix.core")
+local get_routes = require("apisix.router").http_routes
+local utils = require("apisix.admin.utils")
+local schema_plugin = require("apisix.admin.plugins").check_schema
+local v3_adapter = require("apisix.admin.v3_adapter")
+local type = type
+local tostring = tostring
+local ipairs = ipairs
+
+
+local _M = {
+}
+
+
+local function check_conf(id, conf, need_id)
+    if not conf then
+        return nil, {error_msg = "missing configurations"}
+    end
+
+    id = id or conf.id
+    if need_id and not id then
+        return nil, {error_msg = "missing id"}
+    end
+
+    if not need_id and id then
+        return nil, {error_msg = "wrong id, do not need it"}
+    end
+
+    if need_id and conf.id and tostring(conf.id) ~= tostring(id) then
+        return nil, {error_msg = "wrong id"}
+    end
+
+    conf.id = id
+
+    core.log.info("conf: ", core.json.delay_encode(conf))
+
+    local ok, err = schema_plugin(conf.plugins)
+    if not ok then
+        return nil, {error_msg = err}
+    end
+
+    return true
+end
+
+
+function _M.put(id, conf)
+    local ok, err = check_conf(id, conf, true)
+    if not ok then
+        return 400, err
+    end
+
+    local key = "/consumer_groups/" .. id
+
+    local ok, err = utils.inject_conf_with_prev_conf("consumer_group", key, conf)
+    if not ok then
+        return 503, {error_msg = err}
+    end
+
+    local res, err = core.etcd.set(key, conf)
+    if not res then
+        core.log.error("failed to put consumer group[", key, "]: ", err)
+        return 503, {error_msg = err}
+    end
+
+    return res.status, res.body
+end
+
+
+function _M.get(id)
+    local key = "/consumer_groups"
+    if id then
+        key = key .. "/" .. id
+    end
+    local res, err = core.etcd.get(key, not id)
+    if not res then
+        core.log.error("failed to get consumer group[", key, "]: ", err)
+        return 503, {error_msg = err}
+    end
+
+    utils.fix_count(res.body, id)
+    v3_adapter.filter(res.body)
+    return res.status, res.body
+end
+
+
+return _M

--- a/apisix/admin/init.lua
+++ b/apisix/admin/init.lua
@@ -54,6 +54,7 @@ local resources = {
     stream_routes   = require("apisix.admin.stream_routes"),
     plugin_metadata = require("apisix.admin.plugin_metadata"),
     plugin_configs  = require("apisix.admin.plugin_config"),
+    consumer_groups  = require("apisix.admin.consumer_group"),
 }
 
 

--- a/apisix/consumer_group.lua
+++ b/apisix/consumer_group.lua
@@ -14,31 +14,36 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 --
-return {
-    RPC_ERROR = 0,
-    RPC_PREPARE_CONF = 1,
-    RPC_HTTP_REQ_CALL = 2,
-    RPC_EXTRA_INFO = 3,
-    RPC_HTTP_RESP_CALL = 4,
-    HTTP_ETCD_DIRECTORY = {
-        ["/upstreams"] = true,
-        ["/plugins"] = true,
-        ["/ssls"] = true,
-        ["/stream_routes"] = true,
-        ["/plugin_metadata"] = true,
-        ["/routes"] = true,
-        ["/services"] = true,
-        ["/consumers"] = true,
-        ["/global_rules"] = true,
-        ["/protos"] = true,
-        ["/plugin_configs"] = true,
-        ["/consumer_groups"] = true,
-    },
-    STREAM_ETCD_DIRECTORY = {
-        ["/upstreams"] = true,
-        ["/plugins"] = true,
-        ["/ssls"] = true,
-        ["/stream_routes"] = true,
-        ["/plugin_metadata"] = true,
-    },
+local core = require("apisix.core")
+local plugin_checker = require("apisix.plugin").plugin_checker
+local pairs = pairs
+local error = error
+
+
+local consumer_groups
+
+
+local _M = {
 }
+
+
+function _M.init_worker()
+    local err
+    consumer_groups, err = core.config.new("/consumer_groups", {
+        automatic = true,
+        item_schema = nil,
+        checker = plugin_checker,
+    })
+    if not consumer_groups then
+        error("failed to sync /consumer_groups: " .. err)
+    end
+end
+
+
+function _M.get(id)
+    ngx.log(ngx.INFO, "### ", core.json.delay_encode(consumer_groups))
+    return consumer_groups:get(id)
+end
+
+
+return _M

--- a/apisix/consumer_group.lua
+++ b/apisix/consumer_group.lua
@@ -16,7 +16,6 @@
 --
 local core = require("apisix.core")
 local plugin_checker = require("apisix.plugin").plugin_checker
-local pairs = pairs
 local error = error
 
 

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -30,6 +30,7 @@ local core            = require("apisix.core")
 local conf_server     = require("apisix.conf_server")
 local plugin          = require("apisix.plugin")
 local plugin_config   = require("apisix.plugin_config")
+local consumer_group  = require("apisix.consumer_group")
 local script          = require("apisix.script")
 local service_fetch   = require("apisix.http.service").get
 local admin_init      = require("apisix.admin.init")
@@ -139,6 +140,7 @@ function _M.http_init_worker()
     require("apisix.http.service").init_worker()
     plugin_config.init_worker()
     require("apisix.consumer").init_worker()
+    consumer_group.init_worker()
 
     apisix_upstream.init_worker()
     require("apisix.plugins.ext-plugin.init").init_worker()
@@ -435,9 +437,14 @@ function _M.http_access_phase()
         plugin.run_plugin("rewrite", plugins, api_ctx)
         if api_ctx.consumer then
             local changed
+            local group_conf
+            if api_ctx.consumer.group_name then
+                group_conf = consumer_group.get(api_ctx.consumer.group_name)
+            end
             route, changed = plugin.merge_consumer_route(
                 route,
                 api_ctx.consumer,
+                group_conf,
                 api_ctx
             )
 


### PR DESCRIPTION
### Description

Add `consumer_groups` resource, which has the same configuration schema of `plugin_config`.
The order of plugin precedence is always Consumer group > Consumer > Route > Service.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
