### PR TITLE
fix: replace mock tests with real tests in udp-logger

### DIFF
--- a/ci/pod/docker-compose.plugin.yml
+++ b/ci/pod/docker-compose.plugin.yml
@@ -320,6 +320,7 @@ services:
       - ./t/certs:/certs
     ports:
       - '3000:3000'
+      - '8125:8125'
       - '43000:43000'
     networks:
       vector_net:

--- a/ci/pod/vector/vector.toml
+++ b/ci/pod/vector/vector.toml
@@ -23,6 +23,16 @@ port_key = "port"
 shutdown_timeout_secs = 30
 socket_file_mode = 511
 
+
+[sources.log-from-udp]
+type = "socket"
+address = "0.0.0.0:8125"
+host_key = "host"
+mode = "udp"
+port_key = "port"
+
+
+
 [sources.log-from-tls]
 type = "socket"
 address = "0.0.0.0:43000"
@@ -36,7 +46,7 @@ tls.crt_file = "/certs/vector_logs_server.crt"
 tls.key_file = "/certs/vector_logs_server.key"
 
 [sinks.log-2-console]
-inputs = [ "log-from-tcp",  "log-from-tls" ]
+inputs = [ "log-from-tcp",  "log-from-tls", "log-from-udp" ]
 type = "console"
 encoding.codec = "json"
 
@@ -45,6 +55,12 @@ inputs = [ "log-from-tcp" ]
 type = "file"
 encoding.codec = "text"
 path = "/etc/vector/tcp.log"
+
+[sinks.log-2-udp-file]
+inputs = [ "log-from-udp" ]
+type = "file"
+encoding.codec = "json"
+path = "/etc/vector/udp.log"
 
 [sinks.tls-log-2-file]
 inputs = [ "log-from-tls" ]


### PR DESCRIPTION
### Description

Currently we have mock tests with udp logger. This PR uses vector to replace them with real tests by checking the logs from logging server
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
