### PR TITLE
change: sni无法匹配ssl证书的时候，使用默认证书，而不是错误终止

### DIFF
--- a/apisix/ssl/router/radixtree_sni.lua
+++ b/apisix/ssl/router/radixtree_sni.lua
@@ -144,7 +144,7 @@ function _M.match_and_set(api_ctx, match_only)
     local ok = radixtree_router:dispatch(sni_rev, nil, api_ctx)
     if not ok then
         core.log.error("failed to find any SSL certificate by SNI: ", sni)
-        return false
+        return true
     end
 
 
@@ -163,13 +163,13 @@ function _M.match_and_set(api_ctx, match_only)
             end
             core.log.warn("failed to find any SSL certificate by SNI: ",
                           sni, " matched SNIs: ", log_snis)
-            return false
+            return true
         end
     else
         if str_find(sni_rev, ".", #api_ctx.matched_sni) then
             core.log.warn("failed to find any SSL certificate by SNI: ",
                           sni, " matched SNI: ", api_ctx.matched_sni:reverse())
-            return false
+            return true
         end
     end
 


### PR DESCRIPTION
场景： ssl for saas业务场景下，网关层不配置证书，https请求在CF层拦截。CF回源到网关层，使用默认的证书。只要证书在有效期，CF会忽略证书域名的检查。目前的问题是， apisix  sni无法匹配证书的时直接终止了。

期望： apisix  sni无法匹配证书的时候，使用默认证书，使请求可以进行下去。