### PR TITLE
fix(ci): fips: ensure apisix compiles with openssl3

### DIFF
--- a/.github/workflows/fips.yml
+++ b/.github/workflows/fips.yml
@@ -62,13 +62,18 @@ jobs:
           path: ~/openssl-3.0
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ matrix.os_name }}
 
+      - name: set openssl prefix
+        id: set_openssl_prefix
+        shell: bash
+        run: |
+          echo "openssl3_prefix=$HOME" >>$GITHUB_OUTPUT
+
       - name: Toggle openssl compile
         id: test_ssl_env
         shell: bash
         if: steps.cache-openssl.outputs.cache-hit != 'true'
         run: |
           echo "openssl3=yes" >>$GITHUB_OUTPUT
-          echo "openssl3_prefix=$HOME" >>$GITHUB_OUTPUT
 
       - name: Extract test type
         shell: bash

--- a/.github/workflows/fips.yml
+++ b/.github/workflows/fips.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Linux Install
         env:
           COMPILE_OPENSSL3: ${{ steps.test_ssl_env.outputs.openssl3 }}
-          OPENSSL3_PREFIX: ${{ steps.test_ssl_env.outputs.openssl3_prefix }}
+          OPENSSL3_PREFIX: ${{ steps.set_openssl_prefix.outputs.openssl3_prefix }}
           USE_OPENSSL3: yes
         run: |
           sudo --preserve-env=OPENRESTY_VERSION \

--- a/t/node/client-mtls.t
+++ b/t/node/client-mtls.t
@@ -614,7 +614,6 @@ client certificate verification is not passed: FAILED
 
 
 === TEST 20: mtls failed, at handshake phase
---- SKIP
 --- exec
 curl -k -v --resolve "test.com:1994:127.0.0.1" https://test.com:1994/hello
 --- error_log

--- a/t/node/client-mtls.t
+++ b/t/node/client-mtls.t
@@ -609,12 +609,13 @@ curl --cert t/certs/test2.crt --key t/certs/test2.key -k https://localhost:1994/
 --- response_body eval
 qr/400 Bad Request/
 --- error_log
-client certificate verification is not passed: FAILED:self signed certifica
+client certificate verification is not passed: FAILED
 
 
 
 === TEST 20: mtls failed, at handshake phase
+--- SKIP
 --- exec
 curl -k -v --resolve "test.com:1994:127.0.0.1" https://test.com:1994/hello
 --- error_log
-tls_process_client_certificate:peer did not return a certificate
+peer did not return a certificate


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

always set `openssl3_prefix`, so that apisix is compiled with openssl3 even if the build cache is not hit.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
