### PR TITLE
fix: plugin metadata missing v3 adapter call

### DIFF
--- a/apisix/admin/plugin_metadata.lua
+++ b/apisix/admin/plugin_metadata.lua
@@ -21,6 +21,7 @@ local utils   = require("apisix.admin.utils")
 
 local injected_mark = "injected metadata_schema"
 local _M = {
+    need_v3_filter = true,
 }
 
 

--- a/t/admin/plugin-metadata.t
+++ b/t/admin/plugin-metadata.t
@@ -38,14 +38,13 @@ __DATA__
                     "ikey": 1
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "skey": "val",
-                            "ikey": 1
-                        }
-                    }
+                    "value": {
+                        "skey": "val",
+                        "ikey": 1
+                    },
+                    "key": "/apisix/plugin_metadata/example-plugin"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -72,14 +71,12 @@ passed
                     "ikey": 2
                  }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "skey": "val2",
-                            "ikey": 2
-                        }
+                    "value": {
+                        "skey": "val2",
+                        "ikey": 2
                     }
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -92,14 +89,12 @@ passed
                     "ikey": 2
                  }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "skey": "val2",
-                            "ikey": 2
-                        }
+                    "value": {
+                        "skey": "val2",
+                        "ikey": 2
                     }
                 }]]
-                )
+            )
 
             ngx.say(code)
             ngx.say(body)
@@ -125,14 +120,12 @@ passed
                  ngx.HTTP_GET,
                  nil,
                 [[{
-                    "node": {
-                        "value": {
-                            "skey": "val2",
-                            "ikey": 2
-                        }
+                    "value": {
+                        "skey": "val2",
+                        "ikey": 2
                     }
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -153,9 +146,7 @@ passed
         content_by_lua_block {
             ngx.sleep(0.3)
             local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/plugin_metadata/example-plugin',
-                 ngx.HTTP_DELETE
-            )
+            local code, body = t('/apisix/admin/plugin_metadata/example-plugin', ngx.HTTP_DELETE)
 
             ngx.status = code
             ngx.say(body)
@@ -175,9 +166,7 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code = t('/apisix/admin/plugin_metadata/not_found',
-                 ngx.HTTP_DELETE
-            )
+            local code = t('/apisix/admin/plugin_metadata/not_found', ngx.HTTP_DELETE)
             ngx.say("[delete] code: ", code)
         }
     }
@@ -196,14 +185,12 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/plugin_metadata',
-                 ngx.HTTP_PUT,
-                 [[{"k": "v"}]],
+                ngx.HTTP_PUT,
+                [[{"k": "v"}]],
                 [[{
-                    "node": {
-                        "value": "sdf"
-                    }
+                    "value": "sdf"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -225,14 +212,12 @@ GET /t
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/plugin_metadata/test',
-                 ngx.HTTP_PUT,
-                 [[{"k": "v"}]],
+                ngx.HTTP_PUT,
+                [[{"k": "v"}]],
                 [[{
-                    "node": {
-                        "value": "sdf"
-                    }
+                    "value": "sdf"
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.print(body)
@@ -259,14 +244,12 @@ GET /t
                     "skey": "val"
                 }]],
                 [[{
-                    "node": {
-                        "value": {
-                            "skey": "val",
-                            "ikey": 1
-                        }
+                    "value": {
+                        "skey": "val",
+                        "ikey": 1
                     }
                 }]]
-                )
+            )
 
             ngx.status = code
             ngx.say(body)
@@ -289,12 +272,12 @@ qr/\{"error_msg":"invalid configuration: property \\"ikey\\" is required"\}/
             local json = require("toolkit.json")
             local t = require("lib.test_admin").test
             local code, message, res = t('/apisix/admin/plugin_metadata/example-plugin',
-                 ngx.HTTP_PUT,
+                ngx.HTTP_PUT,
                 [[{
                     "skey": "val",
                     "ikey": 1
                 }]]
-                )
+            )
 
             if code >= 300 then
                 ngx.status = code
@@ -303,13 +286,11 @@ qr/\{"error_msg":"invalid configuration: property \\"ikey\\" is required"\}/
             end
 
             res = json.decode(res)
-            res.node.value.create_time = nil
-            res.node.value.update_time = nil
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/plugin_metadata/example-plugin","value":{"ikey":1,"skey":"val"}}}
+{"key":"/apisix/plugin_metadata/example-plugin","value":{"ikey":1,"skey":"val"}}
 --- request
 GET /t
 --- no_error_log
@@ -323,9 +304,7 @@ GET /t
         content_by_lua_block {
             local json = require("toolkit.json")
             local t = require("lib.test_admin").test
-            local code, message, res = t('/apisix/admin/plugin_metadata/example-plugin',
-                 ngx.HTTP_GET
-                )
+            local code, message, res = t('/apisix/admin/plugin_metadata/example-plugin', ngx.HTTP_GET)
 
             if code >= 300 then
                 ngx.status = code
@@ -334,14 +313,17 @@ GET /t
             end
 
             res = json.decode(res)
-            local value = res.node.value
-            assert(res.count ~= nil)
-            res.count = nil
+
+            assert(res.createdIndex ~= nil)
+            res.createdIndex = nil
+            assert(res.modifiedIndex ~= nil)
+            res.modifiedIndex = nil
+
             ngx.say(json.encode(res))
         }
     }
 --- response_body
-{"node":{"key":"/apisix/plugin_metadata/example-plugin","value":{"ikey":1,"skey":"val"}}}
+{"key":"/apisix/plugin_metadata/example-plugin","value":{"ikey":1,"skey":"val"}}
 --- request
 GET /t
 --- no_error_log
@@ -355,9 +337,7 @@ GET /t
         content_by_lua_block {
             local json = require("toolkit.json")
             local t = require("lib.test_admin").test
-            local code, message, res = t('/apisix/admin/plugin_metadata/example-plugin',
-                 ngx.HTTP_DELETE
-                )
+            local code, message, res = t('/apisix/admin/plugin_metadata/example-plugin', ngx.HTTP_DELETE)
 
             if code >= 300 then
                 ngx.status = code
@@ -370,7 +350,7 @@ GET /t
         }
     }
 --- response_body
-{"deleted":"1","key":"/apisix/plugin_metadata/example-plugin","node":{}}
+{"deleted":"1","key":"/apisix/plugin_metadata/example-plugin"}
 --- request
 GET /t
 --- no_error_log

--- a/t/admin/plugin-metadata2.t
+++ b/t/admin/plugin-metadata2.t
@@ -45,9 +45,7 @@ __DATA__
             local json = require("toolkit.json")
             local t = require("lib.test_admin").test
 
-            local code, message, res = t('/apisix/admin/plugin_metadata',
-                ngx.HTTP_GET
-            )
+            local code, message, res = t('/apisix/admin/plugin_metadata', ngx.HTTP_GET)
 
             if code >= 300 then
                 ngx.status = code
@@ -60,4 +58,4 @@ __DATA__
         }
     }
 --- response_body
-{"count":0,"list":[]}
+{"list":[],"total":0}


### PR DESCRIPTION
### Description

The plugin metadata does not implement the filter in v3 adapter, add it in this PR and modify the test cases.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
