### PR TITLE
fix: Non wildcard origin in CORS should sent Vary header

### DIFF
--- a/apisix/plugins/cors.lua
+++ b/apisix/plugins/cors.lua
@@ -190,10 +190,6 @@ local function set_cors_headers(conf, ctx)
     end
 
     core.response.set_header("Access-Control-Allow-Origin", ctx.cors_allow_origins)
-    if ctx.cors_allow_origins ~= "*" then
-        core.response.add_header("Vary", "Origin")
-    end
-
     core.response.set_header("Access-Control-Allow-Methods", allow_methods)
     core.response.set_header("Access-Control-Max-Age", conf.max_age)
     core.response.set_header("Access-Control-Expose-Headers", conf.expose_headers)
@@ -307,6 +303,9 @@ function _M.header_filter(conf, ctx)
         allow_origins = process_with_allow_origins_by_metadata(
                 conf.allow_origins_by_metadata, ctx, req_origin
         )
+    end
+    if conf.allow_origins ~= "*" then
+        core.response.add_header("Vary", "Origin")
     end
     if allow_origins then
         ctx.cors_allow_origins = allow_origins

--- a/t/plugin/cors3.t
+++ b/t/plugin/cors3.t
@@ -163,7 +163,7 @@ Origin: http://foo.example.org
 hello world
 --- response_headers
 Access-Control-Allow-Origin:
-Vary:
+Vary: Origin
 Access-Control-Allow-Methods:
 Access-Control-Allow-Headers:
 Access-Control-Expose-Headers:
@@ -254,7 +254,7 @@ Origin: http://foo.example.org
 hello world
 --- response_headers
 Access-Control-Allow-Origin:
-Vary:
+Vary: Origin
 Access-Control-Allow-Methods:
 Access-Control-Allow-Headers:
 Access-Control-Expose-Headers:


### PR DESCRIPTION
### Description

When CORS requirements are more complicated than setting `Access-Control-Allow-Origin` to `*` then we set the `Vary` to `Origin`. This avoids caching the wrong response.

Last week I was debugging an issue where requests where failing with CORS errors. 
After some digging it became clear that when the first request to the endpoint did not match the allowed origins the request was cached and this cached resolve was then used later on for Origins that should be allowed. This turned out to be because the `Vary` header did not contain `Origin`. 

Secondly I also resolved an issue where I was unable to use only `allow_origins_by_regex` in standalone mode by allowing `allow_origins` to be an empty string. 
*I'm not sure what `metadata_schema` is used for so this maybe wrong.*

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
