### PR TITLE
docs: update default port to 9080

### DIFF
--- a/docs/zh/latest/installation-guide.md
+++ b/docs/zh/latest/installation-guide.md
@@ -244,18 +244,18 @@ brew services start etcd
 
 通过修改本地 `./conf/config.yaml` 文件，或者在启动 APISIX 时使用 `-c` 或 `--config` 添加文件路径参数 `apisix start -c <path string>`，完成对 APISIX 服务本身的基本配置。
 
-比如将 APISIX 默认监听端口修改为 8000，其他配置保持默认，在 `./conf/config.yaml` 中只需这样配置：
+比如将 APISIX 默认监听端口修改为 9080，其他配置保持默认，在 `./conf/config.yaml` 中只需这样配置：
 
 ```yaml title=“./conf/config.yaml”
 apisix:
-  node_listen: 8000 # APISIX listening port
+  node_listen: 9080 # APISIX listening port
 ```
 
-比如指定 APISIX 默认监听端口为 8000，并且设置 etcd 地址为 `http://foo:2379`，其他配置保持默认。在 `./conf/config.yaml` 中只需这样配置：
+比如指定 APISIX 默认监听端口为 9080，并且设置 etcd 地址为 `http://foo:2379`，其他配置保持默认。在 `./conf/config.yaml` 中只需这样配置：
 
 ```yaml title=“./conf/config.yaml”
 apisix:
-  node_listen: 8000 # APISIX listening port
+  node_listen: 9080 # APISIX listening port
 
 deployment:
   role: traditional


### PR DESCRIPTION

### Description
The documentation says the default is 8000,But it seems out of date to me.

Fixes # (issue)
null
### Checklist

- [yes] I have updated the documentation to reflect this change

