### PR TITLE
fix(http-logger): explicitly read the req body in rewrite phase

### DIFF
--- a/apisix/plugins/http-logger.lua
+++ b/apisix/plugins/http-logger.lua
@@ -150,6 +150,22 @@ local function send_http_data(conf, log_message)
 end
 
 
+function _M.rewrite(conf, ctx)
+
+    if conf.include_req_body then
+        -- explicitly read the req body
+        -- When the pre plugins returns, the following collection request will be empty
+        -- Such as the pre jwt plugin in rewrite phase:
+        -- return 401, {message = "Missing JWT token in request"}
+        -- @see log-util line 179 or line 183
+        -- local body = req_get_body_data() or local body_file = ngx.req.get_body_file()
+        -- body or body_file is empty
+        ngx.req.read_body()
+    end
+
+end
+
+
 function _M.body_filter(conf, ctx)
     log_util.collect_body(conf, ctx)
 end


### PR DESCRIPTION
### Description

Explicitly read the req body: 
When the pre plugins returns, the following collection request will be empty
Such as the pre jwt plugin in rewrite phase:
`return 401, {message = "Missing JWT token in request"}`
@see log-util line 179 or line 183
`local body = req_get_body_data() or local body_file = ngx.req.get_body_file()`
body or body_file is empty

如果使用了前置jwt-plugin或者其他自定义的鉴权插件，使用如下的退出
`return 401, {message = "Missing JWT token in request"}`
会导致在log阶段调用 log-util 179行 或者 183行读取请求体为空
`local body = req_get_body_data() or local body_file = ngx.req.get_body_file()`


Fixes #7890

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

