### PR TITLE
fix: Change opentelemetry's span kind to server

### DIFF
--- a/apisix/plugins/opentelemetry.lua
+++ b/apisix/plugins/opentelemetry.lua
@@ -296,7 +296,7 @@ function _M.rewrite(conf, api_ctx)
     end
 
     local ctx = tracer:start(upstream_context, api_ctx.var.request_uri, {
-        kind = span_kind.client,
+        kind = span_kind.server,
         attributes = attributes,
     })
     ctx:attach()

--- a/t/plugin/opentelemetry.t
+++ b/t/plugin/opentelemetry.t
@@ -553,6 +553,7 @@ plugin_attr:
 --- extra_init_by_lua
     local core = require("apisix.core")
     local otlp = require("opentelemetry.trace.exporter.otlp")
+    local span_kind = require("opentelemetry.trace.span_kind")
     otlp.export_spans = function(self, spans)
         if (#spans ~= 1) then
             ngx.log(ngx.ERR, "unexpected spans length: ", #spans)
@@ -562,6 +563,12 @@ plugin_attr:
         local span = spans[1]
         if span:context().trace_id ~= "01010101010101010101010101010101" then
             ngx.log(ngx.ERR, "unexpected trace id: ", span:context().trace_id)
+            return
+        end
+
+        local current_span_kind = span:plain().kind
+        if current_span_kind ~= span_kind.server then
+            ngx.log(ngx.ERR, "expected span.kind to be server but got ", current_span_kind)
             return
         end
 


### PR DESCRIPTION
### Description
According to [opentelemetry's spec](https://github.com/open-telemetry/opentelemetry-specification/blob/ea61daeeaf8a3770a5189528abc09f25b87c7531/specification/trace/api.md#spankind), span kind coming from apisix would make more sense to be `server`, this also allows tools like newrelic or datadog to feed dashboards that are split per transaction (request uri in apisix's case as it is the name of the span) and thei response times and statuses.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
