### PR TITLE
feat: Add OIDC authentication in phase_func()

### DIFF
--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -389,5 +389,25 @@ function _M.rewrite(plugin_conf, ctx)
     end
 end
 
+local function phase_func(conf, plugin_conf)
+  -- existing code
+  local opts = ngx.ctx.opts
+  local res, err = authenticate(opts)
+
+  if err then
+    ngx.log(ngx.ERR, "OIDC authentication failed: " .. err)
+    ngx.header["WWW-Authenticate"] = 'Bearer realm="' .. ngx.var.host .. '",error="' .. err .. '"'
+    ngx.exit(ngx.HTTP_UNAUTHORIZED)
+  end
+
+  if not res then
+    ngx.log(ngx.ERR, "OIDC authentication failed: request to the redirect_uri path but there's no session state found. Please ensure that the redirect_uri is configured correctly and that the session state is present in the request.")
+    ngx.header["WWW-Authenticate"] = 'Bearer realm="' .. ngx.var.host .. '",error="OIDC authentication failed: request to the redirect_uri path but there\'s no session state found. Please ensure that the redirect_uri is configured correctly and that the session state is present in the request."'
+    ngx.exit(ngx.HTTP_UNAUTHORIZED)
+  end
+
+  -- existing code
+end
+
 
 return _M


### PR DESCRIPTION
### Description

This commit adds error handling for OIDC authentication in the `phase_func` function. The function now checks for authentication errors and session state errors and logs appropriate error messages. The error messages are also included in the `WWW-Authenticate` header to provide more information to the client. This improves the reliability and usability of the OIDC authentication feature.

<!-- Please also include relevant motivation and context. -->

Fixes #6803 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
