### PR TITLE
docs: update Debian Installation Guide

### DIFF
--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -202,13 +202,13 @@ sudo apt install -y apisix=3.0.0-0
 Once APISIX is installed, you can initialize the configuration file and etcd by running:
 
 ```shell
-apisix init
+sudo apisix init
 ```
 
 To start APISIX server, run:
 
 ```shell
-apisix start
+sudo apisix start
 ```
 
 :::tip

--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -136,14 +136,14 @@ Currently the only DEB repository supported by APISIX is Debian 11 (Bullseye) an
 
 ```shell
 # amd64
-sudo echo "deb http://openresty.org/package/debian bullseye openresty" | tee /etc/apt/sources.list.d/openresty.list
+echo "deb http://openresty.org/package/debian bullseye openresty" | sudo tee /etc/apt/sources.list.d/openresty.list
 wget -O - http://repos.apiseven.com/pubkey.gpg | apt-key add -
-echo "deb http://repos.apiseven.com/packages/debian bullseye main" | tee /etc/apt/sources.list.d/apisix.list
+echo "deb http://repos.apiseven.com/packages/debian bullseye main" | sudo tee /etc/apt/sources.list.d/apisix.list
 
 # arm64
-sudo echo "deb http://openresty.org/package/debian bullseye openresty" | tee /etc/apt/sources.list.d/openresty.list
+echo "deb http://openresty.org/package/debian bullseye openresty" | sudo tee /etc/apt/sources.list.d/openresty.list
 wget -O - http://repos.apiseven.com/pubkey.gpg | apt-key add -
-echo "deb http://repos.apiseven.com/packages/arm64/debian bullseye main" | tee /etc/apt/sources.list.d/apisix.list
+echo "deb http://repos.apiseven.com/packages/arm64/debian bullseye main" | sudo tee /etc/apt/sources.list.d/apisix.list
 ```
 
 Then, to install APISIX, run:

--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -43,6 +43,7 @@ APISIX can be installed by the different methods listed below:
     {label: 'Docker', value: 'docker'},
     {label: 'Helm', value: 'helm'},
     {label: 'RPM', value: 'rpm'},
+    {label: 'DEB', value: 'deb'},
     {label: 'Source Code', value: 'source code'},
   ]}>
 <TabItem value="docker">
@@ -130,6 +131,47 @@ sudo yum install apisix-2.13.1
 
 :::
 
+### Installation via RPM offline package
+
+First, download APISIX RPM offline package to an `apisix` folder:
+
+```shell
+sudo mkdir -p apisix
+sudo yum install -y https://repos.apiseven.com/packages/centos/apache-apisix-repo-1.0-1.noarch.rpm
+sudo yum clean all && yum makecache
+sudo yum install -y --downloadonly --downloaddir=./apisix apisix
+```
+
+Then copy the `apisix` folder to the target host and run:
+
+```shell
+sudo yum install ./apisix/*.rpm
+```
+
+### Managing APISIX server
+
+Once APISIX is installed, you can initialize the configuration file and etcd by running:
+
+```shell
+apisix init
+```
+
+To start APISIX server, run:
+
+```shell
+apisix start
+```
+
+:::tip
+
+Run `apisix help` to get a list of all available operations.
+
+:::
+
+</TabItem>
+
+<TabItem value="deb">
+
 ### Installation via DEB repository
 
 Currently the only DEB repository supported by APISIX is Debian 11 (Bullseye) and supports both amd64 and arm64 architectures.
@@ -153,23 +195,6 @@ Then, to install APISIX, run:
 ```shell
 sudo apt update
 sudo apt install -y apisix=3.0.0-0
-```
-
-### Installation via RPM offline package
-
-First, download APISIX RPM offline package to an `apisix` folder:
-
-```shell
-sudo mkdir -p apisix
-sudo yum install -y https://repos.apiseven.com/packages/centos/apache-apisix-repo-1.0-1.noarch.rpm
-sudo yum clean all && yum makecache
-sudo yum install -y --downloadonly --downloaddir=./apisix apisix
-```
-
-Then copy the `apisix` folder to the target host and run:
-
-```shell
-sudo yum install ./apisix/*.rpm
 ```
 
 ### Managing APISIX server

--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -137,12 +137,12 @@ Currently the only DEB repository supported by APISIX is Debian 11 (Bullseye) an
 ```shell
 # amd64
 echo "deb http://openresty.org/package/debian bullseye openresty" | sudo tee /etc/apt/sources.list.d/openresty.list
-wget -O - http://repos.apiseven.com/pubkey.gpg | apt-key add -
+wget -O - http://repos.apiseven.com/pubkey.gpg | sudo apt-key add -
 echo "deb http://repos.apiseven.com/packages/debian bullseye main" | sudo tee /etc/apt/sources.list.d/apisix.list
 
 # arm64
 echo "deb http://openresty.org/package/debian bullseye openresty" | sudo tee /etc/apt/sources.list.d/openresty.list
-wget -O - http://repos.apiseven.com/pubkey.gpg | apt-key add -
+wget -O - http://repos.apiseven.com/pubkey.gpg | sudo apt-key add -
 echo "deb http://repos.apiseven.com/packages/arm64/debian bullseye main" | sudo tee /etc/apt/sources.list.d/apisix.list
 ```
 

