### PR TITLE
fix: last_err can be nil when the reconnection is successful

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -574,7 +574,7 @@ local function _automatic_fetch(premature, self)
                 if err ~= self.last_err then
                     self.last_err = err
                     self.last_err_time = ngx_time()
-                else
+                elseif self.last_err then
                     if ngx_time() - self.last_err_time >= 30 then
                         self.last_err = nil
                     end
@@ -602,6 +602,12 @@ local function _automatic_fetch(premature, self)
     if not exiting() and self.running then
         ngx_timer_at(0, _automatic_fetch, self)
     end
+end
+
+-- for test
+_M.test_automatic_fetch = _automatic_fetch
+function _M.inject_sync_data(f)
+    sync_data = f
 end
 
 


### PR DESCRIPTION
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
