### PR TITLE
perf(log-rotate): replace string.sub with string.byte

### DIFF
--- a/apisix/plugins/log-rotate.lua
+++ b/apisix/plugins/log-rotate.lua
@@ -33,6 +33,7 @@ local os_remove = os.remove
 local os_rename = os.rename
 local str_sub = string.sub
 local str_format = string.format
+local str_byte = string.byte
 local ngx_sleep = require("apisix.core.utils").sleep
 local string_rfind = require("pl.stringx").rfind
 local local_conf
@@ -48,6 +49,7 @@ local default_logs
 local enable_compression = false
 local DEFAULT_ACCESS_LOG_FILENAME = "access.log"
 local DEFAULT_ERROR_LOG_FILENAME = "error.log"
+local SLASH_BYTE = str_byte("/")
 
 local schema = {
     type = "object",
@@ -88,9 +90,8 @@ local function get_log_path_info(file_type)
     local prefix = ngx.config.prefix()
 
     if conf_path then
-        local root = str_sub(conf_path, 1, 1)
         -- relative path
-        if root ~= "/" then
+        if str_byte(conf_path) ~= SLASH_BYTE then
             conf_path = prefix .. conf_path
         end
         local n = string_rfind(conf_path, "/")


### PR DESCRIPTION
### Description

replace `string.sub` with `string.byte`

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
