### PR TITLE
fix: limit count plugin conf parameter undefined error

### DIFF
--- a/apisix/plugins/limit-count/limit-count-local.lua
+++ b/apisix/plugins/limit-count/limit-count-local.lua
@@ -51,11 +51,11 @@ local function read_reset(self, key)
     return reset
 end
 
-function _M.new(plugin_name, limit, window, conf)
+function _M.new(plugin_name, limit, window)
     assert(limit > 0 and window > 0)
 
     local self = {
-        limit_count = limit_local_new(plugin_name, limit, window, conf),
+        limit_count = limit_local_new(plugin_name, limit, window),
         dict = ngx.shared["plugin-limit-count-reset-header"]
     }
 


### PR DESCRIPTION
### Description

At the limit-count-local.lua code, there accept a parameter conf, but there doesn't pass it from init.lua. And this code doesn't need this conf parameter. I forget to remove this parameter when I develop this logic so I need to fix that.

Fixes #8893

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
