### PR TITLE
test: use http2 to test limit-req plugin

### DIFF
--- a/t/plugin/limit-req3.t
+++ b/t/plugin/limit-req3.t
@@ -123,7 +123,7 @@ passed
 apisix:
   ssl:
     enable: true
-    listen:                                       # APISIX listening port for HTTPS traffic.
+    listen:
       - port: 9443
         enable_http2: true
 --- exec

--- a/t/plugin/limit-req3.t
+++ b/t/plugin/limit-req3.t
@@ -24,9 +24,6 @@ no_root_location();
 
 add_block_preprocessor(sub {
     my ($block) = @_;
-    my $port = $ENV{TEST_NGINX_SERVER_PORT};
-
-    my $TEST_NGINX_HTML_DIR ||= html_dir();
 
     if (!$block->request) {
         $block->set_value("request", "GET /t");

--- a/t/plugin/limit-req3.t
+++ b/t/plugin/limit-req3.t
@@ -28,8 +28,6 @@ add_block_preprocessor(sub {
 
     my $TEST_NGINX_HTML_DIR ||= html_dir();
 
-    $block->set_value("config", $config);
-
     if (!$block->request) {
         $block->set_value("request", "GET /t");
     }
@@ -85,9 +83,6 @@ passed
 
 
 === TEST 2: create ssl(sni: www.test.com)
---- yaml_config
-apisix:
-    node_listen: 1984
 --- config
 location /t {
     content_by_lua_block {
@@ -116,14 +111,7 @@ passed
 
 
 === TEST 3: use HTTP version 2 to request
---- yaml_config
-apisix:
-  ssl:
-    enable: true
-    listen:
-      - port: 9443
-        enable_http2: true
 --- exec
-curl --http2 --parallel -k https://www.test.com:9443/hello https://www.test.com:9443/hello --resolve www.test.com:9443:127.0.0.1
+curl --http2 --parallel -k https://www.test.com:1994/hello https://www.test.com:1994/hello --resolve www.test.com:1994:127.0.0.1
 --- response_body_like
 503 Service Temporarily Unavailable.*.hello world

--- a/t/plugin/limit-req3.t
+++ b/t/plugin/limit-req3.t
@@ -27,9 +27,6 @@ add_block_preprocessor(sub {
     my $port = $ENV{TEST_NGINX_SERVER_PORT};
 
     my $TEST_NGINX_HTML_DIR ||= html_dir();
-    my $config = $block->config // <<_EOC_;
-    listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
-_EOC_
 
     $block->set_value("config", $config);
 

--- a/t/plugin/limit-req3.t
+++ b/t/plugin/limit-req3.t
@@ -1,0 +1,132 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+log_level('info');
+repeat_each(1);
+no_long_string();
+no_shuffle();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+    my $port = $ENV{TEST_NGINX_SERVER_PORT};
+
+    my $TEST_NGINX_HTML_DIR ||= html_dir();
+    my $config = $block->config // <<_EOC_;
+    listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+_EOC_
+
+    $block->set_value("config", $config);
+
+    if (!$block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+    if (!$block->error_log && !$block->no_error_log) {
+        $block->set_value("no_error_log", "[error]\n[alert]");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: create route with limit-req plugin
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "plugins": {
+                        "limit-req": {
+                            "rate": 0.1,
+                            "burst": 0.1,
+                            "rejected_code": 503,
+                            "key": "$remote_addr",
+                            "key_type": "var_combination"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello",
+                    "host": "www.test.com"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 2: create ssl(sni: www.test.com)
+--- yaml_config
+apisix:
+    node_listen: 1984
+--- config
+location /t {
+    content_by_lua_block {
+        local core = require("apisix.core")
+        local t = require("lib.test_admin")
+        local ssl_cert = t.read_file("t/certs/apisix.crt")
+        local ssl_key =  t.read_file("t/certs/apisix.key")
+        local data = {cert = ssl_cert, key = ssl_key, sni = "www.test.com"}
+        local code, body = t.test('/apisix/admin/ssls/1',
+            ngx.HTTP_PUT,
+            core.json.encode(data),
+            [[{
+                "value": {
+                    "sni": "www.test.com"
+                },
+                "key": "/apisix/ssls/1"
+            }]]
+            )
+        ngx.status = code
+        ngx.say(body)
+    }
+}
+--- response_body
+passed
+
+
+
+=== TEST 3: use HTTP version 2 to request
+--- yaml_config
+apisix:
+  ssl:
+    enable: true
+    listen:                                       # APISIX listening port for HTTPS traffic.
+      - port: 9443
+        enable_http2: true
+--- exec
+curl --http2 --parallel -k https://www.test.com:9443/hello https://www.test.com:9443/hello --resolve www.test.com:9443:127.0.0.1
+--- response_body_like
+503 Service Temporarily Unavailable.*.hello world


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

In this PR, I use curl send http2 request to test the limit-req plugin.



### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
