### PR TITLE
fix: replace github action

### DIFF
--- a/.github/workflows/update-labels.yml
+++ b/.github/workflows/update-labels.yml
@@ -12,8 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: update labels when user responds
-        uses: andymckay/labeler@master
+        uses: actions/github-script@v6
         if: ${{ github.event.comment.user.login == github.event.issue.user.login && contains(github.event.issue.labels.*.name, 'wait for update') && !contains(github.event.issue.labels.*.name, 'user responded') }}
         with:
-          add-labels: 'user responded'
-          remove-labels: 'wait for update'
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["user responded"]
+            })
+            github.rest.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: "wait for update"
+            })


### PR DESCRIPTION
### Description

The auto-labeling github action is failing with the following error:

<img width="1123" alt="image" src="https://github.com/apache/apisix/assets/61597896/b7b59680-cc62-4383-a7f7-93fafd478d3c">

Looks like `apache` does not allow using actions from the marketplace that haven't been verified by github. So this PR replaces `andymckay/labeler@master`  with `actions/github-script@v6`.

For a dry run example, I tried this [github action](https://github.com/shreemaan-abhishek/actions-labels-test/blob/main/.github/workflows/auto-label.yml) on my test repo first. Here is an example: https://github.com/shreemaan-abhishek/actions-labels-test/issues/2


### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
