### PR TITLE
feat: remove useless field in Admin API v3

### DIFF
--- a/apisix/admin/consumers.lua
+++ b/apisix/admin/consumers.lua
@@ -86,7 +86,7 @@ function _M.put(username, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -103,8 +103,7 @@ function _M.get(consumer_name)
     end
 
     utils.fix_count(res.body, consumer_name)
-    v3_adapter.filter(res.body)
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -125,7 +124,7 @@ function _M.delete(consumer_name)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 

--- a/apisix/admin/consumers.lua
+++ b/apisix/admin/consumers.lua
@@ -18,11 +18,11 @@ local core    = require("apisix.core")
 local plugins = require("apisix.admin.plugins")
 local utils   = require("apisix.admin.utils")
 local plugin  = require("apisix.plugin")
-local v3_adapter = require("apisix.admin.v3_adapter")
 local pairs   = pairs
 
 local _M = {
     version = 0.1,
+    need_v3_filter = true,
 }
 
 
@@ -86,7 +86,7 @@ function _M.put(username, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -103,7 +103,7 @@ function _M.get(consumer_name)
     end
 
     utils.fix_count(res.body, consumer_name)
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -124,7 +124,7 @@ function _M.delete(consumer_name)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 

--- a/apisix/admin/global_rules.lua
+++ b/apisix/admin/global_rules.lua
@@ -82,7 +82,7 @@ function _M.put(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -98,8 +98,7 @@ function _M.get(id)
     end
 
     utils.fix_count(res.body, id)
-    v3_adapter.filter(res.body)
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -112,7 +111,7 @@ function _M.delete(id)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -172,7 +171,7 @@ function _M.patch(id, conf, sub_path)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 

--- a/apisix/admin/global_rules.lua
+++ b/apisix/admin/global_rules.lua
@@ -17,13 +17,13 @@
 local core = require("apisix.core")
 local utils = require("apisix.admin.utils")
 local schema_plugin = require("apisix.admin.plugins").check_schema
-local v3_adapter = require("apisix.admin.v3_adapter")
 local type = type
 local tostring = tostring
 
 
 local _M = {
     version = 0.1,
+    need_v3_filter = true,
 }
 
 
@@ -82,7 +82,7 @@ function _M.put(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -98,7 +98,7 @@ function _M.get(id)
     end
 
     utils.fix_count(res.body, id)
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -111,7 +111,7 @@ function _M.delete(id)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -171,7 +171,7 @@ function _M.patch(id, conf, sub_path)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 

--- a/apisix/admin/init.lua
+++ b/apisix/admin/init.lua
@@ -192,7 +192,12 @@ local function run()
         else
             core.response.set_header("X-API-VERSION", "v2")
         end
+        if resource.need_v3_filter then
+            data = v3_adapter.filter(data)
+        end
+
         data = strip_etcd_resp(data)
+
         core.response.exit(code, data)
     end
 end

--- a/apisix/admin/plugin_config.lua
+++ b/apisix/admin/plugin_config.lua
@@ -18,13 +18,13 @@ local core = require("apisix.core")
 local get_routes = require("apisix.router").http_routes
 local utils = require("apisix.admin.utils")
 local schema_plugin = require("apisix.admin.plugins").check_schema
-local v3_adapter = require("apisix.admin.v3_adapter")
 local type = type
 local tostring = tostring
 local ipairs = ipairs
 
 
 local _M = {
+    need_v3_filter = true,
 }
 
 
@@ -82,7 +82,7 @@ function _M.put(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -98,7 +98,7 @@ function _M.get(id)
     end
 
     utils.fix_count(res.body, id)
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -128,7 +128,7 @@ function _M.delete(id)
     end
 
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -188,7 +188,7 @@ function _M.patch(id, conf, sub_path)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 

--- a/apisix/admin/plugin_config.lua
+++ b/apisix/admin/plugin_config.lua
@@ -82,7 +82,7 @@ function _M.put(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -98,8 +98,7 @@ function _M.get(id)
     end
 
     utils.fix_count(res.body, id)
-    v3_adapter.filter(res.body)
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -129,7 +128,7 @@ function _M.delete(id)
     end
 
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -189,7 +188,7 @@ function _M.patch(id, conf, sub_path)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 

--- a/apisix/admin/proto.lua
+++ b/apisix/admin/proto.lua
@@ -83,7 +83,7 @@ function _M.put(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -100,8 +100,7 @@ function _M.get(id)
     end
 
     utils.fix_count(res.body, id)
-    v3_adapter.filter(res.body)
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -119,7 +118,7 @@ function _M.post(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 local function check_proto_used(plugins, deleting, ptype, pid)
@@ -191,7 +190,7 @@ function _M.delete(id)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 

--- a/apisix/admin/proto.lua
+++ b/apisix/admin/proto.lua
@@ -21,12 +21,12 @@ local utils = require("apisix.admin.utils")
 local get_routes = require("apisix.router").http_routes
 local get_services = require("apisix.http.service").services
 local compile_proto = require("apisix.plugins.grpc-transcode.proto").compile_proto
-local v3_adapter = require("apisix.admin.v3_adapter")
 local tostring = tostring
 
 
 local _M = {
     version = 0.1,
+    need_v3_filter = true,
 }
 
 
@@ -83,7 +83,7 @@ function _M.put(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -100,7 +100,7 @@ function _M.get(id)
     end
 
     utils.fix_count(res.body, id)
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -118,7 +118,7 @@ function _M.post(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 local function check_proto_used(plugins, deleting, ptype, pid)
@@ -190,7 +190,7 @@ function _M.delete(id)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 

--- a/apisix/admin/routes.lua
+++ b/apisix/admin/routes.lua
@@ -19,7 +19,6 @@ local core = require("apisix.core")
 local apisix_upstream = require("apisix.upstream")
 local schema_plugin = require("apisix.admin.plugins").check_schema
 local utils = require("apisix.admin.utils")
-local v3_adapter = require("apisix.admin.v3_adapter")
 local tostring = tostring
 local type = type
 local loadstring = loadstring
@@ -27,6 +26,7 @@ local loadstring = loadstring
 
 local _M = {
     version = 0.2,
+    need_v3_filter = true,
 }
 
 
@@ -187,7 +187,7 @@ function _M.put(id, conf, sub_path, args)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -204,7 +204,7 @@ function _M.get(id)
     end
 
     utils.fix_count(res.body, id)
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -222,7 +222,7 @@ function _M.post(id, conf, sub_path, args)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -239,7 +239,7 @@ function _M.delete(id)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -303,7 +303,7 @@ function _M.patch(id, conf, sub_path, args)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 

--- a/apisix/admin/routes.lua
+++ b/apisix/admin/routes.lua
@@ -187,7 +187,7 @@ function _M.put(id, conf, sub_path, args)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -204,8 +204,7 @@ function _M.get(id)
     end
 
     utils.fix_count(res.body, id)
-    v3_adapter.filter(res.body)
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -223,7 +222,7 @@ function _M.post(id, conf, sub_path, args)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -240,7 +239,7 @@ function _M.delete(id)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -304,7 +303,7 @@ function _M.patch(id, conf, sub_path, args)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 

--- a/apisix/admin/services.lua
+++ b/apisix/admin/services.lua
@@ -130,7 +130,7 @@ function _M.put(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -147,8 +147,7 @@ function _M.get(id)
     end
 
     utils.fix_count(res.body, id)
-    v3_adapter.filter(res.body)
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -166,7 +165,7 @@ function _M.post(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -197,7 +196,7 @@ function _M.delete(id)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -257,7 +256,7 @@ function _M.patch(id, conf, sub_path)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 

--- a/apisix/admin/services.lua
+++ b/apisix/admin/services.lua
@@ -19,7 +19,6 @@ local get_routes = require("apisix.router").http_routes
 local apisix_upstream = require("apisix.upstream")
 local schema_plugin = require("apisix.admin.plugins").check_schema
 local utils = require("apisix.admin.utils")
-local v3_adapter = require("apisix.admin.v3_adapter")
 local tostring = tostring
 local ipairs = ipairs
 local type = type
@@ -28,6 +27,7 @@ local loadstring = loadstring
 
 local _M = {
     version = 0.3,
+    need_v3_filter = true,
 }
 
 
@@ -130,7 +130,7 @@ function _M.put(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -147,7 +147,7 @@ function _M.get(id)
     end
 
     utils.fix_count(res.body, id)
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -165,7 +165,7 @@ function _M.post(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -196,7 +196,7 @@ function _M.delete(id)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -256,7 +256,7 @@ function _M.patch(id, conf, sub_path)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 

--- a/apisix/admin/ssl.lua
+++ b/apisix/admin/ssl.lua
@@ -86,7 +86,7 @@ function _M.put(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -108,8 +108,7 @@ function _M.get(id)
     end
 
     utils.fix_count(res.body, id)
-    v3_adapter.filter(res.body)
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -136,7 +135,7 @@ function _M.post(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -153,7 +152,7 @@ function _M.delete(id)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -234,7 +233,7 @@ function _M.patch(id, conf, sub_path)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 

--- a/apisix/admin/ssl.lua
+++ b/apisix/admin/ssl.lua
@@ -17,12 +17,12 @@
 local core              = require("apisix.core")
 local utils             = require("apisix.admin.utils")
 local apisix_ssl        = require("apisix.ssl")
-local v3_adapter        = require("apisix.admin.v3_adapter")
 local tostring          = tostring
 local type              = type
 
 local _M = {
     version = 0.1,
+    need_v3_filter = true,
 }
 
 
@@ -86,7 +86,7 @@ function _M.put(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -108,7 +108,7 @@ function _M.get(id)
     end
 
     utils.fix_count(res.body, id)
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -135,7 +135,7 @@ function _M.post(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -152,7 +152,7 @@ function _M.delete(id)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -233,7 +233,7 @@ function _M.patch(id, conf, sub_path)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 

--- a/apisix/admin/stream_routes.lua
+++ b/apisix/admin/stream_routes.lua
@@ -17,12 +17,12 @@
 local core = require("apisix.core")
 local utils = require("apisix.admin.utils")
 local stream_route_checker = require("apisix.stream.router.ip_port").stream_route_checker
-local v3_adapter = require("apisix.admin.v3_adapter")
 local tostring = tostring
 
 
 local _M = {
     version = 0.1,
+    need_v3_filter = true,
 }
 
 
@@ -98,7 +98,7 @@ function _M.put(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -115,7 +115,7 @@ function _M.get(id)
     end
 
     utils.fix_count(res.body, id)
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -133,7 +133,7 @@ function _M.post(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -150,7 +150,7 @@ function _M.delete(id)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 

--- a/apisix/admin/stream_routes.lua
+++ b/apisix/admin/stream_routes.lua
@@ -98,7 +98,7 @@ function _M.put(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -115,8 +115,7 @@ function _M.get(id)
     end
 
     utils.fix_count(res.body, id)
-    v3_adapter.filter(res.body)
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -134,7 +133,7 @@ function _M.post(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -151,7 +150,7 @@ function _M.delete(id)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 

--- a/apisix/admin/upstreams.lua
+++ b/apisix/admin/upstreams.lua
@@ -19,7 +19,6 @@ local get_routes = require("apisix.router").http_routes
 local get_services = require("apisix.http.service").services
 local apisix_upstream = require("apisix.upstream")
 local utils = require("apisix.admin.utils")
-local v3_adapter = require("apisix.admin.v3_adapter")
 local tostring = tostring
 local ipairs = ipairs
 local type = type
@@ -27,6 +26,7 @@ local type = type
 
 local _M = {
     version = 0.2,
+    need_v3_filter = true,
 }
 
 
@@ -83,7 +83,7 @@ function _M.put(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -100,7 +100,7 @@ function _M.get(id)
     end
 
     utils.fix_count(res.body, id)
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -118,7 +118,7 @@ function _M.post(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -162,7 +162,7 @@ function _M.delete(id)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 
@@ -222,7 +222,7 @@ function _M.patch(id, conf, sub_path)
         return 503, {error_msg = err}
     end
 
-    return res.status, v3_adapter.filter(res.body)
+    return res.status, res.body
 end
 
 

--- a/apisix/admin/upstreams.lua
+++ b/apisix/admin/upstreams.lua
@@ -83,7 +83,7 @@ function _M.put(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -100,8 +100,7 @@ function _M.get(id)
     end
 
     utils.fix_count(res.body, id)
-    v3_adapter.filter(res.body)
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -119,7 +118,7 @@ function _M.post(id, conf)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -163,7 +162,7 @@ function _M.delete(id)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 
@@ -223,7 +222,7 @@ function _M.patch(id, conf, sub_path)
         return 503, {error_msg = err}
     end
 
-    return res.status, res.body
+    return res.status, v3_adapter.filter(res.body)
 end
 
 

--- a/apisix/admin/v3_adapter.lua
+++ b/apisix/admin/v3_adapter.lua
@@ -185,7 +185,7 @@ function _M.filter(body)
     filter(body, args)
 
     -- recalculate the amount of filtered data
-    body.count = #body.list
+    body.count = body.list and #body.list or 0
 end
 
 

--- a/apisix/admin/v3_adapter.lua
+++ b/apisix/admin/v3_adapter.lua
@@ -171,6 +171,9 @@ local function filter(body, args)
             table.remove(body.list, i)
         end
     end
+
+    -- recalculate the amount of filtered data
+    body.count = #body.list
 end
 
 

--- a/apisix/admin/v3_adapter.lua
+++ b/apisix/admin/v3_adapter.lua
@@ -171,9 +171,6 @@ local function filter(body, args)
             table.remove(body.list, i)
         end
     end
-
-    -- recalculate the amount of filtered data
-    body.count = #body.list
 end
 
 
@@ -186,6 +183,9 @@ function _M.filter(body)
 
     pagination(body, args)
     filter(body, args)
+
+    -- recalculate the amount of filtered data
+    body.count = #body.list
 end
 
 

--- a/apisix/admin/v3_adapter.lua
+++ b/apisix/admin/v3_adapter.lua
@@ -181,11 +181,13 @@ function _M.filter(body)
 
     local args = request.get_uri_args()
 
-    pagination(body, args)
     filter(body, args)
 
-    -- recalculate the amount of filtered data
-    body.count = body.list and #body.list or 0
+    -- recalculate the total amount of filtered data and remove count field
+    body.total = body.list and #body.list or 0
+    body.count = nil
+
+    pagination(body, args)
 end
 
 

--- a/apisix/admin/v3_adapter.lua
+++ b/apisix/admin/v3_adapter.lua
@@ -181,15 +181,31 @@ function _M.filter(body)
 
     local args = request.get_uri_args()
 
-    filter(body, args)
+    if body.deleted then
+        body.node = nil
+    end
 
-    -- calculate the total amount of filtered data
-    body.total = body.list and #body.list or 0
+    -- strip node wrapping for single query, create, and update scenarios.
+    if body.node then
+        body = body.node
+    end
 
-    pagination(body, args)
+    -- filter and paging logic for list query only
+    if body.list then
+        filter(body, args)
 
-    -- recalculate the current page count
-    body.count = body.list and #body.list or 0
+        -- calculate the total amount of filtered data
+        body.total = body.list and #body.list or 0
+
+        pagination(body, args)
+
+        -- remove the count field returned by etcd 
+        -- we don't need a field that reflects the length of the currently returned data,
+        -- it doesn't make sense
+        body.count = nil
+    end
+
+    return body
 end
 
 

--- a/apisix/admin/v3_adapter.lua
+++ b/apisix/admin/v3_adapter.lua
@@ -199,7 +199,7 @@ function _M.filter(body)
 
         pagination(body, args)
 
-        -- remove the count field returned by etcd 
+        -- remove the count field returned by etcd
         -- we don't need a field that reflects the length of the currently returned data,
         -- it doesn't make sense
         body.count = nil

--- a/apisix/admin/v3_adapter.lua
+++ b/apisix/admin/v3_adapter.lua
@@ -183,11 +183,13 @@ function _M.filter(body)
 
     filter(body, args)
 
-    -- recalculate the total amount of filtered data and remove count field
+    -- calculate the total amount of filtered data
     body.total = body.list and #body.list or 0
-    body.count = nil
 
     pagination(body, args)
+
+    -- recalculate the current page count
+    body.count = body.list and #body.list or 0
 end
 
 

--- a/t/admin/consumers.t
+++ b/t/admin/consumers.t
@@ -38,12 +38,11 @@ __DATA__
                      "desc": "new consumer"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "username": "jack",
-                            "desc": "new consumer"
-                        }
-                    }
+                    "value": {
+                        "username": "jack",
+                        "desc": "new consumer"
+                    },
+                    "key": "/apisix/consumers/jack"
                 }]]
                 )
 
@@ -85,17 +84,16 @@ passed
                         }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "username": "jack",
-                            "desc": "new consumer",
-                            "plugins": {
-                                "key-auth": {
-                                    "key": "auth-one"
-                                }
+                    "value": {
+                        "username": "jack",
+                        "desc": "new consumer",
+                        "plugins": {
+                            "key-auth": {
+                                "key": "auth-one"
                             }
                         }
-                    }
+                    },
+                    "key": "/apisix/consumers/jack"
                 }]]
                 )
 
@@ -127,17 +125,16 @@ passed
                  ngx.HTTP_GET,
                  nil,
                 [[{
-                    "node": {
-                        "value": {
-                            "username": "jack",
-                            "desc": "new consumer",
-                            "plugins": {
-                                "key-auth": {
-                                    "key": "auth-one"
-                                }
+                    "value": {
+                        "username": "jack",
+                        "desc": "new consumer",
+                        "plugins": {
+                            "key-auth": {
+                                "key": "auth-one"
                             }
                         }
-                    }
+                    },
+                    "key": "/apisix/consumers/jack"
                 }]]
                 )
 
@@ -209,10 +206,8 @@ GET /t
                      "id":"jack"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "id": "jack"
-                        }
+                    "value": {
+                        "id": "jack"
                     }
                 }]]
                 )
@@ -248,17 +243,16 @@ GET /t
                      }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "username": "jack",
-                            "desc": "new consumer",
-                            "labels": {
-                                "build":"16",
-                                "env":"production",
-                                "version":"v2"
-                            }
+                    "value": {
+                        "username": "jack",
+                        "desc": "new consumer",
+                        "labels": {
+                            "build":"16",
+                            "env":"production",
+                            "version":"v2"
                         }
-                    }
+                    },
+                    "key": "/apisix/consumers/jack"
                 }]]
                 )
 
@@ -343,14 +337,13 @@ GET /t
                      "update_time": 1602893670
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "username": "pony",
-                            "desc": "new consumer",
-                            "create_time": 1602883670,
-                            "update_time": 1602893670
-                        }
-                    }
+                    "value": {
+                        "username": "pony",
+                        "desc": "new consumer",
+                        "create_time": 1602883670,
+                        "update_time": 1602893670
+                    },
+                    "key": "/apisix/consumers/pony"
                 }]]
                 )
 

