### PR TITLE
ci: catch up "failed to execute" via no_error_log

### DIFF
--- a/docs/en/latest/internal/testing-framework.md
+++ b/docs/en/latest/internal/testing-framework.md
@@ -356,7 +356,7 @@ ONLY:
 
 ### Executing Shell Commands
 
-It is possible to execute shell commands while writing tests in test-nginx for APISIX. We expose this feature via `exec` code block. The `stdout` of the executed process can be captured via `response_body` code block and `stderr` (if any) can be captured by filtering error.log through `grep_error_log`. Here is an example:
+It is possible to execute shell commands while writing tests in test-nginx for APISIX. We expose this feature via `exec` code block. The `stdout` of the executed process can be captured via `response_body` code block. When the command failed, the `stderr` will be logged in `error` level so we can capture it by filtering error.log. Here is an example:
 
 ```
 === TEST 1: check exec stdout
@@ -369,8 +369,6 @@ hello world
 === TEST 2: when exec returns an error
 --- exec
 echxo hello world
---- grep_error_log eval
-qr/failed to execute the script [ -~]*/
---- grep_error_log_out
+--- error_log
 failed to execute the script with status: 127, reason: exit, stderr: /bin/sh: 1: echxo: not found
 ```

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -359,7 +359,7 @@ _EOC_
                     local shell = require("resty.shell")
                     local ok, stdout, stderr, reason, status = shell.run([[ $exec_snippet ]], $stdin, @{[$timeout*1000]}, $max_size)
                     if not ok then
-                        ngx.log(ngx.WARN, "failed to execute the script with status: " .. status .. ", reason: " .. reason .. ", stderr: " .. stderr)
+                        ngx.log(ngx.ERR, "failed to execute the script with status: " .. status .. ", reason: " .. reason .. ", stderr: " .. stderr)
                         return
                     end
                     ngx.print(stdout)


### PR DESCRIPTION
This feature is required by apisix-plugin-gm.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
