### PR TITLE
fix: grpc_set_header   Te trailers

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -766,7 +766,7 @@ http {
             grpc_set_header   "Host" $upstream_host;
             {% end %}
             grpc_set_header   Content-Type application/grpc;
-            grpc_set_header   Te trailers;
+            grpc_set_header   TE trailers;
             grpc_socket_keepalive on;
             grpc_pass         $upstream_scheme://apisix_backend;
 

--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -766,6 +766,7 @@ http {
             grpc_set_header   "Host" $upstream_host;
             {% end %}
             grpc_set_header   Content-Type application/grpc;
+            grpc_set_header   Te trailers;
             grpc_socket_keepalive on;
             grpc_pass         $upstream_scheme://apisix_backend;
 

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -203,6 +203,7 @@ _EOC_
 
 $grpc_location .= <<_EOC_;
             grpc_set_header   Content-Type application/grpc;
+            grpc_set_header   Te trailers;
             grpc_socket_keepalive on;
             grpc_pass         \$upstream_scheme://apisix_backend;
 

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -203,7 +203,7 @@ _EOC_
 
 $grpc_location .= <<_EOC_;
             grpc_set_header   Content-Type application/grpc;
-            grpc_set_header   Te trailers;
+            grpc_set_header   TE trailers;
             grpc_socket_keepalive on;
             grpc_pass         \$upstream_scheme://apisix_backend;
 


### PR DESCRIPTION
### Description

apisix grpc-transcode dont support  grpc server written by Python, c++ or nodejs. This is because apisix nginx config file miss set  “grpc_set_header   Te trailers”.  

This is error response:
```
HTTP/1.1 500 Internal Server Error
Date: Tue, 11 Apr 2023 14:22:51 GMT
Content-Type: application/json
Transfer-Encoding: chunked
Connection: keep-alive
grpc-status: 2
grpc-message: Missing :te header
Server: APISIX/3.1.0
```


Fixes # (issue)
https://github.com/apache/apisix/issues/8186
https://github.com/apache/apisix/issues/9079

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