--- a/t/admin/consumers2.t
+++ b/t/admin/consumers2.t
@@ -59,13 +59,13 @@ __DATA__
             end
 
             res = json.decode(res)
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
+            res.value.create_time = nil
+            res.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/consumers/jack","value":{"username":"jack"}}}
+{"key":"/apisix/consumers/jack","value":{"username":"jack"}}
 
 
 
@@ -87,18 +87,19 @@ __DATA__
             end
 
             res = json.decode(res)
-            local value = res.node.value
-            assert(value.create_time ~= nil)
-            value.create_time = nil
-            assert(value.update_time ~= nil)
-            value.update_time = nil
-            assert(res.count ~= nil)
-            res.count = nil
+            assert(res.createdIndex ~= nil)
+            res.createdIndex = nil
+            assert(res.modifiedIndex ~= nil)
+            res.modifiedIndex = nil
+            assert(res.value.create_time ~= nil)
+            res.value.create_time = nil
+            assert(res.value.update_time ~= nil)
+            res.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/consumers/jack","value":{"username":"jack"}}}
+{"key":"/apisix/consumers/jack","value":{"username":"jack"}}
 
 
 
@@ -124,7 +125,7 @@ __DATA__
         }
     }
 --- response_body
-{"deleted":"1","key":"/apisix/consumers/jack","node":{}}
+{"deleted":"1","key":"/apisix/consumers/jack"}
 
 
 
@@ -150,7 +151,7 @@ __DATA__
         }
     }
 --- response_body
-{"count":0,"list":[]}
+{"list":[],"total":0}
 
 
 

--- a/t/admin/filter.t
+++ b/t/admin/filter.t
@@ -815,3 +815,66 @@ passed
     }
 --- response_body
 passed
+
+
+
+=== TEST 16: pagination data count
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local core = require("apisix.core")
+            local t = require("lib.test_admin").test
+
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            code, body = t('/apisix/admin/routes/2',
+                ngx.HTTP_PUT,
+                [[{
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            ngx.sleep(0.5)
+
+            local code, body, res = t('/apisix/admin/routes', ngx.HTTP_GET)
+            res = json.decode(res)
+            assert(res.count == #res.list)
+
+            local code, body, res = t('/apisix/admin/routes/?label=', ngx.HTTP_GET)
+            res = json.decode(res)
+            assert(res.count == #res.list)
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed

--- a/t/admin/filter.t
+++ b/t/admin/filter.t
@@ -763,44 +763,6 @@ passed
             local core = require("apisix.core")
             local t = require("lib.test_admin").test
 
-            local code, body = t('/apisix/admin/routes/1',
-                ngx.HTTP_PUT,
-                [[{
-                    "upstream": {
-                        "nodes": {
-                            "127.0.0.1:1980": 1
-                        },
-                        "type": "roundrobin"
-                    },
-                    "uri": "/hello"
-                }]]
-            )
-            if code >= 300 then
-                ngx.status = code
-                ngx.say(body)
-                return
-            end
-
-            code, body = t('/apisix/admin/routes/2',
-                ngx.HTTP_PUT,
-                [[{
-                    "upstream": {
-                        "nodes": {
-                            "127.0.0.1:1980": 1
-                        },
-                        "type": "roundrobin"
-                    },
-                    "uri": "/hello"
-                }]]
-            )
-            if code >= 300 then
-                ngx.status = code
-                ngx.say(body)
-                return
-            end
-
-            ngx.sleep(0.5)
-
             local code, body, res = t('/apisix/admin/routes', ngx.HTTP_GET)
             res = json.decode(res)
             assert(res.count == #res.list)
@@ -826,49 +788,11 @@ passed
             local core = require("apisix.core")
             local t = require("lib.test_admin").test
 
-            local code, body = t('/apisix/admin/routes/1',
-                ngx.HTTP_PUT,
-                [[{
-                    "upstream": {
-                        "nodes": {
-                            "127.0.0.1:1980": 1
-                        },
-                        "type": "roundrobin"
-                    },
-                    "uri": "/hello"
-                }]]
-            )
-            if code >= 300 then
-                ngx.status = code
-                ngx.say(body)
-                return
-            end
-
-            code, body = t('/apisix/admin/routes/2',
-                ngx.HTTP_PUT,
-                [[{
-                    "upstream": {
-                        "nodes": {
-                            "127.0.0.1:1980": 1
-                        },
-                        "type": "roundrobin"
-                    },
-                    "uri": "/hello"
-                }]]
-            )
-            if code >= 300 then
-                ngx.status = code
-                ngx.say(body)
-                return
-            end
-
-            ngx.sleep(0.5)
-
-            local code, body, res = t('/apisix/admin/routes', ngx.HTTP_GET)
+            local code, body, res = t('/apisix/admin/routes?page=1&page_size=10', ngx.HTTP_GET)
             res = json.decode(res)
             assert(res.count == #res.list)
 
-            local code, body, res = t('/apisix/admin/routes/?label=', ngx.HTTP_GET)
+            local code, body, res = t('/apisix/admin/routes?page=10&page_size=10', ngx.HTTP_GET)
             res = json.decode(res)
             assert(res.count == #res.list)
 

--- a/t/admin/filter.t
+++ b/t/admin/filter.t
@@ -413,10 +413,12 @@ passed
             )
             res = json.decode(res)
 
-            -- match the name and label are 1, 10
-            assert(#res.list == 2)
+            -- match the name and label are 1, 10, 11
+            -- we do filtering first now, so it will first filter to 1, 10, 11, and then paginate
+            -- res will contain 1, 10, 11 instead of just 1, 10.
+            assert(#res.list == 3)
 
-            local matched = {1, 10}
+            local matched = {1, 10, 11}
             for _, node in ipairs(res.list) do
                 assert(core.table.array_find(matched, tonumber(node.value.name)))
             end
@@ -760,16 +762,17 @@ passed
     location /t {
         content_by_lua_block {
             local json = require("toolkit.json")
-            local core = require("apisix.core")
             local t = require("lib.test_admin").test
 
             local code, body, res = t('/apisix/admin/routes', ngx.HTTP_GET)
             res = json.decode(res)
-            assert(res.count == #res.list)
+            assert(res.total == 11)
+            assert(#res.list == 11)
 
             local code, body, res = t('/apisix/admin/routes/?label=', ngx.HTTP_GET)
             res = json.decode(res)
-            assert(res.count == #res.list)
+            assert(res.total == 0)
+            assert(#res.list == 0)
 
             ngx.status = code
             ngx.say(body)
@@ -785,16 +788,17 @@ passed
     location /t {
         content_by_lua_block {
             local json = require("toolkit.json")
-            local core = require("apisix.core")
             local t = require("lib.test_admin").test
 
             local code, body, res = t('/apisix/admin/routes?page=1&page_size=10', ngx.HTTP_GET)
             res = json.decode(res)
-            assert(res.count == #res.list)
+            assert(res.total == 11)
+            assert(#res.list == 10)
 
             local code, body, res = t('/apisix/admin/routes?page=10&page_size=10', ngx.HTTP_GET)
             res = json.decode(res)
-            assert(res.count == #res.list)
+            assert(res.total == 11)
+            assert(#res.list == 0)
 
             ngx.status = code
             ngx.say(body)

--- a/t/admin/filter.t
+++ b/t/admin/filter.t
@@ -757,7 +757,7 @@ passed
 
 
 
-=== TEST 15: filtered data count
+=== TEST 15: filtered data total
 --- config
     location /t {
         content_by_lua_block {
@@ -783,7 +783,7 @@ passed
 
 
 
-=== TEST 16: pagination data count
+=== TEST 16: pagination data total
 --- config
     location /t {
         content_by_lua_block {

--- a/t/admin/filter.t
+++ b/t/admin/filter.t
@@ -752,3 +752,66 @@ passed
     }
 --- response_body
 passed
+
+
+
+=== TEST 15: filtered data count
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local core = require("apisix.core")
+            local t = require("lib.test_admin").test
+
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            code, body = t('/apisix/admin/routes/2',
+                ngx.HTTP_PUT,
+                [[{
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            ngx.sleep(0.5)
+
+            local code, body, res = t('/apisix/admin/routes', ngx.HTTP_GET)
+            res = json.decode(res)
+            assert(res.count == #res.list)
+
+            local code, body, res = t('/apisix/admin/routes/?label=', ngx.HTTP_GET)
+            res = json.decode(res)
+            assert(res.count == #res.list)
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed

--- a/t/admin/global-rules.t
+++ b/t/admin/global-rules.t
@@ -45,19 +45,17 @@ __DATA__
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "plugins": {
-                                "limit-count": {
-                                    "count": 2,
-                                    "time_window": 60,
-                                    "rejected_code": 503,
-                                    "key": "remote_addr"
-                                }
+                    "value": {
+                        "plugins": {
+                            "limit-count": {
+                                "count": 2,
+                                "time_window": 60,
+                                "rejected_code": 503,
+                                "key": "remote_addr"
                             }
-                        },
-                        "key": "/apisix/global_rules/1"
-                    }
+                        }
+                    },
+                    "key": "/apisix/global_rules/1"
                 }]]
                 )
 
@@ -89,19 +87,17 @@ passed
                 ngx.HTTP_GET,
                 nil,
                 [[{
-                    "node": {
-                        "value": {
-                            "plugins": {
-                                "limit-count": {
-                                    "count": 2,
-                                    "time_window": 60,
-                                    "rejected_code": 503,
-                                    "key": "remote_addr"
-                                }
+                    "value": {
+                        "plugins": {
+                            "limit-count": {
+                                "count": 2,
+                                "time_window": 60,
+                                "rejected_code": 503,
+                                "key": "remote_addr"
                             }
-                        },
-                        "key": "/apisix/global_rules/1"
-                    }
+                        }
+                    },
+                    "key": "/apisix/global_rules/1"
                 }]]
                 )
 
@@ -127,20 +123,20 @@ passed
                 ngx.HTTP_GET,
                 nil,
                 [[{
-                    "count": 1,
+                    "total": 1,
                     "list": [
                         {
                             "key": "/apisix/global_rules/1",
                             "value": {
-                            "plugins": {
-                                "limit-count": {
-                                "time_window": 60,
-                                "policy": "local",
-                                "count": 2,
-                                "key": "remote_addr",
-                                "rejected_code": 503
+                                "plugins": {
+                                    "limit-count": {
+                                    "time_window": 60,
+                                    "policy": "local",
+                                    "count": 2,
+                                    "key": "remote_addr",
+                                    "rejected_code": 503
+                                    }
                                 }
-                            }
                             }
                         }
                     ]
@@ -185,19 +181,17 @@ passed
                     }
                 }}]],
                 [[{
-                    "node": {
-                        "value": {
-                            "plugins": {
-                                "limit-count": {
-                                    "count": 3,
-                                    "time_window": 60,
-                                    "rejected_code": 503,
-                                    "key": "remote_addr"
-                                }
+                    "value": {
+                        "plugins": {
+                            "limit-count": {
+                                "count": 3,
+                                "time_window": 60,
+                                "rejected_code": 503,
+                                "key": "remote_addr"
                             }
-                        },
-                        "key": "/apisix/global_rules/1"
-                    }
+                        }
+                    },
+                    "key": "/apisix/global_rules/1"
                 }]]
                 )
 
@@ -245,19 +239,17 @@ passed
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "plugins": {
-                                "limit-count": {
-                                    "count": 3,
-                                    "time_window": 60,
-                                    "rejected_code": 503,
-                                    "key": "remote_addr"
-                                }
+                    "value": {
+                        "plugins": {
+                            "limit-count": {
+                                "count": 3,
+                                "time_window": 60,
+                                "rejected_code": 503,
+                                "key": "remote_addr"
                             }
-                        },
-                        "key": "/apisix/global_rules/1"
-                    }
+                        }
+                    },
+                    "key": "/apisix/global_rules/1"
                 }]]
                 )
 
@@ -425,13 +417,13 @@ passed
             end
 
             res = json.decode(res)
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
+            res.value.create_time = nil
+            res.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/global_rules/1","value":{"id":"1","plugins":{"proxy-rewrite":{"uri":"/","use_real_request_uri_unsafe":false}}}}}
+{"key":"/apisix/global_rules/1","value":{"id":"1","plugins":{"proxy-rewrite":{"uri":"/","use_real_request_uri_unsafe":false}}}}
 --- request
 GET /t
 --- no_error_log
@@ -463,13 +455,13 @@ GET /t
             end
 
             res = json.decode(res)
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
+            res.value.create_time = nil
+            res.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/global_rules/1","value":{"id":"1","plugins":{"proxy-rewrite":{"uri":"/","use_real_request_uri_unsafe":false}}}}}
+{"key":"/apisix/global_rules/1","value":{"id":"1","plugins":{"proxy-rewrite":{"uri":"/","use_real_request_uri_unsafe":false}}}}
 --- request
 GET /t
 --- no_error_log
@@ -494,18 +486,19 @@ GET /t
             end
 
             res = json.decode(res)
-            local value = res.node.value
-            assert(value.create_time ~= nil)
-            value.create_time = nil
-            assert(value.update_time ~= nil)
-            value.update_time = nil
-            assert(res.count ~= nil)
-            res.count = nil
+            assert(res.createdIndex ~= nil)
+            res.createdIndex = nil
+            assert(res.modifiedIndex ~= nil)
+            res.modifiedIndex = nil
+            assert(res.value.create_time ~= nil)
+            res.value.create_time = nil
+            assert(res.value.update_time ~= nil)
+            res.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/global_rules/1","value":{"id":"1","plugins":{"proxy-rewrite":{"uri":"/","use_real_request_uri_unsafe":false}}}}}
+{"key":"/apisix/global_rules/1","value":{"id":"1","plugins":{"proxy-rewrite":{"uri":"/","use_real_request_uri_unsafe":false}}}}
 --- request
 GET /t
 --- no_error_log
@@ -534,7 +527,7 @@ GET /t
         }
     }
 --- response_body
-{"deleted":"1","key":"/apisix/global_rules/1","node":{}}
+{"deleted":"1","key":"/apisix/global_rules/1"}
 --- request
 GET /t
 --- no_error_log

--- a/t/admin/global-rules2.t
+++ b/t/admin/global-rules2.t
@@ -60,7 +60,7 @@ __DATA__
         }
     }
 --- response_body
-{"count":0,"list":[]}
+{"list":[],"total":0}
 
 
 
@@ -88,13 +88,13 @@ __DATA__
             end
 
             res = json.decode(res)
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
+            res.value.create_time = nil
+            res.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/global_rules/1","value":{"id":"1","plugins":{"proxy-rewrite":{"uri":"/","use_real_request_uri_unsafe":false}}}}}
+{"key":"/apisix/global_rules/1","value":{"id":"1","plugins":{"proxy-rewrite":{"uri":"/","use_real_request_uri_unsafe":false}}}}
 
 
 
@@ -116,11 +116,18 @@ __DATA__
             end
 
             res = json.decode(res)
-            ngx.say(json.encode(res))
+            assert(res.total == 1)
+            assert(#res.list == 1)
+            assert(res.list[1].createdIndex ~= nil)
+            assert(res.list[1].modifiedIndex ~= nil)
+            assert(res.list[1].key == "/apisix/global_rules/1")
+            assert(res.list[1].value ~= nil)
+
+            ngx.say(message)
         }
     }
 --- response_body_like
-{"count":1,"list":[{"createdIndex":\d+,"key":"/apisix/global_rules/1".*
+passed
 
 
 

--- a/t/admin/health-check.t
+++ b/t/admin/health-check.t
@@ -43,10 +43,8 @@ add_block_preprocessor(sub {
         "uri": "/index.html"
     }]])
     exp_data = {
-        node = {
-            value = req_data,
-            key = "/apisix/routes/1",
-        }
+        value = req_data,
+        key = "/apisix/routes/1",
     }
 _EOC_
 
@@ -86,9 +84,9 @@ __DATA__
                     }
                 }
             }]])
-            exp_data.node.value.upstream.checks = req_data.upstream.checks
+            exp_data.value.upstream.checks = req_data.upstream.checks
 
-            local code, body = t('/apisix/admin/routes/1',
+            local code, body, res = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
                 req_data,
                 exp_data
@@ -129,7 +127,7 @@ passed
                     }
                 }
             }]])
-            exp_data.node.value.upstream.checks = req_data.upstream.checks
+            exp_data.value.upstream.checks = req_data.upstream.checks
 
             local code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
@@ -317,7 +315,7 @@ passed
                     "req_headers": ["User-Agent: curl/7.29.0"]
                 }
             }]])
-            exp_data.node.value.upstream.checks = req_data.upstream.checks
+            exp_data.value.upstream.checks = req_data.upstream.checks
 
             local code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
