### PR TITLE
fix: loki-logger nil context in batch processor

### DIFF
--- a/apisix/plugins/loki-logger.lua
+++ b/apisix/plugins/loki-logger.lua
@@ -191,19 +191,16 @@ function _M.log(conf, ctx)
     if batch_processor_manager:add_entry(conf, entry) then
         return
     end
-
+    local labels = conf.log_labels
+    -- parsing possible variables in label value
+    for key, value in pairs(labels) do
+        local new_val, err, n_resolved = core.utils.resolve_var(value, ctx.var)
+        if not err and n_resolved > 0 then
+            labels[key] = new_val
+        end
+    end
     -- generate a function to be executed by the batch processor
     local func = function(entries)
-        local labels = conf.log_labels
-
-        -- parsing possible variables in label value
-        for key, value in pairs(labels) do
-            local new_val, err, n_resolved = core.utils.resolve_var(value, ctx.var)
-            if not err and n_resolved > 0 then
-                labels[key] = new_val
-            end
-        end
-
         -- build loki request data
         local data = {
             streams = {

--- a/apisix/plugins/loki-logger.lua
+++ b/apisix/plugins/loki-logger.lua
@@ -191,7 +191,9 @@ function _M.log(conf, ctx)
     if batch_processor_manager:add_entry(conf, entry) then
         return
     end
+
     local labels = conf.log_labels
+
     -- parsing possible variables in label value
     for key, value in pairs(labels) do
         local new_val, err, n_resolved = core.utils.resolve_var(value, ctx.var)
@@ -199,6 +201,7 @@ function _M.log(conf, ctx)
             labels[key] = new_val
         end
     end
+
     -- generate a function to be executed by the batch processor
     local func = function(entries)
         -- build loki request data


### PR DESCRIPTION
### Description
Fixes #9848 

The nginx variable evaluation currently takes place inside callback function which is executed by batch processor and `ngx.var` is not available outside of request phases. This change makes sure that the variables are evaluated in the hot path. 

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
