### PR TITLE
docs: corrected sample expose-api test route

### DIFF
--- a/docs/en/latest/tutorials/expose-api.md
+++ b/docs/en/latest/tutorials/expose-api.md
@@ -111,7 +111,7 @@ curl "http://127.0.0.1:9180/apisix/admin/routes/1" \
 After creating the Route, you can test the Service with the following command:
 
 ```
-curl -i -X GET "http://127.0.0.1:9080/get?foo1=bar1&foo2=bar2" -H "Host: example.com"
+curl -i -X GET "http://127.0.0.1:9080/anything/get?foo1=bar1&foo2=bar2" -H "Host: example.com"
 ```
 
 APISIX will forward the request to `http://httpbin.org:80/anything/foo?arg=10`.


### PR DESCRIPTION
fix test route

### Description

The test route was not correct, the _URI_ part was missing.

### Checklist

- [X] I have explained the need for this PR and the problem it solves
- [X] I have explained the changes or the new features added to this PR
- [X] I have updated the documentation to reflect this change

