### PR TITLE
fix: add admin schema to control_plane config

### DIFF
--- a/apisix/cli/schema.lua
+++ b/apisix/cli/schema.lua
@@ -375,6 +375,7 @@ local deployment_schema = {
     control_plane = {
         properties = {
             etcd = etcd_schema,
+            admin = admin_schema,
             role_control_plane = {
                 properties = {
                     config_provider = {

--- a/t/cli/test_deployment_control_plane.sh
+++ b/t/cli/test_deployment_control_plane.sh
@@ -53,7 +53,7 @@ deployment:
             cert: t/certs/mtls_server.crt
             cert_key: t/certs/mtls_server.key
     admin:
-      https_admin: "abc"
+        https_admin: "abc"
     etcd:
         prefix: "/apisix"
         host:

--- a/t/cli/test_deployment_control_plane.sh
+++ b/t/cli/test_deployment_control_plane.sh
@@ -52,6 +52,36 @@ deployment:
             listen: admin.apisix.dev:12345
             cert: t/certs/mtls_server.crt
             cert_key: t/certs/mtls_server.key
+    admin:
+      https_admin: "abc"
+    etcd:
+        prefix: "/apisix"
+        host:
+            - http://127.0.0.1:2379
+    certs:
+        trusted_ca_cert: t/certs/mtls_ca.crt
+' > conf/config.yaml
+
+out=$(make init 2>&1 || true)
+if ! echo "$out" | grep 'property "https_admin" validation failed: wrong type: expected boolean, got string'; then
+    echo "failed: should check deployment schema during init"
+    exit 1
+fi
+
+echo "passed: should check deployment schema during init"
+
+# The 'admin.apisix.dev' is injected by ci/common.sh@set_coredns
+echo '
+apisix:
+    enable_admin: false
+deployment:
+    role: control_plane
+    role_control_plane:
+        config_provider: etcd
+        conf_server:
+            listen: admin.apisix.dev:12345
+            cert: t/certs/mtls_server.crt
+            cert_key: t/certs/mtls_server.key
     etcd:
         prefix: "/apisix"
         host:


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes https://github.com/apache/apisix/issues/8804

Maybe just add the schema of admin to conrol_plane config definition is enough?

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
