### PR TITLE
docs: update docs for LTS v2.15: checkout branch to release/2.15 after clone apisix-docker  to avoid 404 Route Not Found caused by admin port changed in default branch

### DIFF
--- a/docs/en/latest/getting-started.md
+++ b/docs/en/latest/getting-started.md
@@ -125,6 +125,7 @@ First clone the [apisix-docker](https://github.com/apache/apisix-docker) reposit
 
 ```shell
 git clone https://github.com/apache/apisix-docker.git
+git checkout release/2.15
 cd apisix-docker/example
 ```
 

--- a/docs/zh/latest/getting-started.md
+++ b/docs/zh/latest/getting-started.md
@@ -117,6 +117,7 @@ curl --location --request GET "http://httpbin.org/get?foo1=bar1&foo2=bar2"
 
 ```bash
 git clone https://github.com/apache/apisix-docker.git
+git checkout release/2.15
 cd apisix-docker/example
 ```
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)
fix issue:https://github.com/apache/apisix-docker/issues/434
the admin port was changed to 9180 after version upgrate
if don't checkout branches,clone apisix-docker and start docker directly,
when run some command  in  docs of current version
will return  {"error_msg":"404 Route Not Found"}
which leads to confusion for people who select docs of current LTS version (2.15) to learn

for exmaple
```
# 注意：请在运行 Docker 的宿主机上执行 curl 命令。
curl "http://127.0.0.1:9080/apisix/admin/services/" -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1'
```


![image](https://user-images.githubusercontent.com/49020899/220615557-c627efc9-a141-4f93-ab74-03077d37de20.png)


### Checklist

- [x]  I have explained the need for this PR and the problem it solves
- [x]  I have explained the changes or the new features added to this PR
- [x]  I have added tests corresponding to this change
- [x]  I have updated the documentation to reflect this change
- [x] ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
