### PR TITLE
feat: allow proxy-rewrite plugin to rewrite x-forwarded-port request header

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -656,6 +656,9 @@ http {
             set $dubbo_method                '';
             {% end %}
 
+            ### set  before  the proxy-rewrite_plugin update it
+            set $var_x_forwarded_port       $server_port;
+
             access_by_lua_block {
                 apisix.http_access_phase()
             }
@@ -672,7 +675,7 @@ http {
             set $var_x_forwarded_for        $remote_addr;
             set $var_x_forwarded_proto      $scheme;
             set $var_x_forwarded_host       $host;
-            set $var_x_forwarded_port       $server_port;
+	    ### set $var_x_forwarded_port       $server_port;  this direction been setted before lua.
 
             if ($http_x_forwarded_for != "") {
                 set $var_x_forwarded_for "${http_x_forwarded_for}, ${realip_remote_addr}";

--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -675,7 +675,6 @@ http {
             set $var_x_forwarded_for        $remote_addr;
             set $var_x_forwarded_proto      $scheme;
             set $var_x_forwarded_host       $host;
-	    ### set $var_x_forwarded_port       $server_port;  this direction been setted before lua.
 
             if ($http_x_forwarded_for != "") {
                 set $var_x_forwarded_for "${http_x_forwarded_for}, ${realip_remote_addr}";

--- a/apisix/plugins/proxy-rewrite.lua
+++ b/apisix/plugins/proxy-rewrite.lua
@@ -201,6 +201,9 @@ function _M.rewrite(conf, ctx)
             conf.headers_arr = {}
 
             for field, value in pairs(conf.headers) do
+		if field == "X-Forwarded-Port" then
+                    ngx.var.var_x_forwarded_port = value
+		end
                 core.table.insert_tail(conf.headers_arr, field, value)
             end
         end


### PR DESCRIPTION
### Description
   When the proxy forwards a request, the request header "X-Forwarded-Port" is generated by default. This value comes from $server_port , which is the port on which apisix listens. instead of  the original request port. Sometimes it is necessary to transfer the original port. However, after the plugin proxy-rewirte defines X-Forwarded-Port, it will still be overwritten by proxy_set_header X-Forwarded-Port in nginx.conf.
  
Fixes #4942

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
