### PR TITLE
fix: add name field in plugin_config schema for consistency

### DIFF
--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -949,6 +949,9 @@ _M.plugins = {
 _M.plugin_config = {
     type = "object",
     properties = {
+        name = {
+            type = "string",
+        },
         id = id_schema,
         desc = desc_def,
         plugins = plugins_schema,


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes https://github.com/apache/apisix-ingress-controller/issues/2003
All core resources like service, upstream , route, plugin have name field but plugin_config doesn't and after this PR where additional fields were [prohibited](https://github.com/apache/apisix/pull/10233), passing name in plugin_config gives an error. Ingress controller currently doesn't differentiate and adds name to plugin_config as well so currently there is this issue between apisix and ingress controller.

So this PR adds the name field to plugin_config to solve the compatibility issue and also for consistency

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
