### PR TITLE
docs: fix broken links in documentation

### DIFF
--- a/docs/en/latest/getting-started/configure-routes.md
+++ b/docs/en/latest/getting-started/configure-routes.md
@@ -28,7 +28,7 @@ An upstream is a set of target nodes with the same work. It defines a virtual ho
 
 ## Prerequisite(s)
 
-1. Complete [Get APISIX](./README.md) to install APISIX.
+1. Complete [Get APISIX](../README) to install APISIX.
 
 ## Create a Route
 

--- a/docs/en/latest/getting-started/configure-routes.md
+++ b/docs/en/latest/getting-started/configure-routes.md
@@ -28,7 +28,7 @@ An upstream is a set of target nodes with the same work. It defines a virtual ho
 
 ## Prerequisite(s)
 
-1. Complete [Get APISIX](./) to install APISIX.
+1. Complete [Get APISIX](./README.md) to install APISIX.
 
 ## Create a Route
 

--- a/docs/en/latest/getting-started/key-authentication.md
+++ b/docs/en/latest/getting-started/key-authentication.md
@@ -48,8 +48,8 @@ Key authentication is a relatively simple but widely used authentication approac
 
 ### Prerequisite(s)
 
-1. Complete [Get APISIX](./README.md) to install APISIX.
-2. Complete [Configure Routes](./configure-routes.md).
+1. Complete [Get APISIX](../README) to install APISIX.
+2. Complete [Configure Routes](../configure-routes#what-is-a-route).
 
 ### Create a Consumer
 
@@ -77,7 +77,7 @@ You will receive an `HTTP/1.1 201 OK` response if the consumer was created succe
 
 ### Enable Authentication
 
-Inheriting the route `getting-started-ip` from [Configure Routes](./configure-routes.md), we only need to use the `PATCH` method to add the `key-auth` plugin to the route:
+Inheriting the route `getting-started-ip` from [Configure Routes](../configure-routes), we only need to use the `PATCH` method to add the `key-auth` plugin to the route:
 
 ```shell
 curl -i "http://127.0.0.1:9180/apisix/admin/routes/getting-started-ip" -X PATCH -d '

--- a/docs/en/latest/getting-started/key-authentication.md
+++ b/docs/en/latest/getting-started/key-authentication.md
@@ -48,8 +48,8 @@ Key authentication is a relatively simple but widely used authentication approac
 
 ### Prerequisite(s)
 
-1. Complete [Get APISIX](./) to install APISIX.
-2. Complete [Configure Routes](./configure-routes#whats-a-route).
+1. Complete [Get APISIX](./README.md) to install APISIX.
+2. Complete [Configure Routes](./configure-routes.md).
 
 ### Create a Consumer
 
@@ -77,7 +77,7 @@ You will receive an `HTTP/1.1 201 OK` response if the consumer was created succe
 
 ### Enable Authentication
 
-Inheriting the route `getting-started-ip` from [Configure Routes](./configure-routes), we only need to use the `PATCH` method to add the `key-auth` plugin to the route:
+Inheriting the route `getting-started-ip` from [Configure Routes](./configure-routes.md), we only need to use the `PATCH` method to add the `key-auth` plugin to the route:
 
 ```shell
 curl -i "http://127.0.0.1:9180/apisix/admin/routes/getting-started-ip" -X PATCH -d '

--- a/docs/en/latest/getting-started/load-balancing.md
+++ b/docs/en/latest/getting-started/load-balancing.md
@@ -17,8 +17,8 @@ In this tutorial, you will create a route with two upstream services and enable 
 
 ## Prerequisite(s)
 
-1. Complete [Get APISIX](./README.md) to install APISIX.
-2. Understand APISIX [Route and Upstream](./configure-routes.md).
+1. Complete [Get APISIX](../README) to install APISIX.
+2. Understand APISIX [Route and Upstream](../configure-routes#what-is-a-route).
 
 ## Enable Load Balancing
 

--- a/docs/en/latest/getting-started/load-balancing.md
+++ b/docs/en/latest/getting-started/load-balancing.md
@@ -17,8 +17,8 @@ In this tutorial, you will create a route with two upstream services and enable 
 
 ## Prerequisite(s)
 
-1. Complete [Get APISIX](./) to install APISIX.
-2. Understand APISIX [Route and Upstream](./configure-routes#whats-a-route).
+1. Complete [Get APISIX](./README.md) to install APISIX.
+2. Understand APISIX [Route and Upstream](./configure-routes.md).
 
 ## Enable Load Balancing
 

--- a/docs/en/latest/getting-started/rate-limiting.md
+++ b/docs/en/latest/getting-started/rate-limiting.md
@@ -23,8 +23,8 @@ In this tutorial, you will enable the `limit-count` plugin to set a rate limitin
 
 ## Prerequisite(s)
 
-1. Complete the [Get APISIX](./README) step to install APISIX first.
-2. Complete the [Configure Routes](./configure-routes) step.
+1. Complete the [Get APISIX](../README) step to install APISIX first.
+2. Complete the [Configure Routes](../configure-routes#what-is-a-route) step.
 
 ## Enable Rate Limiting
 

--- a/docs/en/latest/getting-started/rate-limiting.md
+++ b/docs/en/latest/getting-started/rate-limiting.md
@@ -23,8 +23,8 @@ In this tutorial, you will enable the `limit-count` plugin to set a rate limitin
 
 ## Prerequisite(s)
 
-1. Complete the [Get APISIX](./) step to install APISIX first.
-2. Complete the [Configure Routes](./configure-routes#whats-a-route) step.
+1. Complete the [Get APISIX](./README) step to install APISIX first.
+2. Complete the [Configure Routes](./configure-routes) step.
 
 ## Enable Rate Limiting
 


### PR DESCRIPTION
### Description

The links in the Prerequisites section of rate limiting were broken.
![image](https://github.com/apache/apisix/assets/84245432/32e111a3-b14a-4207-aea7-0ba045fd5d2f)

This PR takes `Get APISIX` link to the correct readme page
and takes `Configure Routes` to the correct configure-routes page

Fixes #9473 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)