### PR TITLE
fix: hold_body_chunk should use seperate buffer for each plugin in case of pollution

### DIFF
--- a/apisix/core/response.lua
+++ b/apisix/core/response.lua
@@ -178,13 +178,16 @@ function _M.hold_body_chunk(ctx, hold_the_copy)
     local body_buffer
     local chunk, eof = arg[1], arg[2]
     if type(chunk) == "string" and chunk ~= "" then
-        body_buffer = ctx._body_buffer
+        if not ctx._body_buffer then
+            ctx._body_buffer = {}
+        end
+        body_buffer = ctx._body_buffer[ctx._plugin_name]
         if not body_buffer then
             body_buffer = {
                 chunk,
                 n = 1
             }
-            ctx._body_buffer = body_buffer
+            ctx._body_buffer[ctx._plugin_name] = body_buffer
         else
             local n = body_buffer.n + 1
             body_buffer.n = n
@@ -193,13 +196,13 @@ function _M.hold_body_chunk(ctx, hold_the_copy)
     end
 
     if eof then
-        body_buffer = ctx._body_buffer
+        body_buffer = ctx._body_buffer[ctx._plugin_name]
         if not body_buffer then
             return chunk
         end
 
         body_buffer = concat_tab(body_buffer, "", 1, body_buffer.n)
-        ctx._body_buffer = nil
+        ctx._body_buffer[ctx._plugin_name] = nil
         return body_buffer
     end
 

--- a/apisix/core/response.lua
+++ b/apisix/core/response.lua
@@ -177,10 +177,12 @@ end
 function _M.hold_body_chunk(ctx, hold_the_copy)
     local body_buffer
     local chunk, eof = arg[1], arg[2]
+
+    if not ctx._body_buffer then
+        ctx._body_buffer = {}
+    end
+
     if type(chunk) == "string" and chunk ~= "" then
-        if not ctx._body_buffer then
-            ctx._body_buffer = {}
-        end
         body_buffer = ctx._body_buffer[ctx._plugin_name]
         if not body_buffer then
             body_buffer = {

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -1091,7 +1091,9 @@ function _M.run_plugin(phase, plugins, api_ctx)
                 end
 
                 plugin_run = true
+                api_ctx._plugin_name = plugins[i]["name"]
                 local code, body = phase_func(conf, api_ctx)
+                api_ctx._plugin_name = nil
                 if code or body then
                     if is_http then
                         if code >= 400 then
@@ -1126,7 +1128,9 @@ function _M.run_plugin(phase, plugins, api_ctx)
         local conf = plugins[i + 1]
         if phase_func and meta_filter(api_ctx, plugins[i]["name"], conf) then
             plugin_run = true
+            api_ctx._plugin_name = plugins[i]["name"]
             phase_func(conf, api_ctx)
+            api_ctx._plugin_name = nil
         end
     end
 

--- a/t/core/response.t
+++ b/t/core/response.t
@@ -188,6 +188,7 @@ aaa:
         }
         body_filter_by_lua_block {
             local core = require("apisix.core")
+            ngx.ctx._plugin_name = "test"
             local final_body = core.response.hold_body_chunk(ngx.ctx)
             if not final_body then
                 return

--- a/t/plugin/grpc-transcode2.t
+++ b/t/plugin/grpc-transcode2.t
@@ -486,7 +486,7 @@ GET /grpc_plus?a=1&b=2
 --- response_body eval
 qr/\{"result":3\}/
 --- error_log eval
-qr/request log: \{.*body":\"\\u0000\\u0000\\u0000\\u0000\\u0002\\b\\u0003\\u0000\\u0000\\u0000\\u0000\\u0002\\b\\u0003"/
+qr/request log: \{.*body":\"\\u0000\\u0000\\u0000\\u0000\\u0002\\b\\u0003"/
 
 
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #9228 

and fix: 

Fixed a problem with a unit test left before.
This unit test proves that there is a collaboration problem between http-logger and some plugins, which will cause http-logger to repeatedly print the content of the body.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->

