### PR TITLE
feat: support log with traceid when enable the zipkin plugin

### DIFF
--- a/apisix/core/log.lua
+++ b/apisix/core/log.lua
@@ -61,6 +61,12 @@ local function update_log_level()
     end
 end
 
+local function get_trace_id()
+    if ngx_get_phase() ~= "init" and ngx.config.subsystem == "http"  then
+        return ngx.ctx.trace_id
+    end
+    return ''
+end
 
 function _M.new(prefix)
     local m = {version = _M.version}
@@ -91,6 +97,7 @@ function _M.new(prefix)
 end
 
 
+
 setmetatable(_M, {__index = function(self, cmd)
     local log_level = log_levels[cmd]
     local method
@@ -101,7 +108,7 @@ setmetatable(_M, {__index = function(self, cmd)
         method = do_nothing
     else
         method = function(...)
-            return ngx_log(log_level, ...)
+            return ngx_log(log_level, get_trace_id(), " ", ...)
         end
     end
 

--- a/apisix/core/log.lua
+++ b/apisix/core/log.lua
@@ -63,7 +63,10 @@ end
 
 local function get_trace_id()
     if ngx_get_phase() ~= "init" and ngx.config.subsystem == "http"  then
-        return ngx.ctx.trace_id or ''
+        local trace_id = ngx.ctx.trace_id
+        if trace_id then
+            return trace_id .. " "
+        end
     end
     return ''
 end
@@ -108,7 +111,7 @@ setmetatable(_M, {__index = function(self, cmd)
         method = do_nothing
     else
         method = function(...)
-            return ngx_log(log_level, get_trace_id(), " ", ...)
+            return ngx_log(log_level, get_trace_id(), ...)
         end
     end
 

--- a/apisix/core/log.lua
+++ b/apisix/core/log.lua
@@ -63,7 +63,7 @@ end
 
 local function get_trace_id()
     if ngx_get_phase() ~= "init" and ngx.config.subsystem == "http"  then
-        return ngx.ctx.trace_id
+        return ngx.ctx.trace_id or ''
     end
     return ''
 end

--- a/apisix/plugins/zipkin.lua
+++ b/apisix/plugins/zipkin.lua
@@ -23,6 +23,7 @@ local ngx = ngx
 local ngx_re = require("ngx.re")
 local pairs = pairs
 local tonumber = tonumber
+local to_hex = require "resty.string".to_hex
 
 local plugin_name = "zipkin"
 local ZIPKIN_SPAN_VER_1 = 1
@@ -219,6 +220,10 @@ function _M.rewrite(plugin_conf, ctx)
         ctx.opentracing.proxy_span = request_span:start_child_span("apisix.proxy",
                                                                    start_timestamp)
     end
+    -- To set the traceId for the purpose of conveniently retrieving it when logging with core.log,
+    -- it will be automatically injected into the text.
+    local trace_id = request_span:context().trace_id
+    ngx.ctx.trace_id = to_hex(trace_id)
 end
 
 function _M.access(conf, ctx)


### PR DESCRIPTION
### Description

As a user, I would like to automatically include the traceId when logging, especially when I have enabled the Zipkin plugin. This will make it easier for me to quickly identify the logs associated with a particular traceId when troubleshooting issues. Currently, manually concatenating the traceId with each log entry is cumbersome and not user-friendly. I hope that this issue can be addressed at the architectural level.

feat #10209 

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
