### PR TITLE
allow customize x_Forwarded_Port while handling upstream headers

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -258,6 +258,10 @@ local function set_upstream_headers(api_ctx, picked_server)
     if proto then
         api_ctx.var.var_x_forwarded_proto = proto
     end
+    local port = api_ctx.var.http_x_forwarded_port
+    if port then
+        api_ctx.var.var_x_forwarded_port = port
+    end
 end
 
 

--- a/t/plugin/proxy-rewrite2.t
+++ b/t/plugin/proxy-rewrite2.t
@@ -207,3 +207,26 @@ X-Forwarded-Proto: http
 X-Forwarded-Proto: grpc
 --- response_headers
 X-Forwarded-Proto: http
+
+=== TEST 7: customize X-Forwarded-Port
+--- apisix_yaml
+routes:
+  -
+    id: 1
+    uri: /echo
+    plugins:
+        proxy-rewrite:
+            headers:
+                X-Forwarded-Port: 10080
+    upstream_id: 1
+upstreams:
+  -
+    id: 1
+    nodes:
+        "127.0.0.1:1980": 1
+    type: roundrobin
+#END
+--- request
+GET /echo
+--- response_headers
+X-Forwarded-Port: 10080


### PR DESCRIPTION
### Description
       Before this time, the x-Forward-* related settings in proxy rewrite will be overwritten by the default values ​​in the nginx context.  Add simple code to allow setting x-forward-port header  in handle_upstream stage

Fixes #4942

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
