### PR TITLE
docs: fix the apisix version of getting-started document

### DIFF
--- a/docs/en/latest/getting-started/README.md
+++ b/docs/en/latest/getting-started/README.md
@@ -57,11 +57,7 @@ If everything is ok, you will get the following response:
 Server: APISIX/Version
 ```
 
-`Version` refers to the version of APISIX that you have installed. For example, APISIX 3.3.0.
-
-```text
-Server: APISIX/3.3.0
-```
+`Version` refers to the version of APISIX that you have installed. For example, `APISIX/3.3.0`.
 
 You now have APISIX installed and running successfully!​
 

--- a/docs/en/latest/getting-started/README.md
+++ b/docs/en/latest/getting-started/README.md
@@ -57,7 +57,7 @@ If everything is ok, you will get the following response:
 Server: APISIX/Version
 ```
 
-Version is the version number of the version of APISIX you are using. For example, APISIX 3.3.0
+Version is the version number of APISIX, e.g. APISIX/3.3.0
 
 ```text
 Server: APISIX/3.3.0

--- a/docs/en/latest/getting-started/README.md
+++ b/docs/en/latest/getting-started/README.md
@@ -57,7 +57,7 @@ If everything is ok, you will get the following response:
 Server: APISIX/Version
 ```
 
-Version is the version number of APISIX, e.g. APISIX/3.3.0
+`Version` refers to the version of APISIX that you have installed. For example, APISIX 3.3.0.
 
 ```text
 Server: APISIX/3.3.0

--- a/docs/en/latest/getting-started/README.md
+++ b/docs/en/latest/getting-started/README.md
@@ -54,7 +54,7 @@ curl "http://127.0.0.1:9080" --head | grep Server
 If everything is ok, you will get the following response:
 
 ```text
-Server: APISIX/3.1.0
+Server: APISIX/3.3.0
 ```
 
 You now have APISIX installed and running successfully!​

--- a/docs/en/latest/getting-started/README.md
+++ b/docs/en/latest/getting-started/README.md
@@ -54,6 +54,12 @@ curl "http://127.0.0.1:9080" --head | grep Server
 If everything is ok, you will get the following response:
 
 ```text
+Server: APISIX/Version
+```
+
+Version is the version number of the version of APISIX you are using. For example, APISIX 3.3.0
+
+```text
 Server: APISIX/3.3.0
 ```
 

--- a/docs/zh/latest/getting-started.md
+++ b/docs/zh/latest/getting-started.md
@@ -146,6 +146,12 @@ curl "http://127.0.0.1:9080" --head | grep Server
 如果一切顺利，将输出如下信息。
 
 ```text
+Server: APISIX/Version
+```
+
+这里的 Version 是你安装的 APISIX 的版本。例如，APISIX 3.3.0
+
+```text
 Server: APISIX/3.3.0
 ```
 

--- a/docs/zh/latest/getting-started.md
+++ b/docs/zh/latest/getting-started.md
@@ -149,11 +149,7 @@ curl "http://127.0.0.1:9080" --head | grep Server
 Server: APISIX/Version
 ```
 
-`Version` 是指您已经安装的 APISIX 的版本。例如，APISIX 3.3.0
-
-```text
-Server: APISIX/3.3.0
-```
+`Version` 是指您已经安装的 APISIX 的版本。例如，`APISIX/3.3.0`。
 
 现在，你已经成功安装并运行了 APISIX！
 

--- a/docs/zh/latest/getting-started.md
+++ b/docs/zh/latest/getting-started.md
@@ -149,7 +149,7 @@ curl "http://127.0.0.1:9080" --head | grep Server
 Server: APISIX/Version
 ```
 
-这里的 Version 是你安装的 APISIX 的版本。例如，APISIX 3.3.0
+`Version` 是指您已经安装的 APISIX 的版本。例如，APISIX 3.3.0
 
 ```text
 Server: APISIX/3.3.0

--- a/docs/zh/latest/getting-started.md
+++ b/docs/zh/latest/getting-started.md
@@ -146,7 +146,7 @@ curl "http://127.0.0.1:9080" --head | grep Server
 如果一切顺利，将输出如下信息。
 
 ```text
-Server: APISIX/3.1.0
+Server: APISIX/3.3.0
 ```
 
 现在，你已经成功安装并运行了 APISIX！


### PR DESCRIPTION
### Description

Fixes #9496 
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

In document https://apisix.apache.org/zh/docs/apisix/getting-started/README/ , use curl to interact with apisix3.3
get the following response is
```shell
curl "http://127.0.0.1:9080" --head | grep Server
Server: APISIX/3.1.0
```
<img width="1420" alt="image" src="https://github.com/apache/apisix/assets/76942195/bbd9b7e8-e80b-4a24-8cf0-5f5b8ec03fd7">
The correct one is

```shell

curl "http://127.0.0.1:9080" --head | grep Server
Server: APISIX/3.3.0
```


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
