### PR TITLE
docs: improved SEO & fixed typo and localization issues 

### DIFF
--- a/docs/en/latest/FAQ.md
+++ b/docs/en/latest/FAQ.md
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - FAQ
 description: This article lists solutions to common problems when using Apache APISIX.

--- a/docs/en/latest/admin-api.md
+++ b/docs/en/latest/admin-api.md
@@ -1,7 +1,7 @@
 ---
 title: Admin API
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Admin API
   - Route

--- a/docs/en/latest/architecture-design/apisix.md
+++ b/docs/en/latest/architecture-design/apisix.md
@@ -1,7 +1,7 @@
 ---
 title: Architecture
 keywords:
-  - API gateway
+  - API Gateway
   - Apache APISIX
   - APISIX architecture
 description: Architecture of Apache APISIX—the Cloud Native API Gateway.

--- a/docs/en/latest/building-apisix.md
+++ b/docs/en/latest/building-apisix.md
@@ -2,7 +2,7 @@
 id: building-apisix
 title: Building APISIX from source
 keywords:
-  - API gateway
+  - API Gateway
   - Apache APISIX
   - Code Contribution
   - Building APISIX

--- a/docs/en/latest/deployment-modes.md
+++ b/docs/en/latest/deployment-modes.md
@@ -1,7 +1,7 @@
 ---
 title: Deployment modes
 keywords:
-  - API gateway
+  - API Gateway
   - Apache APISIX
   - APISIX deployment modes
 description: Documentation about the three deployment modes of Apache APISIX.

--- a/docs/en/latest/discovery/control-plane-service-discovery.md
+++ b/docs/en/latest/discovery/control-plane-service-discovery.md
@@ -1,8 +1,8 @@
 ---
 title: Control Plane Service Discovery
 keywords:
-  - API Geteway
-  - APISIX
+  - API Gateway
+  - Apache APISIX
   - ZooKeeper
   - Nacos
   - APISIX-Seed

--- a/docs/en/latest/getting-started.md
+++ b/docs/en/latest/getting-started.md
@@ -1,7 +1,8 @@
 ---
 title: Getting started
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Getting Started
 description: This document walks you through how you can get started with Apache APISIX.
 ---

--- a/docs/en/latest/plugins/api-breaker.md
+++ b/docs/en/latest/plugins/api-breaker.md
@@ -1,7 +1,7 @@
 ---
 title: api-breaker
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - API Breaker
 description: This document describes the information about the Apache APISIX api-breaker Plugin, you can use it to protect Upstream services.

--- a/docs/en/latest/plugins/authz-casbin.md
+++ b/docs/en/latest/plugins/authz-casbin.md
@@ -1,7 +1,8 @@
 ---
 title: authz-casbin
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Authz Casbin
   - authz-casbin

--- a/docs/en/latest/plugins/authz-casdoor.md
+++ b/docs/en/latest/plugins/authz-casdoor.md
@@ -1,7 +1,8 @@
 ---
 title: authz-casdoor
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Authz Casdoor
   - authz-casdoor

--- a/docs/en/latest/plugins/authz-keycloak.md
+++ b/docs/en/latest/plugins/authz-keycloak.md
@@ -1,7 +1,8 @@
 ---
 title: authz-keycloak
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Authz Keycloak
   - authz-keycloak

--- a/docs/en/latest/plugins/aws-lambda.md
+++ b/docs/en/latest/plugins/aws-lambda.md
@@ -1,7 +1,7 @@
 ---
 title: aws-lambda
 keywords:
-  - APISIX
+  - Apache APISIX
   - Plugin
   - AWS Lambda
   - aws-lambda

--- a/docs/en/latest/plugins/azure-functions.md
+++ b/docs/en/latest/plugins/azure-functions.md
@@ -1,7 +1,8 @@
 ---
 title: azure-functions
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Azure Functions
   - azure-functions

--- a/docs/en/latest/plugins/basic-auth.md
+++ b/docs/en/latest/plugins/basic-auth.md
@@ -1,7 +1,8 @@
 ---
 title: basic-auth
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Basic Auth
   - basic-auth

--- a/docs/en/latest/plugins/batch-requests.md
+++ b/docs/en/latest/plugins/batch-requests.md
@@ -1,7 +1,8 @@
 ---
 title: batch-requests
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Batch Requests
 description: This document contains information about the Apache APISIX batch-request Plugin.

--- a/docs/en/latest/plugins/body-transformer.md
+++ b/docs/en/latest/plugins/body-transformer.md
@@ -1,7 +1,8 @@
 ---
 title: body-transformer
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - BODY TRANSFORMER
   - body-transformer

--- a/docs/en/latest/plugins/cas-auth.md
+++ b/docs/en/latest/plugins/cas-auth.md
@@ -1,7 +1,8 @@
 ---
 title: cas-auth
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - CAS AUTH
   - cas-auth

--- a/docs/en/latest/plugins/clickhouse-logger.md
+++ b/docs/en/latest/plugins/clickhouse-logger.md
@@ -1,7 +1,7 @@
 ---
 title: clickhouse-logger
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - ClickHouse Logger

--- a/docs/en/latest/plugins/client-control.md
+++ b/docs/en/latest/plugins/client-control.md
@@ -1,7 +1,7 @@
 ---
 title: client-control
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Client Control
 description: This document describes the Apache APISIX client-control Plugin, you can use it to control NGINX behavior to handle a client request dynamically.

--- a/docs/en/latest/plugins/consumer-restriction.md
+++ b/docs/en/latest/plugins/consumer-restriction.md
@@ -1,7 +1,7 @@
 ---
 title: consumer-restriction
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Consumer restriction
 description: The Consumer Restriction Plugin allows users to set access restrictions based on Consumer, Route, or Service.

--- a/docs/en/latest/plugins/cors.md
+++ b/docs/en/latest/plugins/cors.md
@@ -1,7 +1,7 @@
 ---
 title: cors
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - CORS
 description: This document contains information about the Apache APISIX cors Plugin.

--- a/docs/en/latest/plugins/csrf.md
+++ b/docs/en/latest/plugins/csrf.md
@@ -1,7 +1,8 @@
 ---
 title: csrf
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Cross-site request forgery
   - csrf

