### PR TITLE
fix: bugfix of limit-conn plugin

### DIFF
--- a/apisix/plugins/limit-conn/init.lua
+++ b/apisix/plugins/limit-conn/init.lua
@@ -121,11 +121,7 @@ function _M.decrease(conf, ctx)
                 if ctx.proxy_passed then
                     latency = ctx.var.upstream_response_time
                 else
-                    if ctx.var.request_time ~= nil then
-                        latency = ctx.var.request_time - delay
-                    else
-                        latency = ctx.var.upstream_response_time
-                    end
+                    latency = ctx.var.request_time - delay
                 end
             end
             core.log.debug("request latency is ", latency) -- for test

--- a/apisix/plugins/limit-conn/init.lua
+++ b/apisix/plugins/limit-conn/init.lua
@@ -119,7 +119,11 @@ function _M.decrease(conf, ctx)
             if ctx.proxy_passed then
                 latency = ctx.var.upstream_response_time
             else
-                latency = ctx.var.request_time - delay
+                if ctx.var.request_time ~= nil then
+                    latency = ctx.var.request_time - delay
+                else
+                    latency = ctx.var.upstream_response_time
+                end
             end
         end
         core.log.debug("request latency is ", latency) -- for test

--- a/apisix/plugins/limit-conn/init.lua
+++ b/apisix/plugins/limit-conn/init.lua
@@ -104,6 +104,12 @@ function _M.decrease(conf, ctx)
         return
     end
 
+    local is_http = ctx.config.subsystem == "http"
+    if not is_http then
+        core.log.warn("The limit-conn plugin is not applicable in stream mode")
+        return
+    end
+
     for i = 1, #limit_conn, 4 do
         local lim = limit_conn[i]
         local key = limit_conn[i + 1]
@@ -125,7 +131,6 @@ function _M.decrease(conf, ctx)
         core.log.debug("request latency is ", latency) -- for test
 
         if not latency then
-            core.log.warn("The limit-conn plugin is not applicable in stream mode")
             return
         end
 

--- a/t/stream-plugin/limit-conn.t
+++ b/t/stream-plugin/limit-conn.t
@@ -343,12 +343,6 @@ The value of the configured key is empty, use client IP instead
             local core = require("apisix.core")
             local ctx = { proxy_passed = false,config={} }
             ctx.limit_conn = core.tablepool.fetch("plugin#limit-conn", 0, 6)
-            local lrucache = core.lrucache.new({
-                 type = "plugin",
-            })
-            ctx.limit_conn[1] = {lrucache,"key",1,nil}
-            ctx.var = core.tablepool.fetch("plugin#limit-conn", 0, 6)
-
             local plugin = require("apisix.plugins.limit-conn")
             plugin.log({conn = 1, burst = 0, default_conn_delay = 0.1, rejected_code = 503, key = 'remote_addr'},ctx)
             ngx.say("done")

--- a/t/stream-plugin/limit-conn.t
+++ b/t/stream-plugin/limit-conn.t
@@ -21,6 +21,7 @@ no_long_string();
 no_shuffle();
 no_root_location();
 
+
 add_block_preprocessor(sub {
     my ($block) = @_;
 

--- a/t/stream-plugin/limit-conn.t
+++ b/t/stream-plugin/limit-conn.t
@@ -336,6 +336,7 @@ The value of the configured key is empty, use client IP instead
 --- stream_enable
 
 
+
 === TEST 11: decrease
 --- config
     location /t {

--- a/t/stream-plugin/limit-conn.t
+++ b/t/stream-plugin/limit-conn.t
@@ -21,7 +21,6 @@ no_long_string();
 no_shuffle();
 no_root_location();
 
-
 add_block_preprocessor(sub {
     my ($block) = @_;
 
@@ -341,7 +340,7 @@ The value of the configured key is empty, use client IP instead
     location /t {
         content_by_lua_block {
             local core = require("apisix.core")
-            local ctx = { proxy_passed = false}
+            local ctx = { proxy_passed = false,config={} }
             ctx.limit_conn = core.tablepool.fetch("plugin#limit-conn", 0, 6)
             local lrucache = core.lrucache.new({
                  type = "plugin",


### PR DESCRIPTION
### Description
The tcp dynamic proxy protocol does not define the request_time attribute, we need to be compatible with this situation

Fixes #9661 


