### PR TITLE
fix(log-rotate): the max_kept configuration doesn't work when using custom name

### DIFF
--- a/apisix/plugins/log-rotate.lua
+++ b/apisix/plugins/log-rotate.lua
@@ -113,14 +113,14 @@ end
 local function scan_log_folder(log_file_name)
     local t = {}
 
-    local log_dir, _ = get_log_path_info(log_file_name)
+    local log_dir, log_name = get_log_path_info(log_file_name)
 
-    local compression_log_type = log_file_name .. COMPRESSION_FILE_SUFFIX
+    local compression_log_type = log_name .. COMPRESSION_FILE_SUFFIX
     for file in lfs.dir(log_dir) do
         local n = string_rfind(file, "__")
         if n ~= nil then
             local log_type = file:sub(n + 2)
-            if log_type == log_file_name or log_type == compression_log_type then
+            if log_type == log_name or log_type == compression_log_type then
                 core.table.insert(t, file)
             end
         end


### PR DESCRIPTION
### Description

Fix the bug that the `max_kept` configuration of the log-rotate plugin doesn't work when use custom name

Fixes #9061 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