--- a/docs/en/latest/plugins/datadog.md
+++ b/docs/en/latest/plugins/datadog.md
@@ -1,7 +1,7 @@
 ---
 title: datadog
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - Datadog

--- a/docs/en/latest/plugins/degraphql.md
+++ b/docs/en/latest/plugins/degraphql.md
@@ -1,7 +1,7 @@
 ---
 title: degraphql
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - Degraphql

--- a/docs/en/latest/plugins/dubbo-proxy.md
+++ b/docs/en/latest/plugins/dubbo-proxy.md
@@ -1,7 +1,7 @@
 ---
 title: dubbo-proxy
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - Apache Dubbo

--- a/docs/en/latest/plugins/echo.md
+++ b/docs/en/latest/plugins/echo.md
@@ -1,7 +1,8 @@
 ---
 title: echo
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Echo
 description: This document contains information about the Apache APISIX echo Plugin.

--- a/docs/en/latest/plugins/elasticsearch-logger.md
+++ b/docs/en/latest/plugins/elasticsearch-logger.md
@@ -1,7 +1,7 @@
 ---
 title: elasticsearch-logger
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - Elasticsearch-logger

--- a/docs/en/latest/plugins/error-log-logger.md
+++ b/docs/en/latest/plugins/error-log-logger.md
@@ -1,7 +1,7 @@
 ---
 title: error-log-logger
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - Error log logger

--- a/docs/en/latest/plugins/ext-plugin-post-req.md
+++ b/docs/en/latest/plugins/ext-plugin-post-req.md
@@ -1,7 +1,7 @@
 ---
 title: ext-plugin-post-req
 keywords:
-  - APISIX
+  - Apache APISIX
   - Plugin
   - ext-plugin-post-req
 description: This document contains information about the Apache APISIX ext-plugin-post-req Plugin.

--- a/docs/en/latest/plugins/ext-plugin-post-resp.md
+++ b/docs/en/latest/plugins/ext-plugin-post-resp.md
@@ -1,7 +1,8 @@
 ---
 title: ext-plugin-post-resp
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - ext-plugin-post-resp
 description: This document contains information about the Apache APISIX ext-plugin-post-resp Plugin.

--- a/docs/en/latest/plugins/ext-plugin-pre-req.md
+++ b/docs/en/latest/plugins/ext-plugin-pre-req.md
@@ -1,7 +1,8 @@
 ---
 title: ext-plugin-pre-req
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - ext-plugin-pre-req
 description: This document contains information about the Apache APISIX ext-plugin-pre-req Plugin.

--- a/docs/en/latest/plugins/fault-injection.md
+++ b/docs/en/latest/plugins/fault-injection.md
@@ -1,7 +1,8 @@
 ---
 title: fault-injection
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Fault Injection
   - fault-injection

--- a/docs/en/latest/plugins/file-logger.md
+++ b/docs/en/latest/plugins/file-logger.md
@@ -1,7 +1,7 @@
 ---
 title: file-logger
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - File Logger

--- a/docs/en/latest/plugins/forward-auth.md
+++ b/docs/en/latest/plugins/forward-auth.md
@@ -1,7 +1,8 @@
 ---
 title: forward-auth
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Forward Authentication
   - forward-auth

--- a/docs/en/latest/plugins/gm.md
+++ b/docs/en/latest/plugins/gm.md
@@ -1,7 +1,7 @@
 ---
 title: GM
 keywords:
-  - APISIX
+  - Apache APISIX
   - Plugin
   - GM
 description: This article introduces the basic information and usage of the Apache APISIX `gm` plugin.

--- a/docs/en/latest/plugins/google-cloud-logging.md
+++ b/docs/en/latest/plugins/google-cloud-logging.md
@@ -1,7 +1,7 @@
 ---
 title: google-cloud-logging
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - Google Cloud logging

--- a/docs/en/latest/plugins/grpc-transcode.md
+++ b/docs/en/latest/plugins/grpc-transcode.md
@@ -1,7 +1,8 @@
 ---
 title: grpc-transcode
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - gRPC Transcode
   - grpc-transcode

--- a/docs/en/latest/plugins/grpc-web.md
+++ b/docs/en/latest/plugins/grpc-web.md
@@ -1,7 +1,8 @@
 ---
 title: grpc-web
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - gRPC Web
   - grpc-web

--- a/docs/en/latest/plugins/gzip.md
+++ b/docs/en/latest/plugins/gzip.md
@@ -1,7 +1,8 @@
 ---
 title: gzip
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - gzip
 description: This document contains information about the Apache APISIX gzip Plugin.

--- a/docs/en/latest/plugins/hmac-auth.md
+++ b/docs/en/latest/plugins/hmac-auth.md
@@ -1,7 +1,8 @@
 ---
 title: hmac-auth
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - HMAC Authentication
   - hmac-auth

--- a/docs/en/latest/plugins/http-logger.md
+++ b/docs/en/latest/plugins/http-logger.md
@@ -1,8 +1,8 @@
 ---
 title: http-logger
 keywords:
-  - APISIX
-  - API 网关
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - HTTP Logger
 description: This document contains information about the Apache APISIX http-logger Plugin. Using this Plugin, you can push APISIX log data to HTTP or HTTPS servers.

--- a/docs/en/latest/plugins/inspect.md
+++ b/docs/en/latest/plugins/inspect.md
@@ -1,7 +1,8 @@
 ---
 title: inspect
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Inspect
   - Dynamic Lua Debugging

--- a/docs/en/latest/plugins/ip-restriction.md
+++ b/docs/en/latest/plugins/ip-restriction.md
@@ -1,7 +1,8 @@
 ---
 title: ip-restriction
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - IP restriction
   - ip-restriction

--- a/docs/en/latest/plugins/jwt-auth.md
+++ b/docs/en/latest/plugins/jwt-auth.md
@@ -1,7 +1,8 @@
 ---
 title: jwt-auth
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - JWT Auth
   - jwt-auth

--- a/docs/en/latest/plugins/kafka-logger.md
+++ b/docs/en/latest/plugins/kafka-logger.md
@@ -1,7 +1,7 @@
 ---
 title: kafka-logger
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - Kafka Logger