--- a/docs/zh/latest/installation-guide.md
+++ b/docs/zh/latest/installation-guide.md
@@ -139,14 +139,14 @@ sudo yum install apisix-2.13.1
 
 ```shell
 # amd64
-sudo echo "deb http://openresty.org/package/debian bullseye openresty" | tee /etc/apt/sources.list.d/openresty.list
-wget -O - http://repos.apiseven.com/pubkey.gpg | apt-key add -
-echo "deb http://repos.apiseven.com/packages/debian bullseye main" | tee /etc/apt/sources.list.d/apisix.list
+echo "deb http://openresty.org/package/debian bullseye openresty" | sudo tee /etc/apt/sources.list.d/openresty.list
+wget -O - http://repos.apiseven.com/pubkey.gpg | sudo apt-key add -
+echo "deb http://repos.apiseven.com/packages/debian bullseye main" | sudo tee /etc/apt/sources.list.d/apisix.list
 
 # arm64
-sudo echo "deb http://openresty.org/package/debian bullseye openresty" | tee /etc/apt/sources.list.d/openresty.list
-wget -O - http://repos.apiseven.com/pubkey.gpg | apt-key add -
-echo "deb http://repos.apiseven.com/packages/arm64/debian bullseye main" | tee /etc/apt/sources.list.d/apisix.list
+echo "deb http://openresty.org/package/debian bullseye openresty" | sudo tee /etc/apt/sources.list.d/openresty.list
+wget -O - http://repos.apiseven.com/pubkey.gpg | sudo apt-key add -
+echo "deb http://repos.apiseven.com/packages/arm64/debian bullseye main" | sudo tee /etc/apt/sources.list.d/apisix.list
 ```
 
 完成上述操作后使用以下命令安装 APISIX：

--- a/docs/zh/latest/installation-guide.md
+++ b/docs/zh/latest/installation-guide.md
@@ -44,6 +44,7 @@ import TabItem from '@theme/TabItem';
     {label: 'Docker', value: 'docker'},
     {label: 'Helm', value: 'helm'},
     {label: 'RPM', value: 'rpm'},
+    {label: 'DEB', value: 'deb'},
     {label: 'Source Code', value: 'source code'},
   ]}>
 <TabItem value="docker">
@@ -133,6 +134,47 @@ sudo yum install apisix-2.13.1
 
 :::
 
+### 通过 RPM 包离线安装：
+
+将 APISIX 离线 RPM 包下载到 `apisix` 文件夹：
+
+```shell
+sudo mkdir -p apisix
+sudo yum install -y https://repos.apiseven.com/packages/centos/apache-apisix-repo-1.0-1.noarch.rpm
+sudo yum clean all && yum makecache
+sudo yum install -y --downloadonly --downloaddir=./apisix apisix
+```
+
+然后将 `apisix` 文件夹复制到目标主机并运行以下命令：
+
+```shell
+sudo yum install ./apisix/*.rpm
+```
+
+### 管理 APISIX 服务
+
+APISIX 安装完成后，你可以运行以下命令初始化 NGINX 配置文件和 etcd：
+
+```shell
+apisix init
+```
+
+使用以下命令启动 APISIX：
+
+```shell
+apisix start
+```
+
+:::tip
+
+你可以运行 `apisix help` 命令，通过查看返回结果，获取其他操作的命令及描述。
+
+:::
+
+</TabItem>
+
+<TabItem value="deb">
+
 ### 通过 DEB 仓库安装
 
 目前 APISIX 支持的 DEB 仓库仅支持 Debian 11（Bullseye），并且支持 amd64 和 arm64 架构。
@@ -156,23 +198,6 @@ echo "deb http://repos.apiseven.com/packages/arm64/debian bullseye main" | sudo 
 ```shell
 sudo apt update
 sudo apt install -y apisix=3.0.0-0
-```
-
-### 通过 RPM 包离线安装：
-
-将 APISIX 离线 RPM 包下载到 `apisix` 文件夹：
-
-```shell
-sudo mkdir -p apisix
-sudo yum install -y https://repos.apiseven.com/packages/centos/apache-apisix-repo-1.0-1.noarch.rpm
-sudo yum clean all && yum makecache
-sudo yum install -y --downloadonly --downloaddir=./apisix apisix
-```
-
-然后将 `apisix` 文件夹复制到目标主机并运行以下命令：
-
-```shell
-sudo yum install ./apisix/*.rpm
 ```
 
 ### 管理 APISIX 服务

--- a/docs/zh/latest/installation-guide.md
+++ b/docs/zh/latest/installation-guide.md
@@ -205,13 +205,13 @@ sudo apt install -y apisix=3.0.0-0
 APISIX 安装完成后，你可以运行以下命令初始化 NGINX 配置文件和 etcd：
 
 ```shell
-apisix init
+sudo apisix init
 ```
 
 使用以下命令启动 APISIX：
 
 ```shell
-apisix start
+sudo apisix start
 ```
 
 :::tip


### PR DESCRIPTION
### Description

Changes included in this PR to the Debian installation guide.

* Corrects where to sudo (for installation and apisix cli)
* Fixes https://github.com/apache/apisix/issues/9675, moved debian instruction out of RPM

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

## Tests
Build info:
```
$ lsb_release -a
Distributor ID:	Debian
Description:	Debian GNU/Linux 11 (bullseye)
Release:	11
Codename:	bullseye
```
```
$ dpkg --print-architecture
amd64
```

### Add `sudo` before `tee`

![image](https://github.com/apache/apisix/assets/39619599/e81a4274-f4b4-4f1a-a628-daf7fc31c684)

### Add `sudo` before `apt-key`

![image](https://github.com/apache/apisix/assets/39619599/0205ec9a-d4ef-41ba-8c3a-06db1454ac12)
![image](https://github.com/apache/apisix/assets/39619599/706accb3-1f31-4e0d-a021-bb691cfa37bd)

### Add `sudo` for APISIX CLI

![image](https://github.com/apache/apisix/assets/39619599/8234a3cd-6483-4673-b2b4-2ec9bed51971)
