### PR TITLE
docs: k8s discovery: state the restriction on the use of port number

### DIFF
--- a/docs/en/latest/discovery/kubernetes.md
+++ b/docs/en/latest/discovery/kubernetes.md
@@ -135,7 +135,7 @@ The Kubernetes service discovery provides a query interface in accordance with t
 
   + name: The name of the Kubernetes endpoints
 
-  + portName: The ports.name value in the Kubernetes endpoints, if there is no ports.name, use targetPort, port instead
+  + portName: The `ports.name` value in the Kubernetes endpoints, if there is no `ports.name`, use `targetPort`, `port` instead. If `ports.name` exists, then port number cannot be used.
 
 **return value:**
   if the Kubernetes endpoints value is as follows:
@@ -247,7 +247,7 @@ service_name should match pattern: _[id]/[namespace]/[name]:[portName]_
 
 + name: The name of the Kubernetes endpoints
 
-+ portName: The ports.name value in the Kubernetes endpoints, if there is no ports.name, use targetPort, port instead
++ portName: The `ports.name` value in the Kubernetes endpoints, if there is no `ports.name`, use `targetPort`, `port` instead. If `ports.name` exists, then port number cannot be used.
 
 **return value:**
 if the Kubernetes endpoints value is as follows:

--- a/docs/zh/latest/discovery/kubernetes.md
+++ b/docs/zh/latest/discovery/kubernetes.md
@@ -134,7 +134,7 @@ service_name 必须满足格式: [namespace]/[name]:[portName]
 
 + name: Endpoints 的资源名
 
-+ portName: Endpoints 定义包含的 ports.name 值，如果 Endpoints 没有定义 ports.name，请依次使用 targetPort, port 代替
++ portName: Endpoints 定义包含的 `ports.name` 值，如果 Endpoints 没有定义 `ports.name`，请依次使用 `targetPort`, `port` 代替。设置了 `ports.name` 的情况下，不能使用后两者。
 
 **返回值：**
 以如下 Endpoints 为例：
@@ -245,7 +245,7 @@ service_name 必须满足格式: [id]/[namespace]/[name]:[portName]
 
 + name: Endpoints 的资源名
 
-+ portName: Endpoints 定义包含的 ports.name 值，如果 Endpoints 没有定义 ports.name，请依次使用 targetPort, port 代替
++ portName: Endpoints 定义包含的 `ports.name` 值，如果 Endpoints 没有定义 `ports.name`，请依次使用 `targetPort`, `port` 代替。设置了 `ports.name` 的情况下，不能使用后两者。
 
 **返回值：**
 以如下 Endpoints 为例：


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

In k8s discovery, clearly state the restriction on the use of port number.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
