### PR TITLE
chore: remove check of OpenResty in code because APISIX can not start when using an old version of OpenResty

### DIFF
--- a/apisix/discovery/kubernetes/init.lua
+++ b/apisix/discovery/kubernetes/init.lua
@@ -26,7 +26,7 @@ local error = error
 local pcall = pcall
 local setmetatable = setmetatable
 local is_http = ngx.config.subsystem == "http"
-local support_process, process = pcall(require, "ngx.process")
+local process = require("ngx.process")
 local core = require("apisix.core")
 local util = require("apisix.cli.util")
 local local_conf = require("apisix.core.config_local").local_conf()
@@ -520,11 +520,6 @@ end
 
 
 function _M.init_worker()
-    if not support_process then
-        core.log.error("kubernetes discovery not support in subsystem: ", ngx.config.subsystem,
-                       ", please check if your openresty version >= 1.19.9.1 or not")
-        return
-    end
     local discovery_conf = local_conf.discovery.kubernetes
     core.log.info("kubernetes discovery conf: ", core.json.delay_encode(discovery_conf))
     if #discovery_conf == 0 then

--- a/apisix/discovery/tars/init.lua
+++ b/apisix/discovery/tars/init.lua
@@ -23,7 +23,7 @@ local local_conf = require("apisix.core.config_local").local_conf()
 local core = require("apisix.core")
 local mysql = require("resty.mysql")
 local is_http = ngx.config.subsystem == "http"
-local support_process, process = pcall(require, "ngx.process")
+local process = require("ngx.process")
 
 local endpoint_dict
 
@@ -343,12 +343,6 @@ local function get_endpoint_dict()
 end
 
 function _M.init_worker()
-    if not support_process then
-        core.log.error("tars discovery not support in subsystem: ", ngx.config.subsystem,
-                       ", please check if your openresty version >= 1.19.9.1 or not")
-        return
-    end
-
     endpoint_dict = get_endpoint_dict()
     if not endpoint_dict then
         error("failed to get lua_shared_dict: tars, please check your APISIX version")

--- a/docs/en/latest/discovery/kubernetes.md
+++ b/docs/en/latest/discovery/kubernetes.md
@@ -34,12 +34,6 @@ The [_Kubernetes_](https://kubernetes.io/) service discovery [_List-Watch_](http
 
 Discovery also provides a node query interface in accordance with the [_APISIX Discovery Specification_](../discovery.md).
 
-:::note
-
-use kubernetes discovery in L4 require OpenResty version >= 1.19.9.1
-
-:::
-
 ## How To Use
 
 Kubernetes service discovery both support single-cluster and multi-cluster modes, applicable to the case where the service is distributed in single or multiple Kubernetes clusters.

--- a/docs/zh/latest/discovery/kubernetes.md
+++ b/docs/zh/latest/discovery/kubernetes.md
@@ -34,12 +34,6 @@ Kubernetes 服务发现以 [_List-Watch_](https://kubernetes.io/docs/reference/u
 
 同时遵循 [_APISIX Discovery 规范_](../discovery.md) 提供了节点查询接口。
 
-:::note
-
-在四层中使用 Kubernetes 服务发现要求 OpenResty 版本大于等于 1.19.9.1
-
-:::
-
 ## Kubernetes 服务发现的使用
 
 目前 Kubernetes 服务发现支持单集群和多集群模式，分别适用于待发现的服务分布在单个或多个 Kubernetes 的场景。


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

due to this PR https://github.com/apache/apisix/pull/9913 merge, we don't need to check OpenResty support ngx.process in the stream subsystem or not because we use OpenResty version >= 1.21.4.

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
