### PR TITLE
fix(admin): fix wrong http code for patch method

### DIFF
--- a/apisix/core/etcd.lua
+++ b/apisix/core/etcd.lua
@@ -507,7 +507,6 @@ function _M.atomic_set(key, value, ttl, mod_revision)
         key = key,
         value = value,
     }
-    res.status = 200
 
     return res, nil
 end

--- a/apisix/core/etcd.lua
+++ b/apisix/core/etcd.lua
@@ -507,7 +507,7 @@ function _M.atomic_set(key, value, ttl, mod_revision)
         key = key,
         value = value,
     }
-    res.status = 201
+    res.status = 200
 
     return res, nil
 end

--- a/t/admin/ssl.t
+++ b/t/admin/ssl.t
@@ -643,7 +643,7 @@ GET /t
                 core.json.encode({create_time = 0, update_time = 1})
             )
 
-            if code ~= 201 then
+            if code ~= 200 then
                 ngx.status = code
                 ngx.say(body)
                 return


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

The default http code of patch method to admin.resources is `201`. It should be corrected to `200`.

### Checklist

- [X] I have explained the need for this PR and the problem it solves
- [X] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [X] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
