### PR TITLE
fix: 404 error in ci test

### DIFF
--- a/ci/linux_openresty_common_runner.sh
+++ b/ci/linux_openresty_common_runner.sh
@@ -90,7 +90,6 @@ script() {
         sleep 1
     done
 
-
     # APISIX_ENABLE_LUACOV=1 PERL5LIB=.:$PERL5LIB prove -Itest-nginx/lib -r t
     FLUSH_ETCD=1 prove --timer -Itest-nginx/lib -I./ -r $TEST_FILE_SUB_DIR | tee /tmp/test.result
     rerun_flaky_tests /tmp/test.result

--- a/ci/linux_openresty_common_runner.sh
+++ b/ci/linux_openresty_common_runner.sh
@@ -71,6 +71,8 @@ script() {
     export_or_prefix
     openresty -V
 
+    make init
+
     set_coredns
 
     ./t/grpc_server_example/grpc_server_example \
@@ -87,6 +89,7 @@ script() {
         nc -zv 127.0.0.1 50051 && break
         sleep 1
     done
+
 
     # APISIX_ENABLE_LUACOV=1 PERL5LIB=.:$PERL5LIB prove -Itest-nginx/lib -r t
     FLUSH_ETCD=1 prove --timer -Itest-nginx/lib -I./ -r $TEST_FILE_SUB_DIR | tee /tmp/test.result


### PR DESCRIPTION
### Description

The following error always occurs in ci tests because the ETCD is not initialised
![image](https://github.com/apache/apisix/assets/9354193/04e78790-20f3-43f4-979b-f45320a2e046)

Fixes #9417 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
