### PR TITLE
fix: prevent failing to start because of the conf server sock

### DIFF
--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -784,6 +784,17 @@ local function start(env, ...)
               ", the file will be overwritten")
     end
 
+    -- start a new APISIX instance
+
+    local conf_server_sock_path = env.apisix_home .. "/conf/config_listen.sock"
+    if pl_path.exists(conf_server_sock_path) then
+        -- remove stale sock (if exists) so that APISIX can start
+        local ok, err = os_remove(conf_server_sock_path)
+        if not ok then
+            util.die("failed to remove stale conf server sock file, error: ", err)
+        end
+    end
+
     local parser = argparse()
     parser:argument("_", "Placeholder")
     parser:option("-c --config", "location of customized config.yaml")

--- a/t/cli/test_cmd.sh
+++ b/t/cli/test_cmd.sh
@@ -21,6 +21,34 @@
 
 git checkout conf/config.yaml
 
+# remove stale conf server sock
+touch conf/config_listen.sock
+./bin/apisix start
+sleep 0.5
+./bin/apisix stop
+sleep 0.5
+
+if [ -e conf/config_listen.sock ]; then
+    echo "failed: should remove stale conf server sock"
+    exit 1
+fi
+
+# don't remove stale conf server sock when APISIX is running
+./bin/apisix start
+sleep 0.5
+./bin/apisix start
+sleep 0.5
+
+if [ ! -e conf/config_listen.sock ]; then
+    echo "failed: should not remove stale conf server sock"
+    exit 1
+fi
+
+./bin/apisix stop
+sleep 0.5
+
+echo "passed: stale conf server sock removed"
+
 # check restart with old nginx.pid exist
 echo "-1" > logs/nginx.pid
 out=$(./bin/apisix start 2>&1 || true)


### PR DESCRIPTION
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #7986

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
