### PR TITLE
fix: use absolute path as pubsub search path

### DIFF
--- a/apisix/core/pubsub.lua
+++ b/apisix/core/pubsub.lua
@@ -23,6 +23,7 @@ local log          = require("apisix.core.log")
 local ws_server    = require("resty.websocket.server")
 local protoc       = require("protoc")
 local pb           = require("pb")
+local ngx          = ngx
 local setmetatable = setmetatable
 local pcall        = pcall
 local pairs        = pairs
@@ -42,7 +43,7 @@ local function init_pb_state()
     -- initialize protoc compiler
     protoc.reload()
     local pubsub_protoc = protoc.new()
-    pubsub_protoc:addpath("apisix/include/apisix/model")
+    pubsub_protoc:addpath(ngx.config.prefix() .. "apisix/include/apisix/model")
     local ok, err = pcall(pubsub_protoc.loadfile, pubsub_protoc, "pubsub.proto")
     if not ok then
         pubsub_protoc:reset()

--- a/t/pubsub/kafka.t
+++ b/t/pubsub/kafka.t
@@ -26,7 +26,7 @@ add_block_preprocessor(sub {
     my ($block) = @_;
 
     my $block_init = <<_EOC_;
-    `ln -sf $apisix_home/t $apisix_home/t/servroot/t`;
+    `ln -sf $apisix_home/apisix $apisix_home/t/servroot/apisix`;
 _EOC_
 
     $block->set_value("init", $block_init);
@@ -37,7 +37,7 @@ _EOC_
 });
 
 add_test_cleanup_handler(sub {
-    `rm -f $apisix_home/t/servroot/t`;
+    `rm -f $apisix_home/t/servroot/apisix`;
 });
 
 run_tests();

--- a/t/pubsub/kafka.t
+++ b/t/pubsub/kafka.t
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+use Cwd qw(cwd);
 use t::APISIX 'no_plan';
 
 repeat_each(1);

--- a/t/pubsub/kafka.t
+++ b/t/pubsub/kafka.t
@@ -21,7 +21,7 @@ repeat_each(1);
 no_long_string();
 no_root_location();
 
-my $apisix_home = $ENV{TEST_NGINX_SERVROOT} // cwd();
+my $apisix_home = $ENV{APISIX_HOME} // cwd();
 
 add_block_preprocessor(sub {
     my ($block) = @_;

--- a/t/pubsub/kafka.t
+++ b/t/pubsub/kafka.t
@@ -20,12 +20,24 @@ repeat_each(1);
 no_long_string();
 no_root_location();
 
+my $apisix_home = $ENV{TEST_NGINX_SERVROOT} // cwd();
+
 add_block_preprocessor(sub {
     my ($block) = @_;
+
+    my $block_init = <<_EOC_;
+        `ln -sf $apisix_home/t $apisix_home/t/servroot/t`;
+    _EOC_
+
+    $block->set_value("init", $block_init);
 
     if (!defined $block->request) {
         $block->set_value("request", "GET /t");
     }
+});
+
+add_test_cleanup_handler(sub {
+    `rm -f $apisix_home/t/servroot/t`;
 });
 
 run_tests();

--- a/t/pubsub/kafka.t
+++ b/t/pubsub/kafka.t
@@ -26,8 +26,8 @@ add_block_preprocessor(sub {
     my ($block) = @_;
 
     my $block_init = <<_EOC_;
-        `ln -sf $apisix_home/t $apisix_home/t/servroot/t`;
-    _EOC_
+    `ln -sf $apisix_home/t $apisix_home/t/servroot/t`;
+_EOC_
 
     $block->set_value("init", $block_init);
 

--- a/t/pubsub/pubsub.t
+++ b/t/pubsub/pubsub.t
@@ -21,8 +21,7 @@ repeat_each(1);
 no_long_string();
 no_root_location();
 
-
-my $apisix_home = $ENV{TEST_NGINX_SERVROOT} // cwd();
+my $apisix_home = $ENV{APISIX_HOME} // cwd();
 
 add_block_preprocessor(sub {
     my ($block) = @_;

--- a/t/pubsub/pubsub.t
+++ b/t/pubsub/pubsub.t
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+use Cwd qw(cwd);
 use t::APISIX 'no_plan';
 
 repeat_each(1);

--- a/t/pubsub/pubsub.t
+++ b/t/pubsub/pubsub.t
@@ -27,7 +27,7 @@ add_block_preprocessor(sub {
     my ($block) = @_;
 
     my $block_init = <<_EOC_;
-    `ln -sf $apisix_home/t $apisix_home/t/servroot/t`;
+    `ln -sf $apisix_home/apisix $apisix_home/t/servroot/apisix`;
 _EOC_
 
     $block->set_value("init", $block_init);
@@ -38,7 +38,7 @@ _EOC_
 });
 
 add_test_cleanup_handler(sub {
-    `rm -f $apisix_home/t/servroot/t`;
+    `rm -f $apisix_home/t/servroot/apisix`;
 });
 
 run_tests();

--- a/t/pubsub/pubsub.t
+++ b/t/pubsub/pubsub.t
@@ -20,12 +20,25 @@ repeat_each(1);
 no_long_string();
 no_root_location();
 
+
+my $apisix_home = $ENV{TEST_NGINX_SERVROOT} // cwd();
+
 add_block_preprocessor(sub {
     my ($block) = @_;
+
+    my $block_init = <<_EOC_;
+        `ln -sf $apisix_home/t $apisix_home/t/servroot/t`;
+    _EOC_
+
+    $block->set_value("init", $block_init);
 
     if (!defined $block->request) {
         $block->set_value("request", "GET /t");
     }
+});
+
+add_test_cleanup_handler(sub {
+    `rm -f $apisix_home/t/servroot/t`;
 });
 
 run_tests();

--- a/t/pubsub/pubsub.t
+++ b/t/pubsub/pubsub.t
@@ -27,8 +27,8 @@ add_block_preprocessor(sub {
     my ($block) = @_;
 
     my $block_init = <<_EOC_;
-        `ln -sf $apisix_home/t $apisix_home/t/servroot/t`;
-    _EOC_
+    `ln -sf $apisix_home/t $apisix_home/t/servroot/t`;
+_EOC_
 
     $block->set_value("init", $block_init);
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Currently, `pubsub` module uses relative path for pb file loading, once apisix's [`cwd`](https://en.wikipedia.org/wiki/Working_directory) is not `/usr/local/apisix`, it will cause pb file loading failure.

> step to change apisix's `cwd`
```bash
cd ~/

# apisix's cwd will change to user's home folder
apisix start
```

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
