### PR TITLE
ci: update the timeout value in cli.yml

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -31,7 +31,7 @@ jobs:
           - linux_apisix_current_luarocks_in_customed_nginx
 
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     env:
       SERVER_NAME: ${{ matrix.job_name }}
       OPENRESTY_VERSION: default


### PR DESCRIPTION
### Description

There are some failed "CLI Test" workflow runs due to a timeout, such as: https://github.com/apache/apisix/actions/runs/5851037609 .

The successful jobs take nearly 15 minutes to complete, such as https://github.com/apache/apisix/actions/runs/5864979479 .
I think 15 minutes for the timeout value is not sufficient.


Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
