### PR TITLE
feat:  adding tls and tls verify support for Kafka-logger

### DIFF
--- a/apisix/plugins/kafka-logger.lua
+++ b/apisix/plugins/kafka-logger.lua
@@ -86,6 +86,16 @@ local schema = {
             },
             uniqueItems = true,
         },
+        tls = {
+            type = "object",
+            description = "tls config",
+            properties = {
+                verify = {
+                    type = "boolean",
+                   default = false
+                },
+            },
+        },
         kafka_topic = {type = "string"},
         producer_type = {
             type = "string",
@@ -249,6 +259,10 @@ function _M.log(conf, ctx)
     broker_config["max_buffering"] = conf.producer_max_buffering
     broker_config["flush_time"] = conf.producer_time_linger * 1000
     broker_config["refresh_interval"] = conf.meta_refresh_interval * 1000
+    if conf.tls then
+        broker_config["ssl"] = true
+        broker_config["ssl_verify"] = conf.tls.verify
+    end
 
     local prod, err = core.lrucache.plugin_ctx(lrucache, ctx, nil, create_producer,
                                                broker_list, broker_config, conf.cluster_name)


### PR DESCRIPTION
### Description
Adding tls and tls verify support for Kafka-logger, then it will support Kafka's SASL_SSL authentication mode
- attribute tls , type object
- attribute tls.verify, type boolean, default false

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)
https://github.com/apache/apisix/issues/9353

### Checklist

- [v] I have explained the need for this PR and the problem it solves
- [v] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
