### PR TITLE
docs: remove `$consumer_group_id` from `limit-count.group`

### DIFF
--- a/docs/en/latest/terminology/consumer-group.md
+++ b/docs/en/latest/terminology/consumer-group.md
@@ -35,7 +35,9 @@ instead of managing each consumer individually.
 
 ## Example
 
-The example below illustrates how to create a Consumer Group and bind it to a Consumer:
+The example below illustrates how to create a Consumer Group and bind it to a Consumer.
+
+Create a Consumer Group which shares the same rate limiting quota:
 
 ```shell
 curl http://127.0.0.1:9180/apisix/admin/consumer_groups/company_a \
@@ -46,11 +48,13 @@ curl http://127.0.0.1:9180/apisix/admin/consumer_groups/company_a \
             "count": 200,
             "time_window": 60,
             "rejected_code": 503,
-            "group": "$consumer_group_id"
+            "group": "grp_company_a"
         }
     }
 }'
 ```
+
+Create a Consumer within the Consumer Group:
 
 ```shell
 curl http://127.0.0.1:9180/apisix/admin/consumers \

--- a/docs/zh/latest/terminology/consumer-group.md
+++ b/docs/zh/latest/terminology/consumer-group.md
@@ -34,6 +34,8 @@ description: 本文介绍了 Apache APISIX Consumer Group 对象的概念及使�
 
 以下示例展示了如何创建消费者组并将其绑定到消费者中。
 
+创建一个共享相同限流配额的消费者组：
+
 ```shell
 curl http://127.0.0.1:9180/apisix/admin/consumer_groups/company_a \
 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
@@ -43,11 +45,13 @@ curl http://127.0.0.1:9180/apisix/admin/consumer_groups/company_a \
             "count": 200,
             "time_window": 60,
             "rejected_code": 503,
-            "group": "$consumer_group_id"
+            "group": "grp_company_a"
         }
     }
 }'
 ```
+
+在消费者组中创建消费者：
 
 ```shell
 curl http://127.0.0.1:9180/apisix/admin/consumers \

--- a/t/admin/consumer-group-force-delete.t
+++ b/t/admin/consumer-group-force-delete.t
@@ -51,7 +51,7 @@ __DATA__
                             "count": 200,
                             "time_window": 60,
                             "rejected_code": 503,
-                            "group": "$consumer_group_id"
+                            "group": "consumer_group_1"
                         }
                     }
                 }]]


### PR DESCRIPTION
### Description

Fixes #10100 

This PR fixed the issue originally reported for `$consumer_group_id`.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
