### PR TITLE
fix: checker leak for domain nodes

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -223,9 +223,15 @@ local function parse_domain_in_route(route)
     -- don't modify the modifiedIndex to avoid plugin cache miss because of DNS resolve result
     -- has changed
 
-    -- Here we copy the whole route instead of part of it,
-    -- so that we can avoid going back from route.value to route during copying.
-    route.dns_value = core.table.deepcopy(route).value
+    local parent = route.value.upstream.parent
+    if parent then
+        route.value.upstream.parent = nil
+    end
+    route.dns_value = core.table.deepcopy(route.value)
+    if parent then
+        route.value.upstream.parent = parent
+        route.dns_value.upstream.parent = parent
+    end
     route.dns_value.upstream.nodes = new_nodes
     core.log.info("parse route which contain domain: ",
                   core.json.delay_encode(route, true))

--- a/t/node/healthcheck-leak-bugfix.t
+++ b/t/node/healthcheck-leak-bugfix.t
@@ -39,12 +39,7 @@ __DATA__
         return obj
     end
 
---- init_by_lua_block
-    require "resty.core"
-    apisix = require("apisix")
-    core = require("apisix.core")
-    apisix.http_init()
-
+--- extra_init_by_lua
     local utils = require("apisix.core.utils")
     local count = 0
     utils.dns_parse = function (domain)  -- mock: DNS parser

--- a/t/node/healthcheck-leak-bugfix.t
+++ b/t/node/healthcheck-leak-bugfix.t
@@ -1,0 +1,117 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+log_level('warn');
+no_root_location();
+no_shuffle();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: ensure the old check is cleared after configuration updated
+--- extra_init_worker_by_lua
+    local healthcheck = require("resty.healthcheck")
+    local new = healthcheck.new
+    healthcheck.new = function(...)
+        local obj = new(...)
+        local clear = obj.clear
+        obj.clear = function(...)
+            ngx.log(ngx.WARN, "clear checker")
+            return clear(...)
+        end
+        return obj
+    end
+
+--- init_by_lua_block
+    require "resty.core"
+    apisix = require("apisix")
+    core = require("apisix.core")
+    apisix.http_init()
+
+    local utils = require("apisix.core.utils")
+    local count = 0
+    utils.dns_parse = function (domain)  -- mock: DNS parser
+        count = count + 1
+        if domain == "test1.com" then
+            return {address = "127.0.0." .. count}
+        end
+        if domain == "test2.com" then
+            return {address = "127.0.0." .. count+100}
+        end
+
+        error("unknown domain: " .. domain)
+    end
+
+--- config
+location /t {
+    content_by_lua_block {
+        local cfg = [[{
+            "upstream": {
+                "nodes": {
+                    "test1.com:1980": 1,
+                    "test2.com:1980": 1
+                },
+                "type": "roundrobin",
+                "checks":{
+                    "active":{
+                        "healthy":{
+                            "http_statuses":[
+                                200,
+                                302
+                            ],
+                            "interval":1,
+                            "successes":2
+                        },
+                        "http_path":"/hello",
+                        "timeout":1,
+                        "type":"http",
+                        "unhealthy":{
+                            "http_failures":5,
+                            "http_statuses":[
+                                429,
+                                404,
+                                500,
+                                501,
+                                502,
+                                503,
+                                504,
+                                505
+                            ],
+                            "interval":1,
+                            "tcp_failures":2,
+                            "timeouts":3
+                        }
+                    }
+                }
+            },
+            "uri": "/hello"
+        }]]
+        local t = require("lib.test_admin").test
+        assert(t('/apisix/admin/routes/1', ngx.HTTP_PUT, cfg) < 300)
+        t('/hello', ngx.HTTP_GET)
+        assert(t('/apisix/admin/routes/1', ngx.HTTP_PUT, cfg) < 300)
+        ngx.sleep(1)
+    }
+}
+
+--- request
+GET /t
+--- error_log
+clear checker


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #8932

Only `route.value.upstream.parent` has table reference to `route`, so skip it in `deepcopy` to fix this bug and also avoid a recursive copy (https://github.com/apache/apisix/commit/27c37b191f35da983d40dd42e5ea517105107567).

```
  dns_value = {
    create_time = 1678955679,
    id = "1",
    plugins = {
      ["serverless-pre-function"] = {
        functions = {...},
        phase = "before_proxy"
      }
    },
    priority = 0,
    status = 1,
    update_time = 1678955679,
    upstream = <1>{
      checks = {
        active = {...}
      },
      hash_on = "vars",
      nodes = <2>{ {...}, {...} },
      nodes_ref = <table 2>,
      original_nodes = <table 2>,
      parent = <3>{
        checker = {...},
        checker_idx = 1,
        checker_upstream = <table 1>,
        clean_handlers = {...},
        createdIndex = 2688845,
        has_domain = true,
        key = "/apisix/routes/1",
        modifiedIndex = 2688845,
        orig_modifiedIndex = 2688845,
        update_count = 0,
        value = {...}
      },
      pass_host = "pass",
      scheme = "http",
      type = "roundrobin"
    },
    uri = "/get"
  },

```

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
