### PR TITLE
docs: use shell instead of python to configure ssls resources

### DIFF
--- a/docs/en/latest/certificate.md
+++ b/docs/en/latest/certificate.md
@@ -31,73 +31,51 @@ It is most common for an SSL certificate to contain only one domain. We can crea
 * `key`: PEM-encoded private key of the SSL key pair.
 * `snis`: Hostname(s) to associate with this certificate as SNIs. To set this attribute this certificate must have a valid private key associated with it.
 
-We will use the Python script below to simplify the example:
-
-```python title="create-ssl.py"
-#!/usr/bin/env python
-# coding: utf-8
-import sys
-# sudo pip install requests
-import requests
-
-if len(sys.argv) <= 3:
-    print("bad argument")
-    sys.exit(1)
-with open(sys.argv[1]) as f:
-    cert = f.read()
-with open(sys.argv[2]) as f:
-    key = f.read()
-sni = sys.argv[3]
-api_key = "edd1c9f034335f136f87ad84b625c8f1"
-resp = requests.put("http://127.0.0.1:9180/apisix/admin/ssls/1", json={
-    "cert": cert,
-    "key": key,
-    "snis": [sni],
-}, headers={
-    "X-API-KEY": api_key,
-})
-print(resp.status_code)
-print(resp.text)
-```
+We will use the shell command below to simplify the example:
 
 ```shell
 # create SSL object
-./create-ssl.py t.crt t.key test.com
+curl http://127.0.0.1:9180/apisix/admin/ssls/1 \
+-H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+     "cert" : "'"$(cat t/certs/apisix.crt)"'",
+     "key": "'"$(cat t/certs/apisix.key)"'",
+     "snis": ["test.com"]
+}'
 
 # create Router object
 curl http://127.0.0.1:9180/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -i -d '
 {
-    "uri": "/hello",
+    "uri": "/get",
     "hosts": ["test.com"],
     "methods": ["GET"],
     "upstream": {
         "type": "roundrobin",
         "nodes": {
-            "127.0.0.1:1980": 1
+            "httpbin.org": 1
         }
     }
 }'
 
 # make a test
 
-curl --resolve 'test.com:9443:127.0.0.1' https://test.com:9443/hello  -vvv
+curl --resolve 'test.com:9443:127.0.0.1' https://test.com:9443/hello -k -vvv
 * Added test.com:9443:127.0.0.1 to DNS cache
 * About to connect() to test.com port 9443 (#0)
 *   Trying 127.0.0.1...
 * Connected to test.com (127.0.0.1) port 9443 (#0)
-* Initializing NSS with certpath: sql:/etc/pki/nssdb
-* skipping SSL peer certificate verification
-* SSL connection using TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
+* ALPN, server accepted to use h2
 * Server certificate:
-* 	subject: CN=test.com,O=iresty,L=ZhuHai,ST=GuangDong,C=CN
-* 	start date: Jun 24 22:18:05 2019 GMT
-* 	expire date: May 31 22:18:05 2119 GMT
-* 	common name: test.com
-* 	issuer: CN=test.com,O=iresty,L=ZhuHai,ST=GuangDong,C=CN
-> GET /hello HTTP/1.1
-> User-Agent: curl/7.29.0
+*   subject: C=CN; ST=GuangDong; L=ZhuHai; O=iresty; CN=test.com
+*   start date: Jun 24 22:18:05 2019 GMT
+*   expire date: May 31 22:18:05 2119 GMT
+*   issuer: C=CN; ST=GuangDong; L=ZhuHai; O=iresty; CN=test.com
+*   SSL certificate verify result: self-signed certificate (18), continuing anyway.
+> GET /get HTTP/2
 > Host: test.com:9443
-> Accept: */*
+> user-agent: curl/7.81.0
+> accept: */*
 ```
 
 ### wildcard SNI

