### PR TITLE
fix(inspect): jit should be recovered after all hooks are done

### DIFF
--- a/apisix/inspect/dbg.lua
+++ b/apisix/inspect/dbg.lua
@@ -98,6 +98,9 @@ local function hook(_, arg)
         if #hooks == 0 then
             core.log.warn("inspect: all hooks removed")
             debug.sethook()
+            if jit then
+                jit.on()
+            end
         end
     end
 end


### PR DESCRIPTION
### Description

if all hooks are done and debug mode are disabled, it would be better turn on jit on immediately.

https://api7.ai/blog/apisix-lua-dynamic-debugging-plugin
`Once debugging ends and all breakpoints have been revoked, the system will return to normal JIT mode, and the cleared JIT cache will be regenerated once it re-enters the hot spot.`

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
