### PR TITLE
fix(google-cloud-logging): add missing config

### DIFF
--- a/apisix/plugins/google-cloud-logging.lua
+++ b/apisix/plugins/google-cloud-logging.lua
@@ -35,6 +35,7 @@ local schema = {
         auth_config = {
             type = "object",
             properties = {
+                client_email = { type = "string" },
                 private_key = { type = "string" },
                 project_id = { type = "string" },
                 token_uri = {
@@ -62,7 +63,7 @@ local schema = {
                     default = "https://logging.googleapis.com/v2/entries:write"
                 },
             },
-            required = { "private_key", "project_id", "token_uri" }
+            required = { "client_email", "private_key", "project_id", "token_uri" }
         },
         ssl_verify = {
             type = "boolean",

--- a/docs/en/latest/plugins/google-cloud-logging.md
+++ b/docs/en/latest/plugins/google-cloud-logging.md
@@ -37,6 +37,7 @@ This plugin also allows to push logs as a batch to your Google Cloud Logging Ser
 | Name                    | Required | Default                                                                                                                                                                                              | Description                                                                                                                                                        |
 |-------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | auth_config             | True     |                                                                                                                                                                                                      | Either `auth_config` or `auth_file` must be provided.                                                                                                              |
+| auth_config.client_email | True     |                                                                                                                                                                                                    | Email address of the Google Cloud service account.                                                                                                                   |
 | auth_config.private_key | True     |                                                                                                                                                                                                      | Private key of the Google Cloud service account.                                                                                                                   |
 | auth_config.project_id  | True     |                                                                                                                                                                                                      | Project ID in the Google Cloud service account.                                                                                                                    |
 | auth_config.token_uri   | True    | https://oauth2.googleapis.com/token                                                                                                                                                                  | Token URI of the Google Cloud service account.                                                                                                                     |
@@ -98,6 +99,7 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
         "google-cloud-logging": {
             "auth_config":{
                 "project_id":"apisix",
+                "client_email":"your service account email@apisix.iam.gserviceaccount.com",
                 "private_key":"-----BEGIN RSA PRIVATE KEY-----your private key-----END RSA PRIVATE KEY-----",
                 "token_uri":"https://oauth2.googleapis.com/token",
                 "scopes":[
@@ -137,6 +139,7 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
         "google-cloud-logging": {
             "auth_config":{
                 "project_id":"apisix",
+                "client_email":"your service account email@apisix.iam.gserviceaccount.com",
                 "private_key":"-----BEGIN RSA PRIVATE KEY-----your private key-----END RSA PRIVATE KEY-----"
             }
         }

--- a/docs/zh/latest/plugins/google-cloud-logging.md
+++ b/docs/zh/latest/plugins/google-cloud-logging.md
@@ -37,6 +37,7 @@ description: API 网关 Apache APISIX 的 google-cloud-logging 插件可用于�
 | 名称                     | 必选项   | 默认值                                           | 描述                                                                                                                             |
 | ----------------------- | -------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------  |
 | auth_config             | 是       |                                                  | `auth_config` 和 `auth_file` 必须配置一个。                                                                                     |
+| auth_config.client_email | 是       |                                                  | 谷歌服务帐号的 email 参数。                                                                                                           |
 | auth_config.private_key | 是       |                                                  | 谷歌服务帐号的私钥参数。                                                                                                           |
 | auth_config.project_id  | 是       |                                                  | 谷歌服务帐号的项目 ID。                                                                                                            |
 | auth_config.token_uri   | 是       | https://oauth2.googleapis.com/token              | 请求谷歌服务帐户的令牌的 URI。                                                                                                     |
@@ -46,7 +47,7 @@ description: API 网关 Apache APISIX 的 google-cloud-logging 插件可用于�
 | ssl_verify              | 否       | true                                             | 当设置为 `true` 时，启用 `SSL` 验证。                 |
 | resource                | 否       | {"type": "global"}                               | 谷歌监控资源，请参考 [MonitoredResource](https://cloud.google.com/logging/docs/reference/v2/rest/v2/MonitoredResource)。             |
 | log_id                  | 否       | apisix.apache.org%2Flogs                         | 谷歌日志 ID，请参考 [LogEntry](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry)。                                |
-| log_format              | 否   |                   | 以 JSON 格式的键值对来声明日志格式。对于值部分，仅支持字符串。如果是以 `$` 开头，则表明是要获取 [APISIX 变量](../apisix-variable.md) 或 [NGINX 内置变量](http://nginx.org/en/docs/varindex.html)。 |
+| log_format              | 否   |{"host": "$host", "@timestamp": "$time_iso8601", "client_ip": "$remote_addr"}| 以 JSON 格式的键值对来声明日志格式。对于值部分，仅支持字符串。如果是以 `$` 开头，则表明是要获取 [APISIX 变量](../apisix-variable.md) 或 [NGINX 内置变量](http://nginx.org/en/docs/varindex.html)。 |
 
 注意：schema 中还定义了 `encrypt_fields = {"auth_config.private_key"}`，这意味着该字段将会被加密存储在 etcd 中。具体参考 [加密存储字段](../plugin-develop.md#加密存储字段)。
 
@@ -98,6 +99,7 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1 \
         "google-cloud-logging": {
             "auth_config":{
                 "project_id":"apisix",
+                "client_email":"your service account email@apisix.iam.gserviceaccount.com",
                 "private_key":"-----BEGIN RSA PRIVATE KEY-----your private key-----END RSA PRIVATE KEY-----",
                 "token_uri":"https://oauth2.googleapis.com/token",
                 "scopes":[
@@ -137,6 +139,7 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1 \
         "google-cloud-logging": {
             "auth_config":{
                 "project_id":"apisix",
+                "client_email":"your service account email@apisix.iam.gserviceaccount.com",
                 "private_key":"-----BEGIN RSA PRIVATE KEY-----your private key-----END RSA PRIVATE KEY-----"
             }
         }

--- a/t/plugin/google-cloud-logging.t
+++ b/t/plugin/google-cloud-logging.t
@@ -74,7 +74,7 @@ passed
             local plugin = require("apisix.plugins.google-cloud-logging")
             local ok, err = plugin.check_schema({
                 auth_config = {
-                    client_email: "email@apisix.iam.gserviceaccount.com",
+                    client_email = "email@apisix.iam.gserviceaccount.com",
                     private_key = "private_key",
                     project_id = "apisix",
                     token_uri = "http://127.0.0.1:1980/token",
@@ -102,6 +102,7 @@ passed
     }
 --- response_body
 passed
+--- LAST
 
 
 
@@ -133,7 +134,7 @@ passed
             local plugin = require("apisix.plugins.google-cloud-logging")
             local ok, err = plugin.check_schema({
                 auth_config = {
-                    client_email: "email@apisix.iam.gserviceaccount.com",
+                    client_email = "email@apisix.iam.gserviceaccount.com",
                     private_key = "private_key",
                     project_id = "apisix",
                     token_uri = "http://127.0.0.1:1980/token",
@@ -192,7 +193,7 @@ value should match only one schema, but matches none
                 plugins = {
                     ["google-cloud-logging"] = {
                         auth_config = {
-                            client_email: "email@apisix.iam.gserviceaccount.com",
+                            client_email = "email@apisix.iam.gserviceaccount.com",
                             private_key = [[
 -----BEGIN RSA PRIVATE KEY-----
 MIIBOwIBAAJBAKeXgPvU/dAfVhOPk5BTBXCaOXy/0S3mY9VHyqvWZBJ97g6tGbLZ
@@ -349,7 +350,7 @@ Batch Processor[google-cloud-logging] exceeded the max_retry_count
                 plugins = {
                     ["google-cloud-logging"] = {
                         auth_config = {
-                            client_email: "email@apisix.iam.gserviceaccount.com",
+                            client_email = "email@apisix.iam.gserviceaccount.com",
                             private_key = [[
 -----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDzrFwnA3EvYyR
@@ -432,7 +433,7 @@ hello world
                 plugins = {
                     ["google-cloud-logging"] = {
                         auth_config = {
-                            client_email: "email@apisix.iam.gserviceaccount.com",
+                            client_email = "email@apisix.iam.gserviceaccount.com",
                             private_key = [[
 -----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDzrFwnA3EvYyR
@@ -515,7 +516,7 @@ hello world
                 plugins = {
                     ["google-cloud-logging"] = {
                         auth_config = {
-                            client_email: "email@apisix.iam.gserviceaccount.com",
+                            client_email = "email@apisix.iam.gserviceaccount.com",
                             private_key = [[
 -----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDzrFwnA3EvYyR

--- a/t/plugin/google-cloud-logging.t
+++ b/t/plugin/google-cloud-logging.t
@@ -74,6 +74,7 @@ passed
             local plugin = require("apisix.plugins.google-cloud-logging")
             local ok, err = plugin.check_schema({
                 auth_config = {
+                    client_email: "email@apisix.iam.gserviceaccount.com",
                     private_key = "private_key",
                     project_id = "apisix",
                     token_uri = "http://127.0.0.1:1980/token",
@@ -132,6 +133,7 @@ passed
             local plugin = require("apisix.plugins.google-cloud-logging")
             local ok, err = plugin.check_schema({
                 auth_config = {
+                    client_email: "email@apisix.iam.gserviceaccount.com",
                     private_key = "private_key",
                     project_id = "apisix",
                     token_uri = "http://127.0.0.1:1980/token",
@@ -190,6 +192,7 @@ value should match only one schema, but matches none
                 plugins = {
                     ["google-cloud-logging"] = {
                         auth_config = {
+                            client_email: "email@apisix.iam.gserviceaccount.com",
                             private_key = [[
 -----BEGIN RSA PRIVATE KEY-----
 MIIBOwIBAAJBAKeXgPvU/dAfVhOPk5BTBXCaOXy/0S3mY9VHyqvWZBJ97g6tGbLZ
@@ -346,6 +349,7 @@ Batch Processor[google-cloud-logging] exceeded the max_retry_count
                 plugins = {
                     ["google-cloud-logging"] = {
                         auth_config = {
+                            client_email: "email@apisix.iam.gserviceaccount.com",
                             private_key = [[
 -----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDzrFwnA3EvYyR
@@ -428,6 +432,7 @@ hello world
                 plugins = {
                     ["google-cloud-logging"] = {
                         auth_config = {
+                            client_email: "email@apisix.iam.gserviceaccount.com",
                             private_key = [[
 -----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDzrFwnA3EvYyR
@@ -510,6 +515,7 @@ hello world
                 plugins = {
                     ["google-cloud-logging"] = {
                         auth_config = {
+                            client_email: "email@apisix.iam.gserviceaccount.com",
                             private_key = [[
 -----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDzrFwnA3EvYyR

--- a/t/plugin/google-cloud-logging.t
+++ b/t/plugin/google-cloud-logging.t
@@ -102,7 +102,6 @@ passed
     }
 --- response_body
 passed
---- LAST
 
 
 

--- a/t/plugin/google-cloud-logging.t
+++ b/t/plugin/google-cloud-logging.t
@@ -263,6 +263,7 @@ Batch Processor[google-cloud-logging] exceeded the max_retry_count
                 plugins = {
                     ["google-cloud-logging"] = {
                         auth_config = {
+                            client_email = "email@apisix.iam.gserviceaccount.com",
                             private_key = [[
 -----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDzrFwnA3EvYyR

--- a/t/plugin/google-cloud-logging2.t
+++ b/t/plugin/google-cloud-logging2.t
@@ -93,7 +93,7 @@ apisix:
                 plugins = {
                     ["google-cloud-logging"] = {
                         auth_config = {
-                            client_email: "email@apisix.iam.gserviceaccount.com",
+                            client_email = "email@apisix.iam.gserviceaccount.com",
                             private_key = [[
 -----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDzrFwnA3EvYyR
@@ -212,7 +212,7 @@ YnwwDKc5vNzo0OU4StTRQbwgCnTZ3dmYiBFm8aGnvTxlE86D2nT07Q3BWhUdky6OGIox4MRLbiHz13NZ
                 plugins = {
                     ["google-cloud-logging"] = {
                         auth_config = {
-                            client_email: "email@apisix.iam.gserviceaccount.com",
+                            client_email = "email@apisix.iam.gserviceaccount.com",
                             private_key = [[
 -----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDzrFwnA3EvYyR
@@ -352,7 +352,7 @@ the mock backend is hit
                 plugins = {
                     ["google-cloud-logging"] = {
                         auth_config = {
-                            client_email: "email@apisix.iam.gserviceaccount.com",
+                            client_email = "email@apisix.iam.gserviceaccount.com",
                             private_key = [[
 -----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDzrFwnA3EvYyR

--- a/t/plugin/google-cloud-logging2.t
+++ b/t/plugin/google-cloud-logging2.t
@@ -93,6 +93,7 @@ apisix:
                 plugins = {
                     ["google-cloud-logging"] = {
                         auth_config = {
+                            client_email: "email@apisix.iam.gserviceaccount.com",
                             private_key = [[
 -----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDzrFwnA3EvYyR
@@ -211,6 +212,7 @@ YnwwDKc5vNzo0OU4StTRQbwgCnTZ3dmYiBFm8aGnvTxlE86D2nT07Q3BWhUdky6OGIox4MRLbiHz13NZ
                 plugins = {
                     ["google-cloud-logging"] = {
                         auth_config = {
+                            client_email: "email@apisix.iam.gserviceaccount.com",
                             private_key = [[
 -----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDzrFwnA3EvYyR
@@ -350,6 +352,7 @@ the mock backend is hit
                 plugins = {
                     ["google-cloud-logging"] = {
                         auth_config = {
+                            client_email: "email@apisix.iam.gserviceaccount.com",
                             private_key = [[
 -----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDzrFwnA3EvYyR


### PR DESCRIPTION
### Description

Add missing config field for google cloud logging plugin

* docs: add client_email field for google-cloud-logging plugin
* docs: add client_email field and log_format default value for google-cloud-logging plugin in zh


Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

