### PR TITLE
docs: fix typo error in observe your api docs

### DIFF
--- a/docs/zh/latest/tutorials/observe-your-api.md
+++ b/docs/zh/latest/tutorials/observe-your-api.md
@@ -54,7 +54,7 @@ APISIX 中提供了很多具有丰富功能的可观测性插件。你可以通�
 - [error-logger](../plugins/error-log-logger.md)
 - [google-cloud-logging](../plugins/google-cloud-logging.md)
 
-你可以在 APISIX [插件中心](../plugins/http-logger.md) 查看 APISIX 支持的所有日志插件。接下来我们将使用 `http-logger` 插件为你演示如何将 APISIX 的日志数据发送到 HTPP/HTTPS 服务器中。
+你可以在 APISIX [插件中心](../plugins/http-logger.md) 查看 APISIX 支持的所有日志插件。接下来我们将使用 `http-logger` 插件为你演示如何将 APISIX 的日志数据发送到 HTTP/HTTPS 服务器中。
 
 :::note 注意
 


### PR DESCRIPTION
### Description

The word ‘HTPP’ in ‘docs/zh/latest/tutorials/observe-your-api.md’ is wrong.'HTTP' is right.so fixed it.