### PR TITLE
fix: remove openldap dependencies from apisix

### DIFF
--- a/apisix-master-0.rockspec
+++ b/apisix-master-0.rockspec
@@ -71,7 +71,6 @@ dependencies = {
     "ext-plugin-proto = 0.6.1",
     "casbin = 1.41.8-1",
     "inspect == 3.1.1",
-    "lualdap = 1.2.6-1",
     "lua-resty-rocketmq = 0.3.0-0",
     "opentelemetry-lua = 0.2-3",
     "net-url = 0.9-1",

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -177,7 +177,7 @@ GRPC_SERVER_EXAMPLE_VER=20210819
 
 linux_get_dependencies () {
     apt update
-    apt install -y cpanminus build-essential libncurses5-dev libreadline-dev libssl-dev perl libpcre3 libpcre3-dev libldap2-dev
+    apt install -y cpanminus build-essential libncurses5-dev libreadline-dev libssl-dev perl libpcre3 libpcre3-dev
 }
 
 function start_grpc_server_example() {

--- a/ci/performance_test.sh
+++ b/ci/performance_test.sh
@@ -22,7 +22,7 @@ set -ex
 
 install_dependencies() {
     apt-get -y update --fix-missing
-    apt-get -y install lua5.1 liblua5.1-0-dev libldap2-dev
+    apt-get -y install lua5.1 liblua5.1-0-dev
     export_or_prefix
     export OPENRESTY_VERSION=source
     ./ci/linux-install-openresty.sh

--- a/ci/pod/docker-compose.plugin.yml
+++ b/ci/pod/docker-compose.plugin.yml
@@ -123,26 +123,6 @@ services:
     networks:
       skywalk_net:
 
-
-  ## OpenLDAP
-  openldap:
-    image: bitnami/openldap:2.5.8
-    environment:
-      - LDAP_ADMIN_USERNAME=amdin
-      - LDAP_ADMIN_PASSWORD=adminpassword
-      - LDAP_USERS=user01,user02
-      - LDAP_PASSWORDS=password1,password2
-      - LDAP_ENABLE_TLS=yes
-      - LDAP_TLS_CERT_FILE=/certs/localhost_slapd_cert.pem
-      - LDAP_TLS_KEY_FILE=/certs/localhost_slapd_key.pem
-      - LDAP_TLS_CA_FILE=/certs/apisix.crt
-    ports:
-      - "1389:1389"
-      - "1636:1636"
-    volumes:
-      - ./t/certs:/certs
-
-
   ## Grafana Loki
   loki:
     image: grafana/loki:2.8.0

--- a/docs/en/latest/building-apisix.md
+++ b/docs/en/latest/building-apisix.md
@@ -69,43 +69,6 @@ make install
 
 This will install the runtime-dependent Lua libraries and `apisix-runtime` the `apisix` CLI tool.
 
-:::note
-
-If you get an error message like `Could not find header file for LDAP/PCRE/openssl` while running `make deps`, use this solution.
-
-`luarocks` supports custom compile-time dependencies (See: [Config file format](https://github.com/luarocks/luarocks/wiki/Config-file-format)). You can use a third-party tool to install the missing packages and add its installation directory to the `luarocks`' variables table. This method works on macOS, Ubuntu, CentOS, and other similar operating systems.
-
-The solution below is for macOS but it works similarly for other operating systems:
-
-1. Install `openldap` by running:
-
-   ```shell
-   brew install openldap
-   ```
-
-2. Locate the installation directory by running:
-
-   ```shell
-   brew --prefix openldap
-   ```
-
-3. Add this path to the project configuration file by any of the two methods shown below:
-   1. You can use the `luarocks config` command to set `LDAP_DIR`:
-
-      ```shell
-      luarocks config variables.LDAP_DIR /opt/homebrew/cellar/openldap/2.6.1
-      ```
-
-   2. You can also change the default configuration file of `luarocks`. Open the file `~/.luaorcks/config-5.1.lua` and add the following:
-
-      ```shell
-      variables = { LDAP_DIR = "/opt/homebrew/cellar/openldap/2.6.1", LDAP_INCDIR = "/opt/homebrew/cellar/openldap/2.6.1/include", }
-      ```
-
-      `/opt/homebrew/cellar/openldap/` is default path `openldap` is installed on Apple Silicon macOS machines. For Intel machines, the default path is  `/usr/local/opt/openldap/`.
-
-:::
-
 To uninstall the APISIX runtime, run:
 
 ```shell

--- a/docs/zh/latest/building-apisix.md
+++ b/docs/zh/latest/building-apisix.md
@@ -70,43 +70,6 @@ make install
 
 该命令将安装 APISIX 运行时依赖的 Lua 库以及 `apisix-runtime` 和 `apisix` 命令。
 
-:::note
-
-如果你在运行 `make deps` 时收到类似 `Could not find header file for LDAP/PCRE/openssl` 的错误消息，请使用此解决方案。
-
-`luarocks` 支持自定义编译时依赖项（请参考：[配置文件格式](https://github.com/luarocks/luarocks/wiki/Config-file-format)）。你可以使用第三方工具安装缺少的软件包并将其安装目录添加到 `luarocks` 变量表中。此方法适用于 macOS、Ubuntu、CentOS 和其他类似操作系统。
-
-此处仅给出 macOS 的具体解决步骤，其他操作系统的解决方案类似：
-
-1. 安装 `openldap`：
-
-   ```shell
-   brew install openldap
-   ```
-
-2. 使用以下命令命令找到本地安装目录：
-
-   ```shell
-   brew --prefix openldap
-   ```
-
-3. 将路径添加到项目配置文件中（选择两种方法中的一种即可）：
-   1. 你可以使用 `luarocks config` 命令设置 `LDAP_DIR`：
-
-      ```shell
-      luarocks config variables.LDAP_DIR /opt/homebrew/cellar/openldap/2.6.1
-      ```
-
-   2. 你还可以更改 `luarocks` 的默认配置文件。打开 `~/.luaorcks/config-5.1.lua` 文件并添加以下内容：
-
-      ```shell
-      variables = { LDAP_DIR = "/opt/homebrew/cellar/openldap/2.6.1", LDAP_INCDIR = "/opt/homebrew/cellar/openldap/2.6.1/include", }
-      ```
-
-      `/opt/homebrew/cellar/openldap/` 是 `brew` 在 macOS(Apple Silicon) 上安装 `openldap` 的默认位置。`/usr/local/opt/openldap/` 是 brew 在 macOS(Intel) 上安装 openldap 的默认位置。
-
-:::
-
 如果你不再需要 APISIX，可以执行以下命令卸载：
 
 ```shell

--- a/t/chaos/utils/Dockerfile
+++ b/t/chaos/utils/Dockerfile
@@ -31,7 +31,6 @@ RUN set -x \
     pkgconfig \
     cmake \
     git \
-    openldap-dev \
     pcre-dev \
     sudo \
     && cd apisix \
@@ -51,7 +50,6 @@ RUN set -x \
         bash \
         curl \
         libstdc++ \
-        openldap \
         pcre \
         tzdata
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #7865 

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->

Modified files checklist based on original issue:

- [x] .github/workflows/fuzzing-ci.yaml:53: sudo apt-get install -y git openresty curl openresty-openssl111-dev unzip make gcc libldap2-dev
- [x] ci/centos7-ci.sh:26: git sudo openldap-devel which libxml2-devel openssl-devel libxslt-devel
- [x] ci/common.sh:130: apt install -y cpanminus build-essential libncurses5-dev libreadline-dev libssl-dev perl libpcre3 libpcre3-dev libldap2-dev
- [x] ci/performance_test.sh:25: apt-get -y install lua5.1 liblua5.1-0-dev libldap2-dev
- [x] ci/pod/docker-compose.plugin.yml:148: openldap:
- [x] docs/en/latest/building-apisix.md:94: brew install openldap
    - did nt modify the documentation page since I am not too sure if I could remove the whole section of installing `openldap` or not
- [x] t/chaos/utils/Dockerfile:34: openldap-dev
- [x] utils/install-dependencies.sh:49: local common_dep="curl wget git gcc openresty-openssl111-devel unzip pcre pcre-devel openldap-devel"
- [x] utils/install-dependencies.sh:87: sudo apt-get install -y git openresty curl openresty-openssl111-dev make gcc libpcre3 libpcre3-dev libldap2-dev unzip
- [x] utils/install-dependencies.sh:93: brew install openresty/brew/openresty luarocks lua@5.1 wget curl git pcre openldap
- [x] utils/linux-install-openresty.sh:51:sudo apt-get install "$openresty" openresty-openssl111-debug-dev libldap2-dev
    - `utils/linux-install-openresty.sh` could not be found
