### PR TITLE
chore(test): split the access log of apisix and test server

### DIFF
--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -642,6 +642,8 @@ _EOC_
         $ipv6_fake_server
         server_tokens off;
 
+        access_log logs/fake-server-access.log main;
+
         location / {
             content_by_lua_block {
                 require("lib.server").go()
@@ -666,6 +668,8 @@ _EOC_
 
     $http_config .= <<_EOC_;
         server_tokens off;
+
+        access_log logs/fake-server-access.log main;
 
         ssl_certificate_by_lua_block {
             local ngx_ssl = require "ngx.ssl"
@@ -703,6 +707,8 @@ _EOC_
         ssl_certificate_by_lua_block {
             apisix.http_ssl_phase()
         }
+
+        access_log logs/access.log main;
 
         set \$dubbo_service_name          '';
         set \$dubbo_service_version       '';

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -570,6 +570,7 @@ function _M.go()
     local action = string.sub(ngx.var.uri, 2)
     action = string.gsub(action, "[/\\.-]", "_")
     if not action or not _M[action] then
+        ngx.log(ngx.WARN, "undefined path in test server, uri: ", ngx.var.uri)
         return ngx.exit(404)
     end
 

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -570,7 +570,7 @@ function _M.go()
     local action = string.sub(ngx.var.uri, 2)
     action = string.gsub(action, "[/\\.-]", "_")
     if not action or not _M[action] then
-        ngx.log(ngx.WARN, "undefined path in test server, uri: ", ngx.var.uri)
+        ngx.log(ngx.WARN, "undefined path in test server, uri: ", ngx.var.request_uri)
         return ngx.exit(404)
     end
 

--- a/t/plugin/ext-plugin/http-req-call.t
+++ b/t/plugin/ext-plugin/http-req-call.t
@@ -515,7 +515,7 @@ GET /hello
         }
     }
 --- error_log
-undefined path in test server, uri: /plugin_proxy_rewrite_args?a=2
+undefined path in test server, uri: /plugin_proxy_rewrite_args%3Fa=2
 --- error_code: 404
 
 

--- a/t/plugin/ext-plugin/http-req-call.t
+++ b/t/plugin/ext-plugin/http-req-call.t
@@ -514,8 +514,8 @@ GET /hello
             ext.go({rewrite_bad_path = true})
         }
     }
---- access_log
-GET /plugin_proxy_rewrite_args%3Fa=2
+--- error_log
+undefined path in test server, uri: /plugin_proxy_rewrite_args?a=2
 --- error_code: 404
 
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

1. Record the logs of apisix and test server separately for better observation
2. Use the defined log format

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
