### PR TITLE
docs: shift workflow plugin to general category

### DIFF
--- a/docs/en/latest/config.json
+++ b/docs/en/latest/config.json
@@ -62,7 +62,8 @@
             "plugins/ext-plugin-pre-req",
             "plugins/ext-plugin-post-req",
             "plugins/ext-plugin-post-resp",
-            "plugins/inspect"
+            "plugins/inspect",
+            "plugins/workflow"
           ]
         },
         {
@@ -184,7 +185,6 @@
             "plugins/azure-functions",
             "plugins/openwhisk",
             "plugins/aws-lambda",
-            "plugins/workflow",
             "plugins/openfunction"
           ]
         },

--- a/docs/zh/latest/config.json
+++ b/docs/zh/latest/config.json
@@ -59,7 +59,6 @@
             "plugins/ext-plugin-pre-req",
             "plugins/ext-plugin-post-req",
             "plugins/ext-plugin-post-resp",
-            "plugins/inspect",
             "plugins/workflow"
           ]
         },

--- a/docs/zh/latest/config.json
+++ b/docs/zh/latest/config.json
@@ -56,9 +56,11 @@
             "plugins/gzip",
             "plugins/real-ip",
             "plugins/server-info",
-            "plugins/ext-plugin-post-req",
             "plugins/ext-plugin-pre-req",
-            "plugins/ext-plugin-post-resp"
+            "plugins/ext-plugin-post-req",
+            "plugins/ext-plugin-post-resp",
+            "plugins/inspect",
+            "plugins/workflow"
           ]
         },
         {
@@ -178,7 +180,6 @@
             "plugins/azure-functions",
             "plugins/openwhisk",
             "plugins/aws-lambda",
-            "plugins/workflow",
             "plugins/openfunction"
           ]
         },


### PR DESCRIPTION
### Description
Currently, the [**_workflow_**](https://github.com/apache/apisix/blob/d3ac217cb26ab731d51f1ef8275932df8bf72c7b/docs/en/latest/config.json#L187) plugin is in the "[**_serverless_**](https://github.com/apache/apisix/blob/d3ac217cb26ab731d51f1ef8275932df8bf72c7b/docs/en/latest/config.json#LL180-L181C33)" category (for both [`EN`](https://github.com/apache/apisix/blob/d3ac217cb26ab731d51f1ef8275932df8bf72c7b/docs/en/latest/config.json#LL180-L187C32) & [`ZH`](https://github.com/apache/apisix/blob/7926408305c36af1003f76c860a9dd027ab32026/docs/zh/latest/config.json#L173&L180)). However, the workflow plugin doesn't run user-defined code, and it doesn't integrate with serverless platforms like AWS-lambda either. Hence, it's recommended to put the workflow plugin in the "[**_general_**](https://github.com/apache/apisix/blob/d3ac217cb26ab731d51f1ef8275932df8bf72c7b/docs/en/latest/config.json#LL53-L54C30)" category, as it's similar to the batch-requests plugin. The workflow plugin allows users to combine multiple actions just like the _batch-requests_ allow users to connect to multiple APIs.

> ~~Moreover, I also noticed that the [`config.json`](https://github.com/apache/apisix/blob/master/docs/zh/latest/config.json) in the Mandarin version ([`ZH`](https://github.com/apache/apisix/blob/d3ac217cb26ab731d51f1ef8275932df8bf72c7b/docs/zh/latest/config.json#L50-L61)), is missing the inspect plugin ("`plugins/inspect`") which is present in the [`EN`](https://github.com/apache/apisix/blob/d3ac217cb26ab731d51f1ef8275932df8bf72c7b/docs/en/latest/config.json#L65) version. Hence I added it to the "config.json" for `ZH`.~~

**Fixes #8422**



### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

cc: @navendu-pottekkat , @membphis , @spacewander 