### PR TITLE
docs: fix typo error in observe your api docs

### DIFF
--- a/docs/zh/latest/tutorials/observe-your-api.md
+++ b/docs/zh/latest/tutorials/observe-your-api.md
@@ -219,7 +219,7 @@ curl -i http://127.0.0.1:9080/get
 "X-B3-Traceid": "e18985df47dab632d62083fd96626692",
 ```
 
-你可以通过访问 `http://127.0.0.1:9411/zipkin`，在 Zinkin 的 Web UI 上看到请求链路。
+你可以通过访问 `http://127.0.0.1:9411/zipkin`，在 Zipkin 的 Web UI 上看到请求链路。
 
 ![Zipkin plugin output 1](https://static.apiseven.com/2022/09/14/6321dc27f3d33.png)
 


### PR DESCRIPTION
### Description
The word 'Zinpin' in 'docs/zh/latest/tutorials/observe-your-api.md' is wrong.'Zipkin' is right.so fixed it.

