### PR TITLE
docs: fix typo in prometheus doc

### DIFF
--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -75,7 +75,7 @@ plugin_attr:
             extra_labels:
                 - upstream_addr: $upstream_addr
                 - upstream_status: $upstream_status
-```                
+```
 
 ## API
 

--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -75,6 +75,7 @@ plugin_attr:
             extra_labels:
                 - upstream_addr: $upstream_addr
                 - upstream_status: $upstream_status
+```                
 
 ## API
 


### PR DESCRIPTION
add missing closing quotes in example block

### Description

Improve readability of documentation

There is a code block not ended and documentation doesn't render fine.

### Checklist

- [X] I have explained the need for this PR and the problem it solves
- [X] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [X] I have updated the documentation to reflect this change
- [X] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