--- a/docs/en/latest/plugins/kafka-proxy.md
+++ b/docs/en/latest/plugins/kafka-proxy.md
@@ -1,7 +1,8 @@
 ---
 title: kafka-proxy
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Kafka proxy
 description: This document contains information about the Apache APISIX kafka-proxy Plugin.

--- a/docs/en/latest/plugins/key-auth.md
+++ b/docs/en/latest/plugins/key-auth.md
@@ -1,7 +1,8 @@
 ---
 title: key-auth
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Key Auth
   - key-auth

--- a/docs/en/latest/plugins/ldap-auth.md
+++ b/docs/en/latest/plugins/ldap-auth.md
@@ -1,7 +1,8 @@
 ---
 title: ldap-auth
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - LDAP Authentication
   - ldap-auth

--- a/docs/en/latest/plugins/limit-conn.md
+++ b/docs/en/latest/plugins/limit-conn.md
@@ -1,7 +1,7 @@
 ---
 title: limit-conn
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Limit Connection
 description: This document contains information about the Apache APISIX limit-con Plugin, you can use it to limits the number of concurrent requests to your services.

--- a/docs/en/latest/plugins/limit-count.md
+++ b/docs/en/latest/plugins/limit-count.md
@@ -1,7 +1,7 @@
 ---
 title: limit-count
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Limit Count
 description: This document contains information about the Apache APISIX limit-count Plugin, you can use it to limit the number of requests to your service by a given count per time.

--- a/docs/en/latest/plugins/limit-req.md
+++ b/docs/en/latest/plugins/limit-req.md
@@ -1,7 +1,7 @@
 ---
 title: limit-req
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Limit Request
   - limit-req

--- a/docs/en/latest/plugins/log-rotate.md
+++ b/docs/en/latest/plugins/log-rotate.md
@@ -1,7 +1,7 @@
 ---
 title: log-rotate
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - Log rotate

--- a/docs/en/latest/plugins/loggly.md
+++ b/docs/en/latest/plugins/loggly.md
@@ -1,7 +1,7 @@
 ---
 title: loggly
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - SolarWinds Loggly

--- a/docs/en/latest/plugins/mocking.md
+++ b/docs/en/latest/plugins/mocking.md
@@ -1,7 +1,8 @@
 ---
 title: mocking
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Mocking
   - mocking

--- a/docs/en/latest/plugins/mocking.md
+++ b/docs/en/latest/plugins/mocking.md
@@ -5,7 +5,6 @@ keywords:
   - API Gateway
   - Plugin
   - Mocking
-  - mocking
 description: This document contains information about the Apache APISIX mocking Plugin.
 ---
 

--- a/docs/en/latest/plugins/mqtt-proxy.md
+++ b/docs/en/latest/plugins/mqtt-proxy.md
@@ -1,7 +1,7 @@
 ---
 title: mqtt-proxy
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - MQTT Proxy

--- a/docs/en/latest/plugins/node-status.md
+++ b/docs/en/latest/plugins/node-status.md
@@ -1,7 +1,7 @@
 ---
 title: node-status
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - Node status

--- a/docs/en/latest/plugins/opa.md
+++ b/docs/en/latest/plugins/opa.md
@@ -1,7 +1,8 @@
 ---
 title: opa
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Open Policy Agent
   - opa

--- a/docs/en/latest/plugins/openfunction.md
+++ b/docs/en/latest/plugins/openfunction.md
@@ -5,7 +5,6 @@ keywords:
   - API Gateway
   - Plugin
   - OpenFunction
-  - openfunction
 description: This document contains information about the Apache APISIX openfunction Plugin.
 ---
 

--- a/docs/en/latest/plugins/openfunction.md
+++ b/docs/en/latest/plugins/openfunction.md
@@ -1,7 +1,8 @@
 ---
 title: openfunction
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - OpenFunction
   - openfunction

--- a/docs/en/latest/plugins/openid-connect.md
+++ b/docs/en/latest/plugins/openid-connect.md
@@ -1,7 +1,7 @@
 ---
 title: openid-connect
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - OpenID Connect
   - OIDC

--- a/docs/en/latest/plugins/opentelemetry.md
+++ b/docs/en/latest/plugins/opentelemetry.md
@@ -5,7 +5,6 @@ keywords:
   - API Gateway
   - Plugin
   - OpenTelemetry
-  - opentelemetry
 description: This document contains information about the Apache opentelemetry Plugin.
 ---
 <!--

--- a/docs/en/latest/plugins/opentelemetry.md
+++ b/docs/en/latest/plugins/opentelemetry.md
@@ -1,7 +1,8 @@
 ---
 title: opentelemetry
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - OpenTelemetry
   - opentelemetry

--- a/docs/en/latest/plugins/openwhisk.md
+++ b/docs/en/latest/plugins/openwhisk.md
@@ -5,7 +5,6 @@ keywords:
   - API Gateway
   - Plugin
   - OpenWhisk
-  - openwhisk
 description: This document contains information about the Apache openwhisk Plugin.
 ---
 

--- a/docs/en/latest/plugins/openwhisk.md
+++ b/docs/en/latest/plugins/openwhisk.md
@@ -1,7 +1,8 @@
 ---
 title: openwhisk
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - OpenWhisk
   - openwhisk

--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -1,7 +1,7 @@
 ---
 title: prometheus
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - Prometheus

--- a/docs/en/latest/plugins/proxy-cache.md
+++ b/docs/en/latest/plugins/proxy-cache.md
@@ -1,7 +1,7 @@
 ---
 title: proxy-cache
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Proxy Cache
 description: This document contains information about the Apache APISIX proxy-cache Plugin, you can use it to cache the response from the Upstream.

--- a/docs/en/latest/plugins/proxy-control.md
+++ b/docs/en/latest/plugins/proxy-control.md
@@ -1,7 +1,7 @@
 ---
 title: proxy-control
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Proxy Control
 description: This document contains information about the Apache APISIX proxy-control Plugin, you can use it to control the behavior of the NGINX proxy dynamically.