@@ -351,7 +349,7 @@ passed
                     "req_headers": ["User-Agent: curl/7.29.0", "Accept: */*"]
                 }
             }]])
-            exp_data.node.value.upstream.checks = req_data.upstream.checks
+            exp_data.value.upstream.checks = req_data.upstream.checks
 
             local code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
@@ -385,7 +383,7 @@ passed
                     "req_headers": ["User-Agent: curl/7.29.0", 2233]
                 }
             }]])
-            exp_data.node.value.upstream.checks = req_data.upstream.checks
+            exp_data.value.upstream.checks = req_data.upstream.checks
 
             local code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
@@ -421,7 +419,7 @@ passed
                     }
                 }
             }]])
-            exp_data.node.value.upstream.checks = req_data.upstream.checks
+            exp_data.value.upstream.checks = req_data.upstream.checks
 
             local code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
@@ -459,8 +457,8 @@ passed
                     }
                 }
             }]])
-            exp_data.node.value.upstream.checks.active = req_data.upstream.checks.active
-            exp_data.node.value.upstream.checks.passive = {
+            exp_data.value.upstream.checks.active = req_data.upstream.checks.active
+            exp_data.value.upstream.checks.passive = {
                 type = "http",
                 healthy = {
                     http_statuses = { 200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
@@ -511,7 +509,7 @@ passed
                     }
                 }
             }]])
-            exp_data.node.value.upstream.checks = req_data.upstream.checks
+            exp_data.value.upstream.checks = req_data.upstream.checks
 
             local code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,

--- a/t/admin/plugin-configs.t
+++ b/t/admin/plugin-configs.t
@@ -57,19 +57,17 @@ __DATA__
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "plugins": {
-                                "limit-count": {
-                                    "count": 2,
-                                    "time_window": 60,
-                                    "rejected_code": 503,
-                                    "key": "remote_addr"
-                                }
+                    "value": {
+                        "plugins": {
+                            "limit-count": {
+                                "count": 2,
+                                "time_window": 60,
+                                "rejected_code": 503,
+                                "key": "remote_addr"
                             }
-                        },
-                        "key": "/apisix/plugin_configs/1"
-                    }
+                        }
+                    },
+                    "key": "/apisix/plugin_configs/1"
                 }]]
                 )
 
@@ -97,19 +95,17 @@ passed
                 ngx.HTTP_GET,
                 nil,
                 [[{
-                    "node": {
-                        "value": {
-                            "plugins": {
-                                "limit-count": {
-                                    "count": 2,
-                                    "time_window": 60,
-                                    "rejected_code": 503,
-                                    "key": "remote_addr"
-                                }
+                    "value": {
+                        "plugins": {
+                            "limit-count": {
+                                "count": 2,
+                                "time_window": 60,
+                                "rejected_code": 503,
+                                "key": "remote_addr"
                             }
-                        },
-                        "key": "/apisix/plugin_configs/1"
-                    }
+                        }
+                    },
+                    "key": "/apisix/plugin_configs/1"
                 }]]
                 )
 
@@ -131,20 +127,20 @@ passed
                 ngx.HTTP_GET,
                 nil,
                 [[{
-                    "count": 1,
+                    "total": 1,
                     "list": [
                         {
                             "key": "/apisix/plugin_configs/1",
                             "value": {
-                            "plugins": {
-                                "limit-count": {
-                                "time_window": 60,
-                                "policy": "local",
-                                "count": 2,
-                                "key": "remote_addr",
-                                "rejected_code": 503
+                                "plugins": {
+                                    "limit-count": {
+                                    "time_window": 60,
+                                    "policy": "local",
+                                    "count": 2,
+                                    "key": "remote_addr",
+                                    "rejected_code": 503
+                                    }
                                 }
-                            }
                             }
                         }
                     ]
@@ -185,19 +181,17 @@ passed
                     }
                 }}]],
                 [[{
-                    "node": {
-                        "value": {
-                            "plugins": {
-                                "limit-count": {
-                                    "count": 3,
-                                    "time_window": 60,
-                                    "rejected_code": 503,
-                                    "key": "remote_addr"
-                                }
+                    "value": {
+                        "plugins": {
+                            "limit-count": {
+                                "count": 3,
+                                "time_window": 60,
+                                "rejected_code": 503,
+                                "key": "remote_addr"
                             }
-                        },
-                        "key": "/apisix/plugin_configs/1"
-                    }
+                        }
+                    },
+                    "key": "/apisix/plugin_configs/1"
                 }]]
                 )
 
@@ -241,19 +235,17 @@ passed
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "plugins": {
-                                "limit-count": {
-                                    "count": 2,
-                                    "time_window": 60,
-                                    "rejected_code": 503,
-                                    "key": "remote_addr"
-                                }
+                    "value": {
+                        "plugins": {
+                            "limit-count": {
+                                "count": 2,
+                                "time_window": 60,
+                                "rejected_code": 503,
+                                "key": "remote_addr"
                             }
-                        },
-                        "key": "/apisix/plugin_configs/1"
-                    }
+                        }
+                    },
+                    "key": "/apisix/plugin_configs/1"
                 }]]
                 )
 
@@ -324,23 +316,21 @@ passed
                     "desc": "blah"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "plugins": {
-                                "limit-count": {
-                                    "count": 2,
-                                    "time_window": 60,
-                                    "rejected_code": 503,
-                                    "key": "remote_addr"
-                                }
-                            },
-                            "labels": {
-                                "你好": "世界"
-                            },
-                            "desc": "blah"
+                    "value": {
+                        "plugins": {
+                            "limit-count": {
+                                "count": 2,
+                                "time_window": 60,
+                                "rejected_code": 503,
+                                "key": "remote_addr"
+                            }
                         },
-                        "key": "/apisix/plugin_configs/1"
-                    }
+                        "labels": {
+                            "你好": "世界"
+                        },
+                        "desc": "blah"
+                    },
+                    "key": "/apisix/plugin_configs/1"
                 }]]
                 )
 
@@ -368,23 +358,21 @@ passed
                 ngx.HTTP_GET,
                 nil,
                 [[{
-                    "node": {
-                        "value": {
-                            "plugins": {
-                                "limit-count": {
-                                    "count": 2,
-                                    "time_window": 60,
-                                    "rejected_code": 503,
-                                    "key": "remote_addr"
-                                }
-                            },
-                            "labels": {
-                                "你好": "世界"
-                            },
-                            "desc": "blah"
+                    "value": {
+                        "plugins": {
+                            "limit-count": {
+                                "count": 2,
+                                "time_window": 60,
+                                "rejected_code": 503,
+                                "key": "remote_addr"
+                            }
                         },
-                        "key": "/apisix/plugin_configs/1"
-                    }
+                        "labels": {
+                            "你好": "世界"
+                        },
+                        "desc": "blah"
+                    },
+                    "key": "/apisix/plugin_configs/1"
                 }]]
                 )
 

--- a/t/admin/routes-array-nodes.t
+++ b/t/admin/routes-array-nodes.t
@@ -47,26 +47,24 @@ __DATA__
                     "uri": "/index.html"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "methods": [
-                                "GET"
-                            ],
-                            "uri": "/index.html",
-                            "desc": "new route",
-                            "upstream": {
-                                "nodes": [{
-                                    "host": "127.0.0.1",
-                                    "port": 8080,
-                                    "weight": 1
-                                }],
-                                "type": "roundrobin"
-                            }
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "methods": [
+                            "GET"
+                        ],
+                        "uri": "/index.html",
+                        "desc": "new route",
+                        "upstream": {
+                            "nodes": [{
+                                "host": "127.0.0.1",
+                                "port": 8080,
+                                "weight": 1
+                            }],
+                            "type": "roundrobin"
+                        }
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
-                )
+            ) 
 
             ngx.status = code
             ngx.say(body)
@@ -87,29 +85,27 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/routes/1',
-                 ngx.HTTP_GET,
-                 nil,
+                ngx.HTTP_GET,
+                nil,
                 [[{
-                    "node": {
-                        "value": {
-                            "methods": [
-                                "GET"
-                            ],
-                            "uri": "/index.html",
-                            "desc": "new route",
-                            "upstream": {
-                                "nodes": [{
-                                    "host": "127.0.0.1",
-                                    "port": 8080,
-                                    "weight": 1
-                                }],
-                                "type": "roundrobin"
-                            }
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "methods": [
+                            "GET"
+                        ],
+                        "uri": "/index.html",
+                        "desc": "new route",
+                        "upstream": {
+                            "nodes": [{
+                                "host": "127.0.0.1",
+                                "port": 8080,
+                                "weight": 1
+                            }],
+                            "type": "roundrobin"
+                        }
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)

--- a/t/admin/routes-array-nodes.t
+++ b/t/admin/routes-array-nodes.t
@@ -64,7 +64,7 @@ __DATA__
                     },
                     "key": "/apisix/routes/1"
                 }]]
-            ) 
+            )
 
             ngx.status = code
             ngx.say(body)

--- a/t/admin/routes.t
+++ b/t/admin/routes.t
@@ -45,22 +45,20 @@ __DATA__
                     "uri": "/index.html"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "methods": [
-                                "GET"
-                            ],
-                            "uri": "/index.html",
-                            "desc": "new route",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
-                            }
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "methods": [
+                            "GET"
+                        ],
+                        "uri": "/index.html",
+                        "desc": "new route",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
+                            },
+                            "type": "roundrobin"
+                        }
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
                 )
 
@@ -86,22 +84,20 @@ passed
                  ngx.HTTP_GET,
                  nil,
                 [[{
-                    "node": {
-                        "value": {
-                            "methods": [
-                                "GET"
-                            ],
-                            "uri": "/index.html",
-                            "desc": "new route",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
-                            }
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "methods": [
+                            "GET"
+                        ],
+                        "uri": "/index.html",
+                        "desc": "new route",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
+                            },
+                            "type": "roundrobin"
+                        }
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
                 )
 
@@ -177,18 +173,16 @@ GET /t
                         "uri": "/index.html"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "methods": [
-                                "GET"
-                            ],
-                            "uri": "/index.html",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
-                            }
+                    "value": {
+                        "methods": [
+                            "GET"
+                        ],
+                        "uri": "/index.html",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
+                            },
+                            "type": "roundrobin"
                         }
                     }
                 }]]
@@ -201,8 +195,7 @@ GET /t
             end
 
             ngx.say("[push] code: ", code, " message: ", message)
-
-            local id = string.sub(res.node.key, #"/apisix/routes/" + 1)
+            local id = string.sub(res.key, #"/apisix/routes/" + 1)
             local res = assert(etcd.get('/routes/' .. id))
             local create_time = res.body.node.value.create_time
             assert(create_time ~= nil, "create_time is nil")
@@ -244,15 +237,13 @@ GET /t
                         "uri": "/index.html"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "uri": "/index.html",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
-                            }
+                    "value": {
+                        "uri": "/index.html",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
+                            },
+                            "type": "roundrobin"
                         }
                     }
                 }]]
@@ -302,16 +293,14 @@ GET /t
                     "uri": "/index.html"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "uri": "/index.html",
-                            "plugins": {
-                                "limit-count": {
-                                    "count": 2,
-                                    "time_window": 60,
-                                    "rejected_code": 503,
-                                    "key": "remote_addr"
-                                }
+                    "value": {
+                        "uri": "/index.html",
+                        "plugins": {
+                            "limit-count": {
+                                "count": 2,
+                                "time_window": 60,
+                                "rejected_code": 503,
+                                "key": "remote_addr"
                             }
                         }
                     }
@@ -699,19 +688,17 @@ GET /t
                         "uri": "/index.html"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "host": "*.foo.com",
-                            "uri": "/index.html",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
-                            }
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "host": "*.foo.com",
+                        "uri": "/index.html",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
+                            },
+                            "type": "roundrobin"
+                        }
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
                 )
 

--- a/t/admin/routes2.t
+++ b/t/admin/routes2.t
@@ -194,18 +194,18 @@ GET /t
             end
 
             res = json.decode(res)
-            res.node.key = nil
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
-            assert(res.node.value.id ~= nil)
-            res.node.value.id = nil
+            res.key = nil
+            res.value.create_time = nil
+            res.value.update_time = nil
+            assert(res.value.id ~= nil)
+            res.value.id = nil
             ngx.say(json.encode(res))
         }
     }
 --- request
 GET /t
 --- response_body
-{"node":{"value":{"methods":["GET"],"priority":0,"status":1,"upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"},"uri":"/not_unwanted_data_post"}}}
+{"value":{"methods":["GET"],"priority":0,"status":1,"upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"},"uri":"/not_unwanted_data_post"}}
 --- no_error_log
 [error]
 
@@ -239,15 +239,15 @@ GET /t
             end
 
             res = json.decode(res)
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
+            res.value.create_time = nil
+            res.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- request
 GET /t
 --- response_body
-{"node":{"key":"/apisix/routes/1","value":{"id":1,"methods":["GET"],"priority":0,"status":1,"upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"},"uri":"/index.html"}}}
+{"key":"/apisix/routes/1","value":{"id":1,"methods":["GET"],"priority":0,"status":1,"upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"},"uri":"/index.html"}}
 --- no_error_log
 [error]
 
@@ -280,15 +280,15 @@ GET /t
             end
 
             res = json.decode(res)
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
+            res.value.create_time = nil
+            res.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- request
 GET /t
 --- response_body
-{"node":{"key":"/apisix/routes/1","value":{"id":"1","methods":["GET"],"priority":0,"status":1,"upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"},"uri":"/index"}}}
+{"key":"/apisix/routes/1","value":{"id":"1","methods":["GET"],"priority":0,"status":1,"upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"},"uri":"/index"}}
 --- no_error_log
 [error]
 
@@ -311,20 +311,21 @@ GET /t
             end
 
             res = json.decode(res)
-            local value = res.node.value
-            assert(value.create_time ~= nil)
-            value.create_time = nil
-            assert(value.update_time ~= nil)
-            value.update_time = nil
-            assert(res.count ~= nil)
-            res.count = nil
+            assert(res.createdIndex ~= nil)
+            res.createdIndex = nil
+            assert(res.modifiedIndex ~= nil)
+            res.modifiedIndex = nil
+            assert(res.value.create_time ~= nil)
+            res.value.create_time = nil
+            assert(res.value.update_time ~= nil)
+            res.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- request
 GET /t
 --- response_body
-{"node":{"key":"/apisix/routes/1","value":{"id":"1","methods":["GET"],"priority":0,"status":1,"upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"},"uri":"/index"}}}
+{"key":"/apisix/routes/1","value":{"id":"1","methods":["GET"],"priority":0,"status":1,"upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"},"uri":"/index"}}
 --- no_error_log
 [error]
 
@@ -353,7 +354,7 @@ GET /t
 --- request
 GET /t
 --- response_body
-{"deleted":"1","key":"/apisix/routes/1","node":{}}
+{"deleted":"1","key":"/apisix/routes/1"}
 --- no_error_log
 [error]
 
@@ -550,24 +551,22 @@ GET /t
                     "uri": "/index.html"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "methods": [
-                                "GET"
-                            ],
-                            "uri": "/index.html",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "methods": [
+                            "GET"
+                        ],
+                        "uri": "/index.html",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "labels": {
-                                "您好": "世界"
-                            }
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/routes/1"
-                    }
+                        "labels": {
+                            "您好": "世界"
+                        }
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
                 )
 

--- a/t/admin/routes3.t
+++ b/t/admin/routes3.t
@@ -60,7 +60,7 @@ __DATA__
         }
     }
 --- response_body
-{"count":0,"list":[]}
+{"list":[],"total":0}
 
 
 
@@ -82,19 +82,17 @@ __DATA__
                     "uri": "/index.html"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "remote_addr": "127.0.0.1",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "remote_addr": "127.0.0.1",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "uri": "/index.html"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/routes/1"
-                    }
+                        "uri": "/index.html"
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
                 )
 
@@ -127,19 +125,17 @@ passed
                     "uri": "/index.html"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "remote_addr": "127.0.0.0/24",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "remote_addr": "127.0.0.0/24",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "uri": "/index.html"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/routes/1"
-                    }
+                        "uri": "/index.html"
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
                 )
 
@@ -233,12 +229,10 @@ passed
                     "uri": "/patch_test"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "uri": "/patch_test"
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "uri": "/patch_test"
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
             )
 
@@ -275,22 +269,20 @@ passed
                     "desc": "new route"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "methods": [
-                                "GET"
-                            ],
-                            "uri": "/patch_test",
-                            "desc": "new route",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.2:8080": 1
-                                },
-                                "type": "roundrobin"
-                            }
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "methods": [
+                            "GET"
+                        ],
+                        "uri": "/patch_test",
+                        "desc": "new route",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.2:8080": 1
+                            },
+                            "type": "roundrobin"
+                        }
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
             )
 
@@ -314,12 +306,10 @@ passed
                     "methods": ["GET", "DELETE", "PATCH", "POST", "PUT"]
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "methods": ["GET", "DELETE", "PATCH", "POST", "PUT"]
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "methods": ["GET", "DELETE", "PATCH", "POST", "PUT"]
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
             )
 
@@ -343,12 +333,10 @@ passed
                     "methods": ["GET", "POST"]
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "methods": ["GET", "POST"]
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "methods": ["GET", "POST"]
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
             )
 
@@ -370,14 +358,12 @@ passed
                 ngx.HTTP_PATCH,
                 '["POST"]',
                 [[{
-                    "node": {
-                        "value": {
-                            "methods": [
-                                "POST"
-                            ]
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "methods": [
+                            "POST"
+                        ]
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
             )
 
@@ -399,12 +385,10 @@ passed
                 ngx.HTTP_PATCH,
                 '"/patch_uri_test"',
                 [[{
-                    "node": {
-                        "value": {
-                            "uri": "/patch_uri_test"
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "uri": "/patch_uri_test"
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
             )
 
@@ -436,22 +420,20 @@ passed
                     "uri": "/index.html"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "methods": [
-                                "GET"
-                            ],
-                            "uri": "/index.html",
-                            "desc": "new route",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
-                            }
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "methods": [
+                            "GET"
+                        ],
+                        "uri": "/index.html",
+                        "desc": "new route",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
+                            },
+                            "type": "roundrobin"
+                        }
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
             )
 
@@ -483,10 +465,8 @@ passed
                     "desc": "new route"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "hosts": ["foo.com", "*.bar.com"]
-                        }
+                    "value": {
+                        "hosts": ["foo.com", "*.bar.com"]
                     }
                 }]]
                 )
