### PR TITLE
fix(ci): remove matrix.os_name from image cache key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
           cache-name: cache-apisix-docker-images
         with:
           path: docker-images-backup
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ steps.test_env.outputs.type }}-${{ hashFiles(format('./ci/pod/docker-compose.{0}.yml', steps.test_env.outputs.type )) }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ steps.test_env.outputs.type }}-a-${{ hashFiles(format('./ci/pod/docker-compose.{0}.yml', steps.test_env.outputs.type )) }}
 
       - if: ${{ steps.cache-images.outputs.cache-hit == 'true' }}
         name: Load saved docker images

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
           cache-name: cache-apisix-docker-images
         with:
           path: docker-images-backup
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ steps.test_env.outputs.type }}-a-${{ hashFiles(format('./ci/pod/docker-compose.{0}.yml', steps.test_env.outputs.type )) }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ steps.test_env.outputs.type }}-${{ hashFiles(format('./ci/pod/docker-compose.{0}.yml', steps.test_env.outputs.type )) }}
 
       - if: ${{ steps.cache-images.outputs.cache-hit == 'true' }}
         name: Load saved docker images

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
           cache-name: cache-apisix-docker-images
         with:
           path: docker-images-backup
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ steps.test_env.outputs.type }}-${{ matrix.os_name }}-${{ hashFiles(format('./ci/pod/docker-compose.{0}.yml', steps.test_env.outputs.type )) }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ steps.test_env.outputs.type }}-${{ hashFiles(format('./ci/pod/docker-compose.{0}.yml', steps.test_env.outputs.type )) }}
 
       - if: ${{ steps.cache-images.outputs.cache-hit == 'true' }}
         name: Load saved docker images


### PR DESCRIPTION
### Description

Removing `matrix.os_name` from the image cache key will create a single docker image regardless of the difference in operating systems. In the current implementation, multiple caches are created for the same type of test run on different OS. Due to this the cache storage limit is exceeded and GitHub evicts the least recently used cache, resulting in cache miss which leads to longer CI runtime.

<img width="730" alt="image" src="https://user-images.githubusercontent.com/61597896/220857967-bda69723-983d-421e-bb50-160c105ea794.png">


Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
