### PR TITLE
feat: Body transformer plugin

### DIFF
--- a/apisix/plugins/body-transformer.lua
+++ b/apisix/plugins/body-transformer.lua
@@ -140,12 +140,13 @@ local function transform(conf, body, typ, ctx)
         return nil, 500, err
     end
 
+    core.log.info(typ, " body transform output=", out)
     return out
 end
 
 
 local function set_input_format(conf, typ, ct)
-    if conf.input_format == nil and ct then
+    if conf[typ].input_format == nil and ct then
         if ct:find("text/xml") then
             conf[typ].input_format = "xml"
         elseif ct:find("application/json") then

--- a/apisix/plugins/body-transformer.lua
+++ b/apisix/plugins/body-transformer.lua
@@ -53,7 +53,8 @@ local _M = {
 }
 
 
-local function escape_xml(s)
+-- luacheck: ignore
+function string.escape_xml(s)
     return s:gsub("&", "&amp;")
         :gsub("<", "&lt;")
         :gsub(">", "&gt;")
@@ -62,7 +63,8 @@ local function escape_xml(s)
 end
 
 
-local function escape_json(s)
+-- luacheck: ignore
+function string.escape_json(s)
     return core.json.encode(s)
 end
 
@@ -132,15 +134,7 @@ local function transform(conf, body, typ, ctx)
     end
 
     out._ctx = ctx
-
-    string.escape_xml = escape_xml
-    string.escape_json = escape_json
-
     local ok, render_out = pcall(render, out)
-
-    string.escape_xml = nil
-    string.escape_json = nil
-
     if not ok then
         local err = str_format("%s template rendering: %s", typ, render_out)
         core.log.error(err)

--- a/apisix/plugins/body-transformer.lua
+++ b/apisix/plugins/body-transformer.lua
@@ -1,0 +1,153 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+local core        = require("apisix.core")
+local xml2lua     = require("xml2lua")
+local handler     = require("xmlhandler.tree")
+local template    = require("resty.template")
+local ngx         = ngx
+local req_set_body_data = ngx.req.set_body_data
+local str_format  = string.format
+local pcall       = pcall
+local pairs       = pairs
+
+
+local transform_schema = {
+    type = "object",
+    properties = {
+        input_format = { type = "string", enum = {"xml", "json"} },
+        template = { type = "string" },
+    },
+    required = {"input_format", "template"},
+}
+
+local schema = {
+    type = "object",
+    properties = {
+        request = transform_schema,
+        response = transform_schema,
+    },
+}
+
+local _M = {
+    version  = 0.1,
+    priority = -1999,
+    name     = "body-transformer",
+    schema   = schema,
+}
+
+
+local function remove_namespace(tbl)
+    for k, v in pairs(tbl) do
+        if type(k) == "string" then
+            k = k:match(".*:(.*)")
+            if k then
+                tbl[k] = v
+            end
+            if type(v) == "table" then
+                remove_namespace(v)
+            end
+        end
+    end
+    return tbl
+end
+
+
+local decoders = {
+    xml = function(data)
+        local handler = handler:new()
+        local parser = xml2lua.parser(handler)
+        local ok, err = pcall(parser.parse, parser, data)
+        if ok then
+            return remove_namespace(handler.root)
+        else
+            return nil, err
+        end
+    end,
+    json = function(data)
+        return core.json.decode(data)
+    end,
+}
+
+
+function _M.check_schema(conf)
+    return core.schema.check(schema, conf)
+end
+
+
+local function transform(conf, body, typ)
+    local out, err = decoders[conf[typ].input_format](body)
+    if not out then
+        err = str_format("%s body decode: %s", typ, err)
+        core.log.error(err)
+        return nil, 400, err
+    end
+
+    local ok, render = pcall(template.compile, conf[typ].template)
+    if not ok then
+        local err = render
+        err = str_format("%s template compile: %s", typ, err)
+        core.log.error(err)
+        return nil, 500, err
+    end
+
+    ok, out = pcall(render, out)
+    if not ok then
+        err = str_format("%s template rendering: %s", typ, out)
+        core.log.error(err)
+        return nil, 500, err
+    end
+
+    return out
+end
+
+
+function _M.access(conf, ctx)
+    if conf.request then
+        local body = core.request.get_body()
+        local out, status, err = transform(conf, body, "request")
+        if not out then
+            return status, { message = err }
+        end
+        req_set_body_data(out)
+    end
+end
+
+
+function _M.header_filter(conf, ctx)
+    if conf.response then
+        core.response.clear_header_as_body_modified()
+    end
+end
+
+
+function _M.body_filter(conf, ctx)
+    local body = core.response.hold_body_chunk(ctx)
+    if not body then
+        return
+    end
+
+    local out = transform(conf, body, "response")
+    if not out then
+        core.log.error("failed to transform response body: ", body)
+        return
+    end
+
+    ngx.arg[1] = out
+end
+
+
+return _M