--- a/docs/en/latest/plugins/proxy-mirror.md
+++ b/docs/en/latest/plugins/proxy-mirror.md
@@ -1,7 +1,7 @@
 ---
 title: proxy-mirror
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Proxy Mirror
 description: This document describes the information about the Apache APISIX proxy-mirror Plugin, you can use it to mirror the client requests.

--- a/docs/en/latest/plugins/proxy-rewrite.md
+++ b/docs/en/latest/plugins/proxy-rewrite.md
@@ -1,7 +1,8 @@
 ---
 title: proxy-rewrite
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Proxy Rewrite
   - proxy-rewrite

--- a/docs/en/latest/plugins/public-api.md
+++ b/docs/en/latest/plugins/public-api.md
@@ -1,7 +1,7 @@
 ---
 title: public-api
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Public API
 description: The public-api is used for exposing an API endpoint through a general HTTP API router.

--- a/docs/en/latest/plugins/real-ip.md
+++ b/docs/en/latest/plugins/real-ip.md
@@ -1,7 +1,8 @@
 ---
 title: real-ip
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Real IP
   - real ip

--- a/docs/en/latest/plugins/real-ip.md
+++ b/docs/en/latest/plugins/real-ip.md
@@ -5,7 +5,6 @@ keywords:
   - API Gateway
   - Plugin
   - Real IP
-  - real ip
 description: This document contains information about the Apache APISIX real-ip Plugin.
 ---
 

--- a/docs/en/latest/plugins/redirect.md
+++ b/docs/en/latest/plugins/redirect.md
@@ -1,7 +1,8 @@
 ---
 title: redirect
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Redirect
 description: This document contains information about the Apache APISIX redirect Plugin.

--- a/docs/en/latest/plugins/referer-restriction.md
+++ b/docs/en/latest/plugins/referer-restriction.md
@@ -1,7 +1,7 @@
 ---
 title: referer-restriction
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Referer restriction
 description: This document contains information about the Apache APISIX referer-restriction Plugin, which can be used to restrict access to a Service or a Route by whitelisting/blacklisting the Referer request header.

--- a/docs/en/latest/plugins/request-id.md
+++ b/docs/en/latest/plugins/request-id.md
@@ -1,7 +1,7 @@
 ---
 title: request-id
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Request ID
 description: This document describes information about the Apache APISIX request-id Plugin, you can use it to track API requests by adding a unique ID to each request.

--- a/docs/en/latest/plugins/request-validation.md
+++ b/docs/en/latest/plugins/request-validation.md
@@ -1,7 +1,7 @@
 ---
 title: request-validation
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Request Validation
 description: This document describes the information about the Apache APISIX request-validation Plugin, you can use it to validate the requests before forwarding them to an Upstream service.

--- a/docs/en/latest/plugins/response-rewrite.md
+++ b/docs/en/latest/plugins/response-rewrite.md
@@ -1,7 +1,8 @@
 ---
 title: response-rewrite
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Response Rewrite
   - response-rewrite

--- a/docs/en/latest/plugins/rocketmq-logger.md
+++ b/docs/en/latest/plugins/rocketmq-logger.md
@@ -1,7 +1,7 @@
 ---
 title: rocketmq-logger
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - RocketMQ Logger

--- a/docs/en/latest/plugins/server-info.md
+++ b/docs/en/latest/plugins/server-info.md
@@ -1,7 +1,8 @@
 ---
 title: server-info
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Server info
   - server-info

--- a/docs/en/latest/plugins/serverless.md
+++ b/docs/en/latest/plugins/serverless.md
@@ -1,7 +1,8 @@
 ---
 title: serverless
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Serverless
   - serverless

--- a/docs/en/latest/plugins/serverless.md
+++ b/docs/en/latest/plugins/serverless.md
@@ -5,7 +5,6 @@ keywords:
   - API Gateway
   - Plugin
   - Serverless
-  - serverless
 description: This document contains information about the Apache APISIX serverless Plugin.
 ---
 

--- a/docs/en/latest/plugins/skywalking-logger.md
+++ b/docs/en/latest/plugins/skywalking-logger.md
@@ -1,7 +1,8 @@
 ---
 title: skywalking-logger
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - SkyWalking Logger
   - skywalking-logger

--- a/docs/en/latest/plugins/skywalking.md
+++ b/docs/en/latest/plugins/skywalking.md
@@ -1,7 +1,8 @@
 ---
 title: skywalking
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - SkyWalking
 description: This document will introduce how the API gateway Apache APISIX reports metrics to Apache SkyWalking (an open-source APM) with the skywalking plugin.

--- a/docs/en/latest/plugins/sls-logger.md
+++ b/docs/en/latest/plugins/sls-logger.md
@@ -1,7 +1,7 @@
 ---
 title: sls-logger
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - SLS Logger

--- a/docs/en/latest/plugins/splunk-hec-logging.md
+++ b/docs/en/latest/plugins/splunk-hec-logging.md
@@ -1,7 +1,8 @@
 ---
 title: splunk-hec-logging
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Splunk HTTP Event Collector
   - splunk-hec-logging

--- a/docs/en/latest/plugins/syslog.md
+++ b/docs/en/latest/plugins/syslog.md
@@ -1,7 +1,7 @@
 ---
 title: syslog
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - Syslog

--- a/docs/en/latest/plugins/tcp-logger.md
+++ b/docs/en/latest/plugins/tcp-logger.md
@@ -1,7 +1,8 @@
 ---
 title: tcp-logger
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - TCP Logger
   - tcp-logger

--- a/docs/en/latest/plugins/tencent-cloud-cls.md
+++ b/docs/en/latest/plugins/tencent-cloud-cls.md
@@ -1,7 +1,7 @@
 ---
 title: tencent-cloud-cls
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - CLS

--- a/docs/en/latest/plugins/traffic-split.md
+++ b/docs/en/latest/plugins/traffic-split.md
@@ -1,7 +1,7 @@
 ---
 title: traffic-split
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Traffic Split
   - Blue-green Deployment

--- a/docs/en/latest/plugins/ua-restriction.md
+++ b/docs/en/latest/plugins/ua-restriction.md
@@ -1,7 +1,7 @@
 ---
 title: ua-restriction
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - UA restriction
 description: This document contains information about the Apache APISIX ua-restriction Plugin, which allows you to restrict access to a Route or Service based on the User-Agent header with an allowlist and a denylist.

