### PR TITLE
fix: mocking plugin panic when response_example contain $ (#8810)

### DIFF
--- a/apisix/plugins/mocking.lua
+++ b/apisix/plugins/mocking.lua
@@ -191,7 +191,7 @@ function gen_by_property(property)
 end
 
 
-function _M.access(conf)
+function _M.access(conf, ctx)
     local response_content = ""
 
     if conf.response_example then
@@ -218,7 +218,7 @@ function _M.access(conf)
     if conf.delay > 0 then
         ngx.sleep(conf.delay)
     end
-    return conf.response_status, core.utils.resolve_var(response_content)
+    return conf.response_status, core.utils.resolve_var(response_content, ctx.var)
 end
 
 return _M

--- a/docs/en/latest/plugins/mocking.md
+++ b/docs/en/latest/plugins/mocking.md
@@ -38,7 +38,7 @@ The `mocking` Plugin is used for mocking an API. When executed, it returns rando
 | delay            | integer | False    |                  | Response delay in seconds.                                                             |
 | response_status  | integer | False    | 200              | HTTP status code of the response.                                                      |
 | content_type     | string  | False    | application/json | Header `Content-Type` of the response.                                                 |
-| response_example | string  | False    |                  | Body of the response.                                                                  |
+| response_example | string  | False    |                  | Body of the response, support use variables, like `$remote_addr $consumer_name`.       |
 | response_schema  | object  | False    |                  | The JSON schema object for the response. Works when `response_example` is unspecified. |
 | with_mock_header | boolean | False    | true             | When set to `true`, adds a response header `x-mock-by: APISIX/{version}`.              |
 

--- a/docs/zh/latest/plugins/mocking.md
+++ b/docs/zh/latest/plugins/mocking.md
@@ -38,7 +38,7 @@ description: 本文介绍了关于 Apache APISIX `mocking` 插件的基本信息
 | delay           | integer| 否    |                  | 延时返回的时间，单位为秒。                                            |
 | response_status | integer| 否    | 200              | 返回响应的 HTTP 状态码。                                            |
 | content_type    | string | 否    | application/json | 返回响应的 Header `Content-Type`。                                            |
-| response_example| string | 否    |                  | 返回响应的 Body，与 `response_schema` 字段二选一。                                            |
+| response_example| string | 否    |                  | 返回响应的 Body，支持使用变量，例如 `$remote_addr $consumer_name`，与 `response_schema` 字段二选一。 |
 | response_schema | object | 否    |                  | 指定响应的 `jsonschema` 对象，未指定 `response_example` 字段时生效。                        |
 | with_mock_header| boolean| 否    | true             | 当设置为 `true` 时，将添加响应头 `x-mock-by: APISIX/{version}`。设置为 `false` 时则不添加该响应头。   |
 

--- a/t/plugin/mocking.t
+++ b/t/plugin/mocking.t
@@ -346,3 +346,81 @@ passed
 GET /hello
 --- response_headers
 Content-Type: application/json
+
+
+
+=== TEST 15: set route(return response example:"remote_addr:127.0.0.1")
+--- config
+       location /t {
+           content_by_lua_block {
+               local t = require("lib.test_admin").test
+               local code, body = t('/apisix/admin/routes/1',
+                    ngx.HTTP_PUT,
+                    [[{
+                           "plugins": {
+                               "mocking": {
+                                   "delay": 1,
+                                   "content_type": "text/plain",
+                                   "response_status": 200,
+                                   "response_example": "remote_addr:$remote_addr"
+                               }
+                           },
+                           "uri": "/hello"
+                   }]]
+                   )
+
+               if code >= 300 then
+                   ngx.status = code
+               end
+               ngx.say(body)
+           }
+       }
+--- response_body
+passed
+
+
+
+=== TEST 16: hit route(return response example:"remote_addr:127.0.0.1")
+--- request
+GET /hello
+--- response_body chomp
+remote_addr:127.0.0.1
+
+
+
+=== TEST 17: set route(return response example:"empty_var:")
+--- config
+       location /t {
+           content_by_lua_block {
+               local t = require("lib.test_admin").test
+               local code, body = t('/apisix/admin/routes/1',
+                    ngx.HTTP_PUT,
+                    [[{
+                           "plugins": {
+                               "mocking": {
+                                   "delay": 1,
+                                   "content_type": "text/plain",
+                                   "response_status": 200,
+                                   "response_example": "empty_var:$foo"
+                               }
+                           },
+                           "uri": "/hello"
+                   }]]
+                   )
+
+               if code >= 300 then
+                   ngx.status = code
+               end
+               ngx.say(body)
+           }
+       }
+--- response_body
+passed
+
+
+
+=== TEST 18: hit route(return response example:"empty_var:")
+--- request
+GET /hello
+--- response_body chomp
+empty_var:


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (8810)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
