### PR TITLE
fix: proxy-rewrite should set ngx.var.uri

### DIFF
--- a/apisix/plugins/proxy-rewrite.lua
+++ b/apisix/plugins/proxy-rewrite.lua
@@ -22,6 +22,7 @@ local ngx         = ngx
 local type        = type
 local re_sub      = ngx.re.sub
 local re_match    = ngx.re.match
+local req_set_uri = ngx.req.set_uri
 local sub_str     = string.sub
 local str_find    = core.string.find
 
@@ -316,6 +317,8 @@ function _M.rewrite(conf, ctx)
             -- via regex_uri
             upstream_uri = core.utils.uri_safe_encode(upstream_uri)
         end
+
+        req_set_uri(upstream_uri)
 
         if ctx.var.is_args == "?" then
             if index then

--- a/t/plugin/proxy-rewrite.t
+++ b/t/plugin/proxy-rewrite.t
@@ -1180,7 +1180,7 @@ done
 
 
 
-=== TEST 43: set route(rewrite host with port)
+=== TEST 43: set route(rewrite host with port), ensure ngx.var.uri matched the rewritten version
 --- config
     location /t {
         content_by_lua_block {
@@ -1193,6 +1193,12 @@ done
                             "proxy-rewrite": {
                                 "uri": "/uri",
                                 "host": "test.com:6443"
+                            },
+                            "serverless-post-function": {
+                                "phase": "access",
+                                "functions" : ["return function(conf, ctx)
+                                    assert(ngx.var.uri == \"/uri\", \"proxy-rewrite do not call ngx.req.set_uri\")
+                                end"]
                             }
                         },
                         "upstream": {


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Besides custom `upstream_uri` var, it should set `ngx.var.uri` to keep compatible.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
