### PR TITLE
fix(log-rotate): log warn if file not exists in rename_file

### DIFF
--- a/apisix/plugins/log-rotate.lua
+++ b/apisix/plugins/log-rotate.lua
@@ -145,9 +145,14 @@ local function rename_file(log, date_str)
     end
 
     local ok, err = os_rename(log.file, new_file)
-    if not ok then
-        core.log.error("move file from ", log.file, " to ", new_file,
-                       " res:", ok, " msg:", err)
+    if err then
+        if string.sub(err, -25) == "No such file or directory" then
+          core.log.warn("move file from ", log.file, " to ", new_file,
+                        " res:", ok, " msg:", err)
+        else
+          core.log.error("move file from ", log.file, " to ", new_file,
+                         " res:", ok, " msg:", err)
+        end
         return
     end
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #9722 

changes: check the error, if it's "No such file or directory", use `log.warn` instead

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
