### PR TITLE
feat(elasticsearch-logger): support multi elasticsearch endpoints

### DIFF
--- a/docs/en/latest/plugins/elasticsearch-logger.md
+++ b/docs/en/latest/plugins/elasticsearch-logger.md
@@ -37,7 +37,8 @@ When the Plugin is enabled, APISIX will serialize the request context informatio
 
 | Name          | Type    | Required | Default                     | Description                                                  |
 | ------------- | ------- | -------- | --------------------------- | ------------------------------------------------------------ |
-| endpoint_addr | string/array  | True     |                             | Elasticsearch API.                                            |
+| endpoint_addr | string  | Deprecated     |                             | Deprecated. Use `endpoint_addrs` instead. Elasticsearch API.                                            |
+| endpoint_addrs  | array  | True     |                             | Elasticsearch API. If multiple endpoints are configured, they will be written randomly.                                            |
 | field         | array   | True     |                             | Elasticsearch `field` configuration.                          |
 | field.index   | string  | True     |                             | Elasticsearch [_index field](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-index-field.html#mapping-index-field). |
 | field.type    | string  | False    | Elasticsearch default value | Elasticsearch [_type field](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/mapping-type-field.html#mapping-type-field). |
@@ -52,8 +53,6 @@ NOTE: `encrypt_fields = {"auth.password"}` is also defined in the schema, which 
 This Plugin supports using batch processors to aggregate and process entries (logs/data) in a batch. This avoids the need for frequently submitting the data. The batch processor submits data every `5` seconds or when the data in the queue reaches `1000`. See [Batch Processor](../batch-processor.md#configuration) for more information or setting your custom configuration.
 
 ## Enabling the Plugin
-
-If multiple endpoints are configured, they will be written randomly.
 
 ### Full configuration
 

--- a/docs/en/latest/plugins/elasticsearch-logger.md
+++ b/docs/en/latest/plugins/elasticsearch-logger.md
@@ -37,7 +37,7 @@ When the Plugin is enabled, APISIX will serialize the request context informatio
 
 | Name          | Type    | Required | Default                     | Description                                                  |
 | ------------- | ------- | -------- | --------------------------- | ------------------------------------------------------------ |
-| endpoint_addr | string  | True     |                             | Elasticsearch API.                                            |
+| endpoint_addr | string/array  | True     |                             | Elasticsearch API.                                            |
 | field         | array   | True     |                             | Elasticsearch `field` configuration.                          |
 | field.index   | string  | True     |                             | Elasticsearch [_index field](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-index-field.html#mapping-index-field). |
 | field.type    | string  | False    | Elasticsearch default value | Elasticsearch [_type field](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/mapping-type-field.html#mapping-type-field). |
@@ -52,6 +52,8 @@ NOTE: `encrypt_fields = {"auth.password"}` is also defined in the schema, which 
 This Plugin supports using batch processors to aggregate and process entries (logs/data) in a batch. This avoids the need for frequently submitting the data. The batch processor submits data every `5` seconds or when the data in the queue reaches `1000`. See [Batch Processor](../batch-processor.md#configuration) for more information or setting your custom configuration.
 
 ## Enabling the Plugin
+
+If multiple endpoints are configured, they will be written randomly.
 
 ### Full configuration
 

--- a/docs/zh/latest/plugins/elasticsearch-logger.md
+++ b/docs/zh/latest/plugins/elasticsearch-logger.md
@@ -38,7 +38,8 @@ description: 本文介绍了 API 网关 Apache APISIX 的 elasticsearch-logger �
 
 | 名称          | 类型    | 必选项 | 默认值               | 描述                                                         |
 | ------------- | ------- | -------- | -------------------- | ------------------------------------------------------------ |
-| endpoint_addr | string/array  | 是       |                      | Elasticsearch API。                                           |
+| endpoint_addr | string  | 废弃       |                      | Elasticsearch API。推荐使用 `endpoint_addrs`                                           |
+| endpoint_addrs | array  | 是       |                      | Elasticsearch API。如果配置多个 `endpoints`，日志将会随机写入到各个 `endpoints`。                                           |
 | field         | array   | 是       |                      | Elasticsearch `field`配置信息。                                |
 | field.index   | string  | 是       |                      | Elasticsearch `[_index field](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-index-field.html#mapping-index-field)`。 |
 | field.type    | string  | 否       | Elasticsearch 默认值 | Elasticsearch `[_type field](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/mapping-type-field.html#mapping-type-field)` |
@@ -92,12 +93,6 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1 \
     "uri":"/elasticsearch.do"
 }'
 ```
-
-:::note 注意
-
-如果配置多个 `endpoints`，日志将会随机写入到各个 `endpoints`。
-
-:::
 
 ### 最小化配置示例
 

--- a/docs/zh/latest/plugins/elasticsearch-logger.md
+++ b/docs/zh/latest/plugins/elasticsearch-logger.md
@@ -38,7 +38,7 @@ description: 本文介绍了 API 网关 Apache APISIX 的 elasticsearch-logger �
 
 | 名称          | 类型    | 必选项 | 默认值               | 描述                                                         |
 | ------------- | ------- | -------- | -------------------- | ------------------------------------------------------------ |
-| endpoint_addr | string  | 是       |                      | Elasticsearch API。                                           |
+| endpoint_addr | string/array  | 是       |                      | Elasticsearch API。                                           |
 | field         | array   | 是       |                      | Elasticsearch `field`配置信息。                                |
 | field.index   | string  | 是       |                      | Elasticsearch `[_index field](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-index-field.html#mapping-index-field)`。 |
 | field.type    | string  | 否       | Elasticsearch 默认值 | Elasticsearch `[_type field](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/mapping-type-field.html#mapping-type-field)` |
@@ -92,6 +92,12 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1 \
     "uri":"/elasticsearch.do"
 }'
 ```
+
+:::note 注意
+
+如果配置多个 `endpoints`，日志将会随机写入到各个 `endpoints`。
+
+:::
 
 ### 最小化配置示例
 

--- a/t/plugin/elasticsearch-logger.t
+++ b/t/plugin/elasticsearch-logger.t
@@ -551,3 +551,32 @@ PTQvJEaPcNOXcOHeErC0XQ==
     }
 --- response_body
 passed
+
+
+
+=== TEST 14: to show that different endpoints will be chosen randomly
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            for i = 1, 10 do
+                local code, body = t('/hello', ngx.HTTP_GET)
+                ngx.say("code: ", code)
+            end
+
+        }
+    }
+--- response_body
+code: 200
+code: 200
+code: 200
+code: 200
+code: 200
+code: 200
+code: 200
+code: 200
+code: 200
+code: 200
+--- error_log
+http://127.0.0.1:9200/_bulk
+http://127.0.0.1:9201/_bulk

--- a/t/plugin/elasticsearch-logger.t
+++ b/t/plugin/elasticsearch-logger.t
@@ -106,10 +106,10 @@ __DATA__
 --- response_body_like
 passed
 passed
-property "endpoint_addr" is required
-property "field" is required
+value should match only one schema, but matches none
+value should match only one schema, but matches none
 property "field" validation failed: property "index" is required
-property "endpoint_addr" validation failed: object matches none of the required
+property "endpoint_addr" validation failed: failed to match pattern "\[\^/\]\$" with "http://127.0.0.1:9200/"
 
 
 
@@ -533,7 +533,7 @@ PTQvJEaPcNOXcOHeErC0XQ==
                 },
                 plugins = {
                     ["elasticsearch-logger"] = {
-                        endpoint_addr = {"http://127.0.0.1:9200", "http://127.0.0.1:9201"},
+                        endpoint_addrs = {"http://127.0.0.1:9200", "http://127.0.0.1:9201"},
                         field = {
                             index = "services"
                         },

--- a/t/plugin/elasticsearch-logger.t
+++ b/t/plugin/elasticsearch-logger.t
@@ -109,7 +109,7 @@ passed
 property "endpoint_addr" is required
 property "field" is required
 property "field" validation failed: property "index" is required
-property "endpoint_addr" validation failed: failed to match pattern "\[\^/\]\$" with "http://127.0.0.1:9200/"
+property "endpoint_addr" validation failed: object matches none of the required
 
 
 
@@ -515,3 +515,39 @@ apisix:
 --- response_body
 123456
 PTQvJEaPcNOXcOHeErC0XQ==
+
+
+
+=== TEST 13: add plugin on routes using multi elasticsearch-logger
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, {
+                uri = "/hello",
+                upstream = {
+                    type = "roundrobin",
+                    nodes = {
+                        ["127.0.0.1:1980"] = 1
+                    }
+                },
+                plugins = {
+                    ["elasticsearch-logger"] = {
+                        endpoint_addr = {"http://127.0.0.1:9200", "http://127.0.0.1:9201"},
+                        field = {
+                            index = "services"
+                        },
+                        batch_max_size = 1,
+                        inactive_timeout = 1
+                    }
+                }
+            })
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed

--- a/t/plugin/elasticsearch-logger.t
+++ b/t/plugin/elasticsearch-logger.t
@@ -558,25 +558,27 @@ passed
 --- config
     location /t {
         content_by_lua_block {
+            local code_count = {}
             local t = require("lib.test_admin").test
-            for i = 1, 10 do
+            for i = 1, 12 do
                 local code, body = t('/hello', ngx.HTTP_GET)
-                ngx.say("code: ", code)
+                if code ~= 200 then
+                    ngx.say("code: ", code, " body: ", body)
+                end
+                code_count[code] = (code_count[code] or 0) + 1
             end
 
+            local code_arr = {}
+            for code, count in pairs(code_count) do
+                table.insert(code_arr, {code = code, count = count})
+            end
+
+            ngx.say(require("toolkit.json").encode(code_arr))
+            ngx.exit(200)
         }
     }
 --- response_body
-code: 200
-code: 200
-code: 200
-code: 200
-code: 200
-code: 200
-code: 200
-code: 200
-code: 200
-code: 200
+[{"code":200,"count":12}]
 --- error_log
 http://127.0.0.1:9200/_bulk
 http://127.0.0.1:9201/_bulk


### PR DESCRIPTION
### Description

When the apisix load is heavy, there are many logs, and the endpoint load of a single elasticsearch is too heavy. The elasticsearch-logger plugin supports multiple endpoints to share the load.

Fixes  (#8431)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
