### PR TITLE
feat: Add authorization params to openid-connect plugin

### DIFF
--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -156,7 +156,7 @@ local schema = {
                     description = "Comma separated list of hosts that should not be proxied.",
                 }
             },
-        }
+        },
         authorization_params = {
             description = "Extra authorization params to the authorize endpoint",
             type = "object"

--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -157,6 +157,10 @@ local schema = {
                 }
             },
         }
+        authorization_params = {
+            description = "Extra authorization params to the authorize endpoint",
+            type = "object"
+        }
     },
     encrypt_fields = {"client_secret"},
     required = {"client_id", "client_secret", "discovery"}

--- a/docs/en/latest/plugins/openid-connect.md
+++ b/docs/en/latest/plugins/openid-connect.md
@@ -67,6 +67,7 @@ description: OpenID Connect allows the client to obtain user information from th
 | proxy_opts.http_proxy_authorization  | string  | False    |                       | Basic [base64 username:password] | Default `Proxy-Authorization` header value to be used with `http_proxy`.                                                                                                                                      |
 | proxy_opts.https_proxy_authorization | string  | False    |                       | Basic [base64 username:password] | As `http_proxy_authorization` but for use with `https_proxy` (since with HTTPS the authorisation is done when connecting, this one cannot be overridden by passing the `Proxy-Authorization` request header). |
 | proxy_opts.no_proxy                  | string  | False    |                       |                                  | Comma separated list of hosts that should not be proxied.                                                                                                                                                     |
+| authorization_params                 | object  | False    |                       |                                  | Additional parameters to send in the in the request to the authorization endpoint.                   |
 
 NOTE: `encrypt_fields = {"client_secret"}` is also defined in the schema, which means that the field will be stored encrypted in etcd. See [encrypted storage fields](../plugin-develop.md#encrypted-storage-fields).
 

--- a/docs/zh/latest/plugins/openid-connect.md
+++ b/docs/zh/latest/plugins/openid-connect.md
@@ -67,6 +67,7 @@ description: OpenID Connect（OIDC）是基于 OAuth 2.0 的身份认证协议�
 | proxy_opts.http_proxy_authorization  | string  | 否    |                       | Basic [base64 username:password] | `http_proxy` 默认的 `Proxy-Authorization` 请求头参数值。                                                                 |
 | proxy_opts.https_proxy_authorization | string  | 否    |                       | Basic [base64 username:password] | 与`http_proxy_authorization`相同，但与`https_proxy`一起使用（因为使用 HTTPS 时，授权是在连接时完成的，因此不能通过传递 Proxy-Authorization 请求头来覆盖此授权）。 |
 | proxy_opts.no_proxy                  | string  | 否    |                       |                                  | 不应被代理的主机的逗号分隔列表。                                                                                               |
+| authorization_params                 | object  | false    |                       |                                  | 在请求中发送到授权端点的附加参数                   |
 
 注意：schema 中还定义了 `encrypt_fields = {"client_secret"}`，这意味着该字段将会被加密存储在 etcd 中。具体参考 [加密存储字段](../plugin-develop.md#加密存储字段)。
 

--- a/t/plugin/openid-connect4.t
+++ b/t/plugin/openid-connect4.t
@@ -1,0 +1,111 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+log_level('debug');
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if ((!defined $block->error_log) && (!defined $block->no_error_log)) {
+        $block->set_value("no_error_log", "[error]");
+    }
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: Set up new route access the auth server with header test
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "openid-connect": {
+                                "client_id": "kbyuFDidLLm280LIwVFiazOqjO3ty8KH",
+                                "client_secret": "60Op4HFM0I8ajz0WdiStAbziZ-VFQttXuxixHHs2R7r7-CW8GR79l-mmLqMhc-Sa",
+                                "discovery": "https://samples.auth0.com/.well-known/openid-configuration",
+                                "redirect_uri": "https://iresty.com",
+                                "authorization_params":{
+                                    "test":"abc"
+                                },
+                                "ssl_verify": false,
+                                "timeout": 10,
+                                "scope": "apisix",
+                                "proxy_opts": {
+                                    "http_proxy": "http://127.0.0.1:8080",
+                                    "http_proxy_authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQK"
+                                },
+                                "use_pkce": false
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 2: Check the uri of the authorization endpoint for passed headers
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/hello"
+            local res, err = httpc:request_uri(uri, {method = "GET"})
+            ngx.status = res.status
+            local location = res.headers['Location']
+            if location and string.find(location, 'https://samples.auth0.com/authorize') ~= -1 and
+                string.find(location, 'test=abc') ~= -1 then
+                ngx.say(true)
+            end
+        }
+    }
+--- timeout: 10s
+--- response_body
+true
+--- error_code: 302
+--- error_log
+use http proxy


### PR DESCRIPTION
### Description

Add the ability to configure additional authorization params included in the openid-connect plugin.

Fixes #10057 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

If tests are required, I may need assistance in writing those.
