### PR TITLE
test: correct the customized-config-path name in test_cmd.sh

### DIFF
--- a/t/cli/test_cmd.sh
+++ b/t/cli/test_cmd.sh
@@ -87,7 +87,7 @@ deployment:
 # check if .customized_config_path has been created
 if [ ! -e conf/.customized_config_path ]; then
     rm conf/customized_config.yaml
-    echo ".config_path file should exits"
+    echo ".customized_config_path should exits"
     exit 1
 fi
 
@@ -102,9 +102,9 @@ fi
 make stop
 
 # check if .customized_config_path has been removed
-if [ -e conf/.config_path ]; then
+if [ -e conf/.customized_config_path ]; then
     rm conf/customized_config_path.yaml
-    echo ".config_path file should be removed"
+    echo ".customized_config_path should be removed"
     exit 1
 fi
 


### PR DESCRIPTION
### Description

correct the customized-config-path name in test_cmd.sh

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
