### PR TITLE
docs: update certificate names in decoupled mode and add configurations for different deployment modes to `config-default.yaml`

### DIFF
--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -611,9 +611,34 @@ plugin_attr:          # Plugin attributes
                                                               # write access to this file for security.
 
 deployment:                    # Deployment configurations
-  role: traditional            # Set deployment mode: traditional, control_plane, data_plane.
+  role: traditional            # Set deployment mode: traditional, control_plane, or data_plane.
   role_traditional:
     config_provider: etcd      # Set the configuration center.
+
+    # role_data_plane:         # Set data plane details if role is data_plane.
+    #   config_provider: control_plane          # Set the configuration center: control_plane, or yaml.
+    #   control_plane:                          # Set control plane details if config_provider is control_plane.
+    #     host:                                 # Set the address of control plane.
+    #       - https://${control_plane_IP}:9280
+    #     prefix: /apisix
+    #     timeout: 30                           # Set timeout in seconds.
+    #   certs:
+    #     cert: /path/to/client.crt           # Set path to the client certificate.
+    #     cert_key: /path/to/client.key       # Set path to the client key.
+    #     trusted_ca_cert: /path/to/ca.crt    # Set path to the trusted CA certificate.
+
+    # role_control_plane:         # Set control plane details if role is control_plane.
+    #   config_provider: etcd     # Set the configuration center.
+    #   conf_server:
+    #     listen: 0.0.0.0:9280                # Set the address of the conf server.
+    #     cert: /path/to/server.crt           # Set path to the server certificate.
+    #     cert_key: /path/to/server.key       # Set path to the server key.
+    #     client_ca_cert: /path/to/ca.crt     # Set path to the trusted CA certificate.
+    # certs:
+    #   cert: /path/to/client.crt             # Set path to the client certificate.
+    #   cert_key: /path/to/client.key         # Set path to the client key.
+    #   trusted_ca_cert: /path/to/ca.crt      # Set path to the trusted CA certificate.
+
   admin:                       # Admin API
     admin_key_required: true   # Enable Admin API authentication by default for security.
     admin_key:

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -620,7 +620,7 @@ deployment:                    # Deployment configurations
     #   control_plane:                          # Set control plane details if config_provider is control_plane.
     #     host:                                 # Set the address of control plane.
     #       - https://${control_plane_IP}:9280
-    #     prefix: /apisix
+    #     prefix: /apisix                       # Set etcd prefix.
     #     timeout: 30                           # Set timeout in seconds.
     #   certs:
     #     cert: /path/to/client.crt           # Set path to the client certificate.
@@ -671,7 +671,7 @@ deployment:                    # Deployment configurations
   etcd:
     host:                         # Set etcd address(es) in the same etcd cluster.
       - "http://127.0.0.1:2379"   # If TLS is enabled for etcd, use https://127.0.0.1:2379.
-    prefix: /apisix               # Set prefix in etcd.
+    prefix: /apisix               # Set etcd prefix.
     use_grpc: false               # Use gRPC (experimental) for etcd configuration sync.
     timeout: 30                   # Set timeout in seconds.
                                   # Set a higher timeout (e.g. an hour) if `use_grpc` is true.

--- a/docs/en/latest/deployment-modes.md
+++ b/docs/en/latest/deployment-modes.md
@@ -97,9 +97,9 @@ deployment:
            prefix: /apisix
            timeout: 30
     certs:
-        cert: /path/to/ca-cert
-        cert_key: /path/to/ca-cert
-        trusted_ca_cert: /path/to/ca-cert
+        cert: /path/to/client.crt
+        cert_key: /path/to/client.key
+        trusted_ca_cert: /path/to/ca.crt
 #END
 ```
 
@@ -117,18 +117,18 @@ deployment:
         config_provider: etcd
         conf_server:
             listen: 0.0.0.0:9280
-            cert: /path/to/ca-cert
-            cert_key: /path/to/ca-cert
-            client_ca_cert: /path/to/ca-cert
+            cert: /path/to/server.crt
+            cert_key: /path/to/server.key
+            client_ca_cert: /path/to/ca.crt
     etcd:
        host:
            - https://${etcd_IP}:${etcd_Port}
        prefix: /apisix
        timeout: 30
     certs:
-        cert: /path/to/ca-cert
-        cert_key: /path/to/ca-cert
-        trusted_ca_cert: /path/to/ca-cert
+        cert: /path/to/client.crt
+        cert_key: /path/to/client.key
+        trusted_ca_cert: /path/to/ca.crt
 #END
 ```
 
@@ -143,15 +143,15 @@ deployment:
         config_provider: etcd
         conf_server:
             listen: 0.0.0.0:9280
-            cert: /path/to/ca-cert
-            cert_key: /path/to/ca-cert
+            cert: /path/to/server.crt
+            cert_key: /path/to/server.key
     etcd:
        host:
            - https://${etcd_IP}:${etcd_Port}
        prefix: /apisix
        timeout: 30
     certs:
-        trusted_ca_cert: /path/to/ca-cert
+        trusted_ca_cert: /path/to/ca.crt
 #END
 ```
 


### PR DESCRIPTION
### Description

* Update certificate names in decoupled mode
* Add configuration blocks of `role_data_plane` and `role_control_plane` in `config-default.yaml` to better document for different modes of APISIX deployment.

Fixes #9883 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
