### PR TITLE
fix: add support for dependency installation on endeavouros

### DIFF
--- a/utils/install-dependencies.sh
+++ b/utils/install-dependencies.sh
@@ -112,7 +112,7 @@ function multi_distro_installation() {
         install_dependencies_with_apt "debian"
     elif grep -Eqi "Ubuntu" /etc/issue || grep -Eq "Ubuntu" /etc/*-release; then
         install_dependencies_with_apt "ubuntu"
-    elif grep -Eqi "Arch" /etc/issue || grep -Eq "Arch" /etc/*-release; then
+    elif grep -Eqi "Arch" /etc/issue || grep -Eqi "EndeavourOS" /etc/issue || grep -Eq "Arch" /etc/*-release; then
         install_dependencies_with_aur
     else
         echo "Non-supported operating system version"


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

EndeavourOS is a Linux distribution based on Arch Linux but the output of `cat /etc/issue` doesn't contain `Arch` which is the current check for installing dependencies from AUR in install-dependencies.sh. This PR makes consideration for EndeavourOS
![dep](https://github.com/apache/apisix/assets/43276904/ef0bb8b8-5ecd-43d1-8222-02ed05a6e7a3)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
