### PR TITLE
test: replace all httpbin upstream

### DIFF
--- a/t/admin/routes4.t
+++ b/t/admin/routes4.t
@@ -611,7 +611,7 @@ failed to read request body: request size 1678025 is greater than the maximum si
                         "methods": ["GET", "GET"],
                         "upstream": {
                             "nodes": {
-                                "httpbin.org:8080": 1,
+                                "apisix.com:8080": 1,
                                 "test.com:8080": 1
                             },
                             "type": "roundrobin",

--- a/t/admin/upstream4.t
+++ b/t/admin/upstream4.t
@@ -205,7 +205,7 @@ passed
                 ngx.HTTP_PUT,
                 [[{
                     "nodes": {
-                        "httpbin.org:8080": 1,
+                        "apisix.com:8080": 1,
                         "test.com:8080": 1
                     },
                     "type": "roundrobin",

--- a/t/config-center-yaml/route-upstream.t
+++ b/t/config-center-yaml/route-upstream.t
@@ -140,17 +140,17 @@ hello world
 routes:
     -
         id: 1
-        uri: /get
+        uri: /hello
         upstream_id: 1
 upstreams:
     -
         id: 1
         nodes:
-            "httpbin.org:80": 1
+            "test.com:1980": 1
         type: roundrobin
 #END
 --- request
-GET /get
+GET /hello
 --- error_code: 200
 
 
@@ -161,19 +161,19 @@ GET /get
 routes:
     -
         id: 1
-        uri: /get
+        uri: /hello
         upstream_id: 1
 upstreams:
     -
         id: 1
         nodes:
-            "httpbin.org:80": 1
+            "test.com:1980": 1
         type: chash
         hash_on: header
         key: "$aaa"
 #END
 --- request
-GET /get
+GET /hello
 --- error_code: 502
 --- error_log
 invalid configuration: failed to match pattern

--- a/t/node/merge-route.t
+++ b/t/node/merge-route.t
@@ -235,10 +235,10 @@ qr/merge_service_route.*"time_window":60/]
                 ngx.HTTP_PUT,
                 [[{
                     "upstream": {
-                        "scheme": "https",
+                        "scheme": "http",
                         "type": "roundrobin",
                         "nodes": {
-                            "httpbin.org:443": 1
+                            "test.com:1980": 1
                         }
                     }
                 }]]
@@ -266,10 +266,10 @@ passed
                 ngx.HTTP_PUT,
                 [[{
                     "uri": "/fake",
-                    "host": "httpbin.org",
+                    "host": "test.com",
                     "plugins": {
                         "proxy-rewrite": {
-                            "uri": "/get"
+                            "uri": "/echo"
                         }
                     },
                     "service_id": "1"
@@ -293,10 +293,9 @@ passed
 --- request
 GET /fake
 --- more_headers
-host: httpbin.org
---- response_body eval
-qr/"Host": "httpbin.org"/
---- timeout: 5
+host: test.com
+--- response_headers
+host: test.com
 
 
 
@@ -304,7 +303,7 @@ qr/"Host": "httpbin.org"/
 --- request
 GET /fake
 --- more_headers
-host: httpbin.orgxxx
+host: test.comxxx
 --- error_code: 404
 
 

--- a/t/node/route-domain.t
+++ b/t/node/route-domain.t
@@ -92,9 +92,9 @@ qr/dns resolver domain: www.apiseven.com to \d+.\d+.\d+.\d+/
                             },
                             "type": "roundrobin",
                             "pass_host": "rewrite",
-                            "upstream_host": "httpbin.org"
+                            "upstream_host": "test.com"
                         },
-                        "uri": "/uri"
+                        "uri": "/echo"
                 }]]
                 )
 
@@ -113,10 +113,9 @@ passed
 
 === TEST 5: hit route
 --- request
-GET /uri
---- response_body eval
-qr/host: httpbin.org/
---- timeout: 10
+GET /echo
+--- response_headers
+host: test.com
 
 
 
@@ -130,13 +129,13 @@ qr/host: httpbin.org/
                  [[{
                         "upstream": {
                             "nodes": {
-                                "httpbin.org:80": 1
+                                "test.com:1980": 1
                             },
                             "type": "roundrobin",
                             "desc": "new upstream",
                             "pass_host": "node"
                         },
-                        "uri": "/get"
+                        "uri": "/echo"
                 }]]
                 )
 
@@ -155,10 +154,9 @@ passed
 
 === TEST 7: hit route
 --- request
-GET /get
---- response_body eval
-qr/"Host": "httpbin.org"/
---- timeout: 10
+GET /echo
+--- response_headers
+host: test.com:1980
 
 
 

