### PR TITLE
fix(etcd): reuse cli and enable keepalive

### DIFF
--- a/apisix/cli/snippet.lua
+++ b/apisix/cli/snippet.lua
@@ -28,6 +28,9 @@ upstream apisix_conf_backend {
         local conf_server = require("apisix.conf_server")
         conf_server.balancer()
     }
+    keepalive 320;
+    keepalive_requests 1000;
+    keepalive_timeout 60s;
 }
 
 {% if trusted_ca_cert then %}

--- a/apisix/core/etcd.lua
+++ b/apisix/core/etcd.lua
@@ -349,7 +349,9 @@ do
                     return nil, nil, err
                 end
 
-                etcd_cli_init_phase = tmp_etcd_cli
+                if tmp_etcd_cli.use_grpc then
+                    etcd_cli_init_phase = tmp_etcd_cli
+                end
 
                 return tmp_etcd_cli, prefix
             end

--- a/apisix/core/etcd.lua
+++ b/apisix/core/etcd.lua
@@ -349,9 +349,7 @@ do
                     return nil, nil, err
                 end
 
-                if tmp_etcd_cli.use_grpc then
-                    etcd_cli_init_phase = tmp_etcd_cli
-                end
+                etcd_cli_init_phase = tmp_etcd_cli
 
                 return tmp_etcd_cli, prefix
             end
@@ -372,9 +370,7 @@ do
                 return nil, nil, err
             end
 
-            if tmp_etcd_cli.use_grpc then
-                etcd_cli = tmp_etcd_cli
-            end
+            etcd_cli = tmp_etcd_cli
 
             return tmp_etcd_cli, prefix
         end

--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -233,44 +233,7 @@ passed
 
 
 
-=== TEST 7: ensure only one auth request per subsystem for all the etcd sync
---- yaml_config
-apisix:
-  node_listen: 1984
-deployment:
-  role: traditional
-  role_traditional:
-    config_provider: etcd
-  etcd:
-    host:
-      - "http://127.0.0.1:1980" -- fake server port
-    timeout: 1
-    user: root                    # root username for etcd
-    password: 5tHkHhYkjr6cQY      # root password for etcd
---- extra_init_by_lua
-local health_check = require("resty.etcd.health_check")
-health_check.get_target_status = function()
-    return true
-end
---- config
-    location /t {
-        content_by_lua_block {
-            ngx.sleep(0.5)
-        }
-    }
---- request
-GET /t
---- grep_error_log eval
-qr/etcd auth failed/
---- grep_error_log_out
-etcd auth failed
-etcd auth failed
-etcd auth failed
-etcd auth failed
-
-
-
-=== TEST 8: ensure add prefix automatically for _M.getkey
+=== TEST 7: ensure add prefix automatically for _M.getkey
 --- config
     location /t {
         content_by_lua_block {
@@ -301,7 +264,7 @@ passed
 
 
 
-=== TEST 9: Test ETCD health check mode switch during APISIX startup
+=== TEST 8: Test ETCD health check mode switch during APISIX startup
 --- config
     location /t {
         content_by_lua_block {
@@ -320,7 +283,7 @@ qr/healthy check use round robin
 
 
 
-=== TEST 10: last_err can be nil when the reconnection is successful
+=== TEST 9: last_err can be nil when the reconnection is successful
 --- config
     location /t {
         content_by_lua_block {
@@ -350,7 +313,7 @@ passed
 
 
 
-=== TEST 11: reloaded data may be in res.body.node (special kvs structure)
+=== TEST 10: reloaded data may be in res.body.node (special kvs structure)
 --- yaml_config
 deployment:
     role: traditional
@@ -397,7 +360,7 @@ qr/readdir key: fake res: \{("value":"bar","key":"foo"|"key":"foo","value":"bar"
 
 
 
-=== TEST 12: reloaded data may be in res.body.node (admin_api_version is v2)
+=== TEST 11: reloaded data may be in res.body.node (admin_api_version is v2)
 --- yaml_config
 deployment:
     role: traditional

--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -233,7 +233,43 @@ passed
 
 
 
-=== TEST 7: ensure add prefix automatically for _M.getkey
+=== TEST 7: ensure only one auth request per subsystem for all the etcd sync
+--- yaml_config
+apisix:
+  node_listen: 1984
+deployment:
+  role: traditional
+  role_traditional:
+    config_provider: etcd
+  etcd:
+    host:
+      - "http://127.0.0.1:1980" -- fake server port
+    timeout: 1
+    user: root                    # root username for etcd
+    password: 5tHkHhYkjr6cQY      # root password for etcd
+--- extra_init_by_lua
+local health_check = require("resty.etcd.health_check")
+health_check.get_target_status = function()
+    return true
+end
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.sleep(0.5)
+        }
+    }
+--- request
+GET /t
+--- grep_error_log eval
+qr/etcd auth failed/
+--- grep_error_log_out
+etcd auth failed
+etcd auth failed
+etcd auth failed
+
+
+
+=== TEST 8: ensure add prefix automatically for _M.getkey
 --- config
     location /t {
         content_by_lua_block {
@@ -264,7 +300,7 @@ passed
 
 
 
-=== TEST 8: Test ETCD health check mode switch during APISIX startup
+=== TEST 9: Test ETCD health check mode switch during APISIX startup
 --- config
     location /t {
         content_by_lua_block {
@@ -283,7 +319,7 @@ qr/healthy check use round robin
 
 
 
-=== TEST 9: last_err can be nil when the reconnection is successful
+=== TEST 10: last_err can be nil when the reconnection is successful
 --- config
     location /t {
         content_by_lua_block {
@@ -313,7 +349,7 @@ passed
 
 
 
-=== TEST 10: reloaded data may be in res.body.node (special kvs structure)
+=== TEST 11: reloaded data may be in res.body.node (special kvs structure)
 --- yaml_config
 deployment:
     role: traditional
@@ -360,7 +396,7 @@ qr/readdir key: fake res: \{("value":"bar","key":"foo"|"key":"foo","value":"bar"
 
 
 
-=== TEST 11: reloaded data may be in res.body.node (admin_api_version is v2)
+=== TEST 12: reloaded data may be in res.body.node (admin_api_version is v2)
 --- yaml_config
 deployment:
     role: traditional

--- a/t/core/etcd.t
+++ b/t/core/etcd.t
@@ -401,35 +401,3 @@ qr/init_by_lua:\d+: \S+/
 init_by_lua:12: ab
 init_by_lua:19: 200
 init_by_lua:26: 404
-
-
-
-=== TEST 8: error handling in server_version
---- yaml_config
-deployment:
-  role: traditional
-  role_traditional:
-    config_provider: etcd
-  etcd:
-    host:
-      - "http://127.0.0.1:2379"
-    prefix: "/apisix"
---- config
-    location /t {
-        content_by_lua_block {
-            local etcd_lib = require("resty.etcd")
-            -- the mock won't take effect when using gRPC because the connection will be cached
-            etcd_lib.new = function()
-                return nil, "ouch"
-            end
-            local etcd = require("apisix.core.etcd")
-            local res, err = etcd.server_version()
-            ngx.say(err)
-        }
-    }
---- request
-GET /t
---- response_body
-ouch
---- error_log
-failed to get server_info from etcd


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

1. The JWT auth token is stored in the etcd cli table, so reuse the table between calls to avoid repeat auth calls.
2. The path between conf server and etcd should enable keepalive so that we could reuse the same connection to do etcd calls. Besides avoiding connection overhead, the etcd v3 uses [connection based auth](https://etcd.io/docs/v3.5/learning/design-auth-v3/).

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
