### PR TITLE
fix: response-rewrite plugin can't add only one character

### DIFF
--- a/apisix/plugins/response-rewrite.lua
+++ b/apisix/plugins/response-rewrite.lua
@@ -58,7 +58,7 @@ local schema = {
                             items = {
                                 type = "string",
                                 -- "Set-Cookie: <cookie-name>=<cookie-value>; Max-Age=<number>"
-                                pattern = "^[^:]+:[^:]+[^/]$"
+                                pattern = "^[^:]+:[^:]*[^/]$"
                             }
                         },
                         set = {

--- a/t/plugin/response-rewrite.t
+++ b/t/plugin/response-rewrite.t
@@ -696,3 +696,38 @@ passed
 --- request
 GET /hello
 --- response_body
+
+
+
+=== TEST 27: test add header with one word
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "plugins": {
+                        "response-rewrite": {
+                            "headers": {
+                                "add": [
+                                    "X-Server-test:a"
+                                ]
+                            }
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uris": ["/hello"]
+                }]]
+                )
+
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed

--- a/t/plugin/response-rewrite.t
+++ b/t/plugin/response-rewrite.t
@@ -729,5 +729,7 @@ GET /hello
             ngx.say(body)
         }
     }
+--- request
+GET /t
 --- response_body
 passed


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
fix response-rewrite plugin can't add only one character

Fixes https://github.com/apache/apisix/issues/9223
### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
