### PR TITLE
fix: use warn log for get healthcheck target status failure

### DIFF
--- a/apisix/balancer.lua
+++ b/apisix/balancer.lua
@@ -79,7 +79,7 @@ local function fetch_health_nodes(upstream, checker)
         if ok then
             up_nodes = transform_node(up_nodes, node)
         elseif err then
-            core.log.error("failed to get health check target status, addr: ",
+            core.log.warn("failed to get health check target status, addr: ",
                 node.host, ":", port or node.port, ", host: ", host, ", err: ", err)
         end
     end


### PR DESCRIPTION
### Description

https://github.com/apache/apisix/blob/35349ef508351364216c0c2f1c0fd8798905b9e2/apisix/balancer.lua#L82-L83
The above error log reports an error in some cases even if the request is valid and successful. In the initial requests, `get_target_status()` will always fail as the target status is not yet finalized. It does not make sense to report an error for positive outcomes.

Note that the `get_target_status()` failure just signifies that the system failed to get the health status only. We do not know if the target is actually unhealthy. And even if the node is unavailable/unhealthy `get_target_status()` does not report the error, but some warn logs like this:
```
2023/09/04 22:13:09 [warn] 14709#16724107: *2442 [lua] healthcheck.lua:650: [healthcheck] (upstream#/apisix/upstreams/1) unhealthy TCP increment (2/2) for '(127.0.0.1:8765)', context: ngx.timer, client: 127.0.0.1, server: 0.0.0.0:9080
```
#### Background information:

I encountered this problem while writing a test case for `https` based healthcheck.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
