### PR TITLE
docs: fix code block

### DIFF
--- a/docs/en/latest/terminology/plugin-config.md
+++ b/docs/en/latest/terminology/plugin-config.md
@@ -52,7 +52,8 @@ curl http://127.0.0.1:9180/apisix/admin/plugin_configs/1 \
 ```
 
 ```shell
-curl http://127.0.0.1:9180/apisix/admin/routes/1 -H 'X-API-KEY:edd1c9f034335f136f87ad84b625c8f1' -X PUT -i -d '
+curl http://127.0.0.1:9180/apisix/admin/routes/1 \
+-H 'X-API-KEY:edd1c9f034335f136f87ad84b625c8f1' -X PUT -i -d '
 {
     "uris": ["/index.html"],
     "plugin_config_id": 1,

--- a/docs/en/latest/terminology/plugin-config.md
+++ b/docs/en/latest/terminology/plugin-config.md
@@ -36,34 +36,34 @@ While configuring the same plugin, only one copy of the configuration is valid. 
 
 The example below illustrates how to create a Plugin Config and bind it to a Route:
 
-    ```shell
-    curl http://127.0.0.1:9180/apisix/admin/plugin_configs/1 \
-    -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -i -d '
-    {
-        "desc": "blah",
-        "plugins": {
-            "limit-count": {
-                "count": 2,
-                "time_window": 60,
-                "rejected_code": 503
-            }
+```shell
+curl http://127.0.0.1:9180/apisix/admin/plugin_configs/1 \
+-H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -i -d '
+{
+    "desc": "blah",
+    "plugins": {
+        "limit-count": {
+            "count": 2,
+            "time_window": 60,
+            "rejected_code": 503
         }
-    }'
-    ```
+    }
+}'
+```
 
-    ```shell
-    curl http://127.0.0.1:9180/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -i -d '
-    {
-        "uris": ["/index.html"],
-        "plugin_config_id": 1,
-        "upstream": {
-            "type": "roundrobin",
-            "nodes": {
-                "127.0.0.1:1980": 1
-            }
+```shell
+curl http://127.0.0.1:9180/apisix/admin/routes/1 -H 'X-API-KEY:edd1c9f034335f136f87ad84b625c8f1' -X PUT -i -d '
+{
+    "uris": ["/index.html"],
+    "plugin_config_id": 1,
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "127.0.0.1:1980": 1
         }
-    }'
-    ```
+    }
+}'
+```
 
 When APISIX can't find the Plugin Config with the `id`, the requests reaching this Route are terminated with a status code of `503`.
 


### PR DESCRIPTION
### Description

The documentation for plugin config looks like this currently (inappropriate code block formatting):

<img width="1020" alt="image" src="https://user-images.githubusercontent.com/61597896/212868122-c2cfa309-d72a-44ce-8a63-c43d1d2c71cc.png">

This has been fixed:

<img width="1027" alt="image" src="https://user-images.githubusercontent.com/61597896/212872424-742c6610-ed49-495a-bd57-a56e62d87a07.png">


Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
