### PR TITLE
chore(etcd): only one watching stream at most in each `core.config` object

### DIFF
--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -337,7 +337,6 @@ qr/healthy check use round robin
             config_etcd.test_automatic_fetch(false, {
                 running = true,
                 resync_delay = 1,
-                watching_streams = {},
             })
             ngx.say("passed")
         }


### PR DESCRIPTION
There is no need to use table to hold it.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
