### PR TITLE
docs: fix typo in pubsub.md

### DIFF
--- a/docs/en/latest/pubsub.md
+++ b/docs/en/latest/pubsub.md
@@ -44,7 +44,7 @@ Currently, Apache APISIX supports WebSocket communication with the client, which
 
 ## Supported messaging systems
 
-- [Aapche Kafka](pubsub/kafka.md)
+- [Apache Kafka](pubsub/kafka.md)
 
 ## How to support other messaging systems
 


### PR DESCRIPTION
Fix typo in pubsub.md.The word 'Aapche' is wrong.Fixed it to 'Apache'.