### PR TITLE
fix: Label http_requests_total metric as counter

### DIFF
--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -138,7 +138,7 @@ function _M.http_init(prometheus_enabled_in_stream)
             "Number of HTTP connections",
             {"state"})
 
-    metrics.requests = prometheus:gauge("http_requests_total",
+    metrics.requests = prometheus:counter("http_requests_total",
             "The total number of client requests since APISIX started")
 
     metrics.etcd_reachable = prometheus:gauge("etcd_reachable",

--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -310,7 +310,7 @@ apisix_http_status{code="200",route="1",matched_uri="/hello",matched_host="",ser
 apisix_http_status{code="200",route="2",matched_uri="/world",matched_host="",service="",consumer="",node="127.0.0.1"} 4
 apisix_http_status{code="404",route="",matched_uri="",matched_host="",service="",consumer="",node=""} 1
 # HELP apisix_http_requests_total The total number of client requests
-# TYPE apisix_http_requests_total gauge
+# TYPE apisix_http_requests_total counter
 apisix_http_requests_total 1191780
 # HELP apisix_nginx_http_current_connections Number of HTTP connections
 # TYPE apisix_nginx_http_current_connections gauge

--- a/docs/en/latest/tutorials/monitor-api-health-check.md
+++ b/docs/en/latest/tutorials/monitor-api-health-check.md
@@ -156,7 +156,7 @@ Example Output:
 
 ```bash
 # HELP apisix_http_requests_total The total number of client requests since APISIX started
-# TYPE apisix_http_requests_total gauge
+# TYPE apisix_http_requests_total counter
 apisix_http_requests_total 119740
 # HELP apisix_http_status HTTP status codes per service in APISIX
 # TYPE apisix_http_status counter

--- a/docs/zh/latest/plugins/prometheus.md
+++ b/docs/zh/latest/plugins/prometheus.md
@@ -280,7 +280,7 @@ apisix_http_status{code="200",route="1",matched_uri="/hello",matched_host="",ser
 apisix_http_status{code="200",route="2",matched_uri="/world",matched_host="",service="",consumer="",node="127.0.0.1"} 4
 apisix_http_status{code="404",route="",matched_uri="",matched_host="",service="",consumer="",node=""} 1
 # HELP apisix_http_requests_total The total number of client requests
-# TYPE apisix_http_requests_total gauge
+# TYPE apisix_http_requests_total counter
 apisix_http_requests_total 1191780
 # HELP apisix_nginx_http_current_connections Number of HTTP connections
 # TYPE apisix_nginx_http_current_connections gauge


### PR DESCRIPTION
### Description
The number never goes down, except for when it gets reset to zero, which is in line with the definition from [Prometheus docs](https://prometheus.io/docs/concepts/metric_types/#counter).
> A counter is a cumulative metric that represents a single monotonically increasing counter whose value can only increase or be reset to zero on restart. For example, you can use a counter to represent the number of requests served, tasks completed, or errors.

Fixes #10289 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
