### PR TITLE
fix: update_count is reset once updated, cause cache key conflict 

### DIFF
--- a/apisix/plugin_config.lua
+++ b/apisix/plugin_config.lua
@@ -78,8 +78,7 @@ function _M.merge(route_conf, plugin_config)
         end
     end
 
-    route_conf.update_count = route_conf.update_count + 1
-    route_conf.modifiedIndex = route_conf.orig_modifiedIndex .. "#" .. route_conf.update_count
+    route_conf.modifiedIndex = route_conf.orig_modifiedIndex .. "#" .. plugin_config.modifiedIndex
     route_conf.prev_plugin_config_ver = plugin_config.modifiedIndex
 
     return route_conf

--- a/apisix/router.lua
+++ b/apisix/router.lua
@@ -29,7 +29,6 @@ local _M = {version = 0.3}
 
 local function filter(route)
     route.orig_modifiedIndex = route.modifiedIndex
-    route.update_count = 0
 
     route.has_domain = false
     if not route.value then

--- a/docs/en/latest/control-api.md
+++ b/docs/en/latest/control-api.md
@@ -210,7 +210,6 @@ Returns all configured [Routes](./terminology/route.md):
 ```json
 [
   {
-    "update_count": 0,
     "value": {
       "priority": 0,
       "uris": [
@@ -249,7 +248,6 @@ Returns the Route with the specified `route_id`:
 
 ```json
 {
-  "update_count": 0,
   "value": {
     "priority": 0,
     "uris": [

--- a/t/config-center-yaml/plugin-configs.t
+++ b/t/config-center-yaml/plugin-configs.t
@@ -115,7 +115,7 @@ world
 --- response_headers
 in: out
 --- error_log eval
-qr/conf_version: \d+#1,/
+qr/conf_version: \d+#\d+,/
 
 
 

--- a/t/node/plugin-configs.t
+++ b/t/node/plugin-configs.t
@@ -113,10 +113,10 @@ __DATA__
 hello
 world
 --- grep_error_log eval
-qr/conf_version: \d+#\d/
+qr/conf_version: \d+#\d+/
 --- grep_error_log_out eval
-qr/conf_version: \d+#1
-conf_version: \d+#2
+qr/conf_version: \d+#\d+
+conf_version: \d+#\d+
 /
 
 


### PR DESCRIPTION
### Description

update_count is reset once updated, which will cause lru cache key conflict, in turn reusing the old route conf.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
