### PR TITLE
fix: remove backslash before slash when encoding

### DIFF
--- a/apisix/core/json.lua
+++ b/apisix/core/json.lua
@@ -29,6 +29,7 @@ local pairs = pairs
 local cached_tab = {}
 
 
+cjson.encode_escape_forward_slash(false)
 cjson.decode_array_with_array_mt(true)
 local _M = {
     version = 0.1,

--- a/t/admin/api.t
+++ b/t/admin/api.t
@@ -137,4 +137,4 @@ deployment:
 X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
 --- response_headers
 X-API-VERSION: v2
---- response_body_like: "\\/apisix\\/routes"
+--- response_body_like: "/apisix/routes"

--- a/t/core/json.t
+++ b/t/core/json.t
@@ -139,3 +139,22 @@ qr/\{"b":\{"a":\{"b":"table: 0x[\w]+"\}\}\}/
 --- response_body
 {"arr":[]}
 {"obj":{}}
+
+
+
+=== TEST 7: encode slash without escape
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local json_data = core.json.encode({test="/test"})
+
+            ngx.say("encode: ", json_data)
+
+            local data = core.json.decode(json_data)
+            ngx.say("data: ", data.test)
+        }
+    }
+--- response_body
+encode: {"test":"/test"}
+data: /test

--- a/t/gm/gm.t
+++ b/t/gm/gm.t
@@ -157,7 +157,7 @@ location /t {
 }
 --- error_code: 400
 --- response_body
-{"error_msg":"sign cert\/key are required"}
+{"error_msg":"sign cert/key are required"}
 
 
 

--- a/t/plugin/ext-plugin/sanity.t
+++ b/t/plugin/ext-plugin/sanity.t
@@ -225,7 +225,7 @@ EXPIRE 3600
     }
 --- error_log
 runner exited with reason: exit, status: 111
-respawn runner 3 seconds later with cmd: ["t\/plugin\/ext-plugin\/runner.sh","0.1"]
+respawn runner 3 seconds later with cmd: ["t/plugin/ext-plugin/runner.sh","0.1"]
 
 
 

--- a/t/plugin/real-ip.t
+++ b/t/plugin/real-ip.t
@@ -80,7 +80,7 @@ __DATA__
 --- response_body
 {"error_msg":"failed to check the configuration of plugin real-ip err: property \"source\" is required"}
 {"error_msg":"failed to check the configuration of plugin real-ip err: property \"trusted_addresses\" validation failed: failed to validate item 1: object matches none of the required"}
-{"error_msg":"failed to check the configuration of plugin real-ip err: invalid ip address: ::1\/129"}
+{"error_msg":"failed to check the configuration of plugin real-ip err: invalid ip address: ::1/129"}
 
 
 

--- a/t/stream-node/sanity.t
+++ b/t/stream-node/sanity.t
@@ -317,7 +317,7 @@ hello world
 GET /t
 --- error_code: 400
 --- response_body
-{"error_msg":"invalid remote_addr: :\/8"}
+{"error_msg":"invalid remote_addr: :/8"}
 
 
 


### PR DESCRIPTION
### Description
Remove backslash before slash when encoding.

issue: #7785 
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #7785 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
