### PR TITLE
docs: (fix) tutorial expose your service

### DIFF
--- a/docs/en/latest/tutorials/expose-api.md
+++ b/docs/en/latest/tutorials/expose-api.md
@@ -114,7 +114,7 @@ After creating the Route, you can test the Service with the following command:
 curl -i -X GET "http://127.0.0.1:9080/anything/get?foo1=bar1&foo2=bar2" -H "Host: example.com"
 ```
 
-APISIX will forward the request to `http://httpbin.org:80/anything/foo?arg=10`.
+APISIX will forward the request to `http://httpbin.org:80/anything/get?foo1=bar1&foo2=bar2`.
 
 ## More Tutorials
 

--- a/docs/en/latest/tutorials/expose-api.md
+++ b/docs/en/latest/tutorials/expose-api.md
@@ -111,7 +111,7 @@ curl "http://127.0.0.1:9180/apisix/admin/routes/1" \
 After creating the Route, you can test the Service with the following command:
 
 ```
-curl -i -X GET "http://127.0.0.1:9080/get?foo1=bar1&foo2=bar2" -H "Host: example.com"
+curl -i -X GET "http://127.0.0.1:9080/anything/get?foo1=bar1&foo2=bar2" -H "Host: example.com"
 ```
 
 APISIX will forward the request to `http://httpbin.org:80/anything/foo?arg=10`.

--- a/docs/zh/latest/getting-started.md
+++ b/docs/zh/latest/getting-started.md
@@ -257,10 +257,10 @@ curl "http://127.0.0.1:9180/apisix/admin/routes/1" -H "X-API-KEY: edd1c9f034335f
 我们已经创建了路由与上游服务，现在可以通过以下命令访问上游服务：
 
 ```bash
-curl -i -X GET "http://127.0.0.1:9080/anything/get?foo1=bar1&foo2=bar2" -H "Host: httpbin.org"
+curl -i -X GET "http://127.0.0.1:9080/get?foo1=bar1&foo2=bar2" -H "Host: httpbin.org"
 ```
 
-该请求将被 APISIX 转发到 `http://httpbin.org:80/anything/get?foo1=bar1&foo2=bar2`。
+该请求将被 APISIX 转发到 `http://httpbin.org:80/anything/foo?arg=10`。
 
 ## 使用 APISIX Dashboard
 

--- a/docs/zh/latest/getting-started.md
+++ b/docs/zh/latest/getting-started.md
@@ -260,7 +260,7 @@ curl "http://127.0.0.1:9180/apisix/admin/routes/1" -H "X-API-KEY: edd1c9f034335f
 curl -i -X GET "http://127.0.0.1:9080/anything/get?foo1=bar1&foo2=bar2" -H "Host: httpbin.org"
 ```
 
-该请求将被 APISIX 转发到 `http://httpbin.org:80/anything/foo?arg=10`。
+该请求将被 APISIX 转发到 `http://httpbin.org:80/anything/get?foo1=bar1&foo2=bar2`。
 
 ## 使用 APISIX Dashboard
 

--- a/docs/zh/latest/getting-started.md
+++ b/docs/zh/latest/getting-started.md
@@ -257,7 +257,7 @@ curl "http://127.0.0.1:9180/apisix/admin/routes/1" -H "X-API-KEY: edd1c9f034335f
 我们已经创建了路由与上游服务，现在可以通过以下命令访问上游服务：
 
 ```bash
-curl -i -X GET "http://127.0.0.1:9080/get?foo1=bar1&foo2=bar2" -H "Host: httpbin.org"
+curl -i -X GET "http://127.0.0.1:9080/anything/get?foo1=bar1&foo2=bar2" -H "Host: httpbin.org"
 ```
 
 该请求将被 APISIX 转发到 `http://httpbin.org:80/anything/foo?arg=10`。

--- a/docs/zh/latest/tutorials/expose-api.md
+++ b/docs/zh/latest/tutorials/expose-api.md
@@ -114,7 +114,7 @@ curl "http://127.0.0.1:9180/apisix/admin/routes/1" \
 在创建完成路由后，你可以通过以下命令测试路由是否正常：
 
 ```
-curl -i -X GET "http://127.0.0.1:9080/get?foo1=bar1&foo2=bar2" -H "Host: example.com"
+curl -i -X GET "http://127.0.0.1:9080/anything/get?foo1=bar1&foo2=bar2" -H "Host: example.com"
 ```
 
 该请求将被 APISIX 转发到 `http://httpbin.org:80/anything/foo?arg=10`。

--- a/docs/zh/latest/tutorials/expose-api.md
+++ b/docs/zh/latest/tutorials/expose-api.md
@@ -117,7 +117,7 @@ curl "http://127.0.0.1:9180/apisix/admin/routes/1" \
 curl -i -X GET "http://127.0.0.1:9080/anything/get?foo1=bar1&foo2=bar2" -H "Host: example.com"
 ```
 
-该请求将被 APISIX 转发到 `http://httpbin.org:80/anything/foo?arg=10`。
+该请求将被 APISIX 转发到 `http://httpbin.org:80/anything/get?foo1=bar1&foo2=bar2`。
 
 ## 更多教程
 


### PR DESCRIPTION
### Description

For [this](https://apisix.apache.org/docs/apisix/tutorials/expose-api/#expose-your-service), after `step1` and `step2`, when we execute step3 test, 

`curl -i -X GET "http://127.0.0.1:9080/get?foo1=bar1&foo2=bar2" -H "Host: example.com"`

throws {"error_msg":"404 Route Not Found"}. So, the endpoint has been updated to  `http://127.0.0.1:9080/anything/get` from `http://127.0.0.1:9080/get`.

Fixes #8729, (Review https://github.com/apache/apisix/pull/7952#discussion_r1150118134)

P.S. > @navendu-pottekkat I've made the changes, but I'm uncertain whether I need to update [this](https://github.com/apache/apisix/blob/master/docs/en/latest/terminology/plugin.md#:~:text=curl%20%2Dv%20/dev/null%20http%3A//127.0.0.1%3A9080/get%3Fversion%3Dv2%20%2DH%22host%3Ahttpbin.org%22) & [this](https://github.com/apache/apisix/blob/master/docs/zh/latest/terminology/plugin.md#:~:text=curl%20%2Dv%20/dev/null%20http%3A//127.0.0.1%3A9080/get%20%2DH%22host%3Ahttpbin.org%22) respectively.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
