### PR TITLE
docs: update info about plugin execution order and phases

### DIFF
--- a/docs/en/latest/terminology/global-rule.md
+++ b/docs/en/latest/terminology/global-rule.md
@@ -34,7 +34,7 @@ Compared with the plugin configuration in Route, Service, Plugin Config, and Con
 
 ::: note
 
-For stream routes, only plugins that run on `before_proxy` phase get executed as Global Rules.
+For stream routes, only plugins that run on `before_proxy` [phase](../terminology/plugin.md#plugins-execution-order) get executed as Global Rules.
 
 :::
 

--- a/docs/en/latest/terminology/global-rule.md
+++ b/docs/en/latest/terminology/global-rule.md
@@ -32,12 +32,6 @@ A [Plugin](./plugin.md) configuration can be bound directly to a [Route](./route
 
 Compared with the plugin configuration in Route, Service, Plugin Config, and Consumer, the plugin in the Global Rules is always executed first.
 
-::: note
-
-For stream routes, only plugins that run on `before_proxy` [phase](../terminology/plugin.md#plugins-execution-order) get executed as Global Rules.
-
-:::
-
 ## Example
 
 The example below shows how you can use the `limit-count` Plugin on all requests:

--- a/docs/en/latest/terminology/global-rule.md
+++ b/docs/en/latest/terminology/global-rule.md
@@ -34,7 +34,7 @@ Compared with the plugin configuration in Route, Service, Plugin Config, and Con
 
 ::: note
 
-Global Rules do not apply for Stream Routes.
+For stream routes, only plugins that run on `before_proxy` phase get executed as Global Rules.
 
 :::
 

--- a/docs/en/latest/terminology/global-rule.md
+++ b/docs/en/latest/terminology/global-rule.md
@@ -32,6 +32,12 @@ A [Plugin](./plugin.md) configuration can be bound directly to a [Route](./route
 
 Compared with the plugin configuration in Route, Service, Plugin Config, and Consumer, the plugin in the Global Rules is always executed first.
 
+::: note
+
+Global Rules do not apply for Stream Routes.
+
+:::
+
 ## Example
 
 The example below shows how you can use the `limit-count` Plugin on all requests:

--- a/docs/en/latest/terminology/plugin-config.md
+++ b/docs/en/latest/terminology/plugin-config.md
@@ -31,7 +31,6 @@ description: Plugin Config in Apache APISIX.
 Plugin Configs are used to extract commonly used [Plugin](./plugin.md) configurations and can be bound directly to a [Route](./route.md).
 
 While configuring the same plugin, only one copy of the configuration is valid. The order of precedence is always `Consumer` > `Consumer Group` > `Route` > `Plugin Config` > `Service`. Plugins configured in `Global Rules` will be executed first at all times.
- 
 
 ## Example
 

--- a/docs/en/latest/terminology/plugin-config.md
+++ b/docs/en/latest/terminology/plugin-config.md
@@ -30,7 +30,7 @@ description: Plugin Config in Apache APISIX.
 
 Plugin Configs are used to extract commonly used [Plugin](./plugin.md) configurations and can be bound directly to a [Route](./route.md).
 
-While configuring the same plugin, only one copy of the configuration is valid. The order of precedence is always `Consumer` > `Consumer Group` > `Route` > `Plugin Config` > `Service`.
+While configuring the same plugin, only one copy of the configuration is valid. The order of precedence is always `Consumer` > `Consumer Group` > `Route` > `Plugin Config` > `Service`. Plugins configured in `Global Rules` will be executed first at all times. 
 
 ## Example
 

--- a/docs/en/latest/terminology/plugin-config.md
+++ b/docs/en/latest/terminology/plugin-config.md
@@ -30,7 +30,7 @@ description: Plugin Config in Apache APISIX.
 
 Plugin Configs are used to extract commonly used [Plugin](./plugin.md) configurations and can be bound directly to a [Route](./route.md).
 
-While configuring the same plugin, only one copy of the configuration is valid. The order of precedence is always `Consumer` > `Consumer Group` > `Route` > `Plugin Config` > `Service`. Plugins configured in `Global Rules` will be executed first at all times.
+While configuring the same plugin, only one copy of the configuration is valid. Please read the [plugin execution order](../terminology/plugin.md#plugins-execution-order) and [plugin merging order](../terminology/plugin.md#plugins-merging-precedence).
 
 ## Example
 

--- a/docs/en/latest/terminology/plugin-config.md
+++ b/docs/en/latest/terminology/plugin-config.md
@@ -30,7 +30,8 @@ description: Plugin Config in Apache APISIX.
 
 Plugin Configs are used to extract commonly used [Plugin](./plugin.md) configurations and can be bound directly to a [Route](./route.md).
 
-While configuring the same plugin, only one copy of the configuration is valid. The order of precedence is always `Consumer` > `Consumer Group` > `Route` > `Plugin Config` > `Service`. Plugins configured in `Global Rules` will be executed first at all times. 
+While configuring the same plugin, only one copy of the configuration is valid. The order of precedence is always `Consumer` > `Consumer Group` > `Route` > `Plugin Config` > `Service`. Plugins configured in `Global Rules` will be executed first at all times.
+ 
 
 ## Example
 

--- a/docs/en/latest/tutorials/protect-api.md
+++ b/docs/en/latest/tutorials/protect-api.md
@@ -37,7 +37,7 @@ This represents the configuration of the plugins that are executed during the HT
 
 :::note
 
-If [Route](../terminology/route.md), [Service](../terminology/service.md), [Plugin Config](../terminology/plugin-config.md) or Consumer are all bound to the same for plugins, only one plugin configuration will take effect. The priority of plugin configurations is given here: [plugin execution order](../terminology/plugin.md#plugins-execution-order). At the same time, there are various stages involved in the plugin execution process described here: [plugin execution lifecycle](../terminology/plugin.md#plugins-execution-order)
+If [Route](../terminology/route.md), [Service](../terminology/service.md), [Plugin Config](../terminology/plugin-config.md) or [Consumer](../terminology/consumer.md) are all bound to the same for plugins, only one plugin configuration will take effect. The priority of plugin configurations is described in [plugin execution order](../terminology/plugin.md#plugins-execution-order). At the same time, there are various stages involved in the plugin execution process. See [plugin execution lifecycle](../terminology/plugin.md#plugins-execution-order).
 
 :::
 

--- a/docs/en/latest/tutorials/protect-api.md
+++ b/docs/en/latest/tutorials/protect-api.md
@@ -37,7 +37,7 @@ This represents the configuration of the plugins that are executed during the HT
 
 :::note
 
-If [Route](../terminology/route.md), [Service](../terminology/service.md), [Plugin Config](../terminology/plugin-config.md) or Consumer are all bound to the same for plugins, only one plugin configuration will take effect. The priority of plugin configurations is: Consumer > Route > Plugin Config > Service. At the same time, there are 6 stages involved in the plugin execution process, namely `rewrite`, `access`, `before_proxy`, `header_filter`, `body_filter` and `log`.
+If [Route](../terminology/route.md), [Service](../terminology/service.md), [Plugin Config](../terminology/plugin-config.md) or Consumer are all bound to the same for plugins, only one plugin configuration will take effect. The priority of plugin configurations is: `Consumer` > `Route` > `Plugin Config` > `Service`. Plugins configured in `Global Rules` will be executed first at all times. At the same time, there are 6 stages involved in the plugin execution process, namely `rewrite`, `access`, `before_proxy`, `header_filter`, `body_filter` and `log`.
 
 :::
 

--- a/docs/en/latest/tutorials/protect-api.md
+++ b/docs/en/latest/tutorials/protect-api.md
@@ -37,7 +37,7 @@ This represents the configuration of the plugins that are executed during the HT
 
 :::note
 
-If [Route](../terminology/route.md), [Service](../terminology/service.md), [Plugin Config](../terminology/plugin-config.md) or Consumer are all bound to the same for plugins, only one plugin configuration will take effect. The priority of plugin configurations is: `Consumer` > `Route` > `Plugin Config` > `Service`. Plugins configured in `Global Rules` will be executed first at all times. At the same time, there are 6 stages involved in the plugin execution process, namely `rewrite`, `access`, `before_proxy`, `header_filter`, `body_filter` and `log`.
+If [Route](../terminology/route.md), [Service](../terminology/service.md), [Plugin Config](../terminology/plugin-config.md) or Consumer are all bound to the same for plugins, only one plugin configuration will take effect. The priority of plugin configurations is given here: [plugin execution order](../terminology/plugin.md#plugins-execution-order). At the same time, there are various stages involved in the plugin execution process described here: [plugin execution lifecycle](../terminology/plugin.md#plugins-execution-order)
 
 :::
 


### PR DESCRIPTION
### Description

With the current situation of documentation, it's very likely that users might end up not having any context about `Global rules` when considering the plugin execution precedence.


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
