### PR TITLE
fix: corrected minimum in healthcheck schema

### DIFF
--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -236,7 +236,7 @@ local health_checker = {
                         },
                         successes = {
                             type = "integer",
-                            minimum = 0,
+                            minimum = 1,
                             maximum = 254,
                             default = 5
                         }


### PR DESCRIPTION
### Description

It's meaningless to use *zero as the minimum* in [`schema_def.lua`](https://github.com/apache/apisix/blob/d3ac217cb26ab731d51f1ef8275932df8bf72c7b/apisix/schema_def.lua#L239) which was set to use as a default healthcheck in #5589.

**Fixes #8937** 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

cc: @spacewander, @navendu-pottekkat 
