### PR TITLE
docs: updated consumer-restriction plugin use with Global Rule

### DIFF
--- a/docs/en/latest/plugins/consumer-restriction.md
+++ b/docs/en/latest/plugins/consumer-restriction.md
@@ -28,7 +28,7 @@ description: The Consumer Restriction Plugin allows users to configure access re
 
 ## Description
 
-The `consumer-restriction` Plugin allows users to configure access restrictions on Consumer, Route, Service, or Global Rule. 
+The `consumer-restriction` Plugin allows users to configure access restrictions on Consumer, Route, Service, or Global Rule.
 
 ## Attributes
 

--- a/docs/en/latest/plugins/consumer-restriction.md
+++ b/docs/en/latest/plugins/consumer-restriction.md
@@ -4,7 +4,7 @@ keywords:
   - Apache APISIX
   - API Gateway
   - Consumer restriction
-description: The Consumer Restriction Plugin allows users to set access restrictions based on Consumer, Route, or Service.
+description: The Consumer Restriction Plugin allows users to configure access restrictions on Consumer, Route, Service, or Global Rule.
 ---
 
 <!--
@@ -28,7 +28,7 @@ description: The Consumer Restriction Plugin allows users to set access restrict
 
 ## Description
 
-The `consumer-restriction` Plugin allows users to set access restrictions based on Consumer, Route, or Service.
+The `consumer-restriction` Plugin allows users to configure access restrictions on Consumer, Route, Service, or Global Rule. 
 
 ## Attributes
 


### PR DESCRIPTION
Same as [this PR](https://github.com/apache/apisix/pull/9251), previous PR merged into the wrong branch. 

Test: https://gist.github.com/kayx23/4c29d608991f5b9216c71d6c45c68d01
Relevant PR: https://github.com/api7/docs/pull/130
