### PR TITLE
fix(ci): specific apisix-base latest versions should be used

### DIFF
--- a/ci/centos7-ci.sh
+++ b/ci/centos7-ci.sh
@@ -31,9 +31,9 @@ install_dependencies() {
     yum install -y libnghttp2-devel
     install_curl
 
-    # install openresty to make apisix's rpm test work
-    yum install -y yum-utils && yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
-    yum install -y openresty openresty-debug openresty-openssl111-debug-devel pcre pcre-devel
+    # install apisix-base to make apisix's rpm test work
+    yum install -y https://repos.apiseven.com/packages/centos/apache-apisix-repo-1.0-1.noarch.rpm
+    yum install -y apisix-base openresty-debug openresty-openssl111-debug-devel pcre pcre-devel
 
     # install luarocks
     ./utils/linux-install-luarocks.sh

--- a/ci/redhat-ci.sh
+++ b/ci/redhat-ci.sh
@@ -30,9 +30,9 @@ install_dependencies() {
     yum install -y libnghttp2-devel
     install_curl
 
-    # install openresty to make apisix's rpm test work
-    yum install -y yum-utils && yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
-    yum install -y openresty openresty-debug openresty-openssl111-debug-devel pcre pcre-devel xz
+    # install apisix-base to make apisix's rpm test work
+    yum install -y https://repos.apiseven.com/packages/centos/apache-apisix-repo-1.0-1.noarch.rpm
+    yum install -y apisix-base openresty-debug openresty-openssl111-debug-devel pcre pcre-devel
 
     # install luarocks
     ./utils/linux-install-luarocks.sh


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
https://github.com/apache/apisix/actions/runs/5677818659/job/15386805689

Usually, the apisix base will only be released when it is compatible with the APISIX mainline version.

CI failure caused by using incompatible latest version (openresty:1.21.4.2)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
