### PR TITLE
feat: support configuring the buffer size of the access log

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -365,7 +365,11 @@ http {
     log_format main escape={* http.access_log_format_escape *} '{* http.access_log_format *}';
     uninitialized_variable_warn off;
 
+    {% if http.access_log_buffer then %}
+    access_log {* http.access_log *} main buffer={* http.access_log_buffer *} flush=3;
+    {% else %}
     access_log {* http.access_log *} main buffer=16384 flush=3;
+    {% end %}
     {% end %}
     open_file_cache  max=1000 inactive=60;
     client_max_body_size {* http.client_max_body_size *};

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -212,6 +212,7 @@ nginx_config:                     # Config for render the template to generate n
   http:
     enable_access_log: true             # Enable HTTP proxy access logging.
     access_log: logs/access.log         # Location of the access log.
+    access_log_buffer: 16384            # buffer size of access log.
     access_log_format: "$remote_addr - $remote_user [$time_local] $http_host \"$request\" $status $body_bytes_sent $request_time \"$http_referer\" \"$http_user_agent\" $upstream_addr $upstream_status $upstream_response_time \"$upstream_scheme://$upstream_host$upstream_uri\""
     # Customize log format: http://nginx.org/en/docs/varindex.html
     access_log_format_escape: default   # Escape default or json characters in variables.


### PR DESCRIPTION
### Description

access log's buffer size can be configed.

Access log buffering can significantly reduce disk I/O and improve server performance. Enabling access log buffering is relatively simple in NGINX. To do this, use the following directive in your NGINX configuration:

access_log /var/log/nginx/access.log main buffer=32k;
This directive tells NGINX to store the access log entries in a buffer of size 32k before writing them to the log file. Increasing the buffer size can minimize the number of write operations to the disk, resulting in improved performance.

Fixes #10219

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
