### PR TITLE
chore: now we ship the Lua module of grpc-client-nginx-module in APISIX-Base

### DIFF
--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -47,7 +47,6 @@ dependencies = {
     "opentracing-openresty = 0.1",
     "lua-resty-radixtree = 2.8.2",
     "lua-protobuf = 0.3.4",
-    "grpc-client-nginx-module = 0.2.2",
     "lua-resty-openidc = 1.7.5",
     "luafilesystem = 1.7.0-2",
     "api7-lua-tinyyaml = 0.4.2",


### PR DESCRIPTION
As we use the latest APISIX-Base in the CI,
we need to ensure the latest Lua code is used.

Now we ship the Lua module of grpc-client-nginx-module in APISIX-Base
so we don't need to install it via luarocks.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
