### PR TITLE
fix(ci): the `set-output` command is deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,8 +65,8 @@ jobs:
         id: branch_env
         shell: bash
         run: |
-          echo "##[set-output name=version;]$(echo ${GITHUB_REF##*/})"
-          echo "##[set-output name=fullname;]$(echo apache-apisix-${GITHUB_REF##*/}-src.tgz)"
+          echo "version=${GITHUB_REF##*/}" >>$GITHUB_OUTPUT
+          echo "fullname=apache-apisix-${GITHUB_REF##*/}-src.tgz" >>$GITHUB_OUTPUT
 
       - name: Extract test type
         shell: bash
@@ -74,13 +74,13 @@ jobs:
         run: |
           test_dir="${{ matrix.test_dir }}"
           if [[ $test_dir =~ 't/plugin' ]]; then
-            echo "##[set-output name=type;]$(echo 'plugin')"
+            echo "type=plugin" >>$GITHUB_OUTPUT
           fi
           if [[ $test_dir =~ 't/admin ' ]]; then
-            echo "##[set-output name=type;]$(echo 'first')"
+            echo "type=first" >>$GITHUB_OUTPUT
           fi
           if [[ $test_dir =~ ' t/xrpc' ]]; then
-            echo "##[set-output name=type;]$(echo 'last')"
+            echo "type=last" >>$GITHUB_OUTPUT
           fi
 
       - name: Linux launch common services

--- a/.github/workflows/centos7-ci.yml
+++ b/.github/workflows/centos7-ci.yml
@@ -52,7 +52,7 @@ jobs:
       id: branch_env
       shell: bash
       run: |
-        echo "##[set-output name=version;]$(echo ${GITHUB_REF##*/})"
+        echo "version=${GITHUB_REF##*/}" >>$GITHUB_OUTPUT
 
     - name: Extract test type
       shell: bash
@@ -60,13 +60,13 @@ jobs:
       run: |
         test_dir="${{ matrix.test_dir }}"
         if [[ $test_dir =~ 't/plugin' ]]; then
-          echo "##[set-output name=type;]$(echo 'plugin')"
+          echo "type=plugin" >>$GITHUB_OUTPUT
         fi
         if [[ $test_dir =~ 't/admin ' ]]; then
-          echo "##[set-output name=type;]$(echo 'first')"
+          echo "type=first" >>$GITHUB_OUTPUT
         fi
-        if [[ $test_dir =~ ' t/xds-library' ]]; then
-          echo "##[set-output name=type;]$(echo 'last')"
+        if [[ $test_dir =~ ' t/xrpc' ]]; then
+          echo "type=last" >>$GITHUB_OUTPUT
         fi
 
     - name: Linux launch common services

--- a/.github/workflows/centos7-ci.yml
+++ b/.github/workflows/centos7-ci.yml
@@ -65,7 +65,7 @@ jobs:
         if [[ $test_dir =~ 't/admin ' ]]; then
           echo "type=first" >>$GITHUB_OUTPUT
         fi
-        if [[ $test_dir =~ ' t/xrpc' ]]; then
+        if [[ $test_dir =~ ' t/xds-library' ]]; then
           echo "type=last" >>$GITHUB_OUTPUT
         fi
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #8203 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
