### PR TITLE
chore: remove stream_proxy.only in config-default.yaml

### DIFF
--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -76,7 +76,6 @@ apisix:
   # http is the default proxy mode. proxy_mode can be one of `http`, `stream`, or `http&stream`
   proxy_mode: http
   # stream_proxy:                 # TCP/UDP L4 proxy
-  #   only: true                  # Enable L4 proxy only without L7 proxy.
   #   tcp:
   #     - addr: 9100              # Set the TCP proxy listening ports.
   #       tls: true


### PR DESCRIPTION
### Description

 Remove the configuration item `apisix.stream_proxy.only`, the L4/L7 proxy needs to be enabled through the configuration item `apisix.proxy_mode`: [#9607](https://github.com/apache/apisix/pull/9607)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