--- a/docs/en/latest/plugins/udp-logger.md
+++ b/docs/en/latest/plugins/udp-logger.md
@@ -1,7 +1,7 @@
 ---
 title: udp-logger
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Plugin
   - UDP Logger

--- a/docs/en/latest/plugins/uri-blocker.md
+++ b/docs/en/latest/plugins/uri-blocker.md
@@ -1,7 +1,7 @@
 ---
 title: uri-blocker
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - URI Blocker
 description: This document contains information about the Apache APISIX uri-blocker Plugin.

--- a/docs/en/latest/plugins/wolf-rbac.md
+++ b/docs/en/latest/plugins/wolf-rbac.md
@@ -1,7 +1,8 @@
 ---
 title: wolf-rbac
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - wolf RBAC
   - wolf-rbac

--- a/docs/en/latest/plugins/workflow.md
+++ b/docs/en/latest/plugins/workflow.md
@@ -1,7 +1,8 @@
 ---
 title: workflow
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - workflow
   - traffic control

--- a/docs/en/latest/plugins/zipkin.md
+++ b/docs/en/latest/plugins/zipkin.md
@@ -1,7 +1,8 @@
 ---
 title: zipkin
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - Plugin
   - Zipkin
   - zipkin

--- a/docs/en/latest/plugins/zipkin.md
+++ b/docs/en/latest/plugins/zipkin.md
@@ -5,7 +5,6 @@ keywords:
   - API Gateway
   - Plugin
   - Zipkin
-  - zipkin
 description: This document contains information about the Apache zipkin Plugin.
 ---
 

--- a/docs/en/latest/pubsub/kafka.md
+++ b/docs/en/latest/pubsub/kafka.md
@@ -1,7 +1,8 @@
 ---
 title: Apache Kafka
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - PubSub
   - Kafka
 description: This document contains information about the Apache APISIX kafka pubsub scenario.

--- a/docs/en/latest/support-fips-in-apisix.md
+++ b/docs/en/latest/support-fips-in-apisix.md
@@ -2,7 +2,7 @@
 id: support-fips-in-apisix
 title: Support FIPS in APISIX
 keywords:
-  - API gateway
+  - API Gateway
   - Apache APISIX
   - Code Contribution
   - Building APISIX

--- a/docs/en/latest/terminology/api-gateway.md
+++ b/docs/en/latest/terminology/api-gateway.md
@@ -1,7 +1,7 @@
 ---
 title: API Gateway
 keywords:
-  - APISIX
+  - Apache APISIX
   - API Gateway
   - Gateway
 description: This article mainly introduces the role of the API gateway and why it is needed.

--- a/docs/en/latest/terminology/global-rule.md
+++ b/docs/en/latest/terminology/global-rule.md
@@ -1,7 +1,7 @@
 ---
 title: Global Rules
 keywords:
-  - API gateway
+  - API Gateway
   - Apache APISIX
   - Global Rules
 description: This article describes how to use global rules.

--- a/docs/en/latest/terminology/plugin-config.md
+++ b/docs/en/latest/terminology/plugin-config.md
@@ -1,7 +1,7 @@
 ---
 title: Plugin Config
 keywords:
-  - API gateway
+  - API Gateway
   - Apache APISIX
   - Plugin Config
 description: Plugin Config in Apache APISIX.

--- a/docs/en/latest/tutorials/add-multiple-api-versions.md
+++ b/docs/en/latest/tutorials/add-multiple-api-versions.md
@@ -2,6 +2,8 @@
 title: Add multiple API versions
 keywords:
   - API Versioning
+  - Apache APISIX
+  - API Gateway
   - Multiple APIs
   - Proxy rewrite
   - Request redirect

--- a/docs/en/latest/tutorials/client-to-apisix-mtls.md
+++ b/docs/en/latest/tutorials/client-to-apisix-mtls.md
@@ -3,7 +3,7 @@ title: Configure mTLS for client to APISIX
 keywords:
   - mTLS
   - API Gateway
-  - APISIX
+  - Apache APISIX
 description: This article describes how to configure mutual authentication (mTLS) between the client and Apache APISIX.
 ---
 

--- a/docs/en/latest/xrpc/redis.md
+++ b/docs/en/latest/xrpc/redis.md
@@ -1,7 +1,8 @@
 ---
 title: redis
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API Gateway
   - xRPC
   - redis
 description: This document contains information about the Apache APISIX xRPC implementation for Redis.

--- a/docs/zh/latest/FAQ.md
+++ b/docs/zh/latest/FAQ.md
@@ -1,7 +1,7 @@
 ---
 title: 常见问题
 keywords:
-  - APISIX
+  - Apache APISIX
   - API 网关
   - 常见问题
   - FAQ

--- a/docs/zh/latest/plugins/api-breaker.md
+++ b/docs/zh/latest/plugins/api-breaker.md
@@ -1,7 +1,7 @@
 ---
 title: api-breaker
 keywords:
-  - APISIX
+  - Apache APISIX
   - API 网关
   - API Breaker
 description: 本文介绍了 Apache APISIX api-breaker 插件的相关操作，你可以使用此插件的 API 熔断机制来保护上游业务服务。

--- a/docs/zh/latest/plugins/authz-casbin.md
+++ b/docs/zh/latest/plugins/authz-casbin.md
@@ -1,7 +1,8 @@
 ---
 title: authz-casbin
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Authz Casbin
   - authz-casbin

--- a/docs/zh/latest/plugins/authz-casdoor.md
+++ b/docs/zh/latest/plugins/authz-casdoor.md
@@ -1,7 +1,8 @@
 ---
 title: authz-casdoor
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Authz Casdoor
   - authz-casdoor

--- a/docs/zh/latest/plugins/authz-keycloak.md
+++ b/docs/zh/latest/plugins/authz-keycloak.md
@@ -1,7 +1,8 @@
 ---
 title: authz-keycloak
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Authz Keycloak
   - authz-keycloak

