### PR TITLE
openid-connect plugin - check token request against granted scopes 

### DIFF
--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -19,6 +19,7 @@ local core    = require("apisix.core")
 local ngx_re  = require("ngx.re")
 local openidc = require("resty.openidc")
 local random  = require("resty.random")
+local cjson = require "cjson"
 local string  = string
 local ngx     = ngx
 
@@ -304,7 +305,7 @@ function _M.rewrite(plugin_conf, ctx)
         conf.ssl_verify = "no"
     end
 
-    local response, err, session, _
+    local response, err, session, result, _
 
     if conf.bearer_only or conf.introspection_endpoint or conf.public_key then
         -- An introspection endpoint or a public key has been configured. Try to
@@ -312,7 +313,9 @@ function _M.rewrite(plugin_conf, ctx)
         -- request header. Otherwise, return a nil response. See below for
         -- handling of the case where the access token is stored in a session cookie.
         local access_token, userinfo
+        core.log.debug("conf to introspect:", cjson.encode(conf))
         response, err, access_token, userinfo = introspect(ctx, conf)
+        core.log.debug("introspect response:", cjson.encode(response))
 
         if err then
             -- Error while validating token or invalid token.
@@ -321,13 +324,31 @@ function _M.rewrite(plugin_conf, ctx)
         end
 
         if response then
-            -- Add configured access token header, maybe.
-            add_access_token_header(ctx, conf, access_token)
+            if response.scope then
+                local scopes, err = ngx_re.split(response.scope, " ")
+                if err then
+                    core.log.error("OIDC request scope failed: ", err)
+                    return 500
+                end
+                core.log.debug("OIDC scopes:", cjson.encode(scopes))
+                for _, scope in ipairs(scopes) do
+                    core.log.debug("check OIDC scope:", scope)
+                    if scope == conf.scope then
+                        result = true
+                        -- Add configured access token header, maybe.
+                        add_access_token_header(ctx, conf, access_token)
 
-            if userinfo and conf.set_userinfo_header then
-                -- Set X-Userinfo header to introspection endpoint response.
-                core.request.set_header(ctx, "X-Userinfo",
-                    ngx_encode_base64(core.json.encode(userinfo)))
+                        if userinfo and conf.set_userinfo_header then
+                            -- Set X-Userinfo header to introspection endpoint response.
+                            core.request.set_header(ctx, "X-Userinfo",
+                                    ngx_encode_base64(core.json.encode(userinfo)))
+                        end
+                        break
+                    end
+                end
+                if not result then
+                    return 401
+                end
             end
         end
     end

--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -19,7 +19,6 @@ local core    = require("apisix.core")
 local ngx_re  = require("ngx.re")
 local openidc = require("resty.openidc")
 local random  = require("resty.random")
-local cjson = require "cjson"
 local string  = string
 local ngx     = ngx
 
@@ -313,9 +312,9 @@ function _M.rewrite(plugin_conf, ctx)
         -- request header. Otherwise, return a nil response. See below for
         -- handling of the case where the access token is stored in a session cookie.
         local access_token, userinfo
-        core.log.debug("conf to introspect:", cjson.encode(conf))
+        core.log.debug("conf to introspect:", core.json.encode(conf))
         response, err, access_token, userinfo = introspect(ctx, conf)
-        core.log.debug("introspect response:", cjson.encode(response))
+        core.log.debug("introspect response:", core.json.encode(response))
 
         if err then
             -- Error while validating token or invalid token.
@@ -327,12 +326,12 @@ function _M.rewrite(plugin_conf, ctx)
             if response.scope then
                 local scopes, err = ngx_re.split(response.scope, " ")
                 if err then
-                    core.log.error("OIDC request scope failed: ", err)
+                    core.log.error("OIDC extract scope failed: ", err)
                     return 500
                 end
-                core.log.debug("OIDC scopes:", cjson.encode(scopes))
+                core.log.debug("OIDC scopes:", core.json.encode(scopes))
                 for _, scope in ipairs(scopes) do
-                    core.log.debug("check OIDC scope:", scope)
+                    core.log.debug("Check OIDC scope:", scope)
                     if scope == conf.scope then
                         result = true
                         -- Add configured access token header, maybe.


### PR DESCRIPTION
### Description

Current openid connect plugin does not check for access token scope permission. For example, a client-id clientX has been granted for scope-a, apisix with openid connect has 2 routes set up with scope-a and scope-b for different client-id. 

ClientX then use client-id and client-secret to get access-token to request for service defined with scope-a, this access token can still be used to access service defined with scope-b since this plugin does not check for scope when doing oidc introspect. 

This fixes issue mentioned above by also checking allowed scope of access token with granted scope in oidc 



### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)


