### PR TITLE
chore: update the default HTTP router

### DIFF
--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -75,7 +75,7 @@ apisix:
   # Turn this option on if you want to be compatible with servlet when matching URI path.
   normalize_uri_like_servlet: false
   router:
-    http: radixtree_uri         # radixtree_uri: match route by uri(base on radixtree)
+    http: radixtree_host_uri      # radixtree_uri: match route by uri(base on radixtree)
                                   # radixtree_host_uri: match route by host + uri(base on radixtree)
                                   # radixtree_uri_with_parameter: like radixtree_uri but match uri with parameters,
                                   #   see https://github.com/api7/lua-resty-radixtree/#parameters-in-path for

--- a/docs/en/latest/terminology/router.md
+++ b/docs/en/latest/terminology/router.md
@@ -44,7 +44,8 @@ A Router can have the following configurations:
     - `match priority`: First try an absolute match, if it didn't match, try prefix matching.
     - `Any filter attribute`: This allows you to specify any Nginx built-in variable as a filter, such as URL request parameters, request headers, and cookies.
   - `radixtree_uri_with_parameter`: Like `radixtree_uri` but also supports parameter match.
-  - `radixtree_host_uri`: Matches both host and URI of the request. Use `host + uri` as the primary index (based on the `radixtree` engine).
+  - `radixtree_host_uri`: Matches both host and URI of the request. Use `host + uri` as the primary index (based on the `radixtree` engine). It may lag in performance as compared to redixtree_uri.
+For better performance or stress test, you can change the HTTP router back to the radixtree_uri.
 
 - `apisix.router.ssl`: SSL loads the matching route.
   - `radixtree_sni`: (Default) Use `SNI` (Server Name Indication) as the primary index (based on the radixtree engine).


### PR DESCRIPTION
### Description

Updated the default HTTP router from radixtree_uri to radixtree_host_uri to remove the confusion that which route will hit first. Let's say, we have two routes, the first one requires the host matches *.example.com, and the URI path is /anything, And the second one needs the host matches foo.example.com exactly, and the URI path is also /anything. In such a case, if we send an API request, we may hit the first route, which is counterintuitive.

This is also helpful as most of the users have been in confusion since they think Apache APISIX will consider the HTTP host match by default. Also updated the documentation reflecting the result of these changes. i.e, Comparatively low performance can be expected in radixtree_host_uri

Fixes #8354

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
