### PR TITLE
fix: safely check for upstream field in traffic split plugin

### DIFF
--- a/apisix/plugins/traffic-split.lua
+++ b/apisix/plugins/traffic-split.lua
@@ -200,7 +200,7 @@ local function new_rr_obj(weighted_upstreams)
     for i, upstream_obj in ipairs(weighted_upstreams) do
         if upstream_obj.upstream_id then
             server_list[upstream_obj.upstream_id] = upstream_obj.weight
-        elseif type(upstream_obj.upstream) == "table" then
+        elseif upstream_obj.upstream and type(upstream_obj.upstream) == "table" then
             -- Add a virtual id field to uniquely identify the upstream key.
             upstream_obj.upstream.vid = i
             -- Get the table id of the nodes as part of the upstream_key,

--- a/apisix/plugins/traffic-split.lua
+++ b/apisix/plugins/traffic-split.lua
@@ -200,7 +200,7 @@ local function new_rr_obj(weighted_upstreams)
     for i, upstream_obj in ipairs(weighted_upstreams) do
         if upstream_obj.upstream_id then
             server_list[upstream_obj.upstream_id] = upstream_obj.weight
-        elseif upstream_obj.upstream then
+        elseif type(upstream_obj.upstream) == "table" then
             -- Add a virtual id field to uniquely identify the upstream key.
             upstream_obj.upstream.vid = i
             -- Get the table id of the nodes as part of the upstream_key,

--- a/t/plugin/traffic-split6.t
+++ b/t/plugin/traffic-split6.t
@@ -12,7 +12,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations 
+# limitations under the License.
 #
 use t::APISIX 'no_plan';
 add_block_preprocessor(sub{

--- a/t/plugin/traffic-split6.t
+++ b/t/plugin/traffic-split6.t
@@ -16,19 +16,18 @@
 #
 use t::APISIX 'no_plan';
 add_block_preprocessor(sub{
-	 my ($block) = @_;
-	if (!$block->extra_init_by_lua) {
-        my $extra_init_by_lua = <<_EOC_;
+    my ($block) = @_;
+    if (!$block->extra_init_by_lua) {
+    my $extra_init_by_lua = <<_EOC_;
 -- bypass schema validation
 local plugin = require("apisix.plugins.traffic-split")
 plugin.check_schema = function(schema)
-	return true
+    return true
 end
 _EOC_
-
         $block->set_value("extra_init_by_lua", $extra_init_by_lua);
     }
-	$block;
+    $block;
 });
 
 run_tests;

--- a/t/plugin/traffic-split6.t
+++ b/t/plugin/traffic-split6.t
@@ -1,0 +1,83 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations 
+#
+use t::APISIX 'no_plan';
+add_block_preprocessor(sub{
+	 my ($block) = @_;
+	if (!$block->extra_init_by_lua) {
+        my $extra_init_by_lua = <<_EOC_;
+-- bypass schema validation
+local plugin = require("apisix.plugins.traffic-split")
+plugin.check_schema = function(schema)
+	return true
+end
+_EOC_
+
+        $block->set_value("extra_init_by_lua", $extra_init_by_lua);
+    }
+	$block;
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: even when schema validation is bypassed, upstream "abc" will be assigned "plugin#upstream#is#empty" instead of panic
+--- config
+    location /t {
+        content_by_lua_block {
+           local json = require("toolkit.json")
+            local t = require("lib.test_admin").test
+            local data = {
+                uri = "/server_port",
+                plugins = {
+                    ["traffic-split"] = {
+                        rules = { {
+                        weighted_upstreams = { {
+                            upstream = "abc",
+                        }, {
+                            weight = 1
+                        } }
+                        } }
+                    }
+                },
+                upstream = {
+                    type = "roundrobin",
+                    nodes = {
+                        ["127.0.0.1:1980"] = 1
+                    }
+                }
+            }
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                json.encode(data)
+            )
+
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+
+
+
+=== TEST 2: there should be no panic
+--- request
+GET /server_port
+--- response_body eval
+1980


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #9831 

Although the schema check disallows anything other than the object inside `upstream` field but in certain edge cases there can be issues with etcd like in the above mentioned issue so having a concrete check whether the upstream field is a table is needed. Otherwise in edge case, if upstream is set as string then it will result in nil error. 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
