### PR TITLE
refactor: return concise error when invalid resource is used

### DIFF
--- a/apisix/admin/init.lua
+++ b/apisix/admin/init.lua
@@ -176,7 +176,7 @@ local function run()
 
     local resource = resources[seg_res]
     if not resource then
-        core.response.exit(404, {error_msg = "resource: '".. seg_res .. "' is not supported"})
+        core.response.exit(404, {error_msg = "Unsupported resource type: ".. seg_res})
     end
 
     local method = str_lower(get_method())

--- a/apisix/admin/init.lua
+++ b/apisix/admin/init.lua
@@ -176,7 +176,7 @@ local function run()
 
     local resource = resources[seg_res]
     if not resource then
-        core.response.exit(404, {error_msg = "not found"})
+        core.response.exit(404, {error_msg = "invalid resource: '" .. seg_res .. "' is not supported"})
     end
 
     local method = str_lower(get_method())

--- a/apisix/admin/init.lua
+++ b/apisix/admin/init.lua
@@ -176,7 +176,7 @@ local function run()
 
     local resource = resources[seg_res]
     if not resource then
-        core.response.exit(404, {error_msg = "invalid resource: '" .. seg_res .. "' is not supported"})
+        core.response.exit(404, {error_msg = "resource: '".. seg_res .. "' is not supported"})
     end
 
     local method = str_lower(get_method())

--- a/t/admin/resources.t
+++ b/t/admin/resources.t
@@ -52,4 +52,4 @@ __DATA__
 --- request
 GET /t
 --- response_body_like
-{"error_msg":"resource: 'routs' is not supported"}
+{"error_msg":"Unsupported resource type: routs"}

--- a/t/admin/resources.t
+++ b/t/admin/resources.t
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+log_level("info");
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: invalid resource type: 'routs'
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routs/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "methods": ["GET"],
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:8080": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "desc": "new route",
+                    "uri": "/index.html"
+                }]]
+                )
+
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+{"error_msg":"resource: 'routs' is not supported"}


### PR DESCRIPTION
### Description

When user tries to create an invalid resource using the admin API, the error response is not clear.

#### Existing situation:

<img width="795" alt="image" src="https://github.com/apache/apisix/assets/61597896/836b5205-309b-47a9-b336-942ba3ae5c53">

#### Proposed:

<img width="783" alt="image" src="https://github.com/apache/apisix/assets/61597896/3858a6f4-5fa6-41f6-976f-7bbf51c7d3a0">

Fixes #9569

ref: https://github.com/apache/apisix/issues/9569#issuecomment-1567654262
### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
