### PR TITLE
log request_header when key set

### DIFF
--- a/apisix/plugins/file-logger.lua
+++ b/apisix/plugins/file-logger.lua
@@ -38,6 +38,13 @@ local schema = {
             items = {
                 type = "array"
             }
+        },
+        request_header_keys = {
+            type = "array",
+            minItems = 1,
+            items = {
+                type = "string"
+            }
         }
     },
     required = {"path"}

--- a/apisix/utils/log-util.lua
+++ b/apisix/utils/log-util.lua
@@ -223,6 +223,16 @@ function _M.get_log_entry(plugin_name, conf, ctx)
     if conf.log_format or has_meta_log_format then
         customized = true
         entry = get_custom_format_log(ctx, conf.log_format or metadata.value.log_format)
+        if conf.request_header_keys then
+
+            local req_headers = ngx.req.get_headers()
+            for i, v in pairs(conf.request_header_keys) do
+                local key_name = string.format("request_headers_%s",v)
+                entry[key_name]  =  req_headers[v]
+
+            end
+
+        end
     else
         if is_http then
             entry = get_full_log(ngx, conf)


### PR DESCRIPTION
### Description
When the log format is configured, it is also expected to print some important request headers such as the release that identifies the lane to help troubleshoot the request problem, so the user needs to configure the header list to be printed


### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

#### eg
- config like this
```shell
"request_header_keys": [
    "release",
    "env",
  ]
```
- log like  
```shell
"release"="dev",
"env"="stage"
```