### PR TITLE
ci: fix low disk space error when loading saved docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,9 +118,12 @@ jobs:
           if [[ -f docker-images-backup/apisix-images.tar ]]; then
             [[ ${{ steps.test_env.outputs.type }} != first ]] && sudo ./ci/init-${{ steps.test_env.outputs.type }}-test-service.sh before
             docker load --input docker-images-backup/apisix-images.tar
-            rm docker-images-backup/apisix-images.tar
-            make ci-env-up project_compose_ci=ci/pod/docker-compose.${{ steps.test_env.outputs.type }}.yml
             echo "loaded docker images"
+
+            # preserve storage space
+            rm docker-images-backup/apisix-images.tar
+
+            make ci-env-up project_compose_ci=ci/pod/docker-compose.${{ steps.test_env.outputs.type }}.yml
             if [[ ${{ steps.test_env.outputs.type }} != first ]]; then
               sudo ./ci/init-${{ steps.test_env.outputs.type }}-test-service.sh after
             fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,10 @@ jobs:
             echo "type=last" >>$GITHUB_OUTPUT
           fi
 
+      - name: Free disk space
+        run: |
+          bash ./ci/free_disk_space.sh
+
       - name: Linux launch common services
         run: |
           make ci-env-up project_compose_ci=ci/pod/docker-compose.common.yml
@@ -168,8 +172,6 @@ jobs:
       - if: ${{ steps.cache-images.outputs.cache-hit != 'true' }}
         name: Save docker images
         run: |
-          # free disk space
-          bash ./ci/free_disk_space.sh
           echo "start backing up, $(date)"
           bash ./ci/backup-docker-images.sh ${{ steps.test_env.outputs.type }}
           echo "backup done, $(date)"


### PR DESCRIPTION
### Description

Ref: https://github.com/apache/apisix/pull/8735#discussion_r1102232577

Freeing up disk space when saving docker images helps, but sometimes, disk space may become full even while loading docker images. Take this [job](https://github.com/apache/apisix/actions/runs/4420311721/jobs/7776553142) for example.

Creating a new github action step that would free disk space will prevent disk space from becoming full in both cases:

- When there is a cache miss and we need to save the docker images
- When there is a cache hit and we need to load the saved docker images from the cache.

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
