### PR TITLE
docs: add in-memory caching example for `proxy-cache`

### DIFF
--- a/docs/en/latest/plugins/proxy-cache.md
+++ b/docs/en/latest/plugins/proxy-cache.md
@@ -60,22 +60,33 @@ The data to be cached can be filtered with response codes, request modes, or mor
 You can add your cache configuration in you APISIX configuration file (`conf/config.yaml`) as shown below:
 
 ```yaml title="conf/config.yaml"
-proxy_cache:
-    cache_ttl: 10s                 # default caching time if the upstream doesn't specify the caching time
-    zones:
-    - name: disk_cache_one         # name of the cache. Admin can specify which cache to use in the Admin API by name
-      memory_size: 50m             # size of shared memory, used to store the cache index
-      disk_size: 1G                # size of disk, used to store the cache data
-      disk_path: "/tmp/disk_cache_one" # path to store the cache data
-      cache_levels: "1:2"          # hierarchy levels of the cache
+apisix:
+  proxy_cache:
+  cache_ttl: 10s  # for caching on disk
+  zones:
+    - name: disk_cache_one
+      memory_size: 50m
+      disk_size: 1G
+      disk_path: /tmp/disk_cache_one
+      cache_levels: 1:2
+    # - name: disk_cache_two
+    #   memory_size: 50m
+    #   disk_size: 1G
+    #   disk_path: "/tmp/disk_cache_two"
+    #   cache_levels: "1:2"
+    - name: memory_cache
+      memory_size: 50m
 ```
 
-You can enable the Plugin on a specific Route as shown below:
+### Use disk-based caching
+
+You can enable the Plugin on a Route as shown below. The Plugin uses the disk-based `cache_strategy` and `disk_cache_one` as the `cache_zone` by default:
 
 ```shell
 curl http://127.0.0.1:9180/apisix/admin/routes/1 \
 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
+    "uri": "/ip",
     "plugins": {
         "proxy-cache": {
             "cache_key":  ["$uri", "-cache-id"],
@@ -88,22 +99,44 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1 \
     },
     "upstream": {
         "nodes": {
-            "127.0.0.1:1999": 1
+            "httpbin.org": 1
         },
         "type": "roundrobin"
-    },
-    "uri": "/hello"
+    }
 }'
 ```
 
-In the above configuration, the `cache_zone` attribute defaults to `disk_cache_one`.
+### Use memory-based caching
+
+You can enable the Plugin on a Route with in-memory `cache_strategy` and a corresponding in-memory `cache_zone` as shown below:
+
+```shell
+curl http://127.0.0.1:9180/apisix/admin/routes/1 \
+-H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "uri": "/ip",
+    "plugins": {
+        "proxy-cache": {
+            "cache_strategy": "memory",
+            "cache_zone": "memory_cache",
+            "cache_ttl": 10
+        }
+    },
+    "upstream": {
+        "nodes": {
+            "httpbin.org": 1
+        },
+        "type": "roundrobin"
+    }
+}'
+```
 
 ## Example usage
 
 Once you have configured the Plugin as shown above, you can make an initial request:
 
 ```shell
-curl http://127.0.0.1:9080/hello -i
+curl http://127.0.0.1:9080/ip -i
 ```
 
 ```shell
@@ -117,7 +150,7 @@ hello
 The `Apisix-Cache-Status` in the response shows `MISS` meaning that the response is not cached, as expected. Now, if you make another request, you will see that you get a cached response:
 
 ```shell
-curl http://127.0.0.1:9080/hello -i
+curl http://127.0.0.1:9080/ip -i
 ```
 
 ```shell
