### PR TITLE
Add 'id' property to global_rule schema, closes #9429

### DIFF
--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -836,7 +836,7 @@ _M.global_rule = {
         create_time = timestamp_def,
         update_time = timestamp_def
     },
-    required = {"plugins"},
+    required = {"id", "plugins"},
 }
 
 


### PR DESCRIPTION
Added 'id' property to the required section of global_rule schema as per issue #9429.

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [*] I have explained the need for this PR and the problem it solves
- [*] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [*] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
