### PR TITLE
docs: update certificate docs to remove `create-ssl.py`

### DIFF
--- a/docs/en/latest/certificate.md
+++ b/docs/en/latest/certificate.md
@@ -31,10 +31,11 @@ It is most common for an SSL certificate to contain only one domain. We can crea
 * `key`: PEM-encoded private key of the SSL key pair.
 * `snis`: Hostname(s) to associate with this certificate as SNIs. To set this attribute this certificate must have a valid private key associated with it.
 
-We will use the shell command below to simplify the example:
+The following is an example of configuring an SSL certificate with a single SNI in APISIX.
+
+Create an SSL object with the certificate and key valid for the SNI:
 
 ```shell
-# create SSL object
 curl http://127.0.0.1:9180/apisix/admin/ssls/1 \
 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
@@ -42,8 +43,11 @@ curl http://127.0.0.1:9180/apisix/admin/ssls/1 \
      "key": "'"$(cat t/certs/apisix.key)"'",
      "snis": ["test.com"]
 }'
+```
 
-# create Router object
+Create a Router object:
+
+```shell
 curl http://127.0.0.1:9180/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -i -d '
 {
     "uri": "/get",
@@ -56,54 +60,71 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
         }
     }
 }'
+```
 
-# make a test
+Send a request to verify:
 
-curl --resolve 'test.com:9443:127.0.0.1' https://test.com:9443/hello -k -vvv
-* Added test.com:9443:127.0.0.1 to DNS cache
-* About to connect() to test.com port 9443 (#0)
-*   Trying 127.0.0.1...
-* Connected to test.com (127.0.0.1) port 9443 (#0)
+```shell
+curl --resolve 'test.com:9443:127.0.0.1' https://test.com:9443/get -k -vvv
+
+* Added www.test.com:9443:127.0.0.1 to DNS cache
+* Hostname www.test.com was found in DNS cache
+*   Trying 127.0.0.1:9443...
+* Connected to www.test.com (127.0.0.1) port 9443 (#0)
 * SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
 * ALPN, server accepted to use h2
 * Server certificate:
-*   subject: C=CN; ST=GuangDong; L=ZhuHai; O=iresty; CN=test.com
-*   start date: Jun 24 22:18:05 2019 GMT
-*   expire date: May 31 22:18:05 2119 GMT
-*   issuer: C=CN; ST=GuangDong; L=ZhuHai; O=iresty; CN=test.com
-*   SSL certificate verify result: self-signed certificate (18), continuing anyway.
+*  subject: C=CN; ST=GuangDong; L=ZhuHai; O=iresty; CN=test.com
+*  start date: Jun 24 22:18:05 2019 GMT
+*  expire date: May 31 22:18:05 2119 GMT
+*  issuer: C=CN; ST=GuangDong; L=ZhuHai; O=iresty; CN=test.com
+*  SSL certificate verify result: self signed certificate (18), continuing anyway.
 > GET /get HTTP/2
-> Host: test.com:9443
-> user-agent: curl/7.81.0
+> Host: www.test.com:9443
+> user-agent: curl/7.74.0
 > accept: */*
 ```
 
 ### wildcard SNI
 
-Sometimes, one SSL certificate may contain a wildcard domain like `*.test.com`,
-that means it can accept more than one domain, eg: `www.test.com` or `mail.test.com`.
+An SSL certificate could also be valid for a wildcard domain like `*.test.com`, which means it is valid for any domain of that pattern, including `www.test.com` and `mail.test.com`.
 
-Here is an example, note that the value we pass as `sni` is `*.test.com`.
+The following is an example of configuring an SSL certificate with a wildcard SNI in APISIX.
+
+Create an SSL object with the certificate and key valid for the SNI:
 
 ```shell
-./create-ssl.py t.crt t.key '*.test.com'
+curl http://127.0.0.1:9180/apisix/admin/ssls/1 \
+ -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+ {
+      "cert" : "'"$(cat t/certs/apisix.crt)"'",
+      "key": "'"$(cat t/certs/apisix.key)"'",
+      "snis": ["*.test.com"]
+ }'
+```
 
+Create a Router object:
+
+```shell
 curl http://127.0.0.1:9180/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -i -d '
 {
-    "uri": "/hello",
+    "uri": "/get",
     "hosts": ["*.test.com"],
     "methods": ["GET"],
     "upstream": {
         "type": "roundrobin",
         "nodes": {
-            "127.0.0.1:1980": 1
+            "httpbin.org": 1
         }
     }
 }'
+```
 
-# make a test
+Send a request to verify:
 
-curl --resolve 'www.test.com:9443:127.0.0.1' https://www.test.com:9443/hello  -vvv
+```shell
+curl --resolve 'www.test.com:9443:127.0.0.1' https://www.test.com:9443/get -k -vvv
+
 * Added test.com:9443:127.0.0.1 to DNS cache
 * About to connect() to test.com port 9443 (#0)
 *   Trying 127.0.0.1...
@@ -125,8 +146,7 @@ curl --resolve 'www.test.com:9443:127.0.0.1' https://www.test.com:9443/hello  -v
 
 ### multiple domain
 
-If your SSL certificate may contain more than one domain, like `www.test.com`
-and `mail.test.com`, then you can add them into the `snis` array. For example:
+If your SSL certificate may contain more than one domain, like `www.test.com` and `mail.test.com`, then you can add them into the `snis` array. For example:
 
 ```json
 {

--- a/docs/zh/latest/certificate.md
+++ b/docs/zh/latest/certificate.md
@@ -47,7 +47,7 @@ curl http://127.0.0.1:9180/apisix/admin/ssls/1 \
 
 创建路由：
 
-```
+```shell
 curl http://127.0.0.1:9180/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -i -d '
 {
     "uri": "/get",
@@ -64,7 +64,7 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
 
 测试：
 
-```
+```shell
 curl --resolve 'test.com:9443:127.0.0.1' https://test.com:9443/get -k -vvv
 
 * Added test.com:9443:127.0.0.1 to DNS cache


### PR DESCRIPTION
### Description

Leftover updates from PR https://github.com/apache/apisix/pull/9908 for issue https://github.com/apache/apisix/issues/9229

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
