### PR TITLE
fix: add `rust-check` target to the makefile for deps pre-checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ help:
 ### check-rust : check if Rust is installed in the environment
 .PHONY: check-rust
 check-rust:
-	@if [ ! which rustc >/dev/null ]; then \
+	@if ! [ $(shell command -v rustc) ]; then \
 		echo "ERROR: Rust is not installed. Please install Rust before continuing." >&2; \
 		exit 1; \
 	fi;

--- a/Makefile
+++ b/Makefile
@@ -147,10 +147,17 @@ help:
 	fi
 	@echo
 
+### check-rust: check if Rust is installed in the environment
+.PHONY: check-rust
+check-rust:
+	@if ! which rustc >/dev/null; then \
+		echo "ERROR: Rust is not installed. Please install Rust before continuing." >&2; \
+		exit 1; \
+	fi;
 
-### deps : Installation dependencies
+### deps : Installing dependencies
 .PHONY: deps
-deps: runtime
+deps: check-rust runtime
 	$(eval ENV_LUAROCKS_VER := $(shell $(ENV_LUAROCKS) --version | grep -E -o "luarocks [0-9]+."))
 	@if [ '$(ENV_LUAROCKS_VER)' = 'luarocks 3.' ]; then \
 		mkdir -p ~/.luarocks; \
@@ -164,7 +171,7 @@ deps: runtime
 	fi
 
 
-### undeps : Uninstallation dependencies
+### undeps : Uninstalling dependencies
 .PHONY: undeps
 undeps:
 	@$(call func_echo_status, "$@ -> [ Start ]")

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ help:
 ### check-rust : check if Rust is installed in the environment
 .PHONY: check-rust
 check-rust:
-	@if ! which rustc >/dev/null; then \
+	@if [ ! which rustc >/dev/null ]; then \
 		echo "ERROR: Rust is not installed. Please install Rust before continuing." >&2; \
 		exit 1; \
 	fi;

--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,7 @@ check-rust:
 		exit 1; \
 	fi;
 
+
 ### deps : Installing dependencies
 .PHONY: deps
 deps: check-rust runtime

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ help:
 	fi
 	@echo
 
-### check-rust: check if Rust is installed in the environment
+### check-rust : check if Rust is installed in the environment
 .PHONY: check-rust
 check-rust:
 	@if ! which rustc >/dev/null; then \


### PR DESCRIPTION
### Issue Description

Following instruction in [Building APISIX from source](https://apisix.apache.org/docs/apisix/next/building-apisix/) to build APISIX and encountered the following issue related to Rust not installed in the environment:

![b2749803-6237-478d-8714-1dbb803049ef](https://github.com/apache/apisix/assets/39619599/cd4f6b4c-0755-495b-937d-e6c2773c116f)

Issue was introduced by this PR about LDAP: https://github.com/apache/apisix/pull/9037

### PR Description

Updated Makefile to check if Rust is installed in the environment before installing other deps. 

### Local Tests

![image](https://github.com/apache/apisix/assets/39619599/304ee48e-2b0a-4185-83ce-8fd8f1119ef6)

### Doc Update
[See here](https://github.com/apache/apisix/pull/9444/commits/f82e9c3de351aa713f05dd69ea6b9cc8f73af19a)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