@@ -550,10 +530,8 @@ passed
                     "desc": "new route"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "remote_addrs": ["127.0.0.1", "192.0.0.1/8", "::1", "fe80::/32"]
-                        }
+                    "value": {
+                        "remote_addrs": ["127.0.0.1", "192.0.0.1/8", "::1", "fe80::/32"]
                     }
                 }]]
                 )
@@ -586,10 +564,8 @@ passed
                     "desc": "new route"
                 }]=],
                 [=[{
-                    "node": {
-                        "value": {
-                            "vars": [["arg_name", "==", "json"], ["arg_age", ">", 18]]
-                        }
+                    "value": {
+                        "vars": [["arg_name", "==", "json"], ["arg_age", ">", 18]]
                     }
                 }]=]
                 )
@@ -621,10 +597,8 @@ passed
                     }
                 }]=],
                 [=[{
-                    "node": {
-                        "value": {
-                            "filter_func": "function(vars) return vars.arg_name == 'json' end"
-                        }
+                    "value": {
+                        "filter_func": "function(vars) return vars.arg_name == 'json' end"
                     }
                 }]=]
                 )
@@ -729,12 +703,10 @@ passed
                 ngx.HTTP_PATCH,
                 'false',
                 [[{
-                    "node": {
-                        "value": {
-                            "enable_websocket": false
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "enable_websocket": false
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
             )
 
@@ -756,12 +728,10 @@ passed
                 ngx.HTTP_PATCH,
                 'true',
                 [[{
-                    "node": {
-                        "value": {
-                            "enable_websocket": true
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "enable_websocket": true
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
             )
 

--- a/t/admin/routes4.t
+++ b/t/admin/routes4.t
@@ -69,12 +69,10 @@ location /t {
             ngx.HTTP_GET,
             nil,
             [[{
-                "node": {
-                    "value": {
-                        "uri": "/index.html"
-                    },
-                    "key": "/apisix/routes/1"
-                }
+                "value": {
+                    "uri": "/index.html"
+                },
+                "key": "/apisix/routes/1"
             }]]
         )
 
@@ -131,7 +129,7 @@ location /t {
         ngx.say("[push] succ: ", body)
         ngx.sleep(2.5)
 
-        local id = string.sub(res.node.key, #"/apisix/routes/" + 1)
+        local id = string.sub(res.key, #"/apisix/routes/" + 1)
         code, body = t('/apisix/admin/routes/' .. id, ngx.HTTP_GET)
 
         ngx.say("code: ", code)
@@ -198,12 +196,10 @@ location /t {
                     "uri": "/index.html"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "priority": 0
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "priority": 0
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
                 )
 
@@ -236,12 +232,10 @@ passed
                     "priority": 1
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "priority": 1
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "priority": 1
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
                 )
 
@@ -387,12 +381,10 @@ passed
                     "uri": "/index.html"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "name": "test name"
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "name": "test name"
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
                 )
 
@@ -661,26 +653,24 @@ failed to read request body: request size 1678025 is greater than the maximum si
                     "uri": "/index.html"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "methods": [
-                                "GET"
-                            ],
-                            "uri": "/index.html",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "methods": [
+                            "GET"
+                        ],
+                        "uri": "/index.html",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "labels": {
-                                "build": "16",
-                                "env": "production",
-                                "version": "v2"
-                            }
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/routes/1"
-                    }
+                        "labels": {
+                            "build": "16",
+                            "env": "production",
+                            "version": "v2"
+                        }
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
                 )
 
@@ -706,26 +696,24 @@ passed
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "methods": [
-                                "GET"
-                            ],
-                            "uri": "/index.html",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "methods": [
+                            "GET"
+                        ],
+                        "uri": "/index.html",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "labels": {
-                                "env": "production",
-                                "version": "v2",
-                                "build": "17"
-                            }
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/routes/1"
-                    }
+                        "labels": {
+                            "env": "production",
+                            "version": "v2",
+                            "build": "17"
+                        }
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
             )
 
@@ -783,20 +771,18 @@ passed
                     "update_time": 1602893670
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "uri": "/index.html",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "uri": "/index.html",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "create_time": 1602883670,
-                            "update_time": 1602893670
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/routes/1"
-                    }
+                        "create_time": 1602883670,
+                        "update_time": 1602893670
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
                 )
 

--- a/t/admin/services-array-nodes.t
+++ b/t/admin/services-array-nodes.t
@@ -32,8 +32,8 @@ __DATA__
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "upstream": {
                         "nodes": [{
                             "host": "127.0.0.1",
@@ -45,22 +45,20 @@ __DATA__
                     "desc": "new service"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": [{
-                                    "host": "127.0.0.1",
-                                    "port": 8080,
-                                    "weight": 1
-                                }],
-                                "type": "roundrobin"
-                            },
-                            "desc": "new service"
+                    "value": {
+                        "upstream": {
+                            "nodes": [{
+                                "host": "127.0.0.1",
+                                "port": 8080,
+                                "weight": 1
+                            }],
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/services/1"
-                    }
+                        "desc": "new service"
+                    },
+                    "key": "/apisix/services/1"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -84,22 +82,20 @@ passed
                  ngx.HTTP_GET,
                  nil,
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": [{
-                                    "host": "127.0.0.1",
-                                    "port": 8080,
-                                    "weight": 1
-                                }],
-                                "type": "roundrobin"
-                            },
-                            "desc": "new service"
+                    "value": {
+                        "upstream": {
+                            "nodes": [{
+                                "host": "127.0.0.1",
+                                "port": 8080,
+                                "weight": 1
+                            }],
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/services/1"
-                    }
+                        "desc": "new service"
+                    },
+                    "key": "/apisix/services/1"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)

--- a/t/admin/services-string-id.t
+++ b/t/admin/services-string-id.t
@@ -43,20 +43,18 @@ __DATA__
                     "desc": "new service"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "desc": "new service"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/services/5eeb3dc90f747328b2930b0b"
-                    }
+                        "desc": "new service"
+                    },
+                    "key": "/apisix/services/5eeb3dc90f747328b2930b0b"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -77,23 +75,21 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services/5eeb3dc90f747328b2930b0b',
-                 ngx.HTTP_GET,
-                 nil,
+                ngx.HTTP_GET,
+                nil,
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "desc": "new service"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/services/5eeb3dc90f747328b2930b0b"
-                    }
+                        "desc": "new service"
+                    },
+                    "key": "/apisix/services/5eeb3dc90f747328b2930b0b"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -113,9 +109,7 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, message = t('/apisix/admin/services/5eeb3dc90f747328b2930b0b',
-                 ngx.HTTP_DELETE
-            )
+            local code, message = t('/apisix/admin/services/5eeb3dc90f747328b2930b0b', ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -133,9 +127,7 @@ GET /t
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code = t('/apisix/admin/services/not_found',
-                 ngx.HTTP_DELETE
-            )
+            local code = t('/apisix/admin/services/not_found', ngx.HTTP_DELETE)
 
             ngx.say("[delete] code: ", code)
         }
@@ -155,8 +147,8 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, message, res = t('/apisix/admin/services',
-                 ngx.HTTP_POST,
-                 [[{
+                ngx.HTTP_POST,
+                [[{
                     "upstream": {
                         "nodes": {
                             "127.0.0.1:8080": 1
@@ -165,18 +157,16 @@ GET /t
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
-                            }
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
+                            },
+                            "type": "roundrobin"
                         }
                     }
                 }]]
-                )
+            )
 
             if code ~= 200 then
                 ngx.status = code
@@ -186,10 +176,8 @@ GET /t
 
             ngx.say("[push] code: ", code, " message: ", message)
 
-            local id = string.sub(res.node.key, #"/apisix/services/" + 1)
-            code, message = t('/apisix/admin/services/' .. id,
-                 ngx.HTTP_DELETE
-            )
+            local id = string.sub(res.key, #"/apisix/services/" + 1)
+            code, message = t('/apisix/admin/services/' .. id, ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -210,8 +198,8 @@ GET /t
             local core = require("apisix.core")
             local t = require("lib.test_admin").test
             local code, message, res = t('/apisix/admin/services/5eeb3dc90f747328b2930b0b',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "upstream": {
                         "nodes": {
                             "127.0.0.1:8080": 1
@@ -220,18 +208,17 @@ GET /t
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
-                            }
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
+                            },
+                            "type": "roundrobin"
                         }
-                    }
+                    },
+                    "key": "/apisix/services/5eeb3dc90f747328b2930b0b"
                 }]]
-                )
+            )
 
             if code ~= 200 then
                 ngx.status = code
@@ -258,8 +245,8 @@ GET /t
             local core = require("apisix.core")
             local t = require("lib.test_admin").test
             local code, message, res = t('/apisix/admin/services/5eeb3dc90f747328b2930b0b',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "plugins": {
                         "limit-count": {
                             "count": 2,
@@ -270,20 +257,19 @@ GET /t
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "plugins": {
-                                "limit-count": {
-                                    "count": 2,
-                                    "time_window": 60,
-                                    "rejected_code": 503,
-                                    "key": "remote_addr"
-                                }
+                    "value": {
+                        "plugins": {
+                            "limit-count": {
+                                "count": 2,
+                                "time_window": 60,
+                                "rejected_code": 503,
+                                "key": "remote_addr"
                             }
                         }
-                    }
+                    },
+                    "key": "/apisix/services/5eeb3dc90f747328b2930b0b"
                 }]]
-                )
+            )
 
             if code ~= 200 then
                 ngx.status = code
