### PR TITLE
docs: replace non-inclusive terms in ua-restriction plugin doc

### DIFF
--- a/docs/en/latest/plugins/ua-restriction.md
+++ b/docs/en/latest/plugins/ua-restriction.md
@@ -30,7 +30,7 @@ description: This document contains information about the Apache APISIX ua-restr
 
 The `ua-restriction` Plugin allows you to restrict access to a Route or Service based on the `User-Agent` header with an `allowlist` and a `denylist`.
 
-A common scenario is to set crawler rules. `User-Agent` is the identity of the client when sending requests to the server, and the user can whitelist or blacklist some crawler request headers in the `ua-restriction` Plugin.
+A common scenario is to set crawler rules. `User-Agent` is the identity of the client when sending requests to the server, and the user can allow or deny some crawler request headers in the `ua-restriction` Plugin.
 
 ## Attributes
 


### PR DESCRIPTION
### Description
_**Blacklist**_ and _**whitelist**_ are profane terms. Hence, the usage of appropriate terms like allowlist and denylist is suggested instead in [ua-restriction.md](https://github.com/apache/apisix/blob/master/docs/en/latest/plugins/ua-restriction.md#description).

Fixes #9042 
cc: @shreemaan-abhishek, @navendu-pottekkat, @nfrankel 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

