### PR TITLE
fix: provide error instead of nil panic when cache_zone is missing

### DIFF
--- a/apisix/plugins/proxy-cache/memory.lua
+++ b/apisix/plugins/proxy-cache/memory.lua
@@ -32,6 +32,10 @@ end
 
 
 function _M:set(key, obj, ttl)
+    if self.dict == nil then
+        return nil, "no cache_zone provided"
+    end
+
     local obj_json = core.json.encode(obj)
     if not obj_json then
         return nil, "could not encode object"
@@ -43,6 +47,9 @@ end
 
 
 function _M:get(key)
+    if self.dict == nil then
+        return nil, "no cache_zone provided"
+    end
     -- If the key does not exist or has expired, then res_json will be nil.
     local res_json, err = self.dict:get(key)
     if not res_json then
@@ -63,6 +70,9 @@ end
 
 
 function _M:purge(key)
+    if self.dict == nil then
+        return nil, "no cache_zone provided"
+    end
     self.dict:delete(key)
 end
 

--- a/t/plugin/proxy-cache/memory.t
+++ b/t/plugin/proxy-cache/memory.t
@@ -661,3 +661,58 @@ GET /hello
 --- more_headers
 Cache-Control: only-if-cached
 --- error_code: 504
+
+
+
+=== TEST 36: configure plugin without memory_cache zone
+--- config
+       location /t {
+           content_by_lua_block {
+               local t = require("lib.test_admin").test
+               local code, body = t('/apisix/admin/routes/1',
+                    ngx.HTTP_PUT,
+                    [[{
+                        "plugins": {
+                            "proxy-cache": {
+                               "cache_strategy": "memory",
+                               "cache_key":["$host","$uri"],
+                               "cache_bypass": ["$arg_bypass"],
+                               "cache_control": true,
+                               "cache_method": ["GET"],
+                               "cache_ttl": 10,
+                               "cache_http_status": [200]
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1986": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                   }]]
+                   )
+
+               if code >= 300 then
+                   ngx.status = code
+               end
+               ngx.say(body)
+           }
+       }
+--- request
+GET /t
+--- error_code: 200
+--- response_body
+passed
+
+
+
+=== TEST 37: hit route
+--- LAST
+--- request
+GET /hello
+--- grep_error_log eval
+qr/no cache_zone provided/
+--- grep_error_log_out
+no cache_zone provided
+no cache_zone provided


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #9957 

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
