### PR TITLE
fix(proxy-rewrite): fix url normalization bypass

### DIFF
--- a/apisix/plugins/proxy-rewrite.lua
+++ b/apisix/plugins/proxy-rewrite.lua
@@ -297,6 +297,8 @@ do
         else
             ctx.var.upstream_uri = upstream_uri
         end
+    else
+        ctx.var.upstream_uri = upstream_uri
     end
 
     if conf.headers then


### PR DESCRIPTION
### Description

This PR fixes a bug where ctx.var.upstream_uri is not set when use_real_request_uri_unsafe is enabled.

It seems that somewhere in the runtime chain (LuaJIT?) a memory jump occurs and ctx.var.upstream_uri _does_ get set even though it definitely **shouldn't**. Hence why this got unnoticed in the CI tests of #7401.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
