### PR TITLE
docs: update how to install apisix on debian

### DIFF
--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -137,11 +137,13 @@ Currently the only DEB repository supported by APISIX is Debian 11 (Bullseye) an
 ```shell
 # amd64
 sudo echo "deb http://openresty.org/package/debian bullseye openresty" | tee /etc/apt/sources.list.d/openresty.list
+wget -O - https://openresty.org/package/pubkey.gpg | apt-key add -
 wget -O - http://repos.apiseven.com/pubkey.gpg | apt-key add -
 echo "deb http://repos.apiseven.com/packages/debian bullseye main" | tee /etc/apt/sources.list.d/apisix.list
 
 # arm64
 sudo echo "deb http://openresty.org/package/debian bullseye openresty" | tee /etc/apt/sources.list.d/openresty.list
+wget -O - https://openresty.org/package/pubkey.gpg | apt-key add -
 wget -O - http://repos.apiseven.com/pubkey.gpg | apt-key add -
 echo "deb http://repos.apiseven.com/packages/arm64/debian bullseye main" | tee /etc/apt/sources.list.d/apisix.list
 ```

--- a/docs/zh/latest/installation-guide.md
+++ b/docs/zh/latest/installation-guide.md
@@ -140,11 +140,13 @@ sudo yum install apisix-2.13.1
 ```shell
 # amd64
 sudo echo "deb http://openresty.org/package/debian bullseye openresty" | tee /etc/apt/sources.list.d/openresty.list
+wget -O - https://openresty.org/package/pubkey.gpg | apt-key add -
 wget -O - http://repos.apiseven.com/pubkey.gpg | apt-key add -
 echo "deb http://repos.apiseven.com/packages/debian bullseye main" | tee /etc/apt/sources.list.d/apisix.list
 
 # arm64
 sudo echo "deb http://openresty.org/package/debian bullseye openresty" | tee /etc/apt/sources.list.d/openresty.list
+wget -O - https://openresty.org/package/pubkey.gpg | apt-key add -
 wget -O - http://repos.apiseven.com/pubkey.gpg | apt-key add -
 echo "deb http://repos.apiseven.com/packages/arm64/debian bullseye main" | tee /etc/apt/sources.list.d/apisix.list
 ```


### PR DESCRIPTION
### Description

The GPG public key of openresty need to be imported

Fixes #9681 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

