### PR TITLE
feat(config_etcd): use a single long http connection to watch all resources

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -46,6 +46,8 @@ local error        = error
 local rand         = math.random
 local constants    = require("apisix.constants")
 local health_check = require("resty.etcd.health_check")
+local semaphore    = require("ngx.semaphore")
+local tablex       = require("pl.tablex")
 
 
 local is_http = ngx.config.subsystem == "http"
@@ -58,6 +60,7 @@ if not is_http then
 end
 local created_obj  = {}
 local loaded_configuration = {}
+local watch_ctx
 
 
 local _M = {
@@ -73,6 +76,223 @@ local mt = {
         return " etcd key: " .. self.key
     end
 }
+
+
+local get_etcd
+do
+    local etcd_cli
+
+    function get_etcd()
+        if etcd_cli ~= nil then
+            return etcd_cli
+        end
+
+        local _, err
+        etcd_cli, _, err = etcd_apisix.get_etcd_syncer()
+        return etcd_cli, err
+    end
+end
+
+
+local function cancel_watch(http_cli)
+    local res, err = watch_ctx.cli:watchcancel(http_cli)
+    if res == 1 then
+        log.info("cancel watch connection success")
+    else
+        log.error("cancel watch failed: ", err)
+    end
+end
+
+
+local function handle_compacted(err)
+    if err == "compacted" then
+        -- update current etcd revision
+        while true do
+            local res, err2 = watch_ctx.cli:get(watch_ctx.prefix)
+            if not res then
+                log.error(err2)
+                ngx.sleep(3)
+            else
+                watch_ctx.rev = res.body.header.revision
+                break
+            end
+        end
+    end
+end
+
+
+local function produce_res(res, err)
+    -- append res and notify pending watchers
+    --log.warn("append res, res: ", require("inspect")(res), ", err: ", require("inspect")(err))
+    table.insert(watch_ctx.res, {res=res, err=err})
+    for _, sema in pairs(watch_ctx.sema) do
+        sema:post()
+    end
+    table.clear(watch_ctx.sema)
+end
+
+
+local function run_watch(premature)
+    if premature then
+        return
+    end
+
+    local local_conf, err = config_local.local_conf()
+    if not local_conf then
+        error("no local conf: " .. err)
+    end
+    local prefix = local_conf.etcd.prefix
+
+    local cli, err = get_etcd()
+    if not cli then
+        error("failed to create etcd instance: " .. string(err))
+    end
+
+    local rev = 0
+    if loaded_configuration then
+        local _, res = next(loaded_configuration)
+        rev = tonumber(res.headers["X-Etcd-Index"])
+        assert(rev > 0, 'invalid res.headers["X-Etcd-Index"]')
+    end
+
+    if rev == 0 then
+        local res, err = cli:get(prefix)
+        if err then
+            error(err)
+        end
+        rev = tonumber(res.body.header.revision)
+        assert(rev > 0, 'invalid res.body.header.revision')
+    end
+
+    log.warn("main watcher started, revision=", rev)
+    watch_ctx.started = true
+    watch_ctx.prefix = prefix
+    watch_ctx.cli = cli
+    watch_ctx.rev = rev
+
+    for _, sema in pairs(watch_ctx.wait_init) do
+        sema:post()
+    end
+    watch_ctx.wait_init = nil
+
+    local opts = {}
+    opts.timeout = 60 -- second
+    opts.need_cancel = true
+
+    ::restart_watch::
+    while true do
+        opts.start_revision = watch_ctx.rev + 1
+        local res_func, func_err, http_cli = watch_ctx.cli:watchdir(watch_ctx.prefix, opts)
+        if not res_func then
+            log.error("watchdir: ", func_err)
+            handle_compacted(func_err)
+            produce_res(nil, func_err)
+            ngx.sleep(3)
+            goto restart_watch
+        end
+
+        while true do
+            local res, err = res_func()
+            --log.warn("res_func: ", require("inspect")(res))
+            --if err then log.warn("res_func_err: ", require("inspect")(err)) end
+
+            if err == "closed" then
+                break
+            end
+
+            if not res then
+                cancel_watch(http_cli)
+                handle_compacted(err)
+                produce_res(nil, err)
+                break
+            end
+
+            -- in etcd v3, the 1st res of watch is watch info, useless to us.
+            -- try twice to skip create info
+            if not res.result or not res.result.events then
+                res, err = res_func()
+            end
+
+            if err == "closed" then
+                break
+            end
+
+            if not res then
+                cancel_watch(http_cli)
+                handle_compacted(err)
+                produce_res(nil, err)
+                break
+            end
+
+            if type(res.result) ~= "table" then
+                cancel_watch(http_cli)
+                err = "failed to wait etcd dir"
+                if res.error and res.error.message then
+                    err = err .. ": " .. res.error.message
+                end
+                handle_compacted(err)
+                produce_res(nil, err)
+                break
+            end
+
+            -- cleanup
+            local min_idx = 0
+            for _, idx in pairs(watch_ctx.idx) do
+                if (min_idx == 0) or (idx < min_idx) then
+                    min_idx = idx
+                end
+            end
+            if min_idx > 10 then
+                for k, idx in pairs(watch_ctx.idx) do
+                    watch_ctx[k] = idx-min_idx+1
+                end
+                -- trim the res table
+                for i = 1,min_idx-1 do
+                    table.remove(watch_ctx.res, i)
+                end
+            end
+
+            local rev = tonumber(res.result.header.revision)
+            if rev > watch_ctx.rev then
+                watch_ctx.rev = rev
+            end
+            produce_res(res)
+        end
+    end
+end
+
+
+local function init_watch_ctx(key)
+    if not watch_ctx then
+        watch_ctx = {
+            idx = {},
+            res = {},
+            sema = {},
+            wait_init = {},
+        }
+    end
+
+    if watch_ctx.started == nil then
+        watch_ctx.started = false
+        ngx_timer_at(0, run_watch)
+    end
+
+    if watch_ctx.started == false then
+        -- wait until the main watcher is started
+        local sema, err = semaphore.new()
+        if not sema then
+            error(err)
+        end
+        watch_ctx.wait_init[key] = sema
+        while true do
+            local ok, err = sema:wait(60)
+            if ok then
+                break
+            end
+            log.error("sema wait, key: ", key, ", err: ", err)
+        end
+    end
+end
 
 
 local function getkey(etcd_cli, key)
@@ -157,45 +377,63 @@ local function flush_watching_streams(self)
 end
 
 
-local function http_waitdir(etcd_cli, key, modified_index, timeout)
-    local opts = {}
-    opts.start_revision = modified_index
-    opts.timeout = timeout
-    opts.need_cancel = true
-    local res_func, func_err, http_cli = etcd_cli:watchdir(key, opts)
-    if not res_func then
-        return nil, func_err
+local function http_waitdir(self, etcd_cli, key, modified_index, timeout)
+    if not watch_ctx.idx[key] then
+        watch_ctx.idx[key] = 1
     end
 
-    -- in etcd v3, the 1st res of watch is watch info, useless to us.
-    -- try twice to skip create info
-    local res, err = res_func()
-    if not res or not res.result or not res.result.events then
-        res, err = res_func()
-    end
+    ::iterate_events::
+    for i = watch_ctx.idx[key],#watch_ctx.res do
+        local item = watch_ctx.res[i]
+        local res, err = item.res, item.err
+        if err then
+            watch_ctx.idx[key] = i+1
+            return res, err
+        end
 
-    if http_cli then
-        local res_cancel, err_cancel = etcd_cli:watchcancel(http_cli)
-        if res_cancel == 1 then
-            log.info("cancel watch connection success")
-        else
-            log.error("cancel watch failed: ", err_cancel)
+        local found = false
+        -- ignore res with revision smaller then self.prev_index
+        if tonumber(res.result.header.revision) > self.prev_index then
+            for _, evt in ipairs(res.result.events) do
+                if evt.kv.key:find(key) == 1 then
+                    found = true
+                    break
+                end
+            end
+        end
+
+        if found then
+            watch_ctx.idx[key] = i+1
+
+            local res2 = tablex.deepcopy(res)
+            table.clear(res2.result.events)
+            for _, evt in ipairs(res.result.events) do
+                if evt.kv.key:find(key) == 1 then
+                    table.insert(res2.result.events, evt)
+                end
+            end
+            --log.warn("res2: ", require("inspect")(res2))
+            return res2
         end
     end
 
-    if not res then
-        return nil, err
-    end
-
-    if type(res.result) ~= "table" then
-        err = "failed to wait etcd dir"
-        if res.error and res.error.message then
-            err = err .. ": " .. res.error.message
+    -- if no events, wait via semaphore
+    if not self.watch_sema then
+        local sema, err = semaphore.new()
+        if not sema then
+            error(err)
         end
-        return nil, err
+        self.watch_sema = sema
     end
 
-    return res, err
+    watch_ctx.sema[key] = self.watch_sema
+    local ok, err = self.watch_sema:wait(60)
+    watch_ctx.sema[key] = nil
+    if ok or err == "timeout" then
+        goto iterate_events
+    else
+        log.error(err)
+    end
 end
 
 
@@ -213,7 +451,7 @@ local function waitdir(self)
     if etcd_cli.use_grpc then
         res, err = grpc_waitdir(self, etcd_cli, key, modified_index, timeout)
     else
-        res, err = http_waitdir(etcd_cli, key, modified_index, timeout)
+        res, err = http_waitdir(self, etcd_cli, key, modified_index, timeout)
     end
 
     if not res then
@@ -358,6 +596,8 @@ local function sync_data(self)
     if not self.key then
         return nil, "missing 'key' arguments"
     end
+
+    init_watch_ctx(self.key)
 
     if self.need_reload then
         flush_watching_streams(self)
@@ -552,22 +792,6 @@ function _M.getkey(self, key)
     end
 
     return getkey(self.etcd_cli, key)
-end
-
-
-local get_etcd
-do
-    local etcd_cli
-
-    function get_etcd()
-        if etcd_cli ~= nil then
-            return etcd_cli
-        end
-
-        local _, err
-        etcd_cli, _, err = etcd_apisix.get_etcd_syncer()
-        return etcd_cli, err
-    end
 end
 
 

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -189,7 +189,8 @@ local function run_watch(premature)
             if not res then
                 if err ~= "closed" and
                     err ~= "timeout" and
-                    err ~= "broken pipe" then
+                    err ~= "broken pipe"
+                then
                     log.error("wait watch event: ", err)
                 end
                 cancel_watch(http_cli)
@@ -225,16 +226,16 @@ local function run_watch(premature)
                 end
             end
 
-            for i = 1,min_idx-1 do
+            for i = 1, min_idx - 1 do
                 watch_ctx.res[i] = false
             end
 
             if min_idx > 100 then
                 for k, idx in pairs(watch_ctx.idx) do
-                    watch_ctx.idx[k] = idx-min_idx+1
+                    watch_ctx.idx[k] = idx - min_idx + 1
                 end
                 -- trim the res table
-                for i = 1,min_idx-1 do
+                for i = 1, min_idx - 1 do
                     table.remove(watch_ctx.res, 1)
                 end
             end
@@ -367,8 +368,8 @@ local function http_waitdir(self, etcd_cli, key, modified_index, timeout)
     end
 
     ::iterate_events::
-    for i = watch_ctx.idx[key],#watch_ctx.res do
-        watch_ctx.idx[key] = i+1
+    for i = watch_ctx.idx[key], #watch_ctx.res do
+        watch_ctx.idx[key] = i + 1
 
         local item = watch_ctx.res[i]
         if item == false then

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -597,7 +597,9 @@ local function sync_data(self)
         return nil, "missing 'key' arguments"
     end
 
-    init_watch_ctx(self.key)
+    if not local_conf.etcd.use_grpc then
+        init_watch_ctx(self.key)
+    end
 
     if self.need_reload then
         flush_watching_streams(self)

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -597,7 +597,7 @@ local function sync_data(self)
         return nil, "missing 'key' arguments"
     end
 
-    if not local_conf.etcd.use_grpc then
+    if not self.use_grpc then
         init_watch_ctx(self.key)
     end
 

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -36,7 +36,6 @@ local setmetatable = setmetatable
 local ngx_sleep    = require("apisix.core.utils").sleep
 local ngx_timer_at = ngx.timer.at
 local ngx_time     = ngx.time
-local ngx_sleep    = ngx.sleep
 local sub_str      = string.sub
 local tostring     = tostring
 local tonumber     = tonumber

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -30,6 +30,7 @@ local new_tab      = require("table.new")
 local inspect      = require("inspect")
 local errlog       = require("ngx.errlog")
 local log_level    = errlog.get_sys_filter_level()
+local NGX_INFO     = ngx.INFO
 local check_schema = require("apisix.core.schema").check
 local exiting      = ngx.worker.exiting
 local insert_tab   = table.insert
@@ -112,7 +113,7 @@ end
 
 -- append res to the queue and notify pending watchers
 local function produce_res(res, err)
-    if log_level >= ngx.INFO then
+    if log_level >= NGX_INFO then
         log.info("append res: ", inspect(res), ", err: ", inspect(err))
     end
     insert_tab(watch_ctx.res, {res=res, err=err})
@@ -188,7 +189,7 @@ local function run_watch(premature)
         ::watch_event::
         while true do
             local res, err = res_func()
-            if log_level >= ngx.INFO then
+            if log_level >= NGX_INFO then
                 log.info("res_func: ", inspect(res))
             end
 
@@ -406,7 +407,7 @@ local function http_waitdir(self, etcd_cli, key, modified_index, timeout)
                     insert_tab(res2.result.events, evt)
                 end
             end
-            if log_level >= ngx.INFO then
+            if log_level >= NGX_INFO then
                 log.info("http_waitdir: ", inspect(res2))
             end
             return res2

--- a/ci/linux_openresty_runner.sh
+++ b/ci/linux_openresty_runner.sh
@@ -18,5 +18,5 @@
 
 
 export OPENRESTY_VERSION=source
-export TEST_CI_USE_GRPC=true
+#export TEST_CI_USE_GRPC=true
 . ./ci/linux_openresty_common_runner.sh

--- a/t/fuzzing/public.py
+++ b/t/fuzzing/public.py
@@ -39,7 +39,10 @@ def check_log():
     apisix_errorlog = apisix_pwd() + "/logs/error.log"
     apisix_accesslog = apisix_pwd() + "/logs/access.log"
 
-    cmds = ['cat %s | grep -a "error" | grep -v "failed to fetch data from etcd: closed" | grep -v "invalid request body"'%apisix_errorlog, 'cat %s | grep -a " 500 "'%apisix_accesslog]
+    cmds = ['cat %s | grep -a "error" \
+            | grep -v "failed to fetch data from etcd: closed" \
+            | grep -v "upstream timed out (110: Connection timed out) while reading upstream, client: unix:, server: , request: \"POST /v3/watch HTTP/1.1\"" \
+            | grep -v "invalid request body"'%apisix_errorlog, 'cat %s | grep -a " 500 "'%apisix_accesslog]
     if os.path.exists(boofuzz_log):
         cmds.append('cat %s | grep -a "fail"'%boofuzz_log)
     for cmd in cmds:

--- a/t/fuzzing/public.py
+++ b/t/fuzzing/public.py
@@ -39,10 +39,7 @@ def check_log():
     apisix_errorlog = apisix_pwd() + "/logs/error.log"
     apisix_accesslog = apisix_pwd() + "/logs/access.log"
 
-    cmds = ['cat %s | grep -a "error" \
-            | grep -v "failed to fetch data from etcd: closed" \
-            | grep -v "upstream timed out (110: Connection timed out) while reading upstream, client: unix:, server: , request: \"POST /v3/watch HTTP/1.1\"" \
-            | grep -v "invalid request body"'%apisix_errorlog, 'cat %s | grep -a " 500 "'%apisix_accesslog]
+    cmds = ['cat %s | grep -a "error" | grep -v "invalid request body"'%apisix_errorlog, 'cat %s | grep -a " 500 "'%apisix_accesslog]
     if os.path.exists(boofuzz_log):
         cmds.append('cat %s | grep -a "fail"'%boofuzz_log)
     for cmd in cmds:

--- a/t/fuzzing/public.py
+++ b/t/fuzzing/public.py
@@ -39,9 +39,9 @@ def check_log():
     apisix_errorlog = apisix_pwd() + "/logs/error.log"
     apisix_accesslog = apisix_pwd() + "/logs/access.log"
 
-    cmds = ['cat %s | grep -a "error" | grep -v "invalid request body"'%apisix_errorlog, 'cat %s | grep -a " 500 "'%apisix_accesslog]
+    cmds = ['cat %s | grep -a "error" | grep -v "failed to fetch data from etcd: closed" | grep -v "invalid request body"'%apisix_errorlog, 'cat %s | grep -a " 500 "'%apisix_accesslog]
     if os.path.exists(boofuzz_log):
-        cmds.append('cat %s | grep -v "failed to fetch data from etcd: closed" | grep -a "fail"'%boofuzz_log)
+        cmds.append('cat %s | grep -a "fail"'%boofuzz_log)
     for cmd in cmds:
         r = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
         err = r.stdout.read().strip()

--- a/t/fuzzing/public.py
+++ b/t/fuzzing/public.py
@@ -41,7 +41,7 @@ def check_log():
 
     cmds = ['cat %s | grep -a "error" | grep -v "invalid request body"'%apisix_errorlog, 'cat %s | grep -a " 500 "'%apisix_accesslog]
     if os.path.exists(boofuzz_log):
-        cmds.append('cat %s | grep -a "fail"'%boofuzz_log)
+        cmds.append('cat %s | grep -v "failed to fetch data from etcd: closed" | grep -a "fail"'%boofuzz_log)
     for cmd in cmds:
         r = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
         err = r.stdout.read().strip()

--- a/t/plugin/error-log-logger-skywalking.t
+++ b/t/plugin/error-log-logger-skywalking.t
@@ -118,8 +118,8 @@ qr/Batch Processor\[error-log-logger\] failed to process entries: error while se
 --- request
 GET /tg
 --- response_body
---- error_log eval
-qr/.*\[\{\"body\":\{\"text\":\{\"text\":\".*this is an error message for test.*\"\}\},\"endpoint\":\"\",\"service\":\"APISIX\",\"serviceInstance\":\"instance\".*/
+--- error_log
+this is an error message for test
 --- wait: 5
 
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

1. only one http connection to watch the prefix for all resources
2. use chunked streaming to receive events in the connection, timeout=50 second

Sequence Diagram:

```
/routes watcher->/routes watcher: first sync_data()
/routes watcher->main watcher: start
/routes watcher->/routes watcher: wait main watcher
/upstreams watcher->/upstreams watcher: first sync_data(), wait main watcher
main watcher->etcd: get current etcd revision and start watch there
main watcher-->/routes watcher: started
main watcher-->/upstreams watcher: started
/routes watcher->etcd: readdir() if need_reloaded
/routes watcher->main watcher: iterate history watch events, found
/upstreams watcher->main watcher: no history event, wait...
etcd-->main watcher: watch event
main watcher->main watcher: save event
main watcher->/upstreams watcher: notify
/upstreams watcher->main watcher: iterate history watch events, found
etcd-->main watcher: timeout
main watcher->etcd: reconnect and restart watch from max received revision
etcd-->main watcher: compacted
main watcher->etcd: reconnect and restart watch from compacted revision
```
![sequence_diagram (21)](https://github.com/apache/apisix/assets/4401042/d3642daf-898d-4f4e-8ad0-446cf46e5694)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
4. Always add/update tests for any changes unless you have a good reason.
5. Always update the documentation to reflect the changes made in the PR.
6. Make a new commit to resolve conversations instead of `push -f`.
7. To resolve merge conflicts, merge master instead of rebasing.
8. Use "request review" to notify the reviewer after making changes.
9. Only a reviewer can mark a conversation as resolved.

-->
