### PR TITLE
docs: update doc for guide user to config auth etcd

### DIFF
--- a/docs/en/latest/FAQ.md
+++ b/docs/en/latest/FAQ.md
@@ -706,7 +706,7 @@ Another solution is to switch to an experimental gRPC-based configuration synchr
 
 ## How does APISIX configure ETCD with authentication
 
-Suppose you have an ETCD cluster that enables the auth. To access this cluster, you need to configure the correct username and password for Apache APISIX. Edit the `conf/config.yaml` file as follows:
+Suppose you have an ETCD cluster that enables the auth. To access this cluster, you need to configure the correct username and password for Apache APISIX in `conf/config.yaml`:
 
 ```yaml
 deployment:

--- a/docs/en/latest/FAQ.md
+++ b/docs/en/latest/FAQ.md
@@ -713,8 +713,8 @@ deployment:
   etcd:
     host:
       - "http://127.0.0.1:2379"
-    user: root                     # root username for etcd
-    password: 5tHkHhYkjr6cQY       # root password for etcd
+    user: etcd_user                       # root username for etcd
+    password: etcd_password     # root password for etcd
 ```
 
 For other ETCD configurations, such as expiration times, retries, and so on, you can see the `ETCD` section in the `conf/config-default.yaml` file.

--- a/docs/en/latest/FAQ.md
+++ b/docs/en/latest/FAQ.md
@@ -704,7 +704,7 @@ Another solution is to switch to an experimental gRPC-based configuration synchr
     prefix: "/apisix"
 ```
 
-## How does APISIX configure ETCD with authentication
+## How does APISIX configure ETCD with authentication?
 
 Suppose you have an ETCD cluster that enables the auth. To access this cluster, you need to configure the correct username and password for Apache APISIX in `conf/config.yaml`:
 

--- a/docs/en/latest/FAQ.md
+++ b/docs/en/latest/FAQ.md
@@ -717,7 +717,7 @@ deployment:
     password: etcd_password     # password for etcd
 ```
 
-For other ETCD configurations, such as expiration times, retries, and so on, you can see the `ETCD` section in the `conf/config-default.yaml` file.
+For other ETCD configurations, such as expiration times, retries, and so on, you can refer to the `ETCD` section in the `conf/config-default.yaml` file.
 
 ## Where can I find more answers?
 

--- a/docs/en/latest/FAQ.md
+++ b/docs/en/latest/FAQ.md
@@ -706,7 +706,7 @@ Another solution is to switch to an experimental gRPC-based configuration synchr
 
 ## How does APISIX configure ETCD with authentication
 
-If you are using an auth ETCD instance, you need to use the correct user and password to access it. You need to do edit this in the `conf/config.yaml` file.
+Suppose you have an ETCD cluster that enables the auth. To access this cluster, you need to configure the correct username and password for Apache APISIX. Edit the `conf/config.yaml` file as follows:
 
 ```yaml
 deployment:

--- a/docs/en/latest/FAQ.md
+++ b/docs/en/latest/FAQ.md
@@ -713,8 +713,8 @@ deployment:
   etcd:
     host:
       - "http://127.0.0.1:2379"
-    user: etcd_user                       # root username for etcd
-    password: etcd_password     # root password for etcd
+    user: etcd_user             # username for etcd
+    password: etcd_password     # password for etcd
 ```
 
 For other ETCD configurations, such as expiration times, retries, and so on, you can see the `ETCD` section in the `conf/config-default.yaml` file.

--- a/docs/en/latest/FAQ.md
+++ b/docs/en/latest/FAQ.md
@@ -704,6 +704,21 @@ Another solution is to switch to an experimental gRPC-based configuration synchr
     prefix: "/apisix"
 ```
 
+## How does APISIX configure ETCD with authentication
+
+If you are using an auth ETCD instance, you need to use the correct user and password to access it. You need to do edit this in the `conf/config.yaml` file.
+
+```yaml
+deployment:
+  etcd:
+    host:
+      - "http://127.0.0.1:2379"
+    user: root                     # root username for etcd
+    password: 5tHkHhYkjr6cQY       # root password for etcd
+```
+
+For other ETCD configurations, such as expiration times, retries, and so on, you can see the `ETCD` section in the `conf/config-default.yaml` file.
+
 ## Where can I find more answers?
 
 You can find more answers on:

--- a/docs/zh/latest/FAQ.md
+++ b/docs/zh/latest/FAQ.md
@@ -709,7 +709,7 @@ make GOOS=linux GOARCH=amd64
 
 ## APISIX 如何配置带认证的 ETCD
 
-假设您有一个启用身份验证的 ETCD 集群。要访问该集群，需要为 Apache APISIX 配置正确的用户名和密码。需要配置 `conf/config.yaml` 文件，添加如下内容：
+假设您有一个启用身份验证的 ETCD 集群。要访问该集群，需要在 `conf/config.yaml` 中为 Apache APISIX 配置正确的用户名和密码：
 
 ```yaml
 deployment:

