### PR TITLE
docs: using curl silent mod when fetching version

### DIFF
--- a/docs/en/latest/getting-started.md
+++ b/docs/en/latest/getting-started.md
@@ -148,7 +148,7 @@ Make sure that all the required ports (default: 9080, 9180, 9443 and 2379) are a
 Once APISIX is running, you can use curl to access it. Send a simple HTTP request to validate if APISIX is working properly or not.
 
 ```sh
-curl -s "http://127.0.0.1:9080" --head | grep Server
+curl -sI "http://127.0.0.1:9080" | grep Server
 ```
 
 If everything is ok, you will get the following response.

--- a/docs/en/latest/getting-started.md
+++ b/docs/en/latest/getting-started.md
@@ -148,7 +148,7 @@ Make sure that all the required ports (default: 9080, 9180, 9443 and 2379) are a
 Once APISIX is running, you can use curl to access it. Send a simple HTTP request to validate if APISIX is working properly or not.
 
 ```sh
-curl "http://127.0.0.1:9080" --head | grep Server
+curl -s "http://127.0.0.1:9080" --head | grep Server
 ```
 
 If everything is ok, you will get the following response.


### PR DESCRIPTION
### Description
Get this: 
```
curl -s "http://127.0.0.1:9080" --head | grep Server
Server: APISIX/2.15.0
```

Instead of: 
```
curl "http://127.0.0.1:9080" --head | grep Server
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
Server: APISIX/2.15.0
```