--- a/docs/zh/latest/plugins/aws-lambda.md
+++ b/docs/zh/latest/plugins/aws-lambda.md
@@ -1,7 +1,7 @@
 ---
 title: aws-lambda
 keywords:
-  - APISIX
+  - Apache APISIX
   - Plugin
   - AWS Lambda
   - aws-lambda

--- a/docs/zh/latest/plugins/azure-functions.md
+++ b/docs/zh/latest/plugins/azure-functions.md
@@ -1,7 +1,8 @@
 ---
 title: azure-functions
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Azure Functions
   - azure-functions

--- a/docs/zh/latest/plugins/basic-auth.md
+++ b/docs/zh/latest/plugins/basic-auth.md
@@ -1,7 +1,8 @@
 ---
 title: basic-auth
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Basic Auth
   - basic-auth

--- a/docs/zh/latest/plugins/batch-requests.md
+++ b/docs/zh/latest/plugins/batch-requests.md
@@ -1,7 +1,8 @@
 ---
 title: batch-requests
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Batch Requests
 description: 本文介绍了关于 Apache APISIX `batch-request` 插件的基本信息及使用方法。

--- a/docs/zh/latest/plugins/consumer-restriction.md
+++ b/docs/zh/latest/plugins/consumer-restriction.md
@@ -1,8 +1,8 @@
 ---
 title: consumer-restriction
 keywords:
-  - APISIX
-  - API Gateway
+  - Apache APISIX
+  - API 网关
   - Consumer restriction
 description: Consumer Restriction 插件允许用户根据 Route、Service 或 Consumer 来设置相应的访问限制。
 ---

--- a/docs/zh/latest/plugins/cors.md
+++ b/docs/zh/latest/plugins/cors.md
@@ -1,8 +1,8 @@
 ---
 title: cors
 keywords:
-  - APISIX
-  - API Gateway
+  - Apache APISIX
+  - API 网关
   - CORS
 description: 本文介绍了 Apache APISIX cors 插件的基本信息及使用方法。
 ---

--- a/docs/zh/latest/plugins/csrf.md
+++ b/docs/zh/latest/plugins/csrf.md
@@ -1,7 +1,7 @@
 ---
 title: csrf
 keywords:
-  - APISIX
+  - Apache APISIX
   - API 网关
   - 跨站请求伪造攻击
   - Cross-site request forgery

--- a/docs/zh/latest/plugins/echo.md
+++ b/docs/zh/latest/plugins/echo.md
@@ -1,7 +1,8 @@
 ---
 title: echo
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Echo
 description: 本文介绍了关于 Apache APISIX `echo` 插件的基本信息及使用方法。

--- a/docs/zh/latest/plugins/ext-plugin-post-req.md
+++ b/docs/zh/latest/plugins/ext-plugin-post-req.md
@@ -1,7 +1,7 @@
 ---
 title: ext-plugin-post-req
 keywords:
-  - APISIX
+  - Apache APISIX
   - Plugin
   - ext-plugin-post-req
 description: 本文介绍了关于 Apache APISIX `ext-plugin-post-req` 插件的基本信息及使用方法。

--- a/docs/zh/latest/plugins/ext-plugin-post-resp.md
+++ b/docs/zh/latest/plugins/ext-plugin-post-resp.md
@@ -1,7 +1,8 @@
 ---
 title: ext-plugin-post-resp
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - ext-plugin-post-resp
 description: 本文介绍了关于 Apache APISIX `ext-plugin-post-resp` 插件的基本信息及使用方法。

--- a/docs/zh/latest/plugins/ext-plugin-pre-req.md
+++ b/docs/zh/latest/plugins/ext-plugin-pre-req.md
@@ -1,7 +1,8 @@
 ---
 title: ext-plugin-pre-req
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - ext-plugin-pre-req
 description: 本文介绍了关于 Apache APISIX `ext-plugin-pre-req` 插件的基本信息及使用方法。

--- a/docs/zh/latest/plugins/fault-injection.md
+++ b/docs/zh/latest/plugins/fault-injection.md
@@ -1,7 +1,8 @@
 ---
 title: fault-injection
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Fault Injection
   - fault-injection

--- a/docs/zh/latest/plugins/forward-auth.md
+++ b/docs/zh/latest/plugins/forward-auth.md
@@ -1,7 +1,8 @@
 ---
 title: forward-auth
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Forward Authentication
   - forward-auth

--- a/docs/zh/latest/plugins/gm.md
+++ b/docs/zh/latest/plugins/gm.md
@@ -1,7 +1,7 @@
 ---
 title: GM
 keywords:
-  - APISIX
+  - Apache APISIX
   - Plugin
   - GM
 description: 本文介绍了关于 Apache APISIX gm 插件的基本信息及使用方法。

--- a/docs/zh/latest/plugins/grpc-transcode.md
+++ b/docs/zh/latest/plugins/grpc-transcode.md
@@ -1,7 +1,8 @@
 ---
 title: grpc-transcode
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - gRPC Web
   - grpc-web

--- a/docs/zh/latest/plugins/grpc-web.md
+++ b/docs/zh/latest/plugins/grpc-web.md
@@ -1,7 +1,8 @@
 ---
 title: grpc-web
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - gRPC Web
   - grpc-web

--- a/docs/zh/latest/plugins/gzip.md
+++ b/docs/zh/latest/plugins/gzip.md
@@ -1,7 +1,8 @@
 ---
 title: gzip
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - gzip
 description: 本文介绍了关于 Apache APISIX `gzip` 插件的基本信息及使用方法。

--- a/docs/zh/latest/plugins/hmac-auth.md
+++ b/docs/zh/latest/plugins/hmac-auth.md
@@ -1,7 +1,8 @@
 ---
 title: hmac-auth
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - HMAC Authentication
   - hmac-auth

--- a/docs/zh/latest/plugins/http-logger.md
+++ b/docs/zh/latest/plugins/http-logger.md
@@ -1,7 +1,7 @@
 ---
 title: http-logger
 keywords:
-  - APISIX
+  - Apache APISIX
   - API 网关
   - 插件
   - HTTP Logger

--- a/docs/zh/latest/plugins/ip-restriction.md
+++ b/docs/zh/latest/plugins/ip-restriction.md
@@ -1,7 +1,8 @@
 ---
 title: ip-restriction
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - IP restriction
   - ip-restriction