--- a/t/node/upstream-domain.t
+++ b/t/node/upstream-domain.t
@@ -110,7 +110,7 @@ qr/dns resolver domain: foo.com to \d+.\d+.\d+.\d+/
                 ngx.HTTP_PUT,
                 [[{
                     "nodes": {
-                        "httpbin.orgx:80": 0
+                        "test.comx:80": 0
                     },
                     "type": "roundrobin",
                     "desc": "new upstream"
@@ -150,8 +150,8 @@ GET /t
 status: 503
 status: 503
 --- error_log
-failed to parse domain: httpbin.orgx
-failed to parse domain: httpbin.orgx
+failed to parse domain: test.comx
+failed to parse domain: test.comx
 --- timeout: 10
 
 

--- a/t/node/upstream.t
+++ b/t/node/upstream.t
@@ -205,7 +205,7 @@ GET /t
                 ngx.HTTP_PUT,
                 [[{
                     "nodes": {
-                        "httpbin.org:80": 1
+                        "test.com:1980": 1
                     },
                     "type": "roundrobin",
                     "desc": "new upstream",
@@ -234,7 +234,7 @@ passed
             local code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
                 [[{
-                    "uri": "/get",
+                    "uri": "/echo",
                     "upstream_id": "1"
                 }]]
                 )
@@ -254,9 +254,9 @@ passed
 
 === TEST 12: hit route
 --- request
-GET /get
---- response_body eval
-qr/"Host": "httpbin.org"/
+GET /echo
+--- response_headers
+host: test.com:1980
 
 
 
@@ -274,7 +274,7 @@ qr/"Host": "httpbin.org"/
                     "type": "roundrobin",
                     "desc": "new upstream",
                     "pass_host": "rewrite",
-                    "upstream_host": "httpbin.org"
+                    "upstream_host": "test.com"
                 }]]
                 )
 
@@ -299,7 +299,7 @@ passed
             local code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
                 [[{
-                    "uri": "/uri",
+                    "uri": "/echo",
                     "upstream_id": "1"
                 }]]
                 )
@@ -319,9 +319,9 @@ passed
 
 === TEST 15: hit route
 --- request
-GET /uri
---- response_body eval
-qr/host: httpbin.org/
+GET /echo
+--- response_headers
+host: test.com
 
 
 

--- a/t/plugin/authz-casdoor.t
+++ b/t/plugin/authz-casdoor.t
@@ -122,7 +122,7 @@ done
                 ngx.HTTP_PUT,
                 [[{
                     "methods": ["GET"],
-                    "uri": "/anything/*",
+                    "uri": "/echo",
                     "plugins": {
                         "authz-casdoor": {
                             "callback_url":"]] .. callback_url .. [[",
@@ -134,7 +134,7 @@ done
                     "upstream": {
                         "type": "roundrobin",
                         "nodes": {
-                        "httpbin.org:80": 1
+                        "test.com:1980": 1
                         }
                     }
                 }]]
@@ -158,7 +158,7 @@ done
             local plugin = require("apisix.plugins.authz-casdoor")
             local t = require("lib.test_admin").test
 
-            local code, body = t('/anything/d?param1=foo&param2=bar', ngx.HTTP_GET, [[]])
+            local code, body = t('/echo?param1=foo&param2=bar', ngx.HTTP_GET, [[]])
             if code ~= 302 then
                 ngx.say("should have redirected")
             end
@@ -459,7 +459,7 @@ apisix:
                 ngx.HTTP_PUT,
                 [[{
                     "methods": ["GET"],
-                    "uri": "/anything/*",
+                    "uri": "/echo",
                     "plugins": {
                         "authz-casdoor": {
                             "callback_url":"]] .. callback_url .. [[",
@@ -471,7 +471,7 @@ apisix:
                     "upstream": {
                         "type": "roundrobin",
                         "nodes": {
-                        "httpbin.org:80": 1
+                        "test.com:1980": 1
                         }
                     }
                 }]]

--- a/t/plugin/forward-auth.t
+++ b/t/plugin/forward-auth.t
@@ -237,7 +237,7 @@ property "request_method" validation failed: matches none of the enum values
                 {
                     url = "/apisix/admin/routes/6",
                     data = [[{
-                        "uri": "/get",
+                        "uri": "/hello",
                         "plugins": {
                             "forward-auth": {
                                 "uri": "http://127.0.0.1:1984/crashed-auth",
@@ -249,7 +249,7 @@ property "request_method" validation failed: matches none of the enum values
                         },
                         "upstream": {
                             "nodes": {
-                                "httpbin.org:80": 1
+                                "test.com:1980": 1
                             },
                             "type": "roundrobin"
                         }
@@ -370,7 +370,7 @@ failed to process forward auth, err: closed
 
 === TEST 12: hit route (unavailable auth server, allow degradation)
 --- request
-GET /get
+GET /hello
 --- more_headers
 Authorization: 111
 --- error_code: 200

--- a/t/plugin/jwt-auth3.t
+++ b/t/plugin/jwt-auth3.t
@@ -280,11 +280,11 @@ hello: world
                     },
                     "upstream": {
                         "nodes": {
-                            "httpbin.org:80": 1
+                            "test.com:1980": 1
                         },
                         "type": "roundrobin"
                     },
-                    "uri": "/get"
+                    "uri": "/hello"
                 }]]
                 )
 
@@ -299,11 +299,11 @@ hello: world
 
 === TEST 12: verify (in cookie) with hiding credentials
 --- request
-GET /get
+GET /hello
 --- more_headers
 Cookie: hello=world; jwt-cookie=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTg3OTMxODU0MX0.fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs; foo=bar
---- response_body eval
-qr/hello=world; foo=bar/
+--- response_body
+hello world
 
 
 

--- a/t/plugin/proxy-mirror.t
+++ b/t/plugin/proxy-mirror.t
@@ -705,8 +705,8 @@ passed
                     [[{
                         "plugins": {
                             "proxy-mirror": {
-                               "host": "http://httpbin.org",
-                               "path": "/get"
+                               "host": "http://test.com",
+                               "path": "/hello"
                             }
                         },
                         "upstream": {
@@ -736,7 +736,7 @@ GET /hello
 --- response_body
 hello world
 --- error_log_like eval
-qr/http:\/\/httpbin\.org is resolved to: http:\/\/((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})(\.((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})){3}/
+qr/http:\/\/test\.com is resolved to: http:\/\/((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})(\.((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})){3}/
 
 
 


### PR DESCRIPTION
### Description

We use httpbin.org as an upstream in many of our test cases, but this service is not stable and often causes ci tests to fail

Fixes #9417 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

