### PR TITLE
fix: the field allowed_by_methods of consumer-restriction

### DIFF
--- a/apisix/plugins/consumer-restriction.lua
+++ b/apisix/plugins/consumer-restriction.lua
@@ -105,7 +105,7 @@ local function is_method_allowed(allowed_methods, method, user)
             return false
         end
     end
-    return true
+    return false
 end
 
 local function reject(conf)

--- a/t/plugin/consumer-restriction.t
+++ b/t/plugin/consumer-restriction.t
@@ -564,13 +564,14 @@ Authorization: Basic amFjazIwMTk6MTIzNDU2
 
 
 
-=== TEST 27: verify jack2
+=== TEST 27: verify jack2 not in whitelist and allowed_by_methods
 --- request
 GET /hello
 --- more_headers
 Authorization: Basic amFjazIwMjA6MTIzNDU2
+--- error_code: 403
 --- response_body
-hello world
+{"message":"The consumer_name is forbidden."}
 
 
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #8792 

when allowed_by_methods is set but not whitelist, it means whitelist

refer: https://github.com/apache/apisix/pull/3691#discussion_r584399533

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
