### PR TITLE
feat: Inform user when request /plugins/reload/ using wrong HTTP methods

### DIFF
--- a/apisix/admin/init.lua
+++ b/apisix/admin/init.lua
@@ -104,9 +104,10 @@ local function check_token(ctx)
     return true
 end
 
--- Set the `apictx` variable and check admin api token, when the check fails, an error
--- response will be returned. This is a higher wrapper for `check_token` function.
--- @returns A boolean value indicates whether the check passed.
+-- Set the `apictx` variable and check admin api token, if the check fails, the current
+-- request will be interrupted and an error response will be returned.
+--
+-- NOTE: This is a higher wrapper for `check_token` function.
 local function set_ctx_and_check_token()
     local api_ctx = {}
     core.ctx.set_vars_meta(api_ctx)
@@ -116,13 +117,8 @@ local function set_ctx_and_check_token()
     if not ok then
         core.log.warn("failed to check token: ", err)
         core.response.exit(401, { error_msg = "failed to check token" })
-        return false
-    else
-        return true
     end
 end
-
-
 
 
 local function strip_etcd_resp(data)
@@ -162,9 +158,7 @@ end
 
 
 local function run()
-    if not set_ctx_and_check_token() then
-        return
-    end
+    set_ctx_and_check_token()
 
     local uri_segs = core.utils.split_uri(ngx.var.uri)
     core.log.info("uri: ", core.json.delay_encode(uri_segs))
@@ -258,9 +252,7 @@ end
 
 
 local function get_plugins_list()
-    if not set_ctx_and_check_token() then
-        return
-    end
+    set_ctx_and_check_token()
 
     local plugins = resources.plugins.get_plugins_list()
     core.response.exit(200, plugins)
@@ -268,9 +260,7 @@ end
 
 -- Handle unsupported request methods for the virtual "reload" plugin
 local function unsupported_methods_reload_plugin()
-    if not set_ctx_and_check_token() then
-        return
-    end
+    set_ctx_and_check_token()
 
     core.response.exit(405, {
         error_msg = "please use PUT method to reload the plugins, "
@@ -280,9 +270,7 @@ end
 
 
 local function post_reload_plugins()
-    if not set_ctx_and_check_token() then
-        return
-    end
+    set_ctx_and_check_token()
 
     local success, err = events.post(reload_event, get_method(), ngx_time())
     if not success then

--- a/apisix/admin/init.lua
+++ b/apisix/admin/init.lua
@@ -56,8 +56,8 @@ local resources = {
     stream_routes   = require("apisix.admin.stream_routes"),
     plugin_metadata = require("apisix.admin.plugin_metadata"),
     plugin_configs  = require("apisix.admin.plugin_config"),
-    consumer_groups  = require("apisix.admin.consumer_group"),
-    secrets             = require("apisix.admin.secrets"),
+    consumer_groups = require("apisix.admin.consumer_group"),
+    secrets         = require("apisix.admin.secrets"),
 }
 
 
@@ -104,6 +104,26 @@ local function check_token(ctx)
     return true
 end
 
+-- Set the `apictx` variable and check admin api token, when the check fails, an error
+-- response will be returned. This is a higher wrapper for `check_token` function.
+-- @returns A boolean value indicates whether the check passed.
+local function set_ctx_and_check_token()
+    local api_ctx = {}
+    core.ctx.set_vars_meta(api_ctx)
+    ngx.ctx.api_ctx = api_ctx
+
+    local ok, err = check_token(api_ctx)
+    if not ok then
+        core.log.warn("failed to check token: ", err)
+        core.response.exit(401, { error_msg = "failed to check token" })
+        return false
+    else
+        return true
+    end
+end
+
+
+
 
 local function strip_etcd_resp(data)
     if type(data) == "table"
@@ -142,14 +162,8 @@ end
 
 
 local function run()
-    local api_ctx = {}
-    core.ctx.set_vars_meta(api_ctx)
-    ngx.ctx.api_ctx = api_ctx
-
-    local ok, err = check_token(api_ctx)
-    if not ok then
-        core.log.warn("failed to check token: ", err)
-        core.response.exit(401, {error_msg = "failed to check token"})
+    if not set_ctx_and_check_token() then
+        return
     end
 
     local uri_segs = core.utils.split_uri(ngx.var.uri)
@@ -244,30 +258,30 @@ end
 
 
 local function get_plugins_list()
-    local api_ctx = {}
-    core.ctx.set_vars_meta(api_ctx)
-    ngx.ctx.api_ctx = api_ctx
-
-    local ok, err = check_token(api_ctx)
-    if not ok then
-        core.log.warn("failed to check token: ", err)
-        core.response.exit(401, {error_msg = "failed to check token"})
+    if not set_ctx_and_check_token() then
+        return
     end
 
     local plugins = resources.plugins.get_plugins_list()
     core.response.exit(200, plugins)
 end
 
+-- Handle unsupported request methods for the virtual "reload" plugin
+local function unsupported_methods_reload_plugin()
+    if not set_ctx_and_check_token() then
+        return
+    end
+
+    core.response.exit(405, {
+        error_msg = "please use PUT method to reload the plugins, "
+                    .. get_method() .. " method is not allowed."
+    })
+end
+
 
 local function post_reload_plugins()
-    local api_ctx = {}
-    core.ctx.set_vars_meta(api_ctx)
-    ngx.ctx.api_ctx = api_ctx
-
-    local ok, err = check_token(api_ctx)
-    if not ok then
-        core.log.warn("failed to check token: ", err)
-        core.response.exit(401, {error_msg = "failed to check token"})
+    if not set_ctx_and_check_token() then
+        return
     end
 
     local success, err = events.post(reload_event, get_method(), ngx_time())
@@ -385,6 +399,12 @@ local uri_route = {
         paths = reload_event,
         methods = {"PUT"},
         handler = post_reload_plugins,
+    },
+    -- Handle methods other than "PUT" on "/plugin/reload" to inform user
+    {
+        paths = reload_event,
+        methods = { "GET", "POST", "DELETE", "PATCH" },
+        handler = unsupported_methods_reload_plugin,
     },
 }
 

--- a/t/admin/plugins-reload.t
+++ b/t/admin/plugins-reload.t
@@ -418,3 +418,12 @@ location /t {
 GET /t
 --- response_body
 hello world
+
+
+
+=== TEST 9: wrong method to reload plugins
+--- request
+GET /apisix/admin/plugins/reload
+--- error_code: 405
+--- response_body
+{"error_msg":"please use PUT method to reload the plugins, GET method is not allowed."}


### PR DESCRIPTION
### Description

Inform user when request /plugins/reload/ using wrong HTTP methods. More details in https://github.com/apache/apisix/issues/9481

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
  - **confirmation required.**

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
