### PR TITLE
feat: route name  recorded  in  access.log

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -673,6 +673,8 @@ http {
             set $upstream_uri                '';
             set $ctx_ref                     '';
 
+            set $route_name                   '';
+
             {% if wasm then %}
             set $wasm_process_req_body       '';
             set $wasm_process_resp_body      '';

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -575,6 +575,7 @@ function _M.http_access_phase()
                     {error_msg = "404 Route Not Found"})
     end
 
+    ngx_var.route_name = api_ctx.matched_route.value.name
     core.log.info("matched route: ",
                   core.json.delay_encode(api_ctx.matched_route, true))
 

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -195,7 +195,7 @@ nginx_config:                     # config for render the template to generate n
   http:
     enable_access_log: true         # enable access log or not, default true
     access_log: logs/access.log
-    access_log_format: "$remote_addr - $remote_user [$time_local] $http_host \"$request\" $status $body_bytes_sent $request_time \"$http_referer\" \"$http_user_agent\" $upstream_addr $upstream_status $upstream_response_time \"$upstream_scheme://$upstream_host$upstream_uri\""
+    access_log_format: "$remote_addr - $remote_user [$time_local] $http_host \"$request\" $status $body_bytes_sent $route_name $request_time \"$http_referer\" \"$http_user_agent\" $upstream_addr $upstream_status $upstream_response_time \"$upstream_scheme://$upstream_host$upstream_uri\""
     access_log_format_escape: default       # allows setting json or default characters escaping in variables
     keepalive_timeout: 60s          # timeout during which a keep-alive client connection will stay open on the server side.
     client_header_timeout: 60s      # timeout for reading client request header, then 408 (Request Time-out) error is returned to the client


### PR DESCRIPTION
### Description
In the log file, there is no flag to indicate which route configuration is working ,when multiple same paths with different priorities exist. It is necessary to record the route name.
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
