### PR TITLE
docs: updated Admin API wording for `HTTP Plugins`

### DIFF
--- a/docs/en/latest/admin-api.md
+++ b/docs/en/latest/admin-api.md
@@ -1343,7 +1343,7 @@ You can use the `/apisix/admin/plugins?all=true` API to get all properties of al
 
 Each Plugin has the attributes `name`, `priority`, `type`, `schema`, `consumer_schema` and `version`.
 
-Defaults to only HTTP Plugins. If you need to get attributes from stream Plugins, use `/apisix/admin/plugins?all=true&subsystem=stream`.
+Defaults to only L7 Plugins. If you need to get attributes of L4 (Stream) Plugins, use `/apisix/admin/plugins?all=true&subsystem=stream`.
 
 :::
 

--- a/docs/en/latest/admin-api.md
+++ b/docs/en/latest/admin-api.md
@@ -1343,7 +1343,7 @@ You can use the `/apisix/admin/plugins?all=true` API to get all properties of al
 
 Each Plugin has the attributes `name`, `priority`, `type`, `schema`, `consumer_schema` and `version`.
 
-Defaults to only L7 Plugins. If you need to get attributes of L4 (Stream) Plugins, use `/apisix/admin/plugins?all=true&subsystem=stream`.
+Defaults to only L7 Plugins. If you need to get attributes of L4 / Stream Plugins, use `/apisix/admin/plugins?all=true&subsystem=stream`.
 
 :::
 

--- a/docs/zh/latest/admin-api.md
+++ b/docs/zh/latest/admin-api.md
@@ -1358,7 +1358,7 @@ Plugin 资源请求地址：/apisix/admin/plugins/{plugin_name}
 
 你可以使用 `/apisix/admin/plugins?all=true` 接口获取所有插件的所有属性，每个插件包括 `name`，`priority`，`type`，`schema`，`consumer_schema` 和 `version`。
 
-默认情况下，该接口只返回 HTTP 插件。如果你需要获取 Stream 插件，需要使用 `/apisix/admin/plugins?all=true&subsystem=stream`。
+默认情况下，该接口只返回 L7 插件。如果你需要获取 L4 / Stream 插件，需要使用 `/apisix/admin/plugins?all=true&subsystem=stream`。
 
 :::
 


### PR DESCRIPTION
### Description
Updated the wording to be more accurate as those plugins are not just for HTTP.

Side note: i have noticed that the default parameter is currently `subsystem=http`. Not too accurate either imho but this will require some changes to the codebase (open for discussion).

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)