--- a/docs/zh/latest/plugins/jwt-auth.md
+++ b/docs/zh/latest/plugins/jwt-auth.md
@@ -1,7 +1,8 @@
 ---
 title: jwt-auth
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - JWT Auth
   - jwt-auth

--- a/docs/zh/latest/plugins/kafka-logger.md
+++ b/docs/zh/latest/plugins/kafka-logger.md
@@ -1,8 +1,8 @@
 ---
 title: kafka-logger
 keywords:
-  - APISIX
-  - API Gateway
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Kafka Logger
 description: API 网关 Apache APISIX 的 kafka-logger 插件用于将日志作为 JSON 对象推送到 Apache Kafka 集群中。

--- a/docs/zh/latest/plugins/key-auth.md
+++ b/docs/zh/latest/plugins/key-auth.md
@@ -1,7 +1,8 @@
 ---
 title: key-auth
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Key Auth
   - key-auth

--- a/docs/zh/latest/plugins/ldap-auth.md
+++ b/docs/zh/latest/plugins/ldap-auth.md
@@ -1,7 +1,8 @@
 ---
 title: ldap-auth
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - LDAP Authentication
   - ldap-auth

--- a/docs/zh/latest/plugins/mocking.md
+++ b/docs/zh/latest/plugins/mocking.md
@@ -5,7 +5,6 @@ keywords:
   - API 网关
   - Plugin
   - Mocking
-  - mocking
 description: 本文介绍了关于 Apache APISIX `mocking` 插件的基本信息及使用方法。
 ---
 

--- a/docs/zh/latest/plugins/mocking.md
+++ b/docs/zh/latest/plugins/mocking.md
@@ -1,7 +1,8 @@
 ---
 title: mocking
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Mocking
   - mocking

--- a/docs/zh/latest/plugins/opa.md
+++ b/docs/zh/latest/plugins/opa.md
@@ -1,7 +1,8 @@
 ---
 title: opa
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Open Policy Agent
   - opa

--- a/docs/zh/latest/plugins/openfunction.md
+++ b/docs/zh/latest/plugins/openfunction.md
@@ -1,7 +1,8 @@
 ---
 title: openfunction
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - OpenFunction
   - openfunction

--- a/docs/zh/latest/plugins/openfunction.md
+++ b/docs/zh/latest/plugins/openfunction.md
@@ -5,7 +5,6 @@ keywords:
   - API 网关
   - Plugin
   - OpenFunction
-  - openfunction
 description: 本文介绍了 API 网关 Apache APISIX 的 openfunction 插件的基本信息及使用方法。
 ---
 

--- a/docs/zh/latest/plugins/openid-connect.md
+++ b/docs/zh/latest/plugins/openid-connect.md
@@ -1,8 +1,8 @@
 ---
 title: openid-connect
 keywords:
-  - APISIX
-  - API Gateway
+  - Apache APISIX
+  - API 网关
   - OpenID Connect
   - OIDC
 description: OpenID Connect（OIDC）是基于 OAuth 2.0 的身份认证协议，APISIX 可以与支持该协议的身份认证服务对接，如 Okta、Keycloak、Ory Hydra、Authing 等，实现对客户端请求的身份认证。

--- a/docs/zh/latest/plugins/opentelemetry.md
+++ b/docs/zh/latest/plugins/opentelemetry.md
@@ -5,7 +5,6 @@ keywords:
   - API 网关
   - Plugin
   - OpenTelemetry
-  - opentelemetry
 description: 本文介绍了关于 Apache APISIX `opentelemetry` 插件的基本信息及使用方法。
 ---
 

--- a/docs/zh/latest/plugins/opentelemetry.md
+++ b/docs/zh/latest/plugins/opentelemetry.md
@@ -1,5 +1,12 @@
 ---
 title: opentelemetry
+keywords:
+  - Apache APISIX
+  - API 网关
+  - Plugin
+  - OpenTelemetry
+  - opentelemetry
+description: 本文介绍了关于 Apache APISIX `opentelemetry` 插件的基本信息及使用方法。
 ---
 
 <!--

--- a/docs/zh/latest/plugins/openwhisk.md
+++ b/docs/zh/latest/plugins/openwhisk.md
@@ -1,7 +1,8 @@
 ---
 title: openwhisk
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - OpenWhisk
   - openwhisk

--- a/docs/zh/latest/plugins/openwhisk.md
+++ b/docs/zh/latest/plugins/openwhisk.md
@@ -5,7 +5,6 @@ keywords:
   - API 网关
   - Plugin
   - OpenWhisk
-  - openwhisk
 description: 本文介绍了关于 Apache APISIX openwhisk 插件的基本信息及使用方法。
 ---
 

--- a/docs/zh/latest/plugins/prometheus.md
+++ b/docs/zh/latest/plugins/prometheus.md
@@ -1,8 +1,8 @@
 ---
 title: prometheus
 keywords:
-  - APISIX
-  - API Gateway
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Prometheus
 description:  本文将介绍 API 网关 Apache APISIX 如何通过 prometheus 插件将 metrics 上报到开源的监控软件 Prometheus。

--- a/docs/zh/latest/plugins/proxy-rewrite.md
+++ b/docs/zh/latest/plugins/proxy-rewrite.md
@@ -1,7 +1,8 @@
 ---
 title: proxy-rewrite
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Proxy Rewrite
   - proxy-rewrite

--- a/docs/zh/latest/plugins/real-ip.md
+++ b/docs/zh/latest/plugins/real-ip.md
@@ -5,7 +5,6 @@ keywords:
   - API 网关
   - Plugin
   - Real IP
-  - real ip
 description: 本文介绍了关于 Apache APISIX `real-ip` 插件的基本信息及使用方法。
 ---
 

--- a/docs/zh/latest/plugins/real-ip.md
+++ b/docs/zh/latest/plugins/real-ip.md
@@ -1,7 +1,8 @@
 ---
 title: real-ip
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Real IP
   - real ip

