### PR TITLE
ci: change base JDK images to eclipse-temurin as openjdk is being deprecated

### DIFF
--- a/ci/pod/nacos/service/Dockerfile
+++ b/ci/pod/nacos/service/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM java
+FROM eclipse-temurin:8
 
 ENV SUFFIX_NUM=${SUFFIX_NUM:-1}
 ENV NACOS_ADDR=${NACOS_ADDR:-127.0.0.1:8848}


### PR DESCRIPTION
OpenJDK images is being deprecated.
ref:
[1]: https://github.com/docker-library/openjdk/issues/505
[2]: https://hub.docker.com/_/openjdk

CI failed by this: https://github.com/apache/apisix/runs/7964485433?check_suite_focus=true#step:9:90

the repo of this images: https://github.com/adoptium/containers (LICENSE is Apache 2.0)

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
