### PR TITLE
fix: APISIX extended variables cannot be used in `_meta.filter`

### DIFF
--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -434,7 +434,7 @@ local function meta_filter(ctx, plugin_name, plugin_conf)
                          " plugin_name: ", plugin_name)
         return true
     end
-    ok, err = ex:eval()
+    ok, err = ex:eval(ctx.var)
     if err then
         core.log.warn("failed to run the 'vars' expression: ", err,
                          " plugin_name: ", plugin_name)

--- a/t/plugin/plugin.t
+++ b/t/plugin/plugin.t
@@ -781,7 +781,7 @@ passed
 
 
 
-=== TEST 30: hit route: proxy-rewrite enable with post_arg_xx in mata.filter
+=== TEST 30: hit route: proxy-rewrite enable with post_arg_xx in meta.filter
 --- request
 POST /hello
 key=abc

--- a/t/plugin/plugin.t
+++ b/t/plugin/plugin.t
@@ -737,3 +737,55 @@ passed
 GET /hello
 --- response_headers
 !x-version
+
+
+
+=== TEST 29: use APISIX's built-in variables in  meta.filter
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                {
+                    plugins = {
+                        ["proxy-rewrite"] = {
+                            _meta = {
+                                filter = {
+                                    {"post_arg_key", "==", "abc"}
+                                }
+                            },
+                            uri = "/echo",
+                            headers = {
+                                ["X-Api-Version"] = "ga"
+                            }
+                        }
+                    },
+                    upstream = {
+                        nodes = {
+                            ["127.0.0.1:1980"] = 1
+                        }
+                    },
+                    uri = "/hello"
+                }
+            )
+            if code >= 300 then
+                ngx.print(body)
+            else
+                ngx.say(body)
+            end
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 30: hit route: proxy-rewrite enable with post_arg_xx in mata.filter
+--- request
+POST /hello
+key=abc
+--- more_headers
+Content-Type: application/x-www-form-urlencoded
+--- response_headers
+x-api-version: ga


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #8251 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
