### PR TITLE
fix: unescaped left brace in test file

### DIFF
--- a/t/secret/vault.t
+++ b/t/secret/vault.t
@@ -210,7 +210,7 @@ value
 --- request
 GET /t
 --- response_body_like
-failed to decode result, res: {\"errors\":\[\"permission denied\"\]}\n
+failed to decode result, res: \{\"errors\":\[\"permission denied\"\]}\n
 
 
 
@@ -235,4 +235,4 @@ failed to decode result, res: {\"errors\":\[\"permission denied\"\]}\n
 --- request
 GET /t
 --- response_body_like
-failed to decode result, res: {\"errors\":\[\"permission denied\"\]}\n
+failed to decode result, res: \{\"errors\":\[\"permission denied\"\]}\n


### PR DESCRIPTION
### Description

unescaped left brace in test file
![image](https://github.com/apache/apisix/assets/9354193/dfb645df-626b-4f66-8789-2e6407975c63)
https://github.com/apache/apisix/actions/runs/6009132173/job/16297969790

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