@@ -309,8 +295,8 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services/*invalid_id$',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "plugins": {
                         "limit-count": {
                             "count": 2,
@@ -320,7 +306,7 @@ GET /t
                         }
                     }
                 }]]
-                )
+            )
 
             ngx.exit(code)
         }
@@ -339,12 +325,12 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services/5eeb3dc90f747328b2930b0b',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "id": "3",
                     "plugins": {}
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -366,20 +352,18 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "id": "5eeb3dc90f747328b2930b0b",
                     "plugins": {}
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "plugins": {}
-                        },
-                        "key": "/apisix/services/5eeb3dc90f747328b2930b0b"
-                    }
+                    "value": {
+                        "plugins": {}
+                    },
+                    "key": "/apisix/services/5eeb3dc90f747328b2930b0b"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -400,12 +384,12 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "id": -100,
                     "plugins": {}
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -432,7 +416,7 @@ GET /t
                     "id": "*invalid_id$",
                     "plugins": {}
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -454,12 +438,12 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "id": "5eeb3dc90f747328b2930b0b",
                     "upstream_id": "invalid$"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -481,12 +465,12 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "id": "5eeb3dc90f747328b2930b0b",
                     "upstream_id": "9999999999"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -508,11 +492,11 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services/5eeb3dc90f747328b2930b0b',
-                 ngx.HTTP_POST,
-                 [[{
+                ngx.HTTP_POST,
+                [[{
                     "plugins": {}
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -539,7 +523,7 @@ GET /t
                     "id": "5eeb3dc90f747328b2930b0b",
                     "plugins": {}
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -572,18 +556,16 @@ GET /t
                     "desc": "new 20 service"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "desc": "new 20 service"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/services/5eeb3dc90f747328b2930b0b"
-                    }
+                        "desc": "new 20 service"
+                    },
+                    "key": "/apisix/services/5eeb3dc90f747328b2930b0b"
                 }]]
             )
 
@@ -611,18 +593,16 @@ passed
                     "desc": "new 19 service"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "desc": "new 19 service"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/services/5eeb3dc90f747328b2930b0b"
-                    }
+                        "desc": "new 19 service"
+                    },
+                    "key": "/apisix/services/5eeb3dc90f747328b2930b0b"
                 }]]
             )
 
@@ -656,16 +636,14 @@ passed
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1,
-                                    "127.0.0.1:8081": 3,
-                                    "127.0.0.1:8082": 4
-                                },
-                                "type": "roundrobin"
-                            }
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1,
+                                "127.0.0.1:8081": 3,
+                                "127.0.0.1:8082": 4
+                            },
+                            "type": "roundrobin"
                         }
                     }
                 }]]
@@ -690,8 +668,8 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services/5eeb3dc90f747328b2930b0b',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "upstream": {
                         "nodes": {
                             "127.0.0.1:8080": 1
@@ -699,7 +677,8 @@ passed
                         "type": "chash"
                     },
                     "desc": "new service"
-                }]])
+                }]]
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -721,8 +700,8 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services/5eeb3dc90f747328b2930b0b',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "upstream": {
                         "nodes": {
                             "127.0.0.1:8080": 1
@@ -731,7 +710,8 @@ GET /t
                         "hash_on": "header"
                     },
                     "desc": "new service"
-                }]])
+                }]]
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -753,8 +733,8 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services/5eeb3dc90f747328b2930b0b',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "upstream": {
                         "nodes": {
                             "127.0.0.1:8080": 1
@@ -763,7 +743,8 @@ GET /t
                         "hash_on": "cookie"
                     },
                     "desc": "new service"
-                }]])
+                }]]
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -785,8 +766,8 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services/5eeb3dc90f747328b2930b0b',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "upstream": {
                         "nodes": {
                             "127.0.0.1:8080": 1
@@ -795,7 +776,8 @@ GET /t
                         "hash_on": "consumer"
                     },
                     "desc": "new service"
-                }]])
+                }]]
+            )
 
             ngx.status = code
             ngx.say(code .. " " .. body)

--- a/t/admin/services.t
+++ b/t/admin/services.t
@@ -44,18 +44,16 @@ __DATA__
                     "desc": "new service"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "desc": "new service"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/services/1"
-                    }
+                        "desc": "new service"
+                    },
+                    "key": "/apisix/services/1"
                 }]]
                 )
 
@@ -87,18 +85,16 @@ passed
                  ngx.HTTP_GET,
                  nil,
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "desc": "new service"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/services/1"
-                    }
+                        "desc": "new service"
+                    },
+                    "key": "/apisix/services/1"
                 }]]
                 )
 
@@ -120,9 +116,8 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, message = t('/apisix/admin/services/1',
-                 ngx.HTTP_DELETE
-            )
+            local code, message,res = t('/apisix/admin/services/1', ngx.HTTP_DELETE)
+
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -140,9 +135,7 @@ GET /t
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code = t('/apisix/admin/services/not_found',
-                 ngx.HTTP_DELETE
-            )
+            local code = t('/apisix/admin/services/not_found', ngx.HTTP_DELETE)
 
             ngx.say("[delete] code: ", code)
         }
@@ -173,14 +166,12 @@ GET /t
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
-                            }
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
+                            },
+                            "type": "roundrobin"
                         }
                     }
                 }]]
@@ -194,16 +185,14 @@ GET /t
 
             ngx.say("[push] code: ", code, " message: ", message)
 
-            local id = string.sub(res.node.key, #"/apisix/services/" + 1)
+            local id = string.sub(res.key, #"/apisix/services/" + 1)
             local res = assert(etcd.get('/services/' .. id))
             local create_time = res.body.node.value.create_time
             assert(create_time ~= nil, "create_time is nil")
             local update_time = res.body.node.value.update_time
             assert(update_time ~= nil, "update_time is nil")
 
-            code, message = t('/apisix/admin/services/' .. id,
-                 ngx.HTTP_DELETE
-            )
+            code, message = t('/apisix/admin/services/' .. id, ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -234,14 +223,12 @@ GET /t
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
-                            }
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
+                            },
+                            "type": "roundrobin"
                         }
                     }
                 }]]
@@ -284,15 +271,13 @@ GET /t
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "plugins": {
-                                "limit-count": {
-                                    "count": 2,
-                                    "time_window": 60,
-                                    "rejected_code": 503,
-                                    "key": "remote_addr"
-                                }
+                    "value": {
+                        "plugins": {
+                            "limit-count": {
+                                "count": 2,
+                                "time_window": 60,
+                                "rejected_code": 503,
+                                "key": "remote_addr"
                             }
                         }
                     }
@@ -353,8 +338,8 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "id": 3,
                     "plugins": {}
                 }]]
@@ -380,18 +365,16 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "id": "1",
                     "plugins": {}
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "plugins": {}
-                        },
-                        "key": "/apisix/services/1"
-                    }
+                    "value": {
+                        "plugins": {}
+                    },
+                    "key": "/apisix/services/1"
                 }]]
                 )
 
@@ -414,8 +397,8 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "id": -100,
                     "plugins": {}
                 }]]
@@ -441,8 +424,8 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "id": "invalid_id$",
                     "plugins": {}
                 }]]
@@ -468,8 +451,8 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "id": 1,
                     "upstream_id": "invalid$"
                 }]]
@@ -495,8 +478,8 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "id": 1,
                     "upstream_id": "9999999999"
                 }]]
@@ -522,8 +505,8 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services/1',
-                 ngx.HTTP_POST,
-                 [[{
+                ngx.HTTP_POST,
+                [[{
                     "plugins": {}
                 }]]
                 )
@@ -594,18 +577,16 @@ GET /t
                     "desc": "new 20 service"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "desc": "new 20 service"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/services/1"
-                    }
+                        "desc": "new 20 service"
+                    },
+                    "key": "/apisix/services/1"
                 }]]
             )
 
@@ -639,18 +620,16 @@ passed
                     "desc": "new 19 service"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "desc": "new 19 service"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/services/1"
-                    }
+                        "desc": "new 19 service"
+                    },
+                    "key": "/apisix/services/1"
                 }]]
             )
 
@@ -684,16 +663,14 @@ passed
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1,
-                                    "127.0.0.1:8081": 3,
-                                    "127.0.0.1:8082": 4
-                                },
-                                "type": "roundrobin"
-                            }
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1,
+                                "127.0.0.1:8081": 3,
+                                "127.0.0.1:8082": 4
+                            },
+                            "type": "roundrobin"
                         }
                     }
                 }]]
@@ -729,18 +706,16 @@ passed
                     "desc": "new 22 service"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "desc": "new 22 service"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/services/1"
-                    }
+                        "desc": "new 22 service"
+                    },
+                    "key": "/apisix/services/1"
                 }]]
             )
 
@@ -766,18 +741,16 @@ passed
                 ngx.HTTP_PATCH,
                 '"new 23 service"',
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "desc": "new 23 service"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/services/1"
-                    }
+                        "desc": "new 23 service"
+                    },
+                    "key": "/apisix/services/1"
                 }]]
             )
 
@@ -809,15 +782,13 @@ passed
                     "type": "roundrobin"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.2:8081": 3,
-                                    "127.0.0.3:8082": 4
-                                },
-                                "type": "roundrobin"
-                            }
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.2:8081": 3,
+                                "127.0.0.3:8082": 4
+                            },
+                            "type": "roundrobin"
                         }
                     }
                 }]]
@@ -979,18 +950,16 @@ GET /t
                     "name": "test service name"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "name": "test service name"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/services/1"
-                    }
+                        "name": "test service name"
+                    },
+                    "key": "/apisix/services/1"
                 }]]
                 )
 
@@ -1047,8 +1016,8 @@ GET /t
                 ngx.HTTP_PUT,
                 '{}',
                 [[{
-                    "node": {
-                        "value": {"id":"1"}
+                    "value": {
+                        "id":"1"
                     }
                 }]]
                 )
@@ -1091,28 +1060,26 @@ passed
                     }
                 }]],
                 [[{
-                    "node":{
-                        "value":{
-                            "desc":"empty service",
-                            "plugins":{
-                                "limit-count":{
-                                    "time_window":60,
-                                    "count":2,
-                                    "rejected_code":503,
-                                    "key":"remote_addr",
-                                    "policy":"local"
-                                }
+                    "value":{
+                        "desc":"empty service",
+                        "plugins":{
+                            "limit-count":{
+                                "time_window":60,
+                                "count":2,
+                                "rejected_code":503,
+                                "key":"remote_addr",
+                                "policy":"local"
+                            }
+                        },
+                        "upstream":{
+                            "type":"roundrobin",
+                            "nodes":{
+                                "127.0.0.1:80":1
                             },
-                            "upstream":{
-                                "type":"roundrobin",
-                                "nodes":{
-                                    "127.0.0.1:80":1
-                                },
-                                "hash_on":"vars",
-                                "pass_host":"pass"
-                            },
-                            "id":"1"
-                        }
+                            "hash_on":"vars",
+                            "pass_host":"pass"
+                        },
+                        "id":"1"
                     }
                 }]]
                 )
@@ -1152,23 +1119,21 @@ passed
                     "desc": "new service"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "labels": {
-                                "build": "16",
-                                "env": "production",
-                                "version": "v2"
-                            },
-                            "desc": "new service"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/services/1"
-                    }
+                        "labels": {
+                            "build": "16",
+                            "env": "production",
+                            "version": "v2"
+                        },
+                        "desc": "new service"
+                    },
+                    "key": "/apisix/services/1"
                 }]]
                 )
 
@@ -1198,23 +1163,21 @@ passed
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "labels": {
-                                "build": "17",
-                                "env": "production",
-                                "version": "v2"
-                            },
-                            "desc": "new service"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/services/1"
-                    }
+                        "labels": {
+                            "build": "17",
+                            "env": "production",
+                            "version": "v2"
+                        },
+                        "desc": "new service"
+                    },
+                    "key": "/apisix/services/1"
                 }]]
             )
 
@@ -1284,19 +1247,17 @@ GET /t
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin",
-                                "create_time": 1602883670,
-                                "update_time": 1602893670
-                            }
-                        },
-                        "key": "/apisix/services/1"
-                    }
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
+                            },
+                            "type": "roundrobin",
+                            "create_time": 1602883670,
+                            "update_time": 1602893670
+                        }
+                    },
+                    "key": "/apisix/services/1"
                 }]]
                 )
 
@@ -1318,9 +1279,7 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, message = t('/apisix/admin/services/1',
-                 ngx.HTTP_DELETE
-            )
+            local code, message = t('/apisix/admin/services/1', ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -1338,10 +1297,8 @@ GET /t
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/services/1',
-                 ngx.HTTP_PUT,
-                 require("toolkit.json").encode({name = ("1"):rep(101)})
-                )
+            local code, body = t('/apisix/admin/services/1', ngx.HTTP_PUT,
+                require("toolkit.json").encode({name = ("1"):rep(101)}))
 
             ngx.status = code
             ngx.print(body)
@@ -1374,18 +1331,16 @@ GET /t
                     "desc": "new service"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "desc": "new service"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/services/a.b"
-                    }
+                        "desc": "new service"
+                    },
+                    "key": "/apisix/services/a.b"
                 }]]
                 )
 

--- a/t/admin/services2.t
+++ b/t/admin/services2.t
@@ -63,16 +63,18 @@ __DATA__
             end
 
             res = json.decode(res)
-            res.node.key = nil
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
-            assert(res.node.value.id ~= nil)
-            res.node.value.id = nil
+            res.key = nil
+            assert(res.value.create_time ~= nil)
+            res.value.create_time = nil
+            assert(res.value.update_time ~= nil)
+            res.value.update_time = nil
+            assert(res.value.id ~= nil)
+            res.value.id = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"value":{"upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}}
+{"value":{"upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}
 
 
 
@@ -101,13 +103,13 @@ __DATA__
             end
 
             res = json.decode(res)
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
+            res.value.create_time = nil
+            res.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/services/1","value":{"id":"1","upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}}
+{"key":"/apisix/services/1","value":{"id":"1","upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}
 
 
 
@@ -136,13 +138,13 @@ __DATA__
             end
 
             res = json.decode(res)
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
+            res.value.create_time = nil
+            res.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/services/1","value":{"id":"1","upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}}
+{"key":"/apisix/services/1","value":{"id":"1","upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}
 
 
 
@@ -152,9 +154,7 @@ __DATA__
         content_by_lua_block {
             local json = require("toolkit.json")
             local t = require("lib.test_admin").test
-            local code, message, res = t('/apisix/admin/services/1',
-                 ngx.HTTP_GET
-                )
+            local code, message, res = t('/apisix/admin/services/1', ngx.HTTP_GET)
 
             if code >= 300 then
                 ngx.status = code
@@ -163,18 +163,19 @@ __DATA__
             end
 
             res = json.decode(res)
-            local value = res.node.value
-            assert(value.create_time ~= nil)
-            value.create_time = nil
-            assert(value.update_time ~= nil)
-            value.update_time = nil
-            assert(res.count ~= nil)
-            res.count = nil
+            assert(res.createdIndex ~= nil)
+            res.createdIndex = nil
+            assert(res.modifiedIndex ~= nil)
+            res.modifiedIndex = nil
+            assert(res.value.create_time ~= nil)
+            res.value.create_time = nil
+            assert(res.value.update_time ~= nil)
+            res.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/services/1","value":{"id":"1","upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}}
+{"key":"/apisix/services/1","value":{"id":"1","upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}
 
 
 
@@ -199,7 +200,7 @@ __DATA__
         }
     }
 --- response_body
-{"deleted":"1","key":"/apisix/services/1","node":{}}
+{"deleted":"1","key":"/apisix/services/1"}
 
 
 
@@ -237,8 +238,8 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/routes/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "service_id": 1,
                     "uri": "/index.html"
                 }]]
@@ -261,9 +262,7 @@ passed
         content_by_lua_block {
             ngx.sleep(0.3)
             local t = require("lib.test_admin").test
-            local code, message = t('/apisix/admin/services/1',
-                 ngx.HTTP_DELETE
-            )
+            local code, message = t('/apisix/admin/services/1', ngx.HTTP_DELETE)
             ngx.print("[delete] code: ", code, " message: ", message)
         }
     }
@@ -278,9 +277,7 @@ passed
         content_by_lua_block {
             ngx.sleep(0.3)
             local t = require("lib.test_admin").test
-            local code, message = t('/apisix/admin/routes/1',
-                 ngx.HTTP_DELETE
-            )
+            local code, message = t('/apisix/admin/routes/1', ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -295,9 +292,7 @@ passed
         content_by_lua_block {
             ngx.sleep(0.3)
             local t = require("lib.test_admin").test
-            local code, message = t('/apisix/admin/services/1',
-                 ngx.HTTP_DELETE
-            )
+            local code, message = t('/apisix/admin/services/1', ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }

--- a/t/admin/ssl.t
+++ b/t/admin/ssl.t
@@ -38,12 +38,10 @@ __DATA__
                 ngx.HTTP_PUT,
                 core.json.encode(data),
                 [[{
-                    "node": {
-                        "value": {
-                            "sni": "test.com"
-                        },
-                        "key": "/apisix/ssls/1"
-                    }
+                    "value": {
+                        "sni": "test.com"
+                    },
+                    "key": "/apisix/ssls/1"
                 }]]
                 )
 
@@ -76,14 +74,11 @@ passed
                 ngx.HTTP_GET,
                 nil,
                 [[{
-                    "node": {
-                        "value": {
-                            "sni": "test.com",
-                            "key": null
-                        },
-
-                        "key": "/apisix/ssls/1"
-                    }
+                    "value": {
+                        "sni": "test.com",
+                        "key": null
+                    },
+                    "key": "/apisix/ssls/1"
                 }]]
                 )
 
@@ -105,9 +100,7 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, message = t('/apisix/admin/ssls/1',
-                 ngx.HTTP_DELETE
-            )
+            local code, message = t('/apisix/admin/ssls/1', ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -125,9 +118,7 @@ GET /t
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code = t('/apisix/admin/ssls/99999999999999',
-                 ngx.HTTP_DELETE
-            )
+            local code = t('/apisix/admin/ssls/99999999999999', ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code)
         }
     }
@@ -155,10 +146,8 @@ GET /t
                 ngx.HTTP_POST,
                 core.json.encode(data),
                 [[{
-                    "node": {
-                        "value": {
-                            "sni": "foo.com"
-                        }
+                    "value": {
+                        "sni": "foo.com"
                     }
                 }]]
                 )
@@ -171,10 +160,8 @@ GET /t
 
             ngx.say("[push] code: ", code, " message: ", message)
 
-            local id = string.sub(res.node.key, #"/apisix/ssls/" + 1)
-            code, message = t.test('/apisix/admin/ssls/' .. id,
-                 ngx.HTTP_DELETE
-            )
+            local id = string.sub(res.key, #"/apisix/ssls/" + 1)
+            code, message = t.test('/apisix/admin/ssls/' .. id, ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -203,12 +190,10 @@ GET /t
                 ngx.HTTP_PUT,
                 core.json.encode(data),
                 [[{
-                    "node": {
-                        "value": {
-                            "sni": "foo.com"
-                        },
-                        "key": "/apisix/ssls/1"
-                    }
+                    "value": {
+                        "sni": "foo.com"
+                    },
+                    "key": "/apisix/ssls/1"
                 }]]
                 )
 
@@ -241,12 +226,10 @@ GET /t
                 ngx.HTTP_PUT,
                 core.json.encode(data),
                 [[{
-                    "node": {
-                        "value": {
-                            "sni": "*.foo.com"
-                        },
-                        "key": "/apisix/ssls/1"
-                    }
+                    "value": {
+                        "sni": "*.foo.com"
+                    },
+                    "key": "/apisix/ssls/1"
                 }]]
                 )
 
@@ -281,12 +264,10 @@ passed
                 ngx.HTTP_PUT,
                 core.json.encode(data),
                 [[{
-                    "node": {
-                        "value": {
-                            "snis": ["*.foo.com", "bar.com"]
-                        },
-                        "key": "/apisix/ssls/1"
-                    }
+                    "value": {
+                        "snis": ["*.foo.com", "bar.com"]
+                    },
+                    "key": "/apisix/ssls/1"
                 }]]
                 )
 
@@ -322,13 +303,11 @@ passed
                 ngx.HTTP_PUT,
                 core.json.encode(data),
                 [[{
-                    "node": {
-                        "value": {
-                            "sni": "bar.com",
-                            "exptime": 1619798400
-                        },
-                        "key": "/apisix/ssls/1"
-                    }
+                    "value": {
+                        "sni": "bar.com",
+                        "exptime": 1619798400
+                    },
+                    "key": "/apisix/ssls/1"
                 }]]
                 )
 
@@ -456,12 +435,10 @@ GET /t
                 ngx.HTTP_PUT,
                 core.json.encode(data),
                 [[{
-                    "node": {
-                        "value": {
-                            "sni": "test.com"
-                        },
-                        "key": "/apisix/ssls/1"
-                    }
+                    "value": {
+                        "sni": "test.com"
+                    },
+                    "key": "/apisix/ssls/1"
                 }]]
               )
 
@@ -497,12 +474,10 @@ passed
                 ngx.HTTP_PUT,
                 core.json.encode(data),
                 [[{
-                    "node": {
-                        "value": {
-                            "sni": "test.com"
-                        },
-                        "key": "/apisix/ssls/1"
-                    }
+                    "value": {
+                        "sni": "test.com"
+                    },
+                    "key": "/apisix/ssls/1"
                 }]]
                 )
 
@@ -535,18 +510,15 @@ GET /t
                 ngx.HTTP_PUT,
                 core.json.encode(data),
                 [[{
-                    "node": {
-                        "value": {
-                            "sni": "test.com",
-                            "labels": {
-                                "version": "v2",
-                                "build": "16",
-                                "env": "production"
-                            }
-                        },
-
-                        "key": "/apisix/ssls/1"
-                    }
+                    "value": {
+                        "sni": "test.com",
+                        "labels": {
+                            "version": "v2",
+                            "build": "16",
+                            "env": "production"
+                        }
+                    },
+                    "key": "/apisix/ssls/1"
                 }]]
                 )
 
@@ -578,16 +550,13 @@ passed
                 ngx.HTTP_PUT,
                 core.json.encode(data),
                 [[{
-                    "node": {
-                        "value": {
-                            "sni": "test.com",
-                            "labels": {
-                                "env": ["production", "release"]
-                            }
-                        },
-
-                        "key": "/apisix/ssls/1"
-                    }
+                    "value": {
+                        "sni": "test.com",
+                        "labels": {
+                            "env": ["production", "release"]
+                        }
+                    },
+                    "key": "/apisix/ssls/1"
                 }]]
                 )
 
@@ -628,16 +597,14 @@ GET /t
                 ngx.HTTP_PUT,
                 core.json.encode(data),
                 [[{
-                    "node": {
-                        "value": {
-                            "sni": "test.com",
-                            "create_time": 1602883670,
-                            "update_time": 1602893670,
-                            "validity_start": 1602873670,
-                            "validity_end": 1603893670
-                        },
-                        "key": "/apisix/ssls/1"
-                    }
+                    "value": {
+                        "sni": "test.com",
+                        "create_time": 1602883670,
+                        "update_time": 1602893670,
+                        "validity_start": 1602873670,
+                        "validity_end": 1603893670
+                    },
+                    "key": "/apisix/ssls/1"
                 }]]
                 )
 
@@ -659,9 +626,7 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, message = t('/apisix/admin/ssls/1',
-                 ngx.HTTP_DELETE
-            )
+            local code, message = t('/apisix/admin/ssls/1', ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -690,13 +655,11 @@ GET /t
                 ngx.HTTP_POST,
                 core.json.encode(data),
                 [[{
-                    "node": {
-                        "value": {
-                            "sni": "test.com"
-                        }
+                    "value": {
+                        "sni": "test.com"
                     }
                 }]]
-                )
+            )
 
             if code ~= 200 then
                 ngx.status = code
@@ -704,7 +667,7 @@ GET /t
                 return
             end
 
-            local id = string.sub(res.node.key, #"/apisix/ssls/" + 1)
+            local id = string.sub(res.key, #"/apisix/ssls/" + 1)
             local res = assert(etcd.get('/ssls/' .. id))
             local prev_create_time = res.body.node.value.create_time
             assert(prev_create_time ~= nil, "create_time is nil")
@@ -714,7 +677,7 @@ GET /t
             local code, body = t.test('/apisix/admin/ssls/' .. id,
                 ngx.HTTP_PATCH,
                 core.json.encode({create_time = 0, update_time = 1})
-                )
+            )
 
             if code ~= 201 then
                 ngx.status = code
@@ -729,9 +692,7 @@ GET /t
             assert(update_time == 1, "update_time mismatched")
 
             -- clean up
-            local code, body = t.test('/apisix/admin/ssls/' .. id,
-                ngx.HTTP_DELETE
-            )
+            local code, body = t.test('/apisix/admin/ssls/' .. id, ngx.HTTP_DELETE)
             ngx.status = code
             ngx.say(body)
         }
@@ -760,9 +721,7 @@ passed
                 ngx.HTTP_PUT,
                 core.json.encode(data),
                 [[{
-                    "node": {
-                        "key": "/apisix/ssls/1"
-                    }
+                    "key": "/apisix/ssls/1"
                 }]]
                 )
 
@@ -795,9 +754,7 @@ GET /t
                 ngx.HTTP_PUT,
                 core.json.encode(data),
                 [[{
-                    "node": {
-                        "key": "/apisix/ssls/1"
-                    }
+                    "key": "/apisix/ssls/1"
                 }]]
                 )
 

--- a/t/admin/ssl2.t
+++ b/t/admin/ssl2.t
@@ -60,18 +60,23 @@ __DATA__
             end
 
             res = json.decode(res)
-            res.node.key = nil
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
-            res.node.value.cert = ""
-            res.node.value.key = ""
-            assert(res.node.value.id ~= nil)
-            res.node.value.id = nil
+            assert(res.key ~= nil)
+            res.key = nil
+            assert(res.value.create_time ~= nil)
+            res.value.create_time = nil
+            assert(res.value.update_time ~= nil)
+            res.value.update_time = nil
+            assert(res.value.cert ~= nil)
+            res.value.cert = ""
+            assert(res.value.key ~= nil)
+            res.value.key = ""
+            assert(res.value.id ~= nil)
+            res.value.id = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"value":{"cert":"","key":"","sni":"not-unwanted-post.com","status":1,"type":"server"}}}
+{"value":{"cert":"","key":"","sni":"not-unwanted-post.com","status":1,"type":"server"}}
 
 
 
@@ -96,15 +101,19 @@ __DATA__
             end
 
             res = json.decode(res)
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
-            res.node.value.cert = ""
-            res.node.value.key = ""
+            assert(res.value.create_time ~= nil)
+            res.value.create_time = nil
+            assert(res.value.update_time ~= nil)
+            res.value.update_time = nil
+            assert(res.value.cert ~= nil)
+            res.value.cert = ""
+            assert(res.value.key ~= nil)
+            res.value.key = ""
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/ssls/1","value":{"cert":"","id":"1","key":"","sni":"test.com","status":1,"type":"server"}}}
+{"key":"/apisix/ssls/1","value":{"cert":"","id":"1","key":"","sni":"test.com","status":1,"type":"server"}}
 
 
 
@@ -129,15 +138,19 @@ __DATA__
             end
 
             res = json.decode(res)
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
-            res.node.value.cert = ""
-            res.node.value.key = ""
+            assert(res.value.create_time ~= nil)
+            res.value.create_time = nil
+            assert(res.value.update_time ~= nil)
+            res.value.update_time = nil
+            assert(res.value.cert ~= nil)
+            res.value.cert = ""
+            assert(res.value.key ~= nil)
+            res.value.key = ""
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/ssls/1","value":{"cert":"","id":"1","key":"","sni":"t.com","status":1,"type":"server"}}}
+{"key":"/apisix/ssls/1","value":{"cert":"","id":"1","key":"","sni":"t.com","status":1,"type":"server"}}
 
 
 
@@ -158,21 +171,22 @@ __DATA__
             end
 
             res = json.decode(res)
-            local value = res.node.value
-            assert(value.create_time ~= nil)
-            value.create_time = nil
-            assert(value.update_time ~= nil)
-            value.update_time = nil
-            assert(value.cert ~= nil)
-            value.cert = ""
-            assert(value.key == nil)
-            assert(res.count ~= nil)
-            res.count = nil
+            assert(res.createdIndex ~= nil)
+            res.createdIndex = nil
+            assert(res.modifiedIndex ~= nil)
+            res.modifiedIndex = nil
+            assert(res.value.create_time ~= nil)
+            res.value.create_time = nil
+            assert(res.value.update_time ~= nil)
+            res.value.update_time = nil
+            assert(res.value.cert ~= nil)
+            res.value.cert = ""
+            assert(res.value.key == nil)
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/ssls/1","value":{"cert":"","id":"1","sni":"t.com","status":1,"type":"server"}}}
+{"key":"/apisix/ssls/1","value":{"cert":"","id":"1","sni":"t.com","status":1,"type":"server"}}
 
 
 
@@ -200,7 +214,7 @@ __DATA__
         }
     }
 --- response_body
-{"deleted":"1","key":"/apisix/ssls/1","node":{}}
+{"deleted":"1","key":"/apisix/ssls/1"}
 
 
 
@@ -441,8 +455,8 @@ apisix:
             end
 
             res = json.decode(res)
-            ngx.say(res.node.value.key == ssl_key)
-            ngx.say(res.node.value.keys[1] == ssl_key)
+            ngx.say(res.value.key == ssl_key)
+            ngx.say(res.value.keys[1] == ssl_key)
         }
     }
 --- response_body
@@ -477,7 +491,7 @@ apisix:
             end
 
             res = json.decode(res)
-            ngx.say(res.node.value.keys[1] == ssl_key)
+            ngx.say(res.value.keys[1] == ssl_key)
         }
     }
 --- response_body

--- a/t/admin/ssl3.t
+++ b/t/admin/ssl3.t
@@ -60,4 +60,4 @@ __DATA__
         }
     }
 --- response_body
-{"count":0,"list":[]}
+{"list":[],"total":0}

--- a/t/admin/ssls.t
+++ b/t/admin/ssls.t
@@ -54,12 +54,10 @@ __DATA__
                 ngx.HTTP_PUT,
                 core.json.encode(data),
                 [[{
-                    "node": {
-                        "value": {
-                            "sni": "test.com"
-                        },
-                        "key": "/apisix/ssls/1"
-                    }
+                    "value": {
+                        "sni": "test.com"
+                    },
+                    "key": "/apisix/ssls/1"
                 }]]
                 )
 
@@ -71,7 +69,6 @@ __DATA__
             assert(prev_create_time ~= nil, "create_time is nil")
             local update_time = res.body.node.value.update_time
             assert(update_time ~= nil, "update_time is nil")
-
         }
     }
 --- response_body

--- a/t/admin/stream-routes.t
+++ b/t/admin/stream-routes.t
@@ -46,20 +46,18 @@ __DATA__
                     "desc": "new route"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "remote_addr": "127.0.0.1",
-                            "desc": "test-desc",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "remote_addr": "127.0.0.1",
+                        "desc": "test-desc",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "desc": "new route"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/stream_routes/1"
-                    }
+                        "desc": "new route"
+                    },
+                    "key": "/apisix/stream_routes/1"
                 }]]
                 )
 
@@ -92,19 +90,17 @@ passed
                  ngx.HTTP_GET,
                  nil,
                 [[{
-                    "node": {
-                        "value": {
-                            "remote_addr": "127.0.0.1",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "remote_addr": "127.0.0.1",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "desc": "new route"
+                            "type": "roundrobin"
                         },
-                        "key": "/apisix/stream_routes/1"
-                    }
+                        "desc": "new route"
+                    },
+                    "key": "/apisix/stream_routes/1"
                 }]]
                 )
 
@@ -126,9 +122,7 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, message = t('/apisix/admin/stream_routes/1',
-                ngx.HTTP_DELETE
-            )
+            local code, message = t('/apisix/admin/stream_routes/1', ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -160,17 +154,15 @@ GET /t
                     "desc": "new route"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "remote_addr": "127.0.0.1",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:8080": 1
-                                },
-                                "type": "roundrobin"
+                    "value": {
+                        "remote_addr": "127.0.0.1",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:8080": 1
                             },
-                            "desc": "new route"
-                        }
+                            "type": "roundrobin"
+                        },
+                        "desc": "new route"
                     }
                 }]]
                 )
@@ -183,7 +175,7 @@ GET /t
 
             ngx.say("[push] code: ", code, " message: ", message)
 
-            local id = string.sub(res.node.key, #"/apisix/stream_routes/" + 1)
+            local id = string.sub(res.key, #"/apisix/stream_routes/" + 1)
 
             local ret = assert(etcd.get('/stream_routes/' .. id))
             local create_time = ret.body.node.value.create_time
@@ -193,9 +185,7 @@ GET /t
             id = ret.body.node.value.id
             assert(id ~= nil, "id is nil")
 
-            code, message = t('/apisix/admin/stream_routes/' .. id,
-                ngx.HTTP_DELETE
-            )
+            code, message = t('/apisix/admin/stream_routes/' .. id, ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -304,9 +294,7 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, message = t('/apisix/admin/stream_routes/1',
-                ngx.HTTP_DELETE
-            )
+            local code, message = t('/apisix/admin/stream_routes/1', ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -356,9 +344,7 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/stream_routes/a-b-c-ABC_0123',
-                ngx.HTTP_DELETE
-            )
+            local code, body = t('/apisix/admin/stream_routes/a-b-c-ABC_0123', ngx.HTTP_DELETE)
             if code >= 300 then
                 ngx.status = code
             end
@@ -432,7 +418,7 @@ GET /t
 
             res = json.decode(res)
             -- clean data
-            local id = string.sub(res.node.key, #"/apisix/stream_routes/" + 1)
+            local id = string.sub(res.key, #"/apisix/stream_routes/" + 1)
             local code, message = t('/apisix/admin/stream_routes/' .. id,
                  ngx.HTTP_DELETE
                 )
@@ -443,16 +429,19 @@ GET /t
                 return
             end
 
-            res.node.key = nil
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
-            assert(res.node.value.id ~= nil)
-            res.node.value.id = nil
+            assert(res.key ~= nil)
+            res.key = nil
+            assert(res.value.create_time ~= nil)
+            res.value.create_time = nil
+            assert(res.value.update_time ~= nil)
+            res.value.update_time = nil
+            assert(res.value.id ~= nil)
+            res.value.id = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"value":{"remote_addr":"127.0.0.1","upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}}
+{"value":{"remote_addr":"127.0.0.1","upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}
 --- request
 GET /t
 --- no_error_log
@@ -486,13 +475,15 @@ GET /t
             end
 
             res = json.decode(res)
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
+            assert(res.value.create_time ~= nil)
+            res.value.create_time = nil
+            assert(res.value.update_time ~= nil)
+            res.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/stream_routes/1","value":{"id":"1","remote_addr":"127.0.0.1","upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}}
+{"key":"/apisix/stream_routes/1","value":{"id":"1","remote_addr":"127.0.0.1","upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}
 --- request
 GET /t
 --- no_error_log
@@ -517,17 +508,19 @@ GET /t
             end
 
             res = json.decode(res)
-            assert(res.count ~= nil)
-            assert(res.node.value.create_time ~= nil)
-            assert(res.node.value.update_time ~= nil)
-            res.count = nil
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
+            assert(res.createdIndex ~= nil)
+            res.createdIndex = nil
+            assert(res.modifiedIndex ~= nil)
+            res.modifiedIndex = nil
+            assert(res.value.create_time ~= nil)
+            res.value.create_time = nil
+            assert(res.value.update_time ~= nil)
+            res.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/stream_routes/1","value":{"id":"1","remote_addr":"127.0.0.1","upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}}
+{"key":"/apisix/stream_routes/1","value":{"id":"1","remote_addr":"127.0.0.1","upstream":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}
 --- request
 GET /t
 --- no_error_log
@@ -556,7 +549,7 @@ GET /t
         }
     }
 --- response_body
-{"deleted":"1","key":"/apisix/stream_routes/1","node":{}}
+{"deleted":"1","key":"/apisix/stream_routes/1"}
 --- request
 GET /t
 --- no_error_log

--- a/t/admin/upstream-array-nodes.t
+++ b/t/admin/upstream-array-nodes.t
@@ -43,20 +43,18 @@ __DATA__
                     "desc": "new upstream"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": [{
-                                 "host": "127.0.0.1",
-                                 "port": 8080,
-                                 "weight": 1
-                            }],
-                            "type": "roundrobin",
-                            "desc": "new upstream"
-                        },
-                        "key": "/apisix/upstreams/1"
-                    }
+                    "value": {
+                        "nodes": [{
+                                "host": "127.0.0.1",
+                                "port": 8080,
+                                "weight": 1
+                        }],
+                        "type": "roundrobin",
+                        "desc": "new upstream"
+                    },
+                    "key": "/apisix/upstreams/1"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -80,20 +78,18 @@ passed
                  ngx.HTTP_GET,
                  nil,
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": [{
-                                 "host": "127.0.0.1",
-                                 "port": 8080,
-                                 "weight": 1
-                            }],
-                            "type": "roundrobin",
-                            "desc": "new upstream"
-                        },
-                        "key": "/apisix/upstreams/1"
-                    }
+                    "value": {
+                        "nodes": [{
+                                "host": "127.0.0.1",
+                                "port": 8080,
+                                "weight": 1
+                        }],
+                        "type": "roundrobin",
+                        "desc": "new upstream"
+                    },
+                    "key": "/apisix/upstreams/1"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -113,9 +109,7 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, message = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_DELETE
-            )
+            local code, message = t('/apisix/admin/upstreams/1', ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -133,9 +127,7 @@ GET /t
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code = t('/apisix/admin/upstreams/not_found',
-                 ngx.HTTP_DELETE
-            )
+            local code = t('/apisix/admin/upstreams/not_found', ngx.HTTP_DELETE)
 
             ngx.say("[delete] code: ", code)
         }
@@ -165,18 +157,16 @@ GET /t
                     "type": "roundrobin"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": [{
-                                "host": "127.0.0.1",
-                                "port": 8080,
-                                "weight": 1
-                            }],
-                            "type": "roundrobin"
-                        }
+                    "value": {
+                        "nodes": [{
+                            "host": "127.0.0.1",
+                            "port": 8080,
+                            "weight": 1
+                        }],
+                        "type": "roundrobin"
                     }
                 }]]
-                )
+            )
 
             if code ~= 200 then
                 ngx.status = code
@@ -186,10 +176,8 @@ GET /t
 
             ngx.say("[push] code: ", code, " message: ", message)
 
-            local id = string.sub(res.node.key, #"/apisix/upstreams/" + 1)
-            code, message = t('/apisix/admin/upstreams/' .. id,
-                 ngx.HTTP_DELETE
-            )
+            local id = string.sub(res.key, #"/apisix/upstreams/" + 1)
+            code, message = t('/apisix/admin/upstreams/' .. id, ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -215,7 +203,7 @@ GET /t
                     "nodes": [],
                     "type": "roundrobin"
                 }]]
-                )
+            )
 
             if code >= 300 then
                 ngx.status = code
@@ -248,7 +236,7 @@ passed
                     "upstream_id": "1",
                     "uri": "/index.html"
                 }]]
-                )
+            )
 
             if code >= 300 then
                 ngx.status = code
@@ -295,7 +283,7 @@ no valid upstream node
                     "_service_name": "xyz",
                     "_discovery_type": "nacos"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -326,7 +314,7 @@ passed
                     }],
                     "type": "chash"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -358,7 +346,7 @@ GET /t
                     }],
                     "type": "chash"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -390,7 +378,7 @@ GET /t
                     }],
                     "type": "chash"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -422,7 +410,7 @@ GET /t
                     }],
                     "type": "chash"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -458,7 +446,7 @@ GET /t
                     },
                     "uri": "/index.html"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)

--- a/t/admin/upstream.t
+++ b/t/admin/upstream.t
@@ -43,18 +43,16 @@ so that we can delete it later)
                     "desc": "new upstream"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.1:8080": 1
-                            },
-                            "type": "roundrobin",
-                            "desc": "new upstream"
+                    "value": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
                         },
-                        "key": "/apisix/upstreams/admin_up"
-                    }
+                        "type": "roundrobin",
+                        "desc": "new upstream"
+                    },
+                    "key": "/apisix/upstreams/admin_up"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -84,18 +82,16 @@ passed
                  ngx.HTTP_GET,
                  nil,
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.1:8080": 1
-                            },
-                            "type": "roundrobin",
-                            "desc": "new upstream"
+                    "value": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
                         },
-                        "key": "/apisix/upstreams/admin_up"
-                    }
+                        "type": "roundrobin",
+                        "desc": "new upstream"
+                    },
+                    "key": "/apisix/upstreams/admin_up"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -115,9 +111,7 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, message = t('/apisix/admin/upstreams/admin_up',
-                 ngx.HTTP_DELETE
-            )
+            local code, message = t('/apisix/admin/upstreams/admin_up', ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -135,9 +129,7 @@ GET /t
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code = t('/apisix/admin/upstreams/not_found',
-                 ngx.HTTP_DELETE
-            )
+            local code = t('/apisix/admin/upstreams/not_found', ngx.HTTP_DELETE)
 
             ngx.say("[delete] code: ", code)
         }
@@ -166,16 +158,14 @@ GET /t
                     "type": "roundrobin"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.1:8080": 1
-                            },
-                            "type": "roundrobin"
-                        }
+                    "value": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
+                        },
+                        "type": "roundrobin"
                     }
                 }]]
-                )
+            )
 
             if code ~= 200 then
                 ngx.status = code
@@ -185,16 +175,14 @@ GET /t
 
             ngx.say("[push] code: ", code, " message: ", message)
 
-            local id = string.sub(res.node.key, #"/apisix/upstreams/" + 1)
+            local id = string.sub(res.key, #"/apisix/upstreams/" + 1)
             local res = assert(etcd.get('/upstreams/' .. id))
             local create_time = res.body.node.value.create_time
             assert(create_time ~= nil, "create_time is nil")
             local update_time = res.body.node.value.update_time
             assert(update_time ~= nil, "update_time is nil")
 
-            code, message = t('/apisix/admin/upstreams/' .. id,
-                 ngx.HTTP_DELETE
-            )
+            code, message = t('/apisix/admin/upstreams/' .. id, ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -221,7 +209,7 @@ GET /t
                     },
                     "type": "roundrobin"
                 }]]
-                )
+            )
 
             ngx.exit(code)
         }
@@ -248,7 +236,7 @@ GET /t
                     },
                     "type": "roundrobin"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -279,17 +267,15 @@ GET /t
                     "type": "roundrobin"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.1:8080": 1
-                            },
-                            "type": "roundrobin"
+                    "value": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
                         },
-                        "key": "/apisix/upstreams/1"
-                    }
+                        "type": "roundrobin"
+                    },
+                    "key": "/apisix/upstreams/1"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -318,7 +304,7 @@ passed
                     },
                     "type": "roundrobin"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -348,7 +334,7 @@ GET /t
                     },
                     "type": "roundrobin"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -380,7 +366,7 @@ GET /t
                     "_service_name": "xyz",
                     "_discovery_type": "nacos"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -410,18 +396,16 @@ passed
                     "type": "chash"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "key": "remote_addr",
-                            "nodes": {
-                                "127.0.0.1:8080": 1
-                            },
-                            "type": "chash"
+                    "value": {
+                        "key": "remote_addr",
+                        "nodes": {
+                            "127.0.0.1:8080": 1
                         },
-                        "key": "/apisix/upstreams/1"
-                    }
+                        "type": "chash"
+                    },
+                    "key": "/apisix/upstreams/1"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -450,7 +434,7 @@ passed
                     },
                     "type": "unknown"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -479,7 +463,7 @@ passed
                     },
                     "type": "chash"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -501,15 +485,15 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "id": 1,
                     "nodes": {
                         "127.0.0.1:8080": -100
                     },
                     "type": "chash"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -531,14 +515,14 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "nodes": {
                         "127.0.0.1:8080": 1
                     },
                     "type": "chash"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -560,14 +544,14 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_POST,
-                 [[{
+                ngx.HTTP_POST,
+                [[{
                     "nodes": {
                         "127.0.0.1:8080": 1
                     },
                     "type": "roundrobin"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -589,15 +573,15 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams',
-                 ngx.HTTP_POST,
-                 [[{
+                ngx.HTTP_POST,
+                [[{
                     "id": 1,
                     "nodes": {
                         "127.0.0.1:8080": 1
                     },
                     "type": "roundrobin"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -634,9 +618,9 @@ GET /t
                 }
             }
             local code, body = t.test('/apisix/admin/upstreams',
-                 ngx.HTTP_POST,
-                 core.json.encode(data)
-                )
+                ngx.HTTP_POST,
+                core.json.encode(data)
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -669,9 +653,9 @@ qr/{"error_msg":"invalid configuration: property \\\"tls\\\" validation failed: 
                 }
             }
             local code, body = t.test('/apisix/admin/upstreams',
-                 ngx.HTTP_POST,
-                 core.json.encode(data)
-                )
+                ngx.HTTP_POST,
+                core.json.encode(data)
+            )
 
             ngx.status = code
             ngx.print(body)

--- a/t/admin/upstream2.t
+++ b/t/admin/upstream2.t
@@ -61,16 +61,19 @@ __DATA__
             end
 
             res = json.decode(res)
-            res.node.key = nil
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
-            assert(res.node.value.id ~= nil)
-            res.node.value.id = nil
+            assert(res.key ~= nil)
+            res.key = nil
+            assert(res.value.create_time ~= nil)
+            res.value.create_time = nil
+            assert(res.value.update_time ~= nil)
+            res.value.update_time = nil
+            assert(res.value.id ~= nil)
+            res.value.id = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"value":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}
+{"value":{"hash_on":"vars","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}
 
 
 
@@ -81,14 +84,14 @@ __DATA__
             local json = require("toolkit.json")
             local t = require("lib.test_admin").test
             local code, message, res = t('/apisix/admin/upstreams/unwanted',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "nodes": {
                         "127.0.0.1:8080": 1
                     },
                     "type": "roundrobin"
                 }]]
-                )
+            )
 
             if code >= 300 then
                 ngx.status = code
@@ -97,13 +100,15 @@ __DATA__
             end
 
             res = json.decode(res)
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
+            assert(res.value.create_time ~= nil)
+            res.value.create_time = nil
+            assert(res.value.update_time ~= nil)
+            res.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/upstreams/unwanted","value":{"hash_on":"vars","id":"unwanted","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}
+{"key":"/apisix/upstreams/unwanted","value":{"hash_on":"vars","id":"unwanted","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}
 
 
 
@@ -114,14 +119,14 @@ __DATA__
             local json = require("toolkit.json")
             local t = require("lib.test_admin").test
             local code, message, res = t('/apisix/admin/upstreams/unwanted',
-                 ngx.HTTP_PATCH,
-                 [[{
+                ngx.HTTP_PATCH,
+                [[{
                     "nodes": {
                         "127.0.0.1:8080": 1
                     },
                     "type": "roundrobin"
                 }]]
-                )
+            )
 
             if code >= 300 then
                 ngx.status = code
@@ -130,13 +135,15 @@ __DATA__
             end
 
             res = json.decode(res)
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
+            assert(res.value.create_time ~= nil)
+            res.value.create_time = nil
+            assert(res.value.update_time ~= nil)
+            res.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/upstreams/unwanted","value":{"hash_on":"vars","id":"unwanted","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}
+{"key":"/apisix/upstreams/unwanted","value":{"hash_on":"vars","id":"unwanted","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}
 
 
 
@@ -146,9 +153,7 @@ __DATA__
         content_by_lua_block {
             local json = require("toolkit.json")
             local t = require("lib.test_admin").test
-            local code, message, res = t('/apisix/admin/upstreams/unwanted',
-                 ngx.HTTP_GET
-                )
+            local code, message, res = t('/apisix/admin/upstreams/unwanted', ngx.HTTP_GET)
 
             if code >= 300 then
                 ngx.status = code
@@ -157,18 +162,19 @@ __DATA__
             end
 
             res = json.decode(res)
-            local value = res.node.value
-            assert(value.create_time ~= nil)
-            value.create_time = nil
-            assert(value.update_time ~= nil)
-            value.update_time = nil
-            assert(res.count ~= nil)
-            res.count = nil
+            assert(res.createdIndex ~= nil)
+            res.createdIndex = nil
+            assert(res.modifiedIndex ~= nil)
+            res.modifiedIndex = nil
+            assert(res.value.create_time ~= nil)
+            res.value.create_time = nil
+            assert(res.value.update_time ~= nil)
+            res.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/upstreams/unwanted","value":{"hash_on":"vars","id":"unwanted","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}}
+{"key":"/apisix/upstreams/unwanted","value":{"hash_on":"vars","id":"unwanted","nodes":{"127.0.0.1:8080":1},"pass_host":"pass","scheme":"http","type":"roundrobin"}}
 
 
 
@@ -178,9 +184,7 @@ __DATA__
         content_by_lua_block {
             local json = require("toolkit.json")
             local t = require("lib.test_admin").test
-            local code, message, res = t('/apisix/admin/upstreams/unwanted',
-                 ngx.HTTP_DELETE
-                )
+            local code, message, res = t('/apisix/admin/upstreams/unwanted', ngx.HTTP_DELETE)
 
             if code >= 300 then
                 ngx.status = code
@@ -193,7 +197,7 @@ __DATA__
         }
     }
 --- response_body
-{"deleted":"1","key":"/apisix/upstreams/unwanted","node":{}}
+{"deleted":"1","key":"/apisix/upstreams/unwanted"}
 
 
 
@@ -204,12 +208,12 @@ __DATA__
             local core = require("apisix.core")
             local t = require("lib.test_admin").test
             local code, message = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "nodes": {},
                     "type": "roundrobin"
                 }]]
-                )
+            )
 
             if code >= 300 then
                 ngx.status = code
@@ -238,7 +242,7 @@ passed
                     "upstream_id": "1",
                     "uri": "/index.html"
                 }]]
-                )
+            )
 
             if code >= 300 then
                 ngx.status = code
@@ -269,8 +273,8 @@ no valid upstream node
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "nodes": {
                         "127.0.0.1:8080": 1
                     },
@@ -281,7 +285,7 @@ no valid upstream node
                         "read": 0
                     }
                 }]]
-                )
+            )
             ngx.status = code
             ngx.print(body)
         }

--- a/t/admin/upstream3.t
+++ b/t/admin/upstream3.t
@@ -60,7 +60,7 @@ __DATA__
         }
     }
 --- response_body
-{"count":0,"list":[]}
+{"list":[],"total":0}
 
 
 
@@ -139,16 +139,14 @@ __DATA__
                     "desc": "new upstream"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.1:8080": 1
-                            },
-                            "type": "roundrobin",
-                            "desc": "new upstream"
+                    "value": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
                         },
-                        "key": "/apisix/upstreams/1"
-                    }
+                        "type": "roundrobin",
+                        "desc": "new upstream"
+                    },
+                    "key": "/apisix/upstreams/1"
                 }]]
             )
 
@@ -178,16 +176,14 @@ passed
                     "desc": "new 21 upstream"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.1:8080": 1
-                            },
-                            "type": "roundrobin",
-                            "desc": "new 21 upstream"
+                    "value": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
                         },
-                        "key": "/apisix/upstreams/1"
-                    }
+                        "type": "roundrobin",
+                        "desc": "new 21 upstream"
+                    },
+                    "key": "/apisix/upstreams/1"
                 }]]
             )
 
@@ -214,16 +210,14 @@ passed
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.1:8080": 1,
-                                "127.0.0.1:8081": 3,
-                                "127.0.0.1:8082": 4
-                            },
-                            "type": "roundrobin",
-                            "desc": "new 21 upstream"
-                        }
+                    "value": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1,
+                            "127.0.0.1:8081": 3,
+                            "127.0.0.1:8082": 4
+                        },
+                        "type": "roundrobin",
+                        "desc": "new 21 upstream"
                     }
                 }]]
             )
@@ -251,15 +245,13 @@ passed
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.1:8081": 3,
-                                "127.0.0.1:8082": 0
-                            },
-                            "type": "roundrobin",
-                            "desc": "new 21 upstream"
-                        }
+                    "value": {
+                        "nodes": {
+                            "127.0.0.1:8081": 3,
+                            "127.0.0.1:8082": 0
+                        },
+                        "type": "roundrobin",
+                        "desc": "new 21 upstream"
                     }
                 }]]
             )
@@ -288,16 +280,14 @@ passed
                     "desc": "new upstream 24"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.1:8080": 1
-                            },
-                            "type": "roundrobin",
-                            "desc": "new upstream 24"
+                    "value": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
                         },
-                        "key": "/apisix/upstreams/1"
-                    }
+                        "type": "roundrobin",
+                        "desc": "new upstream 24"
+                    },
+                    "key": "/apisix/upstreams/1"
                 }]]
             )
 
@@ -319,16 +309,14 @@ passed
                 ngx.HTTP_PATCH,
                 '"new 25 upstream"',
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.1:8080": 1
-                            },
-                            "type": "roundrobin",
-                            "desc": "new 25 upstream"
+                    "value": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
                         },
-                        "key": "/apisix/upstreams/1"
-                    }
+                        "type": "roundrobin",
+                        "desc": "new 25 upstream"
+                    },
+                    "key": "/apisix/upstreams/1"
                 }]]
             )
 
@@ -353,15 +341,13 @@ passed
                     "127.0.0.7:8082": 4
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.6:8081": 3,
-                                "127.0.0.7:8082": 4
-                            },
-                            "type": "roundrobin",
-                            "desc": "new 25 upstream"
-                        }
+                    "value": {
+                        "nodes": {
+                            "127.0.0.6:8081": 3,
+                            "127.0.0.7:8082": 4
+                        },
+                        "type": "roundrobin",
+                        "desc": "new 25 upstream"
                     }
                 }]]
             )
@@ -387,15 +373,13 @@ passed
                     "127.0.0.8:8082": 4
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.7:8081": 0,
-                                "127.0.0.8:8082": 4
-                            },
-                            "type": "roundrobin",
-                            "desc": "new 25 upstream"
-                        }
+                    "value": {
+                        "nodes": {
+                            "127.0.0.7:8081": 0,
+                            "127.0.0.8:8082": 4
+                        },
+                        "type": "roundrobin",
+                        "desc": "new 25 upstream"
                     }
                 }]]
             )
@@ -415,15 +399,15 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "key": "server_name",
                     "nodes": {
                         "127.0.0.1:8080": 1
                     },
                     "type": "chash"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -450,7 +434,7 @@ passed
                     "key": "not_support",
                     "desc": "new upstream"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -468,8 +452,8 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "key": "arg_device_id",
                     "nodes": {
                         "127.0.0.1:8080": 1
@@ -477,7 +461,7 @@ passed
                     "type": "chash",
                     "desc": "new chash upstream"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -494,15 +478,15 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "key": "server_name",
                     "nodes": {
                         "127.0.0.1:8080": 1
                     },
                     "type": "chash"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -529,7 +513,7 @@ passed
                     "key": "not_support",
                     "desc": "new upstream"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -556,7 +540,7 @@ passed
                     "type": "chash",
                     "desc": "new chash upstream"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -573,8 +557,8 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "key": "arg_device_id",
                     "nodes": {
                         "127.0.0.1:8080": 1
@@ -583,7 +567,7 @@ passed
                     "hash_on": "vars",
                     "desc": "new chash upstream"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -600,8 +584,8 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "key": "custom_header",
                     "nodes": {
                         "127.0.0.1:8080": 1
@@ -610,7 +594,7 @@ passed
                     "hash_on": "header",
                     "desc": "new chash upstream"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -627,8 +611,8 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "key": "$#^@",
                     "nodes": {
                         "127.0.0.1:8080": 1
@@ -637,7 +621,7 @@ passed
                     "hash_on": "header",
                     "desc": "new chash upstream"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -655,8 +639,8 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "key": "custom_cookie",
                     "nodes": {
                         "127.0.0.1:8080": 1
@@ -665,7 +649,7 @@ passed
                     "hash_on": "cookie",
                     "desc": "new chash upstream"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -682,8 +666,8 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "key": "$#^@abc",
                     "nodes": {
                         "127.0.0.1:8080": 1
@@ -692,7 +676,7 @@ passed
                     "hash_on": "cookie",
                     "desc": "new chash upstream"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -710,8 +694,8 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "nodes": {
                         "127.0.0.1:8080": 1
                     },
@@ -719,7 +703,7 @@ passed
                     "hash_on": "consumer",
                     "desc": "new chash upstream"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -736,8 +720,8 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "nodes": {
                         "127.0.0.1:8080": 1
                     },
@@ -746,7 +730,7 @@ passed
                     "key": "invalid-key",
                     "desc": "new chash upstream"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -763,8 +747,8 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "key": "dsadas",
                     "nodes": {
                         "127.0.0.1:8080": 1
@@ -773,7 +757,7 @@ passed
                     "hash_on": "aabbcc",
                     "desc": "new chash upstream"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)

--- a/t/admin/upstream4.t
+++ b/t/admin/upstream4.t
@@ -53,16 +53,14 @@ __DATA__
                     "name": "test upstream name"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.1:8080": 1
-                            },
-                            "type": "roundrobin",
-                            "name": "test upstream name"
+                    "value": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
                         },
-                        "key": "/apisix/upstreams/1"
-                    }
+                        "type": "roundrobin",
+                        "name": "test upstream name"
+                    },
+                    "key": "/apisix/upstreams/1"
                 }]]
             )
 
@@ -105,9 +103,7 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/upstreams/a-b-c-ABC_0123',
-                ngx.HTTP_DELETE
-            )
+            local code, body = t('/apisix/admin/upstreams/a-b-c-ABC_0123', ngx.HTTP_DELETE)
             if code >= 300 then
                 ngx.status = code
             end
@@ -206,8 +202,8 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "nodes": {
                         "httpbin.org:8080": 1,
                         "test.com:8080": 1
@@ -216,7 +212,7 @@ passed
                     "pass_host": "rewrite",
                     "upstream_host": ""
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -245,22 +241,20 @@ passed
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.1:8080": 1
-                            },
-                            "type": "roundrobin",
-                            "labels": {
-                                "build":"16",
-                                "env":"production",
-                                "version":"v2"
-                            }
+                    "value": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
                         },
-                        "key": "/apisix/upstreams/1"
-                    }
+                        "type": "roundrobin",
+                        "labels": {
+                            "build":"16",
+                            "env":"production",
+                            "version":"v2"
+                        }
+                    },
+                    "key": "/apisix/upstreams/1"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -277,23 +271,21 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_GET,
-                 nil,
+                ngx.HTTP_GET,
+                nil,
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.1:8080": 1
-                            },
-                            "type": "roundrobin",
-                            "labels": {
-                                "version":"v2",
-                                "build":"16",
-                                "env":"production"
-                            }
+                    "value": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
                         },
-                        "key": "/apisix/upstreams/1"
-                    }
+                        "type": "roundrobin",
+                        "labels": {
+                            "version":"v2",
+                            "build":"16",
+                            "env":"production"
+                        }
+                    },
+                    "key": "/apisix/upstreams/1"
                 }]]
                 )
 
@@ -319,22 +311,20 @@ passed
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.1:8080": 1
-                            },
-                            "type": "roundrobin",
-                            "labels": {
-                                "version":"v2",
-                                "build":"17",
-                                "env":"production"
-                            }
+                    "value": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
                         },
-                        "key": "/apisix/upstreams/1"
-                    }
+                        "type": "roundrobin",
+                        "labels": {
+                            "version":"v2",
+                            "build":"17",
+                            "env":"production"
+                        }
+                    },
+                    "key": "/apisix/upstreams/1"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -361,7 +351,7 @@ passed
                         "env": ["production", "release"]
                     }
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -391,17 +381,15 @@ passed
                     "create_time": 1705252779
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.1:8080": 1
-                            },
-                            "type": "roundrobin",
-                            "desc": "new upstream",
-                            "create_time": 1705252779
+                    "value": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
                         },
-                        "key": "/apisix/upstreams/1"
-                    }
+                        "type": "roundrobin",
+                        "desc": "new upstream",
+                        "create_time": 1705252779
+                    },
+                    "key": "/apisix/upstreams/1"
                 }]]
             )
 
@@ -440,17 +428,15 @@ passed
                     "update_time": 1705252779
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.1:8080": 1
-                            },
-                            "type": "roundrobin",
-                            "desc": "new upstream",
-                            "create_time": 1705252779
+                    "value": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
                         },
-                        "key": "/apisix/upstreams/1"
-                    }
+                        "type": "roundrobin",
+                        "desc": "new upstream",
+                        "create_time": 1705252779
+                    },
+                    "key": "/apisix/upstreams/1"
                 }]]
             )
 
@@ -487,19 +473,17 @@ passed
                     "update_time": 1602893670
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "nodes": {
-                                "127.0.0.1:8080": 1
-                            },
-                            "type": "roundrobin",
-                            "create_time": 1602883670,
-                            "update_time": 1602893670
+                    "value": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
                         },
-                        "key": "/apisix/upstreams/up_create_update_time"
-                    }
+                        "type": "roundrobin",
+                        "create_time": 1602883670,
+                        "update_time": 1602893670
+                    },
+                    "key": "/apisix/upstreams/up_create_update_time"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -515,9 +499,7 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, message = t('/apisix/admin/upstreams/up_create_update_time',
-                 ngx.HTTP_DELETE
-            )
+            local code, message = t('/apisix/admin/upstreams/up_create_update_time', ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -552,8 +534,8 @@ passed
             ngx.sleep(1)
 
             local code, message = t('/apisix/admin/upstreams/1/retries',
-                 ngx.HTTP_PATCH,
-                 json.encode(1)
+                ngx.HTTP_PATCH,
+                json.encode(1)
             )
             if code >= 300 then
                 ngx.status = code
@@ -575,14 +557,14 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "nodes": {
                         "127.0.0.1:8080": 1
                     },
                     "type": "roundrobin"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -599,11 +581,11 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "upstream_id": 1
                 }]]
-                )
+            )
 
             if code >= 300 then
                 ngx.status = code
@@ -622,12 +604,12 @@ passed
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/routes/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                     "upstream_id": 1,
                     "uri": "/index.html"
                 }]]
-                )
+            )
 
             if code >= 300 then
                 ngx.status = code
@@ -646,9 +628,7 @@ passed
         content_by_lua_block {
             ngx.sleep(0.3)
             local t = require("lib.test_admin").test
-            local code, message = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_DELETE
-            )
+            local code, message = t('/apisix/admin/upstreams/1', ngx.HTTP_DELETE)
             ngx.print("[delete] code: ", code, " message: ", message)
         }
     }
@@ -663,9 +643,7 @@ passed
         content_by_lua_block {
             ngx.sleep(0.3)
             local t = require("lib.test_admin").test
-            local code, message = t('/apisix/admin/routes/1',
-                 ngx.HTTP_DELETE
-            )
+            local code, message = t('/apisix/admin/routes/1', ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -680,9 +658,7 @@ passed
         content_by_lua_block {
             ngx.sleep(0.3)
             local t = require("lib.test_admin").test
-            local code, message = t('/apisix/admin/services/1',
-                 ngx.HTTP_DELETE
-            )
+            local code, message = t('/apisix/admin/services/1', ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }
@@ -697,9 +673,7 @@ passed
         content_by_lua_block {
             ngx.sleep(0.3)
             local t = require("lib.test_admin").test
-            local code, message = t('/apisix/admin/upstreams/1',
-                 ngx.HTTP_DELETE
-            )
+            local code, message = t('/apisix/admin/upstreams/1', ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code, " message: ", message)
         }
     }

--- a/t/node/chash-hashon.t
+++ b/t/node/chash-hashon.t
@@ -51,13 +51,11 @@ __DATA__
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "username": "jack",
-                            "plugins": {
-                                "key-auth": {
-                                    "key": "auth-jack"
-                                }
+                    "value": {
+                        "username": "jack",
+                        "plugins": {
+                            "key-auth": {
+                                "key": "auth-jack"
                             }
                         }
                     }
@@ -81,13 +79,11 @@ __DATA__
                     }
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "username": "tom",
-                            "plugins": {
-                                "key-auth": {
-                                    "key": "auth-tom"
-                                }
+                    "value": {
+                        "username": "tom",
+                        "plugins": {
+                            "key-auth": {
+                                "key": "auth-tom"
                             }
                         }
                     }

--- a/t/node/upstream-mtls.t
+++ b/t/node/upstream-mtls.t
@@ -167,7 +167,7 @@ decrypt ssl key failed
             end
 
             res = json.decode(res)
-            ngx.say(res.node.value.upstream.tls.client_key == ssl_key)
+            ngx.say(res.value.upstream.tls.client_key == ssl_key)
 
             -- upstream
             local data = {
@@ -203,7 +203,7 @@ decrypt ssl key failed
             end
 
             res = json.decode(res)
-            ngx.say(res.node.value.tls.client_key == ssl_key)
+            ngx.say(res.value.tls.client_key == ssl_key)
 
             local data = {
                 upstream = {
@@ -240,7 +240,7 @@ decrypt ssl key failed
             end
 
             res = json.decode(res)
-            ngx.say(res.node.value.upstream.tls.client_key == ssl_key)
+            ngx.say(res.value.upstream.tls.client_key == ssl_key)
         }
     }
 --- request
@@ -387,7 +387,7 @@ apisix:
             end
 
             res = json.decode(res)
-            ngx.say(res.node.value.upstream.tls.client_key == ssl_key)
+            ngx.say(res.value.upstream.tls.client_key == ssl_key)
 
             -- upstream
             local data = {
@@ -423,7 +423,7 @@ apisix:
             end
 
             res = json.decode(res)
-            ngx.say(res.node.value.tls.client_key == ssl_key)
+            ngx.say(res.value.tls.client_key == ssl_key)
 
             local data = {
                 upstream = {
@@ -460,7 +460,7 @@ apisix:
             end
 
             res = json.decode(res)
-            ngx.say(res.node.value.upstream.tls.client_key == ssl_key)
+            ngx.say(res.value.upstream.tls.client_key == ssl_key)
         }
     }
 --- request

--- a/t/plugin/echo.t
+++ b/t/plugin/echo.t
@@ -211,7 +211,7 @@ Location: https://www.iresty.com
             end
 
             local resp_data = core.json.decode(body)
-            ngx.say(encode_with_keys_sorted(resp_data.node.value.plugins))
+            ngx.say(encode_with_keys_sorted(resp_data.value.plugins))
         }
     }
 --- request

--- a/t/plugin/google-cloud-logging2.t
+++ b/t/plugin/google-cloud-logging2.t
@@ -58,24 +58,8 @@ __DATA__
                 }
             }
 
-            local expected = {
-                node = {
-                    value = {
-                        plugins = {
-                            ["google-cloud-logging"] = {
-                                max_retry_count = 0,
-                                retry_delay = 1,
-                                buffer_duration = 60,
-                                batch_max_size = 1000,
-                                inactive_timeout = 5,
-                            }
-                        }
-                    }
-                }
-            }
-
             local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, config, expected)
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, config)
 
             if code >= 300 then
                 ngx.status = code

--- a/t/plugin/jwt-auth.t
+++ b/t/plugin/jwt-auth.t
@@ -1126,7 +1126,7 @@ base64_secret required but the secret is not in base64 format
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, body, res_data = t('/apisix/admin/consumers',
+            local code, body, res = t('/apisix/admin/consumers',
                 ngx.HTTP_PUT,
                 [[{
                     "username": "kerouac",
@@ -1136,28 +1136,18 @@ base64_secret required but the secret is not in base64 format
                             "secret": "my-secret-key"
                         }
                     }
-                }]],
-                [[{
-                    "node": {
-                        "value": {
-                            "username": "kerouac",
-                            "plugins": {
-                                "jwt-auth": {
-                                    "key": "exp-not-set",
-                                    "secret": "my-secret-key"
-                                }
-                            }
-                        }
-                    }
                 }]]
-                )
+            )
+
+            res = require("toolkit.json").decode(res)
+            assert(res.value.plugins["jwt-auth"].exp == 86400)
 
             ngx.status = code
-            ngx.say(require("toolkit.json").encode(res_data))
+            ngx.say(body)
         }
     }
---- response_body_like eval
-qr/"exp":86400/
+--- response_body
+passed
 
 
 

--- a/t/plugin/key-auth.t
+++ b/t/plugin/key-auth.t
@@ -188,7 +188,7 @@ GET /hello
                 code, body = t('/apisix/admin/consumers',
                     ngx.HTTP_PUT,
                     string.format('{"username":"%s","plugins":{"key-auth":{"key":"%s"}}}', username, key),
-                    string.format('{"node":{"value":{"username":"%s","plugins":{"key-auth":{"key":"%s"}}}},}', username, key)
+                    string.format('{"value":{"username":"%s","plugins":{"key-auth":{"key":"%s"}}}}', username, key)
                     )
             end
 

--- a/t/plugin/proxy-rewrite.t
+++ b/t/plugin/proxy-rewrite.t
@@ -1060,7 +1060,7 @@ q: apisix)
             end
 
             local resp_data = core.json.decode(body)
-            ngx.say(encode_with_keys_sorted(resp_data.node.value.plugins))
+            ngx.say(encode_with_keys_sorted(resp_data.value.plugins))
         }
     }
 --- request

--- a/t/plugin/response-rewrite.t
+++ b/t/plugin/response-rewrite.t
@@ -471,7 +471,7 @@ invalid base64 content
             end
 
             local resp_data = core.json.decode(body)
-            ngx.say(encode_with_keys_sorted(resp_data.node.value.plugins))
+            ngx.say(encode_with_keys_sorted(resp_data.value.plugins))
         }
     }
 --- request

--- a/t/router/multi-ssl-certs.t
+++ b/t/router/multi-ssl-certs.t
@@ -40,12 +40,10 @@ location /t {
             ngx.HTTP_PUT,
             core.json.encode(data),
             [[{
-                "node": {
-                    "value": {
-                        "sni": "www.test.com"
-                    },
-                    "key": "/apisix/ssls/1"
-                }
+                "value": {
+                    "sni": "www.test.com"
+                },
+                "key": "/apisix/ssls/1"
             }]]
             )
 
@@ -186,12 +184,10 @@ location /t {
             ngx.HTTP_PUT,
             core.json.encode(data),
             [[{
-                "node": {
-                    "value": {
-                        "sni": "*.test2.com"
-                    },
-                    "key": "/apisix/ssls/2"
-                }
+                "value": {
+                    "sni": "*.test2.com"
+                },
+                "key": "/apisix/ssls/2"
             }]]
             )
 
@@ -270,12 +266,10 @@ location /t {
             ngx.HTTP_PUT,
             core.json.encode(data),
             [[{
-                "node": {
-                    "value": {
-                        "sni": "apisix.dev"
-                    },
-                    "key": "/apisix/ssls/3"
-                }
+                "value": {
+                    "sni": "apisix.dev"
+                },
+                "key": "/apisix/ssls/3"
             }]]
             )
 

--- a/t/router/radixtree-sni.t
+++ b/t/router/radixtree-sni.t
@@ -40,14 +40,12 @@ location /t {
             ngx.HTTP_PUT,
             core.json.encode(data),
             [[{
-                "node": {
-                    "value": {
-                        "sni": "www.test.com"
-                    },
-                    "key": "/apisix/ssls/1"
-                }
+                "value": {
+                    "sni": "www.test.com"
+                },
+                "key": "/apisix/ssls/1"
             }]]
-            )
+        )
 
         ngx.status = code
         ngx.say(body)
@@ -78,7 +76,7 @@ passed
                         },
                         "uri": "/hello"
                 }]]
-                )
+            )
 
             if code >= 300 then
                 ngx.status = code
@@ -226,14 +224,12 @@ location /t {
             ngx.HTTP_PUT,
             core.json.encode(data),
             [[{
-                "node": {
-                    "value": {
-                        "sni": "*.test.com"
-                    },
-                    "key": "/apisix/ssls/1"
-                }
+                "value": {
+                    "sni": "*.test.com"
+                },
+                "key": "/apisix/ssls/1"
             }]]
-            )
+        )
 
         ngx.status = code
         ngx.say(body)
@@ -339,14 +335,12 @@ location /t {
             ngx.HTTP_PUT,
             core.json.encode(data),
             [[{
-                "node": {
-                    "value": {
-                        "sni": "test.com"
-                    },
-                    "key": "/apisix/ssls/1"
-                }
+                "value": {
+                    "sni": "test.com"
+                },
+                "key": "/apisix/ssls/1"
             }]]
-            )
+        )
 
         ngx.status = code
         ngx.say(body)
@@ -452,14 +446,12 @@ location /t {
             ngx.HTTP_PUT,
             core.json.encode(data),
             [[{
-                "node": {
-                    "value": {
-                        "sni": "*.test2.com"
-                    },
-                    "key": "/apisix/ssls/1"
-                }
+                "value": {
+                    "sni": "*.test2.com"
+                },
+                "key": "/apisix/ssls/1"
             }]]
-            )
+        )
 
         ngx.status = code
         ngx.say(body)
@@ -579,14 +571,12 @@ location /t {
             ngx.HTTP_PATCH,
             core.json.encode(data),
             [[{
-                "node": {
-                    "value": {
-                        "status": 0
-                    },
-                    "key": "/apisix/ssls/1"
-                }
+                "value": {
+                    "status": 0
+                },
+                "key": "/apisix/ssls/1"
             }]]
-            )
+        )
 
         ngx.status = code
         ngx.say(body)
@@ -659,14 +649,12 @@ location /t {
             ngx.HTTP_PATCH,
             core.json.encode(data),
             [[{
-                "node": {
-                    "value": {
-                        "status": 1
-                    },
-                    "key": "/apisix/ssls/1"
-                }
+                "value": {
+                    "status": 1
+                },
+                "key": "/apisix/ssls/1"
             }]]
-            )
+        )
 
         ngx.status = code
         ngx.say(body)
@@ -742,14 +730,12 @@ location /t {
             ngx.HTTP_PUT,
             core.json.encode(data),
             [[{
-                "node": {
-                    "value": {
-                        "snis": ["test2.com", "*.test2.com"]
-                    },
-                    "key": "/apisix/ssls/1"
-                }
+                "value": {
+                    "snis": ["test2.com", "*.test2.com"]
+                },
+                "key": "/apisix/ssls/1"
             }]]
-            )
+        )
 
         ngx.status = code
         ngx.say(body)

--- a/t/router/radixtree-sni2.t
+++ b/t/router/radixtree-sni2.t
@@ -49,12 +49,10 @@ location /t {
             ngx.HTTP_PUT,
             core.json.encode(data),
             [[{
-                "node": {
-                    "value": {
-                        "sni": "test.com"
-                    },
-                    "key": "/apisix/ssls/1"
-                }
+                "value": {
+                    "sni": "test.com"
+                },
+                "key": "/apisix/ssls/1"
             }]]
         )
         ngx.status = code
@@ -170,14 +168,12 @@ location /t {
             ngx.HTTP_PUT,
             core.json.encode(data),
             [[{
-                "node": {
-                    "value": {
-                        "sni": "*.test2.com"
-                    },
-                    "key": "/apisix/ssls/1"
-                }
+                "value": {
+                    "sni": "*.test2.com"
+                },
+                "key": "/apisix/ssls/1"
             }]]
-            )
+        )
 
         ngx.status = code
         ngx.say(body)
@@ -271,7 +267,7 @@ location /t {
         local code, body = t.test('/apisix/admin/ssls/1',
             ngx.HTTP_PUT,
             core.json.encode(data)
-            )
+        )
 
         ngx.status = code
         ngx.print(body)

--- a/t/router/radixtree-uri-with-parameter.t
+++ b/t/router/radixtree-uri-with-parameter.t
@@ -59,20 +59,18 @@ __DATA__
                     "uri": "/name/:name/bar"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "uri": "/name/:name/bar",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:1980": 1
-                                },
-                                "type": "roundrobin"
-                            }
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "uri": "/name/:name/bar",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        }
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
-                )
+            )
 
             if code >= 300 then
                 ngx.status = code
@@ -161,20 +159,18 @@ qr/404 Not Found/
                     "uri": "/:name/foo"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "uri": "/:name/foo",
-                            "upstream": {
-                                "nodes": {
-                                    "127.0.0.1:1980": 1
-                                },
-                                "type": "roundrobin"
-                            }
-                        },
-                        "key": "/apisix/routes/1"
-                    }
+                    "value": {
+                        "uri": "/:name/foo",
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        }
+                    },
+                    "key": "/apisix/routes/1"
                 }]]
-                )
+            )
 
             if code >= 300 then
                 ngx.status = code
@@ -219,11 +215,11 @@ GET /json/bbb/foo
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                         "hosts": ["bar.com"]
                 }]]
-                )
+            )
 
             if code >= 300 then
                 ngx.status = code
@@ -232,8 +228,8 @@ GET /json/bbb/foo
             end
 
             local code, body = t('/apisix/admin/routes/1',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                         "methods": ["GET"],
                         "upstream": {
                             "nodes": {
@@ -247,7 +243,7 @@ GET /json/bbb/foo
                         "service_id": "1",
                         "uri": "/:name/hello"
                 }]]
-                )
+            )
 
             if code >= 300 then
                 ngx.status = code
@@ -256,8 +252,8 @@ GET /json/bbb/foo
             end
 
             local code, body = t('/apisix/admin/routes/2',
-                 ngx.HTTP_PUT,
-                 [[{
+                ngx.HTTP_PUT,
+                [[{
                         "methods": ["GET"],
                         "upstream": {
                             "nodes": {
@@ -271,7 +267,7 @@ GET /json/bbb/foo
                         "uri": "/:name/hello",
                         "priority": -1
                 }]]
-                )
+            )
 
             if code >= 300 then
                 ngx.status = code


### PR DESCRIPTION
### Description

There are still parts of our current Admin API v3 implementation that don't make sense, they exist for compatibility with the etcd v2 protocol, and we need to remove those parts to simplify the Admin API and make it fit our plans.

- remove nested `node` struct on get single record, create, update
- remove empty `node` field on delete
- remove `count` field and add `total` field that depend by paging

This PR completes them and modifies all the test cases involved, so this PR is large, which is mainly all about the data format modification of the test cases.

Fix problem1 in #7789

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
