### PR TITLE
fix: reload once when log rotate

### DIFF
--- a/apisix/core/table.lua
+++ b/apisix/core/table.lua
@@ -41,6 +41,7 @@ local _M = {
     sort    = table.sort,
     clone   = require("table.clone"),
     isarray = require("table.isarray"),
+    isempty = require("table.isempty"),
 }
 
 

--- a/apisix/plugins/log-rotate.lua
+++ b/apisix/plugins/log-rotate.lua
@@ -48,7 +48,7 @@ local INTERVAL = 60 * 60    -- rotate interval (unit: second)
 local MAX_KEPT = 24 * 7     -- max number of log files will be kept
 local MAX_SIZE = -1         -- max size of file will be rotated
 local COMPRESSION_FILE_SUFFIX = ".tar.gz" -- compression file suffix
-local WAIT_TIME_BEFORE_COMPRESS = 60      -- wait time before compress
+local WAIT_TIME_BEFORE_COMPRESS = 0.5      -- wait time before compress
 local rotate_time
 local default_logs
 local enable_compression = false
@@ -247,7 +247,7 @@ local function rotate_file(files, now_time, max_kept, wait_time)
     end
 
     if enable_compression then
-        -- Waiting for the end of the old requests
+        -- Waiting for nginx reopen files
         -- to avoid losing logs during compression
         ngx_sleep(wait_time)
 

--- a/apisix/plugins/log-rotate.lua
+++ b/apisix/plugins/log-rotate.lua
@@ -35,11 +35,7 @@ local str_sub = string.sub
 local str_find = string.find
 local str_format = string.format
 local str_reverse = string.reverse
-local tab_insert = table.insert
-local tab_sort = table.sort
-local new_tab = require "table.new"
 local ngx_sleep = require("apisix.core.utils").sleep
-local isempty = require "table.isempty"
 local local_conf
 
 
@@ -138,12 +134,12 @@ local function scan_log_folder(log_file_name)
         if n ~= nil then
             local log_type = file:sub(n + 2)
             if log_type == log_file_name then
-                tab_insert(t, file)
+                core.table.insert(t, file)
             end
         end
     end
 
-    tab_sort(t, tab_sort_comp)
+    core.table.sort(t, tab_sort_comp)
     return t, log_dir
 end
 
@@ -222,11 +218,11 @@ end
 
 
 local function rotate_file(files, now_time, max_kept, wait_time)
-    if isempty(files) then
+    if core.table.isempty(files) then
         return
     end
 
-    local new_files = new_tab(2, 0)
+    local new_files = core.table.new(2, 0)
     -- rename the log files
     for _, file in ipairs(files) do
         local now_date = os_date("%Y-%m-%d_%H-%M-%S", now_time)
@@ -235,7 +231,7 @@ local function rotate_file(files, now_time, max_kept, wait_time)
             return
         end
 
-        tab_insert(new_files, new_file)
+        core.table.insert(new_files, new_file)
     end
 
     -- send signal to reopen log files
@@ -315,14 +311,14 @@ local function rotate()
     elseif max_size > 0 then
         local access_log_file_size = file_size(default_logs[DEFAULT_ACCESS_LOG_FILENAME].file)
         local error_log_file_size = file_size(default_logs[DEFAULT_ERROR_LOG_FILENAME].file)
-        local files = new_tab(2, 0)
+        local files = core.table.new(2, 0)
 
         if access_log_file_size >= max_size then
-            tab_insert(files, DEFAULT_ACCESS_LOG_FILENAME)
+            core.table.insert(files, DEFAULT_ACCESS_LOG_FILENAME)
         end
 
         if error_log_file_size >= max_size then
-            tab_insert(files, DEFAULT_ERROR_LOG_FILENAME)
+            core.table.insert(files, DEFAULT_ERROR_LOG_FILENAME)
         end
 
         rotate_file(files, now_time, max_kept, wait_time)

--- a/t/plugin/log-rotate2.t
+++ b/t/plugin/log-rotate2.t
@@ -34,7 +34,7 @@ plugins:
   - log-rotate
 plugin_attr:
   log-rotate:
-    interval: 1
+    interval: 2
     max_kept: 3
     enable_compression: true
 _EOC_
@@ -61,7 +61,7 @@ __DATA__
     location /t {
         content_by_lua_block {
             ngx.log(ngx.ERR, "start xxxxxx")
-            ngx.sleep(2.5)
+            ngx.sleep(3.5)
             local has_split_access_file = false
             local has_split_error_file = false
             local lfs = require("lfs")
@@ -105,7 +105,7 @@ start xxxxxx
 --- config
     location /t {
         content_by_lua_block {
-            ngx.sleep(2)
+            ngx.sleep(3)
 
             local default_logs = {}
             for file_name in lfs.dir(ngx.config.prefix() .. "/logs/") do
@@ -138,6 +138,7 @@ start xxxxxx
     }
 --- response_body
 passed
+--- timeout: 10
 
 
 

--- a/t/plugin/log-rotate2.t
+++ b/t/plugin/log-rotate2.t
@@ -34,9 +34,10 @@ plugins:
   - log-rotate
 plugin_attr:
   log-rotate:
-    interval: 2
+    interval: 1
     max_kept: 3
     enable_compression: true
+    wait_time: 0
 _EOC_
 
         $block->set_value("yaml_config", $yaml_config);
@@ -61,7 +62,7 @@ __DATA__
     location /t {
         content_by_lua_block {
             ngx.log(ngx.ERR, "start xxxxxx")
-            ngx.sleep(3.5)
+            ngx.sleep(2.5)
             local has_split_access_file = false
             local has_split_error_file = false
             local lfs = require("lfs")
@@ -105,7 +106,7 @@ start xxxxxx
 --- config
     location /t {
         content_by_lua_block {
-            ngx.sleep(3)
+            ngx.sleep(2)
 
             local default_logs = {}
             for file_name in lfs.dir(ngx.config.prefix() .. "/logs/") do
@@ -138,7 +139,6 @@ start xxxxxx
     }
 --- response_body
 passed
---- timeout: 10
 
 
 

--- a/t/plugin/log-rotate2.t
+++ b/t/plugin/log-rotate2.t
@@ -37,7 +37,6 @@ plugin_attr:
     interval: 1
     max_kept: 3
     enable_compression: true
-    wait_time: 0
 _EOC_
 
         $block->set_value("yaml_config", $yaml_config);
@@ -62,7 +61,7 @@ __DATA__
     location /t {
         content_by_lua_block {
             ngx.log(ngx.ERR, "start xxxxxx")
-            ngx.sleep(2.5)
+            ngx.sleep(3.5)
             local has_split_access_file = false
             local has_split_error_file = false
             local lfs = require("lfs")
@@ -106,7 +105,7 @@ start xxxxxx
 --- config
     location /t {
         content_by_lua_block {
-            ngx.sleep(2)
+            ngx.sleep(3)
 
             local default_logs = {}
             for file_name in lfs.dir(ngx.config.prefix() .. "/logs/") do


### PR DESCRIPTION
### Description

1.  Waiting for nginx reopen files to avoid losing logs during compression
2.  Refactor code to ensure that the signal is sent once at a time

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

