### PR TITLE
change: update the default value about enable_cpu_affinity

### DIFF
--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -167,7 +167,7 @@ nginx_config:                     # config for render the template to generate n
   error_log: logs/error.log
   error_log_level:  warn          # warn,error
   worker_processes: auto          # if you want use multiple cores in container, you can inject the number of cpu as environment variable "APISIX_WORKER_PROCESSES"
-  enable_cpu_affinity: false       # enable cpu affinity, this is just work well only on physical machine
+  enable_cpu_affinity: false      # disable CPU affinity by default, if APISIX is deployed on a physical machine, it can be enabled and work well.
   worker_rlimit_nofile: 20480     # the number of files a worker process can open, should be larger than worker_connections
   worker_shutdown_timeout: 240s   # timeout for a graceful shutdown of worker processes
 

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -167,7 +167,7 @@ nginx_config:                     # config for render the template to generate n
   error_log: logs/error.log
   error_log_level:  warn          # warn,error
   worker_processes: auto          # if you want use multiple cores in container, you can inject the number of cpu as environment variable "APISIX_WORKER_PROCESSES"
-  enable_cpu_affinity: true       # enable cpu affinity, this is just work well only on physical machine
+  enable_cpu_affinity: false       # enable cpu affinity, this is just work well only on physical machine
   worker_rlimit_nofile: 20480     # the number of files a worker process can open, should be larger than worker_connections
   worker_shutdown_timeout: 240s   # timeout for a graceful shutdown of worker processes
 

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -447,7 +447,7 @@ git checkout conf/config.yaml
 make init
 
 grep -E "worker_cpu_affinity" conf/nginx.conf > /dev/null
-if [ ! $? -eq 0 ]; then
+if [ ! $? -eq 1 ]; then
     echo "failed: nginx.conf file is missing worker_cpu_affinity configuration"
     exit 1
 fi

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -448,7 +448,7 @@ make init
 
 count=`grep -c "worker_cpu_affinity" conf/nginx.conf  || true`
 if [ $count -ne 0 ]; then
-    echo "failed: nginx.conf file found worker_cpu_affinity when disable it"
+    echo "failed: nginx.conf file found worker_cpu_affinity when disabling it"
     exit 1
 fi
 

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -448,11 +448,11 @@ make init
 
 grep -E "worker_cpu_affinity" conf/nginx.conf > /dev/null
 if [ ! $? -eq 1 ]; then
-    echo "failed: nginx.conf file is missing worker_cpu_affinity configuration"
+    echo "failed: nginx.conf file is contains worker_cpu_affinity configuration"
     exit 1
 fi
 
-echo "passed: nginx.conf file contains worker_cpu_affinity configuration"
+echo "passed: nginx.conf file missing worker_cpu_affinity configuration"
 
 # check the 'worker_shutdown_timeout' in 'nginx.conf' .
 
@@ -564,7 +564,7 @@ nginx_config:
 make init
 
 count=`grep -c "worker_cpu_affinity" conf/nginx.conf  || true`
-if [ $count -ne 0 ]; then
+if [ $count -ne 1 ]; then
     echo "failed: nginx.conf file found worker_cpu_affinity when disable it"
     exit 1
 fi

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -452,7 +452,7 @@ if [ $count -ne 0 ]; then
     exit 1
 fi
 
-echo "passed: nginx.conf file disable cpu affinity"
+echo "passed: nginx.conf file disables cpu affinity"
 
 # check the 'worker_shutdown_timeout' in 'nginx.conf' .
 

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -446,13 +446,13 @@ git checkout conf/config.yaml
 
 make init
 
-grep -E "worker_cpu_affinity" conf/nginx.conf > /dev/null
-if [ ! $? -eq 1 ]; then
-    echo "failed: nginx.conf file is contains worker_cpu_affinity configuration"
+count=`grep -c "worker_cpu_affinity" conf/nginx.conf  || true`
+if [ $count -ne 0 ]; then
+    echo "failed: nginx.conf file found worker_cpu_affinity when disable it"
     exit 1
 fi
 
-echo "passed: nginx.conf file missing worker_cpu_affinity configuration"
+echo "passed: nginx.conf file disable cpu affinity"
 
 # check the 'worker_shutdown_timeout' in 'nginx.conf' .
 
@@ -558,18 +558,18 @@ git checkout conf/config.yaml
 
 echo '
 nginx_config:
-  enable_cpu_affinity: false
+  enable_cpu_affinity: true
 ' > conf/config.yaml
 
 make init
 
-count=`grep -c "worker_cpu_affinity" conf/nginx.conf  || true`
-if [ $count -ne 1 ]; then
-    echo "failed: nginx.conf file found worker_cpu_affinity when disable it"
+grep -E "worker_cpu_affinity" conf/nginx.conf > /dev/null
+if [ ! $? -eq 0 ]; then
+    echo "failed: nginx.conf file is missing worker_cpu_affinity configuration"
     exit 1
 fi
 
-echo "passed: nginx.conf file disable cpu affinity"
+echo "passed: nginx.conf file contains worker_cpu_affinity configuration"
 
 # set worker processes with env
 git checkout conf/config.yaml


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Nowadays, more and more users deploy APISIX via container. As Nginx's worker_cpu_affinity doesn't count with cgroup, enabling worker_cpu_affinity by default will affect the behavior of APISIX, for instance, multiple instances will be bound to one CPU. To avoid this problem, it would be better to disable CPU affinity option by default in the conf/config-default.yaml.

Fixes  https://github.com/apache/apisix/issues/8042

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
