### PR TITLE
ci: fix a bug that open nginx.pid failed

### DIFF
--- a/ci/linux_apisix_master_luarocks_runner.sh
+++ b/ci/linux_apisix_master_luarocks_runner.sh
@@ -52,6 +52,13 @@ script() {
     sudo PATH=$PATH apisix init
     sudo PATH=$PATH apisix start
     sudo PATH=$PATH apisix quit
+    for i in {1..10}
+    do
+        if [ ! -f /usr/local/apisix/logs/nginx.pid ];then
+            break
+        fi
+        sleep 0.3
+    done
     sudo PATH=$PATH apisix start
     sudo PATH=$PATH apisix stop
 


### PR DESCRIPTION
### Description

There are some failed "CLI Test (master)" workflow runs, such as https://github.com/apache/apisix/actions/runs/5886312117/job/15963999013 .  

We can get the following error message in the "Linux Script" job:
```
Error: 2023/08/17 03:14:30 [error] 32685#32685: open() "/usr/local/apisix/logs/nginx.pid" failed (2: No such file or directory)
Error: Process completed with exit code 1.
```
The problem code is in `ci/linux_apisix_master_luarocks_runner.sh`
```
sudo PATH=$PATH apisix init
    sudo PATH=$PATH apisix start          # step 1
    sudo PATH=$PATH apisix quit           # step 2
    sudo PATH=$PATH apisix start          # step 3
    sudo PATH=$PATH apisix stop
```
After run `apisix quit`, if the process does not exit totaly before `apisix start` (step 3), the `apisix start` will not create a new process. Then the process created in "step 1" exit and `nginx.pid` is removed, so `apisix stop` will cause an error "open nginx.pid failed"
So it is necessary to wait for the process to exit after `apisix quit`.

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