--- a/docs/zh/latest/FAQ.md
+++ b/docs/zh/latest/FAQ.md
@@ -707,6 +707,21 @@ make GOOS=linux GOARCH=amd64
     prefix: "/apisix"
 ```
 
+## APISIX 如何配置带认证的 ETCD
+
+如果你使用的 ETCD 实例，是需要使用正确的用户和密码才能访问。你需要在`conf/config.yaml`文件中这样配置。
+
+```yaml
+deployment:
+  etcd:
+    host:
+      - "http://127.0.0.1:2379"
+    user: root                     # root username for etcd
+    password: 5tHkHhYkjr6cQY       # root password for etcd
+```
+
+关于 ETCD 的其他配置，比如过期时间、重试次数等等，你可以查看`conf/config-default.yaml`文件中的`ETCD`部分。
+
 ## 如果在使用 APISIX 过程中遇到问题，我可以在哪里寻求更多帮助？
 
 - [Apache APISIX Slack Channel](/docs/general/join/#加入-slack-频道)：加入后请选择 channel-apisix 频道，即可通过此频道进行 APISIX 相关问题的提问。

--- a/docs/zh/latest/FAQ.md
+++ b/docs/zh/latest/FAQ.md
@@ -709,7 +709,7 @@ make GOOS=linux GOARCH=amd64
 
 ## APISIX 如何配置带认证的 ETCD
 
-如果你使用的 ETCD 实例，是需要使用正确的用户和密码才能访问。你需要在`conf/config.yaml`文件中这样配置。
+假设您有一个启用身份验证的 ETCD 集群。要访问该集群，需要为 Apache APISIX 配置正确的用户名和密码。需要配置`conf/config.yaml` 文件，添加如下内容:
 
 ```yaml
 deployment:

--- a/docs/zh/latest/FAQ.md
+++ b/docs/zh/latest/FAQ.md
@@ -720,7 +720,7 @@ deployment:
     password: 5tHkHhYkjr6cQY       # root password for etcd
 ```
 
-关于 ETCD 的其他配置，比如过期时间、重试次数等等，你可以查看`conf/config-default.yaml`文件中的`ETCD`部分。
+关于 ETCD 的其他配置，比如过期时间、重试次数等等，你可以参考 `conf/config-default.yaml` 文件中的 `ETCD` 部分。
 
 ## 如果在使用 APISIX 过程中遇到问题，我可以在哪里寻求更多帮助？
 

--- a/docs/zh/latest/FAQ.md
+++ b/docs/zh/latest/FAQ.md
@@ -709,7 +709,7 @@ make GOOS=linux GOARCH=amd64
 
 ## APISIX 如何配置带认证的 ETCD
 
-假设您有一个启用身份验证的 ETCD 集群。要访问该集群，需要为 Apache APISIX 配置正确的用户名和密码。需要配置`conf/config.yaml` 文件，添加如下内容：
+假设您有一个启用身份验证的 ETCD 集群。要访问该集群，需要为 Apache APISIX 配置正确的用户名和密码。需要配置 `conf/config.yaml` 文件，添加如下内容：
 
 ```yaml
 deployment:

--- a/docs/zh/latest/FAQ.md
+++ b/docs/zh/latest/FAQ.md
@@ -707,7 +707,7 @@ make GOOS=linux GOARCH=amd64
     prefix: "/apisix"
 ```
 
-## APISIX 如何配置带认证的 ETCD
+## APISIX 如何配置带认证的 ETCD？
 
 假设您有一个启用身份验证的 ETCD 集群。要访问该集群，需要在 `conf/config.yaml` 中为 Apache APISIX 配置正确的用户名和密码：
 

--- a/docs/zh/latest/FAQ.md
+++ b/docs/zh/latest/FAQ.md
@@ -709,7 +709,7 @@ make GOOS=linux GOARCH=amd64
 
 ## APISIX 如何配置带认证的 ETCD
 
-假设您有一个启用身份验证的 ETCD 集群。要访问该集群，需要为 Apache APISIX 配置正确的用户名和密码。需要配置`conf/config.yaml` 文件，添加如下内容:
+假设您有一个启用身份验证的 ETCD 集群。要访问该集群，需要为 Apache APISIX 配置正确的用户名和密码。需要配置`conf/config.yaml` 文件，添加如下内容：
 
 ```yaml
 deployment:

--- a/docs/zh/latest/FAQ.md
+++ b/docs/zh/latest/FAQ.md
@@ -716,8 +716,8 @@ deployment:
   etcd:
     host:
       - "http://127.0.0.1:2379"
-    user: root                     # root username for etcd
-    password: 5tHkHhYkjr6cQY       # root password for etcd
+    user: etcd_user             # username for etcd
+    password: etcd_password     # password for etcd
 ```
 
 关于 ETCD 的其他配置，比如过期时间、重试次数等等，你可以参考 `conf/config-default.yaml` 文件中的 `ETCD` 部分。


### PR DESCRIPTION
### Description

This section of the document "How to configure ETCD auth for APISIX" is indeed missing. 

Fixes #8833

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
