### PR TITLE
refactor(jwt-auth): remove unused parameter

### DIFF
--- a/apisix/plugins/jwt-auth.lua
+++ b/apisix/plugins/jwt-auth.lua
@@ -220,7 +220,7 @@ local function fetch_jwt_token(conf, ctx)
     return val
 end
 
-local function get_secret(conf, consumer_name)
+local function get_secret(conf)
     local secret = conf.secret
 
     if conf.base64_secret then
@@ -231,7 +231,7 @@ local function get_secret(conf, consumer_name)
 end
 
 
-local function get_rsa_or_ecdsa_keypair(conf, consumer_name)
+local function get_rsa_or_ecdsa_keypair(conf)
     local public_key = conf.public_key
     local private_key = conf.private_key
 
@@ -261,7 +261,7 @@ end
 
 
 local function sign_jwt_with_HS(key, consumer, payload)
-    local auth_secret, err = get_secret(consumer.auth_conf, consumer.username)
+    local auth_secret, err = get_secret(consumer.auth_conf)
     if not auth_secret then
         core.log.error("failed to sign jwt, err: ", err)
         core.response.exit(503, "failed to sign jwt")
@@ -286,7 +286,7 @@ end
 
 local function sign_jwt_with_RS256_ES256(key, consumer, payload)
     local public_key, private_key, err = get_rsa_or_ecdsa_keypair(
-        consumer.auth_conf, consumer.username
+        consumer.auth_conf
     )
     if not public_key then
         core.log.error("failed to sign jwt, err: ", err)
@@ -321,13 +321,13 @@ local function algorithm_handler(consumer, method_only)
             return sign_jwt_with_HS
         end
 
-        return get_secret(consumer.auth_conf, consumer.username)
+        return get_secret(consumer.auth_conf)
     elseif consumer.auth_conf.algorithm == "RS256" or consumer.auth_conf.algorithm == "ES256"  then
         if method_only then
             return sign_jwt_with_RS256_ES256
         end
 
-        local public_key, _, err = get_rsa_or_ecdsa_keypair(consumer.auth_conf, consumer.username)
+        local public_key, _, err = get_rsa_or_ecdsa_keypair(consumer.auth_conf)
         return public_key, err
     end
 end


### PR DESCRIPTION
### Description

remove unused parameter of function `get_secret` and `get_rsa_or_ecdsa_keypair`

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