--- a/docs/zh/latest/certificate.md
+++ b/docs/zh/latest/certificate.md
@@ -33,73 +33,51 @@ SNI（Server Name Indication）是用来改善 SSL 和 TLS 的一项特性，它
 * `key`：SSL 密钥对的私钥，pem 格式
 * `snis`：SSL 证书所指定的一个或多个域名，注意在设置这个参数之前，你需要确保这个证书对应的私钥是有效的。
 
-为了简化示例，我们会使用下面的 Python 脚本：
-
-```python title="create-ssl.py"
-#!/usr/bin/env python
-# coding: utf-8
-import sys
-# sudo pip install requests
-import requests
-
-if len(sys.argv) <= 3:
-    print("bad argument")
-    sys.exit(1)
-with open(sys.argv[1]) as f:
-    cert = f.read()
-with open(sys.argv[2]) as f:
-    key = f.read()
-sni = sys.argv[3]
-api_key = "edd1c9f034335f136f87ad84b625c8f1"
-resp = requests.put("http://127.0.0.1:9180/apisix/admin/ssls/1", json={
-    "cert": cert,
-    "key": key,
-    "snis": [sni],
-}, headers={
-    "X-API-KEY": api_key,
-})
-print(resp.status_code)
-print(resp.text)
-```
+为了简化示例，我们会使用下面的 shell 命令：
 
 ```shell
 # 创建 SSL 对象
-./create-ssl.py t.crt t.key test.com
+curl http://127.0.0.1:9180/apisix/admin/ssls/1 \
+-H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+     "cert" : "'"$(cat t/certs/apisix.crt)"'",
+     "key": "'"$(cat t/certs/apisix.key)"'",
+     "snis": ["test.com"]
+}'
 
 # 创建 Router 对象
 curl http://127.0.0.1:9180/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -i -d '
 {
-    "uri": "/hello",
+    "uri": "/get",
     "hosts": ["test.com"],
     "methods": ["GET"],
     "upstream": {
         "type": "roundrobin",
         "nodes": {
-            "127.0.0.1:1980": 1
+            "httpbin.org": 1
         }
     }
 }'
 
 # 测试一下
 
-curl --resolve 'test.com:9443:127.0.0.1' https://test.com:9443/hello  -vvv
+curl --resolve 'test.com:9443:127.0.0.1' https://test.com:9443/get -k -vvv
 * Added test.com:9443:127.0.0.1 to DNS cache
 * About to connect() to test.com port 9443 (#0)
 *   Trying 127.0.0.1...
 * Connected to test.com (127.0.0.1) port 9443 (#0)
-* Initializing NSS with certpath: sql:/etc/pki/nssdb
-* skipping SSL peer certificate verification
-* SSL connection using TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
+* ALPN, server accepted to use h2
 * Server certificate:
-* 	subject: CN=test.com,O=iresty,L=ZhuHai,ST=GuangDong,C=CN
-* 	start date: Jun 24 22:18:05 2019 GMT
-* 	expire date: May 31 22:18:05 2119 GMT
-* 	common name: test.com
-* 	issuer: CN=test.com,O=iresty,L=ZhuHai,ST=GuangDong,C=CN
-> GET /hello HTTP/1.1
-> User-Agent: curl/7.29.0
+*   subject: C=CN; ST=GuangDong; L=ZhuHai; O=iresty; CN=test.com
+*   start date: Jun 24 22:18:05 2019 GMT
+*   expire date: May 31 22:18:05 2119 GMT
+*   issuer: C=CN; ST=GuangDong; L=ZhuHai; O=iresty; CN=test.com
+*   SSL certificate verify result: self-signed certificate (18), continuing anyway.
+> GET /get HTTP/2
 > Host: test.com:9443
-> Accept: */*
+> user-agent: curl/7.81.0
+> accept: */*
 ```
 
 ### 泛域名


### PR DESCRIPTION
### Description

use shell instead of python to configure ssls resources

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

