### PR TITLE
fix: the compatibility of weight parameter in nacos

### DIFF
--- a/apisix/discovery/nacos/init.lua
+++ b/apisix/discovery/nacos/init.lua
@@ -32,6 +32,7 @@ local string_sub         = string.sub
 local str_byte           = string.byte
 local str_find           = core.string.find
 local log                = core.log
+local math_floor         = math.floor
 
 local default_weight
 local applications
@@ -314,7 +315,7 @@ local function fetch_full_registry(premature)
             local node = {
                 host = host.ip,
                 port = host.port,
-                weight = host.weight or default_weight,
+                weight = math_floor(host.weight or default_weight),
             }
 
             -- docs: https://github.com/yidongnan/grpc-spring-boot-starter/pull/496

--- a/t/discovery/nacos.t
+++ b/t/discovery/nacos.t
@@ -955,6 +955,8 @@ server 4
             ngx.say(res.body)
         }
     }
+--- request
+GET /t
 --- response_body
 ok
 


### PR DESCRIPTION
### Description
In the official nacos documentation, weight is a parameter of type double

https://nacos.io/en-us/docs/open-api.html
![image](https://github.com/apache/apisix/assets/17425270/b513a7c6-13fc-42af-8f64-0d979894c00d)

However, in the apisix upstream schema definition, weight is of type int
![image](https://github.com/apache/apisix/assets/17425270/f6fcddd6-c8ff-44cf-99f3-e90756bb6e97)



<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->


### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