--- a/docs/zh/latest/plugins/redirect.md
+++ b/docs/zh/latest/plugins/redirect.md
@@ -1,7 +1,8 @@
 ---
 title: redirect
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Redirect
 description: 本文介绍了关于 Apache APISIX `redirect` 插件的基本信息及使用方法。

--- a/docs/zh/latest/plugins/response-rewrite.md
+++ b/docs/zh/latest/plugins/response-rewrite.md
@@ -1,7 +1,8 @@
 ---
 title: response-rewrite
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Response Rewrite
   - response-rewrite

--- a/docs/zh/latest/plugins/server-info.md
+++ b/docs/zh/latest/plugins/server-info.md
@@ -1,7 +1,8 @@
 ---
 title: server-info
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Server info
   - server-info

--- a/docs/zh/latest/plugins/serverless.md
+++ b/docs/zh/latest/plugins/serverless.md
@@ -1,7 +1,8 @@
 ---
 title: serverless
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Serverless
   - serverless

--- a/docs/zh/latest/plugins/serverless.md
+++ b/docs/zh/latest/plugins/serverless.md
@@ -5,7 +5,6 @@ keywords:
   - API 网关
   - Plugin
   - Serverless
-  - serverless
 description: 本文介绍了关于 API 网关 Apache APISIX serverless-pre-function 和 serverless-post-function 插件的基本信息及使用方法。
 ---
 

--- a/docs/zh/latest/plugins/skywalking-logger.md
+++ b/docs/zh/latest/plugins/skywalking-logger.md
@@ -1,7 +1,7 @@
 ---
 title: skywalking-logger
 keywords:
-  - APISIX
+  - Apache APISIX
   - API 网关
   - Plugin
   - SkyWalking

--- a/docs/zh/latest/plugins/skywalking.md
+++ b/docs/zh/latest/plugins/skywalking.md
@@ -1,7 +1,8 @@
 ---
 title: skywalking
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - SkyWalking
 description: 本文将介绍 API 网关 Apache APISIX 如何通过 skywalking 插件将 metrics 上报到 Apache SkyWalking（一个开源的 APM）。

--- a/docs/zh/latest/plugins/splunk-hec-logging.md
+++ b/docs/zh/latest/plugins/splunk-hec-logging.md
@@ -1,7 +1,7 @@
 ---
 title: splunk-hec-logging
 keywords:
-  - APISIX
+  - Apache APISIX
   - API 网关
   - 插件
   - Splunk

--- a/docs/zh/latest/plugins/tcp-logger.md
+++ b/docs/zh/latest/plugins/tcp-logger.md
@@ -1,7 +1,7 @@
 ---
 title: tcp-logger
 keywords:
-  - APISIX
+  - Apache APISIX
   - API 网关
   - Plugin
   - TCP Logger

--- a/docs/zh/latest/plugins/tencent-cloud-cls.md
+++ b/docs/zh/latest/plugins/tencent-cloud-cls.md
@@ -1,7 +1,7 @@
 ---
 title: tencent-cloud-cls
 keywords:
-  - APISIX
+  - Apache APISIX
   - API 网关
   - Plugin
   - CLS

--- a/docs/zh/latest/plugins/ua-restriction.md
+++ b/docs/zh/latest/plugins/ua-restriction.md
@@ -1,8 +1,8 @@
 ---
 title: ua-restriction
 keywords:
-  - APISIX
-  - API Gateway
+  - Apache APISIX
+  - API 网关
   - UA restriction
 description: 本文介绍了 Apache APISIX ua-restriction 插件的使用方法，通过该插件可以将指定的 User-Agent 列入白名单或黑名单来限制对服务或路由的访问。
 ---

--- a/docs/zh/latest/plugins/uri-blocker.md
+++ b/docs/zh/latest/plugins/uri-blocker.md
@@ -1,8 +1,8 @@
 ---
 title: uri-blocker
 keywords:
-  - APISIX
-  - API Gateway
+  - Apache APISIX
+  - API 网关
   - URI Blocker
 description: 本文介绍了 Apache APISIX uri-blocker 插件的基本信息及使用方法。
 ---

--- a/docs/zh/latest/plugins/wolf-rbac.md
+++ b/docs/zh/latest/plugins/wolf-rbac.md
@@ -1,7 +1,8 @@
 ---
 title: wolf-rbac
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - wolf RBAC
   - wolf-rbac

--- a/docs/zh/latest/plugins/workflow.md
+++ b/docs/zh/latest/plugins/workflow.md
@@ -1,7 +1,8 @@
 ---
 title: workflow
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - workflow
   - 流量控制

--- a/docs/zh/latest/plugins/zipkin.md
+++ b/docs/zh/latest/plugins/zipkin.md
@@ -1,7 +1,8 @@
 ---
 title: zipkin
 keywords:
-  - APISIX
+  - Apache APISIX
+  - API 网关
   - Plugin
   - Zipkin
   - zipkin

--- a/docs/zh/latest/plugins/zipkin.md
+++ b/docs/zh/latest/plugins/zipkin.md
@@ -5,7 +5,6 @@ keywords:
   - API 网关
   - Plugin
   - Zipkin
-  - zipkin
 description: 本文介绍了关于 Apache APISIX zipkin 插件的基本信息及使用方法。
 ---
 

--- a/docs/zh/latest/terminology/api-gateway.md
+++ b/docs/zh/latest/terminology/api-gateway.md
@@ -1,7 +1,7 @@
 ---
 title: API Gateway
 keywords:
-  - APISIX
+  - Apache APISIX
   - API 网关
   - 网关
 description: 本文主要介绍了 API 网关的作用以及为什么需要 API 网关。


### PR DESCRIPTION
### Description
Optimizing _keywords_ and _metadata_ of the docs enhances the _SEO_ of APISIX & overall increases the accessibility for current and potential users. Hence, a few of the docs having "_APISIX_" has been updated to "_**Apache APISIX**_" (like the rest), and the keyword "API Gateway" or "API 网关" (in ZH) has been synchronously added to the list. 

Moreover, a few typos and localization mistakes detected during the process have also been rectified.

Fixes: #7218 
Refer to: #8966 

cc: @juzhiyuan, @nfrankel, @navendu-pottekkat, @Ajay-singh1

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)