### PR TITLE
fix(admin): fix secrets do not support to update attributes by PATCH

### DIFF
--- a/apisix/admin/resource.lua
+++ b/apisix/admin/resource.lua
@@ -279,8 +279,8 @@ function _M:patch(id, conf, sub_path, args)
     local typ = nil
     if self.name == "secrets" then
         local uri_segs = core.utils.split_uri(sub_path)
-        if #uri_segs < 2 then
-            return 400, {error_msg = "no secret id and/or sub path in uri"}
+        if #uri_segs < 1 then
+            return 400, {error_msg = "no secret id"}
         end
         typ = id
         id = uri_segs[1]

--- a/t/admin/secrets.t
+++ b/t/admin/secrets.t
@@ -131,7 +131,7 @@ passed
 
 
 
-=== TEST 4: PATCH
+=== TEST 4: PATCH on path
 --- config
     location /t {
         content_by_lua_block {
@@ -169,7 +169,7 @@ passed
 
 
 
-=== TEST 5: PATCH on path 
+=== TEST 5: PATCH
 --- config
     location /t {
         content_by_lua_block {
@@ -211,7 +211,27 @@ passed
 
 
 
-=== TEST 6: DELETE
+=== TEST 6: PATCH without id
+--- config
+    location /t {
+        content_by_lua_block {
+	    local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/secrets/vault',
+                ngx.HTTP_PATCH,
+                [[{}]],
+                [[{}]]
+                )
+            ngx.status = code
+            ngx.print(body)
+        }
+    }
+--- error_code: 400
+--- response_body
+{"error_msg":"no secret id"}
+
+
+
+=== TEST 7: DELETE
 --- config
     location /t {
         content_by_lua_block {
@@ -227,7 +247,7 @@ passed
 
 
 
-=== TEST 7: PUT with invalid format
+=== TEST 8: PUT with invalid format
 --- config
     location /t {
         content_by_lua_block {

--- a/t/admin/secrets.t
+++ b/t/admin/secrets.t
@@ -189,7 +189,7 @@ passed
                     "prefix" : "apisix",
                     "token" : "apisix"
                 }]],
-		[[{
+                [[{
                     "value": {
                         "uri": "http://127.0.0.1:12800/get",
                         "prefix" : "apisix",
@@ -215,7 +215,7 @@ passed
 --- config
     location /t {
         content_by_lua_block {
-	    local t = require("lib.test_admin").test
+            local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/secrets/vault',
                 ngx.HTTP_PATCH,
                 [[{}]],

--- a/t/admin/secrets.t
+++ b/t/admin/secrets.t
@@ -169,7 +169,49 @@ passed
 
 
 
-=== TEST 5: DELETE
+=== TEST 5: PATCH on path 
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local etcd = require("apisix.core.etcd")
+            local res = assert(etcd.get('/secrets/vault/test1'))
+            local prev_create_time = res.body.node.value.create_time
+            assert(prev_create_time ~= nil, "create_time is nil")
+            local prev_update_time = res.body.node.value.update_time
+            assert(prev_update_time ~= nil, "update_time is nil")
+            ngx.sleep(1)
+
+            local code, body = t('/apisix/admin/secrets/vault/test1',
+                ngx.HTTP_PATCH,
+                [[{
+                    "uri": "http://127.0.0.1:12800/get",
+                    "prefix" : "apisix",
+                    "token" : "apisix"
+                }]],
+		[[{
+                    "value": {
+                        "uri": "http://127.0.0.1:12800/get",
+                        "prefix" : "apisix",
+                        "token" : "apisix"
+                    },
+                    "key": "/apisix/secrets/vault/test1"
+                }]]
+                )
+
+            ngx.status = code
+            ngx.say(body)
+
+            local res = assert(etcd.get('/secrets/vault/test1'))
+            assert(res.body.node.value.token == "apisix")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 6: DELETE
 --- config
     location /t {
         content_by_lua_block {
@@ -185,7 +227,7 @@ passed
 
 
 
-=== TEST 6: PUT with invalid format
+=== TEST 7: PUT with invalid format
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Permit updating the selected attributes of the specified, existing secrets by PATCH.

Fixes #9503 

### Checklist

- [X] I have explained the need for this PR and the problem it solves
- [X] I have explained the changes or the new features added to this PR
- [X] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [X] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
