### PR TITLE
fix: keep healthcheck target state when upstream changes

### DIFF
--- a/apisix/core/config_util.lua
+++ b/apisix/core/config_util.lua
@@ -114,7 +114,7 @@ function _M.fire_all_clean_handlers(item)
         clean_handler.f(item)
     end
 
-    item.clean_handlers = nil
+    item.clean_handlers = {}
 end
 
 

--- a/apisix/upstream.lua
+++ b/apisix/upstream.lua
@@ -83,7 +83,7 @@ _M.set = set_directly
 local function release_checker(healthcheck_parent)
     local checker = healthcheck_parent.checker
     core.log.info("try to release checker: ", tostring(checker))
-    checker:clear()
+    checker:delayed_clear(3)
     checker:stop()
 end
 

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -145,7 +145,7 @@ nginx_config:                     # Config for render the template to generate n
                                   # effective if the master process runs with super-user privileges.
   error_log: logs/error.log       # Location of the error log.
   error_log_level:  warn          # Logging level: info, debug, notice, warn, error, crit, alert, or emerg.
-  worker_processes: auto          # Automatically determine the optimal number of worker processes based
+  worker_processes: 4          # Automatically determine the optimal number of worker processes based
                                   # on the available system resources.
                                   # If you want use multiple cores in container, you can inject the number of
                                   # CPU cores as environment variable "APISIX_WORKER_PROCESSES".

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -145,7 +145,7 @@ nginx_config:                     # Config for render the template to generate n
                                   # effective if the master process runs with super-user privileges.
   error_log: logs/error.log       # Location of the error log.
   error_log_level:  warn          # Logging level: info, debug, notice, warn, error, crit, alert, or emerg.
-  worker_processes: 4          # Automatically determine the optimal number of worker processes based
+  worker_processes: auto          # Automatically determine the optimal number of worker processes based
                                   # on the available system resources.
                                   # If you want use multiple cores in container, you can inject the number of
                                   # CPU cores as environment variable "APISIX_WORKER_PROCESSES".

--- a/t/node/healthcheck-leak-bugfix.t
+++ b/t/node/healthcheck-leak-bugfix.t
@@ -31,8 +31,8 @@ __DATA__
     local new = healthcheck.new
     healthcheck.new = function(...)
         local obj = new(...)
-        local clear = obj.clear
-        obj.clear = function(...)
+        local clear = obj.delayed_clear
+        obj.delayed_clear = function(...)
             ngx.log(ngx.WARN, "clear checker")
             return clear(...)
         end


### PR DESCRIPTION
### Description

When we modify the upstream (adding or deleting nodes), APISIX first deletes the health check object and then recreates the health check object. The process of deletion and recreation may affect other parallel requests searching for healthy nodes, leading to the following error:
![image](https://github.com/apache/apisix/assets/9354193/c69bf191-08c0-4851-893d-70832f009191)
So we will replace `checker:clear()` with function `checker:delayed_clear()`. This function marks all targets to be removed, but do not actually remove them. If before the delay parameter any of them is re-added, it is unmarked for removal.
This function makes it possible to keep target state during config changes, where the targets might be removed and then re-added.

It's very hard to add test cases. I tried but failed.

Follow these steps to reproduce:

1. create a router
```
curl http://127.0.0.1:9180/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
{
    "uri": "/get",
    "upstream_id": 1
}'
```
2. Keep updating the upstream object
```
curl http://127.0.0.1:9180/apisix/admin/upstreams/1 \
-H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
{
    "type": "chash",
    "key": "remote_addr",
    "nodes": {
        "127.0.0.1:8080": 1,
        "127.0.0.1:8081": 1,
        "127.0.0.1:8082": 1,
        "127.0.0.1:8083": 1,
        "127.0.0.1:8084": 1,
        "127.0.0.1:8085": 1,
        "127.0.0.1:8086": 1,
        "127.0.0.1:8087": 1,
        "127.0.0.1:8088": 1,
        "127.0.0.1:8089": 1,
        "127.0.0.1:8090": 1
    },
    "retries": 2,
    "checks": {
        "active": {
            "timeout": 5,
            "http_path": "/status",
            "healthy": {
                "interval": 2,
                "successes": 1
            },
            "unhealthy": {
                "interval": 1,
                "http_failures": 2
            }
        }
    }
}'
```
3. Keep sending requests
```
wrk -c 10 -t 5 -d 500s -R 200 http://127.0.0.1:9080/get
```
4. Pay attention to the error.log

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)


