### PR TITLE
feat: Delete the `create_time` and `update_time` attributes in Consumer

### DIFF
--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -702,8 +702,6 @@ _M.consumer = {
         group_id = id_schema,
         plugins = plugins_schema,
         labels = labels_def,
-        create_time = timestamp_def,
-        update_time = timestamp_def,
         desc = desc_def,
     },
     required = {"username"},

--- a/docs/zh/latest/admin-api.md
+++ b/docs/zh/latest/admin-api.md
@@ -822,8 +822,6 @@ Consumer 资源请求地址：/apisix/admin/consumers/{username}
 | plugins     | 否   | Plugin   | 该 Consumer 对应的插件配置，它的优先级是最高的：Consumer > Route > Plugin Config > Service。对于具体插件配置，请参考 [Plugins](#plugin)。     |                                                  |
 | desc        | 否   | 辅助     | consumer 描述。                                                                                                                  |                                                  |
 | labels      | 否   | 匹配规则  | 标识附加属性的键值对。                                                                                                             | {"version":"v2","build":"16","env":"production"} |
-| create_time | 否   | 辅助     | epoch 时间戳，单位为秒。如果不指定则自动创建。                                                                                       | 1602883670                                       |
-| update_time | 否   | 辅助     | epoch 时间戳，单位为秒。如果不指定则自动创建。                                                                                       | 1602883670                                       |
 
 Consumer 对象 JSON 配置示例：
 

--- a/t/admin/consumers.t
+++ b/t/admin/consumers.t
@@ -358,3 +358,55 @@ passed
 GET /t
 --- response_body
 passed
+
+
+
+=== TEST 12: add consumer when there is no create_time and update_time(pony)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                     "username":"pony",
+                     "desc": "new consumer"
+                }]],
+                [[{
+                    "value": {
+                        "username": "pony",
+                        "desc": "new consumer"
+                    },
+                    "key": "/apisix/consumers/pony"
+                }]]
+                )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 13: delete test consumer created without create_time and update_time(pony)
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.sleep(0.3)
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers/pony',
+                 ngx.HTTP_DELETE
+            )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

- Fixes #10094;
- Delete the `create_time` and `update_time` field in consumer;
- Passed compatibility testing;
- Add test cases;

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
