### PR TITLE
fix(cli): fix allow_admin allows non-`127.0.0.0/24` to access admin api with empty admin_key

### DIFF
--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -187,7 +187,7 @@ local function init(env)
     local allow_admin = yaml_conf.deployment.admin and
         yaml_conf.deployment.admin.allow_admin
     if yaml_conf.apisix.enable_admin and allow_admin
-       and table.getn(allow_admin) == 1 and allow_admin[1] == "127.0.0.0/24" then
+       and #allow_admin == 1 and allow_admin[1] == "127.0.0.0/24" then
         checked_admin_key = true
     end
 

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -185,12 +185,9 @@ local function init(env)
     local checked_admin_key = false
     local allow_admin = yaml_conf.deployment.admin and
         yaml_conf.deployment.admin.allow_admin
-    if yaml_conf.apisix.enable_admin and allow_admin then
-        for _, allow_ip in ipairs(allow_admin) do
-            if allow_ip == "127.0.0.0/24" then
-                checked_admin_key = true
-            end
-        end
+    if yaml_conf.apisix.enable_admin and allow_admin
+       and table.getn(allow_admin) == 1 and allow_admin[1] == "127.0.0.0/24" then
+        checked_admin_key = true
     end
 
     if yaml_conf.apisix.enable_admin and not checked_admin_key then

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -50,7 +50,6 @@ local str_find = string.find
 local str_byte = string.byte
 local str_sub = string.sub
 local str_format = string.format
-local table = table
 
 local _M = {}
 

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -50,6 +50,7 @@ local str_find = string.find
 local str_byte = string.byte
 local str_sub = string.sub
 local str_format = string.format
+local table = table
 
 local _M = {}
 

--- a/t/cli/test_admin.sh
+++ b/t/cli/test_admin.sh
@@ -159,15 +159,14 @@ echo "pass: missing admin key and show ERROR message"
 echo '
 deployment:
   admin:
+    admin_key: ~
     allow_admin:
       - 127.0.0.0/24
-    allow_admin: ~
 ' > conf/config.yaml
 
 make init > output.log 2>&1 | true
 
-grep -E "ERROR: missing valid Admin API token." output.log > /dev/null
-if [ $? -eq 0 ]; then
+if grep -E "ERROR: missing valid Admin API token." output.log > /dev/null; then
     echo "failed: should not show 'ERROR: missing valid Admin API token.'"
     exit 1
 fi
@@ -175,16 +174,15 @@ fi
 echo '
 deployment:
   admin:
+    admin_key: ~
     allow_admin:
       - 0.0.0.0/0
       - 127.0.0.0/24
-    allow_admin: ~
 ' > conf/config.yaml
 
 make init > output.log 2>&1 | true
 
-grep -E "ERROR: missing valid Admin API token." output.log > /dev/null
-if [ ! $? -eq 0 ]; then
+if ! grep -E "ERROR: missing valid Admin API token." output.log > /dev/null; then
     echo "failed: should show 'ERROR: missing valid Admin API token.'"
     exit 1
 fi

--- a/t/cli/test_admin.sh
+++ b/t/cli/test_admin.sh
@@ -154,6 +154,45 @@ fi
 
 echo "pass: missing admin key and show ERROR message"
 
+# missing admin key, only allow 127.0.0.0/24 to access admin api
+
+git checkout conf/config.yaml
+
+echo '
+deployment:
+  admin:
+    allow_admin:
+      - 127.0.0.0/24
+    allow_admin: ~
+' > conf/config.yaml
+
+make init > output.log 2>&1 | true
+
+grep -E "ERROR: missing valid Admin API token." output.log > /dev/null
+if [ ! $? -ne 0 ]; then
+    echo "failed: should not show 'ERROR: missing valid Admin API token.'"
+    exit 1
+fi
+
+echo '
+deployment:
+  admin:
+    allow_admin:
+      - 0.0.0.0/0
+      - 127.0.0.0/24
+    allow_admin: ~
+' > conf/config.yaml
+
+make init > output.log 2>&1 | true
+
+grep -E "ERROR: missing valid Admin API token." output.log > /dev/null
+if [ ! $? -eq 0 ]; then
+    echo "failed: should show 'ERROR: missing valid Admin API token.'"
+    exit 1
+fi
+
+echo "pass: missing admin key and only allow 127.0.0.0/24 to access admin api"
+
 # admin api, allow any IP but use default key
 
 echo '

--- a/t/cli/test_admin.sh
+++ b/t/cli/test_admin.sh
@@ -156,8 +156,6 @@ echo "pass: missing admin key and show ERROR message"
 
 # missing admin key, only allow 127.0.0.0/24 to access admin api
 
-git checkout conf/config.yaml
-
 echo '
 deployment:
   admin:
@@ -169,7 +167,7 @@ deployment:
 make init > output.log 2>&1 | true
 
 grep -E "ERROR: missing valid Admin API token." output.log > /dev/null
-if [ ! $? -ne 0 ]; then
+if [ $? -eq 0 ]; then
     echo "failed: should not show 'ERROR: missing valid Admin API token.'"
     exit 1
 fi


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #9055 

### Checklist

- [X] I have explained the need for this PR and the problem it solves
- [X] I have explained the changes or the new features added to this PR
- [X] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [X] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
