### PR TITLE
ci: failing CI due to go build fail

### DIFF
--- a/ci/pod/openfunction/build-function-image.sh
+++ b/ci/pod/openfunction/build-function-image.sh
@@ -23,6 +23,6 @@ if [ ! -f "./pack" ]; then
 fi
 
 # please update function-example/*/hello.go if you want to update function
-./pack build test-uri-image --path ./ci/pod/openfunction/function-example/test-uri  --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="HelloWorld"  --env FUNC_CLEAR_SOURCE=true 
-./pack build test-body-image --path ./ci/pod/openfunction/function-example/test-body --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="HelloWorld"  --env FUNC_CLEAR_SOURCE=true 
-./pack build test-header-image --path ./ci/pod/openfunction/function-example/test-header  --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="HelloWorld"  --env FUNC_CLEAR_SOURCE=true 
+./pack build test-uri-image --path ./ci/pod/openfunction/function-example/test-uri  --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="HelloWorld"  --env FUNC_CLEAR_SOURCE=true --env FUNC_GOPROXY="https://proxy.golang.org"
+./pack build test-body-image --path ./ci/pod/openfunction/function-example/test-body --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="HelloWorld"  --env FUNC_CLEAR_SOURCE=true --env FUNC_GOPROXY="https://proxy.golang.org"
+./pack build test-header-image --path ./ci/pod/openfunction/function-example/test-header  --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="HelloWorld"  --env FUNC_CLEAR_SOURCE=true --env FUNC_GOPROXY="https://proxy.golang.org"

--- a/ci/pod/openfunction/build-function-image.sh
+++ b/ci/pod/openfunction/build-function-image.sh
@@ -23,6 +23,6 @@ if [ ! -f "./pack" ]; then
 fi
 
 # please update function-example/*/hello.go if you want to update function
-./pack build test-uri-image --path ./ci/pod/openfunction/function-example/test-uri  --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="HelloWorld"  --env FUNC_CLEAR_SOURCE=true --env FUNC_GOPROXY="https://goproxy.cn"
-./pack build test-body-image --path ./ci/pod/openfunction/function-example/test-body --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="HelloWorld"  --env FUNC_CLEAR_SOURCE=true --env FUNC_GOPROXY="https://goproxy.cn"
-./pack build test-header-image --path ./ci/pod/openfunction/function-example/test-header  --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="HelloWorld"  --env FUNC_CLEAR_SOURCE=true --env FUNC_GOPROXY="https://goproxy.cn"
+./pack build test-uri-image --path ./ci/pod/openfunction/function-example/test-uri  --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="HelloWorld"  --env FUNC_CLEAR_SOURCE=true 
+./pack build test-body-image --path ./ci/pod/openfunction/function-example/test-body --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="HelloWorld"  --env FUNC_CLEAR_SOURCE=true 
+./pack build test-header-image --path ./ci/pod/openfunction/function-example/test-header  --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="HelloWorld"  --env FUNC_CLEAR_SOURCE=true 


### PR DESCRIPTION
### Description

The tests are failing intermittently due to failed response from goproxy.cn like here - https://github.com/apache/apisix/actions/runs/5117952022/jobs/9201757096?pr=9526#step:13:217

This PR replaces the env variable which sets GOPROXY to point to goproxy.cn for builds and replaces it with https://proxy.golang.org

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
