### PR TITLE
fix: use modifiedIndex as lru key when merge plugins from route and consumer

### DIFF
--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -56,6 +56,7 @@ local function plugin_consumer()
                 -- is 'username' field in admin
                 new_consumer.consumer_name = new_consumer.id
                 new_consumer.auth_conf = config
+                new_consumer.modifiedIndex = consumer.modifiedIndex
                 core.log.info("consumer:", core.json.delay_encode(new_consumer))
                 core.table.insert(plugins[name].nodes, new_consumer)
             end

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -517,7 +517,8 @@ function _M.merge_consumer_route(route_conf, consumer_conf, api_ctx)
     core.log.info("route conf: ", core.json.delay_encode(route_conf))
     core.log.info("consumer conf: ", core.json.delay_encode(consumer_conf))
 
-    local flag = tostring(route_conf) .. tostring(consumer_conf)
+    local flag = route_conf.value.id .. "#" .. route_conf.modifiedIndex
+                 .. "#" .. consumer_conf.id .. "#" .. consumer_conf.modifiedIndex
     local new_conf = merged_route(flag, nil,
                         merge_consumer_route, route_conf, consumer_conf)
 

--- a/t/node/consumer-plugin2.t
+++ b/t/node/consumer-plugin2.t
@@ -303,3 +303,135 @@ apikey: auth-jack
 --- error_code: 403
 --- response_body
 {"message":"Your IP address is not allowed"}
+
+
+
+=== TEST 9: use the latest consumer modifiedIndex as lrucache key
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "foo",
+                    "plugins": {
+                        "basic-auth": {
+                            "username": "foo",
+                            "password": "bar"
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            local code, body = t('/apisix/admin/plugin_configs/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "ip-restriction": {
+                            "whitelist": ["1.1.1.1"]
+                        },
+                        "basic-auth": {}
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugin_config_id": "1",
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uris": ["/hello"]
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.sleep(0.5)
+
+            local http = require "resty.http"
+            local httpc = http.new()
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port
+                        .. "/hello"
+            local headers = {
+                ["Authorization"] = "Basic Zm9vOmJhcg=="
+            }
+            local res, err = httpc:request_uri(uri, {headers = headers})
+            ngx.print(res.body)
+
+            local code, body = t('/apisix/admin/plugin_configs/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "ip-restriction": {
+                            "whitelist": ["1.1.1.1", "127.0.0.1"]
+                        },
+                        "basic-auth": {}
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.sleep(0.5)
+
+            local res, err = httpc:request_uri(uri, {headers = headers})
+            if not res then
+                ngx.say(err)
+                return
+            end
+            ngx.print(res.body)
+
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "foo",
+                    "plugins": {
+                        "basic-auth": {
+                            "username": "foo",
+                            "password": "bala"
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.sleep(0.5)
+
+            local headers = {
+                ["Authorization"] = "Basic Zm9vOmJhbGE="
+            }
+            local res, err = httpc:request_uri(uri, {headers = headers})
+            if not res then
+                ngx.say(err)
+                return
+            end
+            ngx.print(res.body)
+        }
+    }
+--- response_body
+{"message":"Your IP address is not allowed"}
+hello world
+hello world

--- a/t/node/plugin-configs.t
+++ b/t/node/plugin-configs.t
@@ -249,3 +249,105 @@ property "block_rules" validation failed
 --- response_body
 hello
 hello world
+
+
+
+=== TEST 5: use the latest plugin_consigs after merge the plugins from consumer and route
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "foo",
+                    "plugins": {
+                        "basic-auth": {
+                            "username": "foo",
+                            "password": "bar"
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            local code, body = t('/apisix/admin/plugin_configs/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "ip-restriction": {
+                            "whitelist": ["1.1.1.1"]
+                        },
+                        "basic-auth": {}
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugin_config_id": "1",
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uris": ["/hello"]
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.sleep(0.5)
+
+            local http = require "resty.http"
+            local httpc = http.new()
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port
+                        .. "/hello"
+            local headers = {
+                ["Authorization"] = "Basic Zm9vOmJhcg=="
+            }
+            local res, err = httpc:request_uri(uri, {headers = headers})
+            ngx.print(res.body)
+
+            local code, body = t('/apisix/admin/plugin_configs/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "ip-restriction": {
+                            "whitelist": ["1.1.1.1", "127.0.0.1"]
+                        },
+                        "basic-auth": {}
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.sleep(0.5)
+
+            local res, err = httpc:request_uri(uri, {headers = headers})
+            if not res then
+                ngx.say(err)
+                return
+            end
+            ngx.print(res.body)
+        }
+    }
+--- response_body
+{"message":"Your IP address is not allowed"}
+hello world


### PR DESCRIPTION
(cherry picked from commit a47d05a9a32db1ba7de6bda68c67cf0008f8442c)

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
