### PR TITLE
style: fix a confusing comment about Python 2 vs. 3

### DIFF
--- a/utils/check-category.py
+++ b/utils/check-category.py
@@ -24,10 +24,9 @@ from os import path
 EXT = ".md"
 
 try:
-    UNICODE_EXISTS = bool(type(unicode))
-except:
-    # Py2
-    unicode = str
+    unicode  # Python 2
+except NameError:
+    unicode = str  # Python 3
 
 def collect_fn(entries, topic):
     if "id" in topic:


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fix a confusing comment about Python 2 vs. 3.  The path labeled py2 is actually Python 3 and vice versa.

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
