### PR TITLE
docs: fix building apisix misled

### DIFF
--- a/docs/en/latest/building-apisix.md
+++ b/docs/en/latest/building-apisix.md
@@ -56,19 +56,15 @@ APISIX_VERSION='2.99.0'
 mkdir apisix-${APISIX_VERSION}
 ```
 
-You can now download the APISIX source code by running the command below:
+You can now clone the APISIX source code from Github by running the command below:
 
 ```shell
-wget https://downloads.apache.org/apisix/${APISIX_VERSION}/apache-apisix-${APISIX_VERSION}-src.tgz
+git clone --depth 1 --branch ${APISIX_VERSION} https://github.com/apache/apisix.git apisix-${APISIX_VERSION}
 ```
 
-You can also download the source package from the [Downloads page](https://apisix.apache.org/downloads/). You will also find source packages for APISIX Dashboard and APISIX Ingress Controller.
+You can also download the source package from the [Downloads page](https://apisix.apache.org/downloads/). But the source package missing the test case. This may affect subsequent operations. 
 
-After you have downloaded the package, you can extract the files to the folder created previously:
-
-```shell
-tar zxvf apache-apisix-${APISIX_VERSION}-src.tgz -C apisix-${APISIX_VERSION}
-```
+And you will also find source packages for APISIX Dashboard and APISIX Ingress Controller from [Downloads page](https://apisix.apache.org/downloads/).
 
 Now, navigate to the directory, create dependencies, and install APISIX as shown below:
 

--- a/docs/en/latest/building-apisix.md
+++ b/docs/en/latest/building-apisix.md
@@ -62,7 +62,7 @@ You can now clone the APISIX source code from Github by running the command belo
 git clone --depth 1 --branch ${APISIX_VERSION} https://github.com/apache/apisix.git apisix-${APISIX_VERSION}
 ```
 
-You can also download the source package from the [Downloads page](https://apisix.apache.org/downloads/). But the source package missing the test case. This may affect subsequent operations. 
+You can also download the source package from the [Downloads page](https://apisix.apache.org/downloads/). But the source package missing the test case. This may affect subsequent operations.
 
 And you will also find source packages for APISIX Dashboard and APISIX Ingress Controller from [Downloads page](https://apisix.apache.org/downloads/).
 

--- a/docs/zh/latest/building-apisix.md
+++ b/docs/zh/latest/building-apisix.md
@@ -63,7 +63,7 @@ mkdir apisix-${APISIX_VERSION}
 git clone --depth 1 --branch ${APISIX_VERSION} https://github.com/apache/apisix.git apisix-${APISIX_VERSION}
 ```
 
-你可以从[下载页面](https://apisix.apache.org/downloads/)下载源码包。但是官网的源码包，缺少测试用例，可能会对你后续操作产生困扰。
+你可以从[下载页面](https://apisix.apache.org/downloads/)下载源码包。但是官网的源码包缺少测试用例，可能会对你后续操作产生困扰。
 
 另外，你也可以在该页面找到 APISIX Dashboard 和 APISIX Ingress Controller 的源码包。
 

--- a/docs/zh/latest/building-apisix.md
+++ b/docs/zh/latest/building-apisix.md
@@ -57,21 +57,17 @@ APISIX_VERSION='2.99.0'
 mkdir apisix-${APISIX_VERSION}
 ```
 
-现在，你可以运行以下命令来下载 APISIX 源码包：
+现在，你可以运行以下命令，从 Github 克隆 APISIX 源码：
 
 ```shell
-wget https://downloads.apache.org/apisix/${APISIX_VERSION}/apache-apisix-${APISIX_VERSION}-src.tgz
+git clone --depth 1 --branch ${APISIX_VERSION} https://github.com/apache/apisix.git apisix-${APISIX_VERSION}
 ```
 
-你可以从[下载页面](https://apisix.apache.org/downloads/)下载源码包。你也可以在该页面找到 APISIX Dashboard 和 APISIX Ingress Controller 的源码包。
+你可以从[下载页面](https://apisix.apache.org/downloads/)下载源码包。但是官网的源码包，缺少测试用例，可能会对你后续操作产生困扰。
 
-下载源码包后，你可以将文件解压到之前创建的文件夹中：
+另外，你也可以在该页面找到 APISIX Dashboard 和 APISIX Ingress Controller 的源码包。
 
-```shell
-tar zxvf apache-apisix-${APISIX_VERSION}-src.tgz -C apisix-${APISIX_VERSION}
-```
-
-然后切换到解压的目录，创建依赖项并安装 APISIX，如下所示：
+然后切换到 APISIX 源码的目录，创建依赖项并安装 APISIX，命令如下所示：
 
 ```shell
 cd apisix-${APISIX_VERSION}


### PR DESCRIPTION
### Description

Use git clone instead of the source package for development environments. Because of source package is missing test case. Old documents will mislead the user. So I fix that.

Fixes #8168 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
