### PR TITLE
fix(ext-plugin-post-resp): can't set content-type response header

### DIFF
--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -76,7 +76,6 @@ local exclude_resp_header = {
     ["server"] = true,
     ["www-authenticate"] = true,
     ["content-encoding"] = true,
-    ["content-type"] = true,
     ["content-location"] = true,
     ["content-language"] = true,
 }

--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -76,6 +76,7 @@ local exclude_resp_header = {
     ["server"] = true,
     ["www-authenticate"] = true,
     ["content-encoding"] = true,
+    ["content-type"] = true,
     ["content-location"] = true,
     ["content-language"] = true,
 }
@@ -790,13 +791,11 @@ local rpc_handlers = {
             for i = 1, len do
                 local entry = call_resp:Headers(i)
                 local name = str_lower(entry:Name())
-                if not exclude_resp_header[name] then
-                    if resp_headers[name] == nil then
-                        core.response.set_header(name, entry:Value())
-                        resp_headers[name] = true
-                    else
-                        core.response.add_header(name, entry:Value())
-                    end
+                if resp_headers[name] == nil then
+                    core.response.set_header(name, entry:Value())
+                    resp_headers[name] = true
+                else
+                    core.response.add_header(name, entry:Value())
                 end
             end
         else

--- a/t/lib/ext-plugin.lua
+++ b/t/lib/ext-plugin.lua
@@ -534,6 +534,8 @@ function _M.go(case)
                 if runner and runner == "Go-runner" then
                     headers["x-runner"] = "Test-Runner"
                 end
+
+                headers["Content-Type"] = "application/json"
             end
 
             local i = 1

--- a/t/plugin/ext-plugin/response.t
+++ b/t/plugin/ext-plugin/response.t
@@ -155,6 +155,7 @@ resp-X-Runner: Go-runner
 --- error_code: 200
 --- response_headers
 X-Runner: Test-Runner
+Content-Type: application/json
 --- response_body
 hello world
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #8388 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
