### PR TITLE
fix: upgrade lua-resty-ldap to 0.2.2

### DIFF
--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -78,7 +78,7 @@ dependencies = {
     "xml2lua = 1.5-2",
     "nanoid = 0.1-1",
     "lua-resty-mediador = 0.1.2-1",
-    "lua-resty-ldap = 0.2.0-0"
+    "lua-resty-ldap = 0.2.2-0"
 }
 
 build = {

--- a/t/xds-library/main.go
+++ b/t/xds-library/main.go
@@ -34,7 +34,6 @@ import "C"
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"strconv"
 	"time"
 	"unsafe"
@@ -84,7 +83,7 @@ func write_config(config_zone unsafe.Pointer, version_zone unsafe.Pointer) {
 "create_time": 1646972532,
 "uri": "/hello1",
 "priority": 0,
-"id": "1",
+"id": "2",
 "upstream_id": "1"
 }`)
 
@@ -95,17 +94,21 @@ func write_config(config_zone unsafe.Pointer, version_zone unsafe.Pointer) {
 
 }
 
+func get_version() string {
+	return strconv.FormatInt(time.Now().UnixNano()/1e6, 10)
+}
+
 func update_conf_version(zone unsafe.Pointer) {
 	ctx := context.Background()
+	key := "version"
+	write_shdict(key, get_version(), zone)
 	go func() {
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(time.Second * time.Duration(rand.Intn(10))):
-				key := "version"
-				version := strconv.FormatInt(time.Now().UnixNano()/1e6, 10)
-				write_shdict(key, version, zone)
+			case <-time.After(time.Second * 5):
+				write_shdict("version", get_version(), zone)
 			}
 		}
 	}()


### PR DESCRIPTION
Fixes: #9253 


### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [X] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change // not need
- [ ] I have updated the documentation to reflect this change // not need
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first) // not need

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->

I try to upgrade the lua-resty-ldap to 0.2.2 . and to re-try run `make deps`. it's success. 

the output as the follow

```shell
$ make deps
Wrote
	variables.OPENSSL_LIBDIR = "/opt/homebrew/opt/openresty-openssl111/lib"
to
	/Users/guohao/.luarocks/config-5.1.lua
Wrote
	variables.OPENSSL_INCDIR = "/opt/homebrew/opt/openresty-openssl111/include"
to
	/Users/guohao/.luarocks/config-5.1.lua
Missing dependencies for apisix master-0:
   lua-resty-ldap 0.2.2-0 (not installed)

apisix master-0 depends on lua-resty-ctxdump 0.1-0 (0.1-0 installed)
apisix master-0 depends on api7-lua-resty-dns-client 7.0.1 (7.0.1-0 installed)
apisix master-0 depends on lua-resty-template 2.0 (2.0-1 installed)
apisix master-0 depends on lua-resty-etcd 1.10.4 (1.10.4-0 installed)
apisix master-0 depends on api7-lua-resty-http 0.2.0 (0.2.0-0 installed)
apisix master-0 depends on lua-resty-balancer 0.04 (0.04-0 installed)
apisix master-0 depends on lua-resty-ngxvar 0.5.2 (0.5.2-0 installed)
apisix master-0 depends on lua-resty-jit-uuid 0.0.7 (0.0.7-2 installed)
apisix master-0 depends on lua-resty-healthcheck-api7 2.2.3 (2.2.3-0 installed)
apisix master-0 depends on api7-lua-resty-jwt 0.2.4 (0.2.4-0 installed)
apisix master-0 depends on lua-resty-hmac-ffi 0.05 (0.05-0 installed)
apisix master-0 depends on lua-resty-cookie 0.1.0 (0.1.0-1 installed)
apisix master-0 depends on lua-resty-session 3.10 (3.10-1 installed)
apisix master-0 depends on opentracing-openresty 0.1 (0.1-0 installed)
apisix master-0 depends on lua-resty-radixtree 2.8.2 (2.8.2-0 installed)
apisix master-0 depends on lua-protobuf 0.4.1 (0.4.1-1 installed)
apisix master-0 depends on lua-resty-openidc 1.7.5 (1.7.5-1 installed)
apisix master-0 depends on luafilesystem 1.7.0-2 (1.7.0-2 installed)
apisix master-0 depends on api7-lua-tinyyaml 0.4.2 (0.4.2-0 installed)
apisix master-0 depends on nginx-lua-prometheus 0.20220527 (0.20220527-1 installed)
apisix master-0 depends on jsonschema 0.9.8 (0.9.8-0 installed)
apisix master-0 depends on lua-resty-ipmatcher 0.6.1 (0.6.1-0 installed)
apisix master-0 depends on lua-resty-kafka 0.20-0 (0.20-0 installed)
apisix master-0 depends on lua-resty-logger-socket 2.0.1-0 (2.0.1-0 installed)
apisix master-0 depends on skywalking-nginx-lua 0.6.0 (0.6.0-0 installed)
apisix master-0 depends on base64 1.5-2 (1.5-2 installed)
apisix master-0 depends on binaryheap 0.4 (0.4-1 installed)
apisix master-0 depends on api7-dkjson 0.1.1 (0.1.1-0 installed)
apisix master-0 depends on resty-redis-cluster 1.02-4 (1.02-4 installed)
apisix master-0 depends on lua-resty-expr 1.3.2 (1.3.2-0 installed)
apisix master-0 depends on graphql 0.0.2 (0.0.2-1 installed)
apisix master-0 depends on argparse 0.7.1-1 (0.7.1-1 installed)
apisix master-0 depends on luasocket 3.1.0-1 (3.1.0-1 installed)
apisix master-0 depends on luasec 0.9-1 (0.9-1 installed)
apisix master-0 depends on lua-resty-consul 0.3-2 (0.3-2 installed)
apisix master-0 depends on penlight 1.9.2-1 (1.9.2-1 installed)
apisix master-0 depends on ext-plugin-proto 0.6.0 (0.6.0-0 installed)
apisix master-0 depends on casbin 1.41.5 (1.41.5-1 installed)
apisix master-0 depends on api7-snowflake 2.0-1 (2.0-1 installed)
apisix master-0 depends on inspect 3.1.1 (3.1.1-0 installed)
apisix master-0 depends on lualdap 1.2.6-1 (1.2.6-1 installed)
apisix master-0 depends on lua-resty-rocketmq 0.3.0-0 (0.3.0-0 installed)
apisix master-0 depends on opentelemetry-lua 0.2-3 (0.2-3 installed)
apisix master-0 depends on net-url 0.9-1 (0.9-1 installed)
apisix master-0 depends on xml2lua 1.5-2 (1.5-2 installed)
apisix master-0 depends on nanoid 0.1-1 (0.1-1 installed)
apisix master-0 depends on lua-resty-mediador 0.1.2-1 (0.1.2-1 installed)
apisix master-0 depends on lua-resty-ldap 0.2.2-0 (not installed)
Installing https://luarocks.org/lua-resty-ldap-0.2.2-0.src.rock

lua-resty-ldap 0.2.2-0 depends on lua_pack 2.0.0-0 (2.0.0-0 installed)
lua-resty-ldap 0.2.2-0 depends on lpeg 1.0.2-1 (1.0.2-1 installed)
Warning: unmatched variable LUA_LIBDIR
--- Build
CFLAGS: -O2 -fPIC
LIBFLAG: -bundle -undefined dynamic_lookup -all_load
LUA_LIBDIR:
LUA_BINDIR: /opt/homebrew/opt/lua@5.1/bin
LUA_INCDIR: /opt/homebrew/opt/lua@5.1/include/lua5.1
--- Check Rust toolchain
The cargo is installed
--- Build Rust cdylib
cargo build --release
    Updating crates.io index
   Compiling autocfg v1.1.0
   Compiling proc-macro2 v1.0.56
   Compiling unicode-ident v1.0.8
   Compiling quote v1.0.26
   Compiling syn v1.0.109
   Compiling memchr v2.5.0
   Compiling radium v0.7.0
   Compiling doc-comment v0.3.3
   Compiling tap v1.0.1
   Compiling either v1.8.1
   Compiling heck v0.4.1
   Compiling itertools v0.10.5
   Compiling wyz v0.5.1
   Compiling funty v2.0.0
   Compiling cc v1.0.79
   Compiling num-traits v0.2.15
   Compiling num-integer v0.1.45
   Compiling num-bigint v0.4.3
   Compiling pkg-config v0.3.26
   Compiling konst_macro_rules v0.2.19
   Compiling minimal-lexical v0.2.1
   Compiling konst v0.2.19
   Compiling mlua v0.8.8
   Compiling bytes v1.4.0
   Compiling rustc-hash v1.1.0
   Compiling once_cell v1.17.1
   Compiling bitvec v1.0.1
   Compiling nom v7.1.3
   Compiling bstr v0.2.17
   Compiling chrono v0.4.24
   Compiling snafu-derive v0.7.4
   Compiling rasn-derive v0.6.0
   Compiling mlua_derive v0.8.0
   Compiling snafu v0.7.4
   Compiling rasn v0.6.1
   Compiling rasn-ldap v0.6.0
   Compiling lua-resty-ldap v0.2.2 (/private/var/folders/nt/wf1p4w4x07s56l9gvlymhtkc0000gn/T/luarocks_lua-resty-ldap-0.2.2-0-TlHnXt/lua-resty-ldap)
    Finished release [optimized] target(s) in 12.42s
--- Install
INST_PREFIX: /Users/guohao/workspace/apisix/deps/lib/luarocks/rocks-5.1/lua-resty-ldap/0.2.2-0
INST_BINDIR: /Users/guohao/workspace/apisix/deps/lib/luarocks/rocks-5.1/lua-resty-ldap/0.2.2-0/bin
INST_LIBDIR: /Users/guohao/workspace/apisix/deps/lib/luarocks/rocks-5.1/lua-resty-ldap/0.2.2-0/lib
INST_LUADIR: /Users/guohao/workspace/apisix/deps/lib/luarocks/rocks-5.1/lua-resty-ldap/0.2.2-0/lua
INST_CONFDIR: /Users/guohao/workspace/apisix/deps/lib/luarocks/rocks-5.1/lua-resty-ldap/0.2.2-0/conf
install -d /Users/guohao/workspace/apisix/deps/lib/luarocks/rocks-5.1/lua-resty-ldap/0.2.2-0/lua/resty/ldap/
install lib/resty/ldap/*.lua /Users/guohao/workspace/apisix/deps/lib/luarocks/rocks-5.1/lua-resty-ldap/0.2.2-0/lua/resty/ldap/
install target/release/librasn.dylib /Users/guohao/workspace/apisix/deps/lib/luarocks/rocks-5.1/lua-resty-ldap/0.2.2-0/lib/rasn.so
lua-resty-ldap 0.2.2-0 is now installed in /Users/guohao/workspace/apisix/deps (license: Apache License 2.0)

Stopping after installing dependencies for apisix master-0
```
