### PR TITLE
docs: add missing `kubectl exec` step in the installation guide.

### DIFF
--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -216,7 +216,13 @@ brew services start etcd
 
 ### Configuring APISIX
 
-If you install APISIX via Docker, please exec into the apisix pod first:
+If you have done the Docker based installation, you need to exec into the `apisix` docker container to run the `apisix` command:
+
+```shell
+docker exec -it <name-of-container/container-id> sh
+```
+
+If you have installed via helm, you need to exec into the `apisix` kubernetes pod to run the `apisix` command:
 
 ```shell
 kubectl exec -it <name-of-apisix-pod> -n <namespace-running-apisix> -- sh

--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -216,6 +216,8 @@ brew services start etcd
 
 ### Configuring APISIX
 
+:::note
+
 If you have done the Docker based installation, you need to exec into the `apisix` docker container to run the `apisix` command:
 
 ```shell
@@ -227,6 +229,8 @@ If you have installed via helm, you need to exec into the `apisix` kubernetes po
 ```shell
 kubectl exec -it <name-of-apisix-pod> -n <namespace-running-apisix> -- sh
 ```
+
+:::
 
 You can configure your APISIX deployment in two ways:
 

--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -217,6 +217,7 @@ brew services start etcd
 ### Configuring APISIX
 
 If you install APISIX via Docker, please exec into the apisix pod first:
+
 ```shell
 kubectl exec -it <name-of-apisix-pod> -n <namespace-running-apisix> -- sh
 ```

--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -216,7 +216,7 @@ brew services start etcd
 
 ### Configuring APISIX
 
-First exec into the apisix pod:
+If you install APISIX via Docker, please exec into the apisix pod first:
 ```shell
 kubectl exec -it <name-of-apisix-pod> -n <namespace-running-apisix> -- sh
 ```

--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -216,6 +216,15 @@ brew services start etcd
 
 ### Configuring APISIX
 
+You can configure your APISIX deployment in two ways:
+
+1. By directly changing your configuration file (`conf/config.yaml`).
+2. By using the `--config` or the `-c` flag to pass the path to your configuration file while starting APISIX.
+
+   ```shell
+   apisix start -c <path to config file>
+   ```
+
 :::note
 
 If you have done the Docker based installation, you need to exec into the `apisix` docker container to run the `apisix` command:
@@ -231,15 +240,6 @@ kubectl exec -it <name-of-apisix-pod> -n <namespace-running-apisix> -- sh
 ```
 
 :::
-
-You can configure your APISIX deployment in two ways:
-
-1. By directly changing your configuration file (`conf/config.yaml`).
-2. By using the `--config` or the `-c` flag to pass the path to your configuration file while starting APISIX.
-
-   ```shell
-   apisix start -c <path to config file>
-   ```
 
 APISIX will use the configurations added in this configuration file and will fall back to the default configuration if anything is not configured.
 

--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -216,6 +216,11 @@ brew services start etcd
 
 ### Configuring APISIX
 
+First exec into the apisix pod:
+```shell
+kubectl exec -it <name-of-apisix-pod> -n <namespace-running-apisix> -- sh
+```
+
 You can configure your APISIX deployment in two ways:
 
 1. By directly changing your configuration file (`conf/config.yaml`).


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #8530
Slack discussion: https://the-asf.slack.com/archives/CUC5MN17A/p1671152569546829

### Checklist

- [x] I have explained the need for this PR and the problem it solves. (Check the issue description)
- [ ] I have explained the changes or the new features added to this PR. (Irrelevant)
- [ ] I have added tests corresponding to this change. (NA)
- [x] I have updated the documentation to reflect this change. 
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
