### PR TITLE
fix(etcd): reloaded data may be in res.body.node

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -367,12 +367,9 @@ local function sync_data(self)
             return false, err
         end
 
-        local dir_res, headers = res.body.list or {}, res.headers
+        local dir_res, headers = res.body.list or res.body.node or {}, res.headers
         log.debug("readdir key: ", self.key, " res: ",
                   json.delay_encode(dir_res))
-        if not dir_res then
-            return false, err
-        end
 
         if self.values then
             for i, val in ipairs(self.values) do
@@ -673,6 +670,7 @@ local function _automatic_fetch(premature, self)
 end
 
 -- for test
+_M.test_sync_data = sync_data
 _M.test_automatic_fetch = _automatic_fetch
 function _M.inject_sync_data(f)
     sync_data = f

--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -347,3 +347,100 @@ GET /t
 reconnected to etcd
 --- response_body
 passed
+
+
+
+=== TEST 11: reloaded data may be in res.body.node (special kvs structure)
+--- yaml_config
+deployment:
+    role: traditional
+    role_traditional:
+        config_provider: etcd
+    admin:
+        admin_key: null
+--- config
+    location /t {
+        content_by_lua_block {
+            local config_etcd = require("apisix.core.config_etcd")
+            local etcd_cli = {}
+            function etcd_cli.readdir()
+                return {
+                    status = 200,
+                    headers = {},
+                    body = {
+                        header = {revision = 1},
+                        kvs = {{key = "foo", value = "bar"}},
+                    }
+                }
+            end
+            config_etcd.test_sync_data({
+                etcd_cli = etcd_cli,
+                key = "fake",
+                single_item = true,
+                -- need_reload because something wrong happened before
+                need_reload = true,
+                upgrade_version = function() end,
+                conf_version = 1,
+            })
+        }
+    }
+--- request
+GET /t
+--- log_level: debug
+--- grep_error_log eval
+qr/readdir key: fake res: .+/
+--- grep_error_log_out eval
+qr/readdir key: fake res: \{("value":"bar","key":"foo"|"key":"foo","value":"bar")\}/
+--- wait: 1
+--- no_error_log
+[error]
+
+
+
+=== TEST 12: reloaded data may be in res.body.node (admin_api_version is v2)
+--- yaml_config
+deployment:
+    role: traditional
+    role_traditional:
+        config_provider: etcd
+    admin:
+        admin_key: null
+        admin_api_version: v2
+--- config
+    location /t {
+        content_by_lua_block {
+            local config_etcd = require("apisix.core.config_etcd")
+            local etcd_cli = {}
+            function etcd_cli.readdir()
+                return {
+                    status = 200,
+                    headers = {},
+                    body = {
+                        header = {revision = 1},
+                        kvs = {
+                            {key = "/foo"},
+                            {key = "/foo/bar", value = {"bar"}}
+                        },
+                    }
+                }
+            end
+            config_etcd.test_sync_data({
+                etcd_cli = etcd_cli,
+                key = "fake",
+                -- need_reload because something wrong happened before
+                need_reload = true,
+                upgrade_version = function() end,
+                conf_version = 1,
+            })
+        }
+    }
+--- request
+GET /t
+--- log_level: debug
+--- grep_error_log eval
+qr/readdir key: fake res: .+/
+--- grep_error_log_out eval
+qr/readdir key: fake res: \{.*"nodes":\[\{.*"value":\["bar"\].*\}\].*\}/
+--- wait: 1
+--- no_error_log
+[error]


### PR DESCRIPTION
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #8682

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
