### PR TITLE
docs: Missing comma

### DIFF
--- a/docs/en/latest/terminology/plugin-config.md
+++ b/docs/en/latest/terminology/plugin-config.md
@@ -112,7 +112,7 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1 \
         "nodes": {
             "127.0.0.1:1980": 1
         }
-    }
+    },
     "plugins": {
         "proxy-rewrite": {
             "uri": "/test/add",
@@ -140,7 +140,7 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1 \
         "nodes": {
             "127.0.0.1:1980": 1
         }
-    }
+    },
     "plugins": {
         "ip-restriction": {
             "whitelist": [

--- a/docs/zh/latest/terminology/plugin-config.md
+++ b/docs/zh/latest/terminology/plugin-config.md
@@ -117,7 +117,7 @@ description: Plugin Config 对象，可以用于创建一组通用的插件配�
             "nodes": {
                 "127.0.0.1:1980": 1
             }
-        }
+        }.
         "plugins": {
             "proxy-rewrite": {
                 "uri": "/test/add",
@@ -145,7 +145,7 @@ description: Plugin Config 对象，可以用于创建一组通用的插件配�
             "nodes": {
                 "127.0.0.1:1980": 1
             }
-        }
+        },
         "plugins": {
             "ip-restriction": {
                 "whitelist": [


### PR DESCRIPTION
Missing commas in documentation examples lead to execution error: `400`

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