--- a/apisix/plugins/body-transformer.lua
+++ b/apisix/plugins/body-transformer.lua
@@ -42,6 +42,11 @@ local schema = {
         request = transform_schema,
         response = transform_schema,
     },
+    anyOf = {
+        {required = {"request"}},
+        {required = {"response"}},
+        {required = {"request", "response"}},
+    },
 }
 
 

--- a/apisix/plugins/body-transformer.lua
+++ b/apisix/plugins/body-transformer.lua
@@ -21,6 +21,7 @@ local template          = require("resty.template")
 local ngx               = ngx
 local req_set_body_data = ngx.req.set_body_data
 local str_format        = string.format
+local type              = type
 local pcall             = pcall
 local pairs             = pairs
 
@@ -53,17 +54,17 @@ local _M = {
 
 -- luacheck: ignore
 function string.escape_xml(s)
-	return s:gsub("&", "&amp;")
-		:gsub("<", "&lt;")
-		:gsub(">", "&gt;")
-		:gsub("'", "&apos;")
-		:gsub('"', "&quot;")
+    return s:gsub("&", "&amp;")
+        :gsub("<", "&lt;")
+        :gsub(">", "&gt;")
+        :gsub("'", "&apos;")
+        :gsub('"', "&quot;")
 end
 
 
 -- luacheck: ignore
 function string.escape_json(s)
-	return core.json.encode(s)
+    return core.json.encode(s)
 end
 
 
@@ -121,7 +122,7 @@ local function transform(conf, body, typ, ctx)
         return nil, 500, err
     end
 
-	out._ctx = ctx
+    out._ctx = ctx
     ok, out = pcall(render, out)
     if not ok then
         err = str_format("%s template rendering: %s", typ, out)
@@ -134,13 +135,13 @@ end
 
 
 local function set_input_format(conf, typ, ct)
-	if conf.input_format == nil and ct then
-		if ct:find("text/xml") then
-			conf[typ].input_format = "xml"
-		elseif ct:find("application/json") then
-			conf[typ].input_format = "json"
-		end
-	end
+    if conf.input_format == nil and ct then
+        if ct:find("text/xml") then
+            conf[typ].input_format = "xml"
+        elseif ct:find("application/json") then
+            conf[typ].input_format = "json"
+        end
+    end
 end
 
 

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -502,6 +502,7 @@ plugins:                          # plugin list (sorted by priority)
   - openwhisk                      # priority: -1901
   - openfunction                   # priority: -1902
   - serverless-post-function       # priority: -2000
+  - body-transformer               # priority: -1999
   - ext-plugin-post-req            # priority: -3000
   - ext-plugin-post-resp           # priority: -4000
 

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -455,6 +455,7 @@ plugins:                          # plugin list (sorted by priority)
   - opa                            # priority: 2001
   - authz-keycloak                 # priority: 2000
   #- error-log-logger              # priority: 1091
+  - body-transformer               # priority: 1080
   - proxy-mirror                   # priority: 1010
   - proxy-cache                    # priority: 1009
   - proxy-rewrite                  # priority: 1008

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -503,7 +503,6 @@ plugins:                          # plugin list (sorted by priority)
   - openwhisk                      # priority: -1901
   - openfunction                   # priority: -1902
   - serverless-post-function       # priority: -2000
-  - body-transformer               # priority: -1999
   - ext-plugin-post-req            # priority: -3000
   - ext-plugin-post-resp           # priority: -4000
 

--- a/docs/en/latest/config.json
+++ b/docs/en/latest/config.json
@@ -74,7 +74,8 @@
             "plugins/grpc-transcode",
             "plugins/grpc-web",
             "plugins/fault-injection",
-            "plugins/mocking"
+            "plugins/mocking",
+            "plugins/body-transformer"
           ]
         },
         {

--- a/docs/en/latest/plugins/body-transformer.md
+++ b/docs/en/latest/plugins/body-transformer.md
@@ -89,7 +89,17 @@ Currently, it only supports below formats:
   * `json` (`application/json`)
 * `template` specifies the [template](https://github.com/bungle/lua-resty-template) text used by transformation.
 
-Note that you must ensure `template` is a valid JSON string, i.e. you need to take care of special characters escape, e.g. double quote.
+**Notes:**
+
+If you do not specify `input_format` and no `Content-Type` header, or body is `nil`, then this plugin will not parse the body before template rendering.
+In any case, you could access body string via `{{ _body }}`.
+
+This is useful for below use cases:
+
+* you wish to generate body from scratch based on Nginx/APISIX variables, even if the original body is `nil`
+* you wish to parse the body string youself in the template via other lua modules
+
+You must ensure `template` is a valid JSON string, i.e. you need to take care of special characters escape, e.g. double quote.
 If it's cumbersome to escape big text file or complex file, you could use encode your template text file in base64 format instead.
 
 For example, you could use `base64` command to encode your template text file:
@@ -121,7 +131,7 @@ In `template`, you can use below auxiliary functions to escape string to fit spe
 * `str:escape_json()`
 * `str:escape_xml()`
 
-And, you can refer to `_ctx` to access nginx request context, e.g. `_ctx.var.status`.
+And, you can refer to `_ctx` to access nginx request context, e.g. `{{ _ctx.var.status }}`.
 
 ## Example
 

--- a/docs/en/latest/plugins/body-transformer.md
+++ b/docs/en/latest/plugins/body-transformer.md
@@ -90,9 +90,9 @@ Specify one of them, or both of them, to fit your need.
   * `json` (`application/json`)
 * `template` specifies the [template](https://github.com/bungle/lua-resty-template) text used by transformation.
 
-Note that `{{ ... }}` in lua-resty-template will do html-escape, e.g. space character, so if it's not what you wish, use `{* ... *}` instead.
-
 **Notes:**
+
+`{{ ... }}` in lua-resty-template will do html-escape, e.g. space character, so if it's not what you wish, use `{* ... *}` instead.
 
 If you do not specify `input_format` and no `Content-Type` header, or body is `nil`, then this plugin will not parse the body before template rendering.
 In any case, you could access body string via `{{ _body }}`.
@@ -144,7 +144,7 @@ In `template`, you can use below auxiliary functions to escape string to fit spe
 * `str:escape_json()`
 * `str:escape_xml()`
 
-Note that `escape_json()` would double quote the value of string type, so don't repeat double-quote in the template, e.g. `"foobar":{*name:escape_json()*}}`.
+Note that `escape_json()` would double quote the value of string type, so don't repeat double-quote in the template, e.g. `{"foobar":{*name:escape_json()*}}`.
 
 And, you can refer to `_ctx` to access nginx request context, e.g. `{{ _ctx.var.status }}`.
 

--- a/docs/en/latest/plugins/body-transformer.md
+++ b/docs/en/latest/plugins/body-transformer.md
@@ -43,10 +43,10 @@ Use cases:
 | ----------- | ----------- | ----------- | ----------- |
 | `request`      | object       | False      | request body transformation configuration      |
 | `request.input_format`      | string       | False      | request body original format, if not specified, it would be determined from `Content-Type` header.      |
-| `request.template`      | string       | False      | request body transformation template       |
+| `request.template`      | string       | True      | request body transformation template       |
 | `response`      | object       | False      | response body transformation configuration      |
-| `response.input_format`      | string       | False      | response body original format       |
-| `response.template`      | string       | False      | response body transformation template, if not specified, it would be determined from `Content-Type` header.       |
+| `response.input_format`      | string       | False      | response body original format, if not specified, it would be determined from `Content-Type` header.       |
+| `response.template`      | string       | True      | response body transformation template       |
 
 ## Enabling the Plugin
 

--- a/docs/en/latest/plugins/body-transformer.md
+++ b/docs/en/latest/plugins/body-transformer.md
@@ -1,0 +1,252 @@
+---
+title: body-transformer
+keywords:
+  - APISIX
+  - Plugin
+  - BODY TRANSFORMER
+  - body-transformer
+description: This document contains information about the Apache APISIX body-transformer Plugin.
+---
+
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+## Description
+
+This plugin is used to transform the request and/or response body from one
+format to another format, e.g. JSON to XML.
+
+Use cases:
+
+- simple SOAP proxy
+- generic template-based transform, e.g. JSON to JSON, JSON to HTML, XML to YAML
+
+## Attributes
+
+| Name      | Type | Required      | Description |
+| ----------- | ----------- | ----------- | ----------- |
+| `request.input_format`      | string       | False      | request body original format      |
+| `request.template`      | string       | False      | request body transformation template       |
+| `response.input_format`      | string       | False      | response body original format       |
+| `response.template`      | string       | False      | response body transformation template       |
+
+## Enabling the Plugin
+
+You can enable the Plugin on a specific Route as shown below:
+
+```shell
+curl http://127.0.0.1:9180/apisix/admin/routes/test_ws \
+    -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "methods": ["POST"],
+    "uri": "/ws",
+    "plugins": {
+        "body-transformer": {
+            "request": {
+                "template": "..."
+            },
+            "response": {
+                "template": "..."
+            }
+        }
+    },
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "localhost:8080": 1
+        }
+    }
+}'
+```
+
+## Configuration description
+
+The `request` and `response` correspond to configurations of request body and response body transformation perspectively.
+
+Specify one of them, or both of them, to fit your need.
+
+`request`/`response`:
+
+* `input_format` specifies the body original format, if not specified, it would be determined from `Content-Type` header.
+Currently, it only supports below formats:
+  * `xml` (`text/xml`)
+  * `json` (`application/json`)
+* `template` specifies the [template](https://github.com/bungle/lua-resty-template) text used by transformation.
+
+Note that you must ensure `template` is a valid JSON string, i.e. you need to take care of special characters escape, e.g. double quote.
+If it's cumbersome to escape big text file or complex file, you could use encode your template text file in base64 format instead.
+
+For example, you could use `base64` command to encode your template text file:
+
+```bash
+curl http://127.0.0.1:9180/apisix/admin/routes/test_ws \
+    -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "methods": ["POST"],
+    "uri": "/ws",
+    "plugins": {
+        "body-transformer": {
+            "request": {
+                "template": "'"$(base64 -w0 /path/to/my_template_file)"'"
+            }
+        }
+    },
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "localhost:8080": 1
+        }
+    }
+}'
+```
+
+In `template`, you can use below auxiliary functions to escape string to fit specific format:
+
+* `str:escape_json()`
+* `str:escape_xml()`
+
+And, you can refer to `_ctx` to access nginx request context, e.g. `_ctx.var.status`.
+
+## Example
+
+Let's take a simple SOAP proxy as example.
+
+* from downstream to upstream, it transforms the request body from JSON to XML
+* from upstream to downstream, it transforms the response body from XML to JSON
+  * the response `template` distinguishes the normal response from the fault response
+
+### Run a test web service server
+
+```bash
+cd /tmp
+git clone https://github.com/spring-guides/gs-soap-service.git
+cd gs-soap-service
+./mvnw spring-boot:run
+```
+
+### Test
+
+```bash
+req_template=$(cat <<EOF | awk '{gsub(/"/,"\\\"");};1' | awk '{$1=$1};1' | tr -d '\r\n'
+<?xml version="1.0"?>
+<soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
+ <soap-env:Body>
+  <ns0:getCountryRequest xmlns:ns0="http://spring.io/guides/gs-producing-web-service">
+   <ns0:name>{{name:escape_xml()}}</ns0:name>
+  </ns0:getCountryRequest>
+ </soap-env:Body>
+</soap-env:Envelope>
+EOF
+)
+
+rsp_template=$(cat <<EOF | awk '{gsub(/"/,"\\\"");};1' | awk '{$1=$1};1' | tr -d '\r\n'
+{% if Envelope.Body.Fault == nil then %}
+{
+   "status":"{{_ctx.var.status}}",
+   "currency":"{{Envelope.Body.getCountryResponse.country.currency}}",
+   "population":{{Envelope.Body.getCountryResponse.country.population}},
+   "capital":"{{Envelope.Body.getCountryResponse.country.capital}}",
+   "name":"{{Envelope.Body.getCountryResponse.country.name}}"
+}
+{% else %}
+{
+   "message":"{{Envelope.Body.Fault.faultstring[1]:escape_json()}}",
+   "code":"{{Envelope.Body.Fault.faultcode}}"
+   {% if Envelope.Body.Fault.faultactor ~= nil then %}
+   , "actor":"{{Envelope.Body.Fault.faultactor}}"
+   {% end %}
+}
+{% end %}
+EOF
+)
+
+curl http://127.0.0.1:9180/apisix/admin/routes/test_ws \
+    -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "methods": ["POST"],
+    "uri": "/ws",
+    "plugins": {
+        "proxy-rewrite": {
+            "headers": {
+                "set": {
+                    "Accept-Encoding": "identity",
+                    "Content-Type": "text/xml"
+                }
+            }
+        },
+        "response-rewrite": {
+            "headers": {
+                "set": {
+                    "Content-Type": "application/json"
+                }
+            }
+        },
+        "body-transformer": {
+            "request": {
+                "template": "'"$req_template"'"
+            },
+            "response": {
+                "template": "'"$rsp_template"'"
+            }
+        }
+    },
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "localhost:8080": 1
+        }
+    }
+}'
+
+curl -s http://127.0.0.1:9080/ws -H 'content-type: application/json' -X POST -d '{"name": "Spain"}' | jq
+{
+  "status": "200",
+  "currency": "EUR",
+  "population": 46704314,
+  "capital": "Madrid",
+  "name": "Spain"
+}
+
+# Fault response
+curl -s http://127.0.0.1:9080/ws -H 'content-type: application/json' -X POST -d '{"name": "Spain"}' | jq
+{
+  "message": "Your name is required.",
+  "code": "SOAP-ENV:Server"
+}
+```
+
+## Disable Plugin
+
+To disable the `body-transformer` Plugin, you can delete the corresponding JSON configuration from the Plugin configuration. APISIX will automatically reload and you do not have to restart for this to take effect.
+
+```shell
+curl http://127.0.0.1:9180/apisix/admin/routes/test_ws \
+    -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "methods": ["POST"],
+    "uri": "/ws",
+    "plugins": {},
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "localhost:8080": 1
+        }
+    }
+}'
+```

--- a/docs/en/latest/plugins/body-transformer.md
+++ b/docs/en/latest/plugins/body-transformer.md
@@ -97,7 +97,7 @@ In any case, you could access body string via `{{ _body }}`.
 This is useful for below use cases:
 
 * you wish to generate body from scratch based on Nginx/APISIX variables, even if the original body is `nil`
-* you wish to parse the body string youself in the template via other lua modules
+* you wish to parse the body string yourself in the template via other lua modules
 
 You must ensure `template` is a valid JSON string, i.e. you need to take care of special characters escape, e.g. double quote.
 If it's cumbersome to escape big text file or complex file, you could use encode your template text file in base64 format instead.

--- a/docs/en/latest/plugins/body-transformer.md
+++ b/docs/en/latest/plugins/body-transformer.md
@@ -141,10 +141,10 @@ curl http://127.0.0.1:9180/apisix/admin/routes/test_ws \
 
 In `template`, you can use below auxiliary functions to escape string to fit specific format:
 
-* `str:escape_json()`
-* `str:escape_xml()`
+* `_escape_json()`
+* `_escape_xml()`
 
-Note that `escape_json()` would double quote the value of string type, so don't repeat double-quote in the template, e.g. `{"foobar":{*name:escape_json()*}}`.
+Note that `_escape_json()` would double quote the value of string type, so don't repeat double-quote in the template, e.g. `{"foobar":{*_escape_json(name)*}}`.
 
 And, you can refer to `_ctx` to access nginx request context, e.g. `{{ _ctx.var.status }}`.
 
@@ -173,7 +173,7 @@ req_template=$(cat <<EOF | awk '{gsub(/"/,"\\\"");};1' | awk '{$1=$1};1' | tr -d
 <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
  <soap-env:Body>
   <ns0:getCountryRequest xmlns:ns0="http://spring.io/guides/gs-producing-web-service">
-   <ns0:name>{{name:escape_xml()}}</ns0:name>
+   <ns0:name>{{_escape_xml(name)}}</ns0:name>
   </ns0:getCountryRequest>
  </soap-env:Body>
 </soap-env:Envelope>
@@ -191,7 +191,7 @@ rsp_template=$(cat <<EOF | awk '{gsub(/"/,"\\\"");};1' | awk '{$1=$1};1' | tr -d
 }
 {% else %}
 {
-   "message":"{{Envelope.Body.Fault.faultstring[1]:escape_json()}}",
+   "message":{*_escape_json(Envelope.Body.Fault.faultstring[1])*},
    "code":"{{Envelope.Body.Fault.faultcode}}"
    {% if Envelope.Body.Fault.faultactor ~= nil then %}
    , "actor":"{{Envelope.Body.Fault.faultactor}}"

--- a/t/admin/plugins.t
+++ b/t/admin/plugins.t
@@ -88,6 +88,7 @@ consumer-restriction
 forward-auth
 opa
 authz-keycloak
+body-transformer
 proxy-mirror
 proxy-cache
 proxy-rewrite

--- a/t/plugin/body-transformer.t
+++ b/t/plugin/body-transformer.t
@@ -72,7 +72,7 @@ location /demo {
 <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
  <soap-env:Body>
   <ns0:getCountryRequest xmlns:ns0="http://spring.io/guides/gs-producing-web-service">
-   <ns0:name>{{name:escape_xml()}}</ns0:name>
+   <ns0:name>{{_escape_xml(name)}}</ns0:name>
   </ns0:getCountryRequest>
  </soap-env:Body>
 </soap-env:Envelope>
@@ -89,7 +89,7 @@ location /demo {
 }
 {% else %}
 {
-   "message":"{{Envelope.Body.Fault.faultstring[1]:escape_json()}}",
+   "message":{*_escape_json(Envelope.Body.Fault.faultstring[1])*},
    "code":"{{Envelope.Body.Fault.faultcode}}"
    {% if Envelope.Body.Fault.faultactor ~= nil then %}
    , "actor":"{{Envelope.Body.Fault.faultactor}}"
@@ -527,7 +527,7 @@ foobar:
 
 
 
-=== TEST 8: test escape_json
+=== TEST 8: test _escape_json
 --- config
     location /demo {
         content_by_lua_block {
@@ -543,7 +543,7 @@ foobar:
         content_by_lua_block {
             local t = require("lib.test_admin")
             local core = require("apisix.core")
-            local req_template = [[{"foobar":{*name:escape_json()*}}]]
+            local req_template = [[{"foobar":{*_escape_json(name)*}}]]
             local admin_body = [[{
                 "uri": "/foobar",
                 "plugins": {
@@ -590,7 +590,7 @@ foobar:
 
 
 
-=== TEST 9: test escape_xml
+=== TEST 9: test _escape_xml
 --- config
     location /demo {
         content_by_lua_block {
@@ -608,7 +608,7 @@ foobar:
         content_by_lua_block {
             local t = require("lib.test_admin")
             local core = require("apisix.core")
-            local req_template = [[<foobar>{*name:escape_xml()*}</foobar>]]
+            local req_template = [[<foobar>{*_escape_xml(name)*}</foobar>]]
             local admin_body = [[{
                 "uri": "/foobar",
                 "plugins": {

--- a/t/plugin/body-transformer.t
+++ b/t/plugin/body-transformer.t
@@ -1,0 +1,159 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+no_long_string();
+no_shuffle();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!$block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: set route
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin")
+
+            local req_template = ngx.encode_base64[[
+<?xml version="1.0"?>
+<soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
+ <soap-env:Body>
+  <ns0:getCountryRequest xmlns:ns0="http://spring.io/guides/gs-producing-web-service">
+   <ns0:name>{{name:escape_xml()}}</ns0:name>
+  </ns0:getCountryRequest>
+ </soap-env:Body>
+</soap-env:Envelope>
+            ]]
+
+            local rsp_template = ngx.encode_base64[[
+{% if Envelope.Body.Fault == nil then %}
+{
+   "status":"{{_ctx.var.status}}",
+   "currency":"{{Envelope.Body.getCountryResponse.country.currency}}",
+   "population":{{Envelope.Body.getCountryResponse.country.population}},
+   "capital":"{{Envelope.Body.getCountryResponse.country.capital}}",
+   "name":"{{Envelope.Body.getCountryResponse.country.name}}"
+}
+{% else %}
+{
+   "message":"{{Envelope.Body.Fault.faultstring[1]:escape_json()}}",
+   "code":"{{Envelope.Body.Fault.faultcode}}"
+   {% if Envelope.Body.Fault.faultactor ~= nil then %}
+   , "actor":"{{Envelope.Body.Fault.faultactor}}"
+   {% end %}
+}
+{% end %}
+            ]]
+
+            local code, body = t.test('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                string.format([[{
+                    "uri": "/ws",
+                    "plugins": {
+                        "proxy-rewrite": {
+                            "uri": "/demo"
+                        },
+                        "body-transformer": {
+                            "request": {
+                                "template": "%s"
+                            },
+                            "response": {
+                                "input_format": "xml",
+                                "template": "%s"
+                            }
+                        }
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:%d": 1
+                        }
+                    }
+                }]], req_template, rsp_template, ngx.var.server_port)
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.sleep(1)
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 2: hit route
+--- config
+location /demo {
+    content_by_lua_block {
+        local core = require("apisix.core")
+        local body = core.request.get_body()
+        local xml2lua = require("xml2lua")
+        local xmlhandler = require("xmlhandler.tree")
+        local handler = xmlhandler:new()
+        local parser = xml2lua.parser(handler)
+        --core.log.error(parser:parse(body))
+        ngx.print[[
+<SOAP-ENV:Envelope
+    xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Header/>
+    <SOAP-ENV:Body>
+        <ns2:getCountryResponse
+            xmlns:ns2="http://spring.io/guides/gs-producing-web-service">
+            <ns2:country>
+                <ns2:name>Spain</ns2:name>
+                <ns2:population>46704314</ns2:population>
+                <ns2:capital>Madrid</ns2:capital>
+                <ns2:currency>EUR</ns2:currency>
+            </ns2:country>
+        </ns2:getCountryResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+        ]]
+    }
+}
+location /t {
+    content_by_lua_block {
+        local core = require("apisix.core")
+        local http = require("resty.http")
+        local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/ws"
+        local body = [[{"name": "Spain"}]]
+        local opt = {method = "POST", body = body, headers = {["Content-Type"] = "application/json"}}
+        local httpc = http.new()
+        local res, err = httpc:request_uri(uri, opt)
+        if not res then
+            ngx.say(err)
+            return
+        end
+        assert(res.status == 200)
+        local data1 = core.json.decode(res.body)
+        local data2 = core.json.decode[[{"status":"200","currency":"EUR","population":46704314,"capital":"Madrid","name":"Spain"}]]
+        assert(core.json.stably_encode(data1), core.json.stably_encode(data2))
+    }
+}

--- a/t/plugin/body-transformer.t
+++ b/t/plugin/body-transformer.t
@@ -392,7 +392,7 @@ attempt to call global 'name' (a string value)
         content_by_lua_block {
             local t = require("lib.test_admin")
             local core = require("apisix.core")
-            -- html escape would escape '/' to '&#47' in string, which may be unexepcted.
+            -- html escape would escape '/' to '&#47' in string, which may be unexpected.
             -- 'lua-resty-http/0.16.1 (Lua) ngx_lua/10021'
             -- would be escaped into
             -- 'lua-resty-http&#47;0.16.1 (Lua) ngx_lua&#47;10021'

--- a/t/plugin/body-transformer.t
+++ b/t/plugin/body-transformer.t
@@ -43,7 +43,6 @@ location /demo {
         local handler = xmlhandler:new()
         local parser = xml2lua.parser(handler)
         parser:parse(body)
-        --core.log.error(core.json.encode(handler.root))
 
         ngx.print(string.format([[
 <SOAP-ENV:Envelope
@@ -138,11 +137,7 @@ location /demo {
             local body = [[{"name": "Spain"}]]
             local opt = {method = "POST", body = body, headers = {["Content-Type"] = "application/json"}}
             local httpc = http.new()
-            local res, err = httpc:request_uri(uri, opt)
-            if not res then
-                ngx.say(err)
-                return
-            end
+            local res = httpc:request_uri(uri, opt)
             assert(res.status == 200)
             local data1 = core.json.decode(res.body)
             local data2 = core.json.decode[[{"status":"200","currency":"EUR","population":46704314,"capital":"Madrid","name":"Spain"}]]
@@ -203,11 +198,7 @@ location /demo {
             local body = [[{"name":"hello","age":20}]]
             local opt = {method = "POST", body = body, headers = {["Content-Type"] = "application/json"}}
             local httpc = http.new()
-            local res, err = httpc:request_uri(uri, opt)
-            if not res then
-                ngx.say(err)
-                return
-            end
+            local res = httpc:request_uri(uri, opt)
             assert(res.status == 200)
         }
     }
@@ -258,7 +249,8 @@ location /demo {
             local body = [[{"name":"hello","age":20}]]
             local opt = {method = "POST", body = body, headers = {["Content-Type"] = "application/json"}}
             local httpc = http.new()
-            httpc:request_uri(uri, opt)
+            local res = httpc:request_uri(uri, opt)
+            assert(res.status == 400)
         }
     }
 --- error_log
@@ -309,11 +301,14 @@ Error Parsing XML
             local body = [[{"name":"hello","age":20}]]
             local opt = {method = "POST", body = body, headers = {["Content-Type"] = "application/json"}}
             local httpc = http.new()
-            httpc:request_uri(uri, opt)
+            local res = httpc:request_uri(uri, opt)
+            assert(res.status == 503)
         }
     }
---- error_log
-attempt to call global 'name' (a string value)
+--- grep_error_log eval
+qr/transform\(\): request template rendering:.*/
+--- grep_error_log_out eval
+qr/attempt to call global 'name' \(a string value\)/
 
 
 
@@ -370,7 +365,8 @@ attempt to call global 'name' (a string value)
             local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/foobar?name=hello"
             local opt = {method = "GET"}
             local httpc = http.new()
-            httpc:request_uri(uri, opt)
+            local res = httpc:request_uri(uri, opt)
+            assert(res.status == 200)
         }
     }
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

This plugin is used to transform the request or response body from one
format to another format, e.g. JSON to XML.

It depends on xml2lua and lua-resty-template.

Use cases:

* simple SOAP proxy
* generic template-based transform

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
