### PR TITLE
fix: graphql post request route matching exception

### DIFF
--- a/apisix/http/route.lua
+++ b/apisix/http/route.lua
@@ -109,6 +109,7 @@ function _M.match_uri(uri_router, api_ctx)
     match_opts.host = api_ctx.var.host
     match_opts.remote_addr = api_ctx.var.remote_addr
     match_opts.vars = api_ctx.var
+    match_opts.matched = {}
 
     local ok = uri_router:dispatch(api_ctx.var.uri, match_opts, api_ctx, match_opts)
     core.tablepool.release("route_match_opts", match_opts)

--- a/apisix/http/route.lua
+++ b/apisix/http/route.lua
@@ -84,7 +84,7 @@ function _M.create_radixtree_uri_router(routes, uri_routes, with_parameter)
                 handler = function (api_ctx, match_opts)
                     api_ctx.matched_params = nil
                     api_ctx.matched_route = route
-                    api_ctx.curr_req_matched = match_opts.matched
+                    api_ctx.curr_req_matched = core.table.deepcopy(match_opts.matched)
                 end
             })
 
@@ -103,15 +103,15 @@ function _M.create_radixtree_uri_router(routes, uri_routes, with_parameter)
 end
 
 
-function _M.match_uri(uri_router, match_opts, api_ctx)
-    core.table.clear(match_opts)
+function _M.match_uri(uri_router, api_ctx)
+    local match_opts = core.tablepool.fetch("route_match_opts", 0, 16)
     match_opts.method = api_ctx.var.request_method
     match_opts.host = api_ctx.var.host
     match_opts.remote_addr = api_ctx.var.remote_addr
     match_opts.vars = api_ctx.var
-    match_opts.matched = core.tablepool.fetch("matched_route_record", 0, 4)
 
     local ok = uri_router:dispatch(api_ctx.var.uri, match_opts, api_ctx, match_opts)
+    core.tablepool.release("route_match_opts", match_opts)
     return ok
 end
 

--- a/apisix/http/route.lua
+++ b/apisix/http/route.lua
@@ -84,7 +84,7 @@ function _M.create_radixtree_uri_router(routes, uri_routes, with_parameter)
                 handler = function (api_ctx, match_opts)
                     api_ctx.matched_params = nil
                     api_ctx.matched_route = route
-                    api_ctx.curr_req_matched = core.table.deepcopy(match_opts.matched)
+                    api_ctx.curr_req_matched = match_opts.matched
                 end
             })
 
@@ -104,12 +104,12 @@ end
 
 
 function _M.match_uri(uri_router, api_ctx)
-    local match_opts = core.tablepool.fetch("route_match_opts", 0, 16)
+    local match_opts = core.tablepool.fetch("route_match_opts", 0, 4)
     match_opts.method = api_ctx.var.request_method
     match_opts.host = api_ctx.var.host
     match_opts.remote_addr = api_ctx.var.remote_addr
     match_opts.vars = api_ctx.var
-    match_opts.matched = {}
+    match_opts.matched = core.tablepool.fetch("matched_route_record", 0, 4)
 
     local ok = uri_router:dispatch(api_ctx.var.uri, match_opts, api_ctx, match_opts)
     core.tablepool.release("route_match_opts", match_opts)

--- a/apisix/http/router/radixtree_host_uri.lua
+++ b/apisix/http/router/radixtree_host_uri.lua
@@ -78,11 +78,10 @@ local function push_host_router(route, host_routes, only_uri_routes)
         vars = route.value.vars,
         filter_fun = filter_fun,
         handler = function (api_ctx, match_opts)
-            local matched = core.table.deepcopy(match_opts.matched)
             api_ctx.matched_params = nil
             api_ctx.matched_route = route
-            api_ctx.curr_req_matched = matched
-            api_ctx.real_curr_req_matched_path = matched._path
+            api_ctx.curr_req_matched = match_opts.matched
+            api_ctx.real_curr_req_matched_path = match_opts.matched._path
         end
     }
 
@@ -166,7 +165,7 @@ function _M.matching(api_ctx)
     match_opts.remote_addr = api_ctx.var.remote_addr
     match_opts.vars = api_ctx.var
     match_opts.host = api_ctx.var.host
-    match_opts.matched = {}
+    match_opts.matched = core.tablepool.fetch("matched_route_record", 0, 4)
 
     if host_router then
         local host_uri = api_ctx.var.host

--- a/apisix/http/router/radixtree_host_uri.lua
+++ b/apisix/http/router/radixtree_host_uri.lua
@@ -166,6 +166,7 @@ function _M.matching(api_ctx)
     match_opts.remote_addr = api_ctx.var.remote_addr
     match_opts.vars = api_ctx.var
     match_opts.host = api_ctx.var.host
+    match_opts.matched = {}
 
     if host_router then
         local host_uri = api_ctx.var.host

--- a/apisix/http/router/radixtree_uri.lua
+++ b/apisix/http/router/radixtree_uri.lua
@@ -27,7 +27,6 @@ local _M = {version = 0.2}
 
     local uri_routes = {}
     local uri_router
-    local match_opts = {}
 function _M.match(api_ctx)
     local user_routes = _M.user_routes
     local _, service_version = get_services()