@@ -135,7 +168,7 @@ If you set `"cache_zone": "invalid_disk_cache"` attribute to an invalid value (c
 To clear the cached data, you can send a request with `PURGE` method:
 
 ```shell
-curl -i http://127.0.0.1:9080/hello -X PURGE
+curl -i http://127.0.0.1:9080/ip -X PURGE
 ```
 
 ```shell
@@ -154,12 +187,12 @@ To remove the `proxy-cache` Plugin, you can delete the corresponding JSON config
 curl http://127.0.0.1:9180/apisix/admin/routes/1 \
 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
-    "uri": "/hello",
+    "uri": "/ip",
     "plugins": {},
     "upstream": {
         "type": "roundrobin",
         "nodes": {
-            "127.0.0.1:1999": 1
+            "httpbin.org": 1
         }
     }
 }'

--- a/docs/en/latest/plugins/proxy-cache.md
+++ b/docs/en/latest/plugins/proxy-cache.md
@@ -62,20 +62,20 @@ You can add your cache configuration in you APISIX configuration file (`conf/con
 ```yaml title="conf/config.yaml"
 apisix:
   proxy_cache:
-  cache_ttl: 10s  # for caching on disk
-  zones:
-    - name: disk_cache_one
-      memory_size: 50m
-      disk_size: 1G
-      disk_path: /tmp/disk_cache_one
-      cache_levels: 1:2
-    # - name: disk_cache_two
-    #   memory_size: 50m
-    #   disk_size: 1G
-    #   disk_path: "/tmp/disk_cache_two"
-    #   cache_levels: "1:2"
-    - name: memory_cache
-      memory_size: 50m
+    cache_ttl: 10s  # 如果上游未指定缓存时间，则为默认磁盘缓存时间
+    zones:
+      - name: disk_cache_one
+        memory_size: 50m
+        disk_size: 1G
+        disk_path: /tmp/disk_cache_one
+        cache_levels: 1:2
+    #   - name: disk_cache_two
+    #     memory_size: 50m
+    #     disk_size: 1G
+    #     disk_path: "/tmp/disk_cache_two"
+    #     cache_levels: "1:2"
+      - name: memory_cache
+        memory_size: 50m
 ```
 
 ### Use disk-based caching

--- a/docs/zh/latest/plugins/proxy-cache.md
+++ b/docs/zh/latest/plugins/proxy-cache.md
@@ -58,14 +58,22 @@ description: 本文介绍了 Apache APISIX proxy-cache 插件的相关操作，�
 你可以在 APISIX 配置文件 `conf/config.yaml` 中添加你的缓存配置，示例如下：
 
 ```yaml title="conf/config.yaml"
-proxy_cache:                       # 代理缓存配置
-    cache_ttl: 10s                 # 如果上游未指定缓存时间，则为默认缓存时间
-    zones:                         # 缓存的参数
-    - name: disk_cache_one         # 缓存名称（缓存区域），管理员可以通过 admin api 中的 cache_zone 字段指定要使用的缓存区域
-      memory_size: 50m             # 共享内存的大小，用于存储缓存索引
-      disk_size: 1G                # 磁盘大小，用于存储缓存数据
-      disk_path: "/tmp/disk_cache_one" # 存储缓存数据的路径
-      cache_levels: "1:2"          # 缓存的层次结构级别
+apisix:
+   proxy_cache:
+   cache_ttl: 10s  # 如果上游未指定缓存时间，则为默认磁盘缓存时间
+   zones:
+     - name: disk_cache_one
+       memory_size: 50m
+       disk_size: 1G
+       disk_path: /tmp/disk_cache_one
+       cache_levels: 1:2
+     # - name: disk_cache_two
+     #   memory_size: 50m
+     #   disk_size: 1G
+     #   disk_path: "/tmp/disk_cache_two"
+     #   cache_levels: "1:2"
+     - name: memory_cache
+       memory_size: 50m
 ```
 
 ### 使用基于磁盘的缓存

--- a/docs/zh/latest/plugins/proxy-cache.md
+++ b/docs/zh/latest/plugins/proxy-cache.md
@@ -59,21 +59,21 @@ description: 本文介绍了 Apache APISIX proxy-cache 插件的相关操作，�
 
 ```yaml title="conf/config.yaml"
 apisix:
-   proxy_cache:
-   cache_ttl: 10s  # 如果上游未指定缓存时间，则为默认磁盘缓存时间
-   zones:
-     - name: disk_cache_one
-       memory_size: 50m
-       disk_size: 1G
-       disk_path: /tmp/disk_cache_one
-       cache_levels: 1:2
-     # - name: disk_cache_two
-     #   memory_size: 50m
-     #   disk_size: 1G
-     #   disk_path: "/tmp/disk_cache_two"
-     #   cache_levels: "1:2"
-     - name: memory_cache
-       memory_size: 50m
+  proxy_cache:
+    cache_ttl: 10s  # 如果上游未指定缓存时间，则为默认磁盘缓存时间
+    zones:
+      - name: disk_cache_one
+        memory_size: 50m
+        disk_size: 1G
+        disk_path: /tmp/disk_cache_one
+        cache_levels: 1:2
+    #   - name: disk_cache_two
+    #     memory_size: 50m
+    #     disk_size: 1G
+    #     disk_path: "/tmp/disk_cache_two"
+    #     cache_levels: "1:2"
+      - name: memory_cache
+        memory_size: 50m
 ```
 
 ### 使用基于磁盘的缓存


### PR DESCRIPTION
### Description

Added docs as per https://github.com/apache/apisix/issues/9957

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

### Test

```bash
$ curl http://127.0.0.1:9180/apisix/admin/routes/1 \
-H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
{
    "uri": "/ip",
    "plugins": {
        "proxy-cache": {
            "cache_strategy": "memory",
            "cache_zone": "memory_cache",
            "cache_ttl": 10
        }
    },
    "upstream": {
        "nodes": {
            "httpbin.org": 1
        },
        "type": "roundrobin"
    }
}'

{"key":"/apisix/routes/1","value":{"id":"1","update_time":1691137580,"strip_path_prefix":false,"status":1,"upstream":{"nodes":{"httpbin.org":1},"type":"roundrobin","hash_on":"vars","pass_host":"pass","scheme":"http"},"priority":0,"create_time":1690796578,"uri":"/ip","plugins":{"proxy-cache":{"cache_ttl":10,"cache_strategy":"memory","cache_zone":"memory_cache","cache_control":false,"hide_cache_headers":false,"cache_key":["$host","$request_uri"],"cache_method":["GET","HEAD"],"cache_http_status":[200,301,404]}}}}
```

```bash
 $ curl -i http://127.0.0.1:9080/ip

HTTP/1.1 200 OK
Apisix-Cache-Status: MISS
Date: Fri, 04 Aug 2023 08:26:49 GMT
...

{
  "origin": "192.168.112.1, 34.xxx.xxx.xxx"
}
```

```bash
$ curl -i http://127.0.0.1:9080/ip

HTTP/1.1 200 OK
Apisix-Cache-Status: HIT
Age: 5
Date: Fri, 04 Aug 2023 08:26:49 GMT
...

{
  "origin": "192.168.112.1, 34.xxx.xxx.xxx"
}
```