### PR TITLE
fix(response-rewrite): rewrite response code using `ctx.var`

### DIFF
--- a/apisix/plugins/response-rewrite.lua
+++ b/apisix/plugins/response-rewrite.lua
@@ -329,6 +329,7 @@ function _M.header_filter(conf, ctx)
 
     if conf.status_code then
         ngx.status = conf.status_code
+        ctx.var.status = conf.status_code
     end
 
     -- if filters have no any match, response body won't be modified.


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

I find that if I use logger plugin(clickhouse-logger) to send the access logs, the http code doesn't rewrited by response-rewrite plugin, because log-util.lua use `ctx.var` get the status not `ngx.status`. 

https://github.com/apache/apisix/blob/master/apisix/utils/log-util.lua#L63

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
