### PR TITLE
docs: Update standalone docs for change in SSL parameter

### DIFF
--- a/docs/en/latest/stand-alone.md
+++ b/docs/en/latest/stand-alone.md
@@ -169,7 +169,7 @@ plugins:
 ### How to enable SSL
 
 ```yml
-ssl:
+ssls:
     -
         cert: |
             -----BEGIN CERTIFICATE-----

--- a/docs/zh/latest/stand-alone.md
+++ b/docs/zh/latest/stand-alone.md
@@ -167,7 +167,7 @@ plugins:
 ### 启用 SSL
 
 ```yml
-ssl:
+ssls:
     -
         cert: |
             -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
I've recently updated from 2.15.0 to 3.0.0 and experienced an issue with the SSL configuration that I've narrowed down to the parameter `ssl` changed to `ssls` in the `apisix.yml` file when using standalone mode. 