@@ -51,8 +50,7 @@ end
 
 function _M.matching(api_ctx)
     core.log.info("route match mode: radixtree_uri")
-
-    return base_router.match_uri(uri_router, match_opts, api_ctx)
+    return base_router.match_uri(uri_router, api_ctx)
 end
 
 

--- a/apisix/http/router/radixtree_uri_with_parameter.lua
+++ b/apisix/http/router/radixtree_uri_with_parameter.lua
@@ -27,7 +27,6 @@ local _M = {}
 
     local uri_routes = {}
     local uri_router
-    local match_opts = {}
 function _M.match(api_ctx)
     local user_routes = _M.user_routes
     local _, service_version = get_services()
@@ -51,8 +50,7 @@ end
 
 function _M.matching(api_ctx)
     core.log.info("route match mode: radixtree_uri_with_parameter")
-
-    return base_router.match_uri(uri_router, match_opts, api_ctx)
+    return base_router.match_uri(uri_router, api_ctx)
 end
 
 

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -883,10 +883,6 @@ function _M.http_log_phase()
         core.tablepool.release("plugins", api_ctx.plugins)
     end
 
-    if api_ctx.curr_req_matched then
-        core.tablepool.release("matched_route_record", api_ctx.curr_req_matched)
-    end
-
     core.tablepool.release("api_ctx", api_ctx)
 end
 

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -883,6 +883,10 @@ function _M.http_log_phase()
         core.tablepool.release("plugins", api_ctx.plugins)
     end
 
+    if api_ctx.curr_req_matched then
+        core.tablepool.release("matched_route_record", api_ctx.curr_req_matched)
+    end
+
     core.tablepool.release("api_ctx", api_ctx)
 end
 

--- a/t/cli/test_route_match_with_graphql.sh
+++ b/t/cli/test_route_match_with_graphql.sh
@@ -52,7 +52,7 @@ routes:
       - test.com
     plugins:
       echo:
-        body: "test server\n"
+        body: "test server"
     priority: 20
     id: "graphql2"
     upstream_id: "invalid"
@@ -62,7 +62,7 @@ routes:
       - test2.com
     plugins:
       echo:
-        body: "test2\n"
+        body: "test2"
     priority: 20
     id: "graphql3"
     upstream_id: "invalid"

--- a/t/cli/test_route_match_with_graphql.sh
+++ b/t/cli/test_route_match_with_graphql.sh
@@ -56,7 +56,7 @@ routes:
     priority: 20
     id: "graphql2"
     upstream_id: "invalid"
-  
+
   - uri: "/hello"
     hosts:
       - test2.com

--- a/t/cli/test_route_match_with_graphql.sh
+++ b/t/cli/test_route_match_with_graphql.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+. ./t/cli/common.sh
+
+echo '
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+
+apisix:
+  router:
+    http: radixtree_uri
+
+nginx_config:
+  worker_processes: 1
+
+' > conf/config.yaml
+
+echo '
+routes:
+  - uri: "/hello"
+    hosts:
+      - test.com
+    vars:
+      - - "graphql_name"
+        - "=="
+        - "createAccount"
+    priority: 30
+    id: "graphql1"
+    upstream_id: "invalid"
+
+  - uri: "/hello"
+    hosts:
+      - test.com
+    plugins:
+      echo:
+        body: "test server\n"
+    priority: 20
+    id: "graphql2"
+    upstream_id: "invalid"
+  
+  - uri: "/hello"
+    hosts:
+      - test2.com
+    plugins:
+      echo:
+        body: "test2\n"
+    priority: 20
+    id: "graphql3"
+    upstream_id: "invalid"
+
+upstreams:
+  - nodes:
+      127.0.0.1:1999: 1
+    id: "invalid"
+#END
+' > conf/apisix.yaml
+
+make run
+
+dd if=/dev/urandom of=tmp_data.json bs=300K count=1
+
+for i in {1..100}; do
+    curl -s http://127.0.0.1:9080/hello -H "Host: test.com" -H "Content-Type: application/json" -X POST -d @tmp_data.json > /tmp/graphql_request1.txt &
+    curl -s http://127.0.0.1:9080/hello -H "Host: test2.com" -H "Content-Type: application/json" -X POST -d @tmp_data.json > /tmp/graphql_request2.txt &
+
+    wait
+
+    if diff /tmp/graphql_request1.txt /tmp/graphql_request2.txt > /dev/null; then
+        make stop
+        echo "failed: route match error in GraphQL requests, route should not be the same"
+        exit 1
+    fi
+done
+
+make stop
+
+rm tmp_data.json /tmp/graphql_request1.txt /tmp/graphql_request2.txt
+
+echo "passed: GraphQL requests can be correctly matched to the route"


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Reuse of `match_opts` causes the value of the next request to overwrite the value of the current request. GraphQL requests call the `ngx.req.read_body` API, which is a non-blocking call. If the request body has not been fully read (for example, if the body size exceeds the nginx buffer), the coroutine will yield. If there are other requests during this time period, `match_opts` will be contaminated by other requests, resulting in matching the wrong route.

Fixes: #10197 

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
