### PR TITLE
docs: add header validation example

### DIFF
--- a/docs/en/latest/plugins/request-validation.md
+++ b/docs/en/latest/plugins/request-validation.md
@@ -192,6 +192,23 @@ The examples below shows how you can configure this Plugin for different validat
 }
 ```
 
+### Header validation
+
+```json
+{
+    "header_schema": {
+        "type": "object",
+        "required": ["Content-Type"],
+        "properties": {
+            "Content-Type": {
+                "type": "string",
+                "pattern": "^application\/json$"
+            }
+        }
+    }
+}
+```
+
 ### Combined validation
 
 ```json


### PR DESCRIPTION
Signed-off-by: Navendu Pottekkat <navendu@apache.org>

Add example of using `header_schema`to validate headers.