### PR TITLE
chore: add missing `report_interval` option for `skywalking` plugin in `config-default.yaml`

### DIFF
--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -525,6 +525,7 @@ plugin_attr:
     service_name: APISIX
     service_instance_name: APISIX Instance Name
     endpoint_addr: http://127.0.0.1:12800
+    report_interval: 1
   opentelemetry:
     trace_id_source: x-request-id
     resource:

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -525,7 +525,7 @@ plugin_attr:
     service_name: APISIX
     service_instance_name: APISIX Instance Name
     endpoint_addr: http://127.0.0.1:12800
-    report_interval: 1
+    report_interval: 3
   opentelemetry:
     trace_id_source: x-request-id
     resource:


### PR DESCRIPTION
### Description

`report_interval` was [documented in docs](https://apisix.apache.org/docs/apisix/next/plugins/skywalking/#configuring-the-endpoint) but not documented as a configuration option in `config-default.yaml`. 

This PR adds it.

### Test

https://github.com/apache/apisix/blob/7ec3c0f583510ebcdf9c414f83792e1ac247a5b9/t/admin/plugins-reload.t#L294-L299

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)