### PR TITLE
fix: fix consul plugin worker will not exit while reload or quit

### DIFF
--- a/apisix/discovery/consul/init.lua
+++ b/apisix/discovery/consul/init.lua
@@ -29,6 +29,7 @@ local tonumber           = tonumber
 local pairs              = pairs
 local ngx_timer_at       = ngx.timer.at
 local ngx_timer_every    = ngx.timer.every
+local exiting            = ngx.worker.exiting
 local log                = core.log
 local json_delay_encode  = core.json.delay_encode
 local ngx_worker_id      = ngx.worker.id
@@ -530,7 +531,9 @@ function _M.connect(premature, consul_server, retry_delay)
                 health_res.headers['X-Consul-Index'])
     end
 
-    check_keepalive(consul_server, retry_delay)
+    if not exiting() then
+        check_keepalive(consul_server, retry_delay)
+    end
 end
 
 

--- a/apisix/discovery/consul/init.lua
+++ b/apisix/discovery/consul/init.lua
@@ -29,10 +29,10 @@ local tonumber           = tonumber
 local pairs              = pairs
 local ngx_timer_at       = ngx.timer.at
 local ngx_timer_every    = ngx.timer.every
-local exiting            = ngx.worker.exiting
 local log                = core.log
 local json_delay_encode  = core.json.delay_encode
 local ngx_worker_id      = ngx.worker.id
+local exiting            = ngx.worker.exiting
 local thread_spawn       = ngx.thread.spawn
 local thread_wait        = ngx.thread.wait
 local thread_kill        = ngx.thread.kill
@@ -277,7 +277,7 @@ end
 
 
 local function check_keepalive(consul_server, retry_delay)
-    if consul_server.keepalive then
+    if consul_server.keepalive and not exiting() then
         local ok, err = ngx_timer_at(0, _M.connect, consul_server, retry_delay)
         if not ok then
             log.error("create ngx_timer_at got error: ", err)
@@ -531,9 +531,7 @@ function _M.connect(premature, consul_server, retry_delay)
                 health_res.headers['X-Consul-Index'])
     end
 
-    if not exiting() then
-        check_keepalive(consul_server, retry_delay)
-    end
+    check_keepalive(consul_server, retry_delay)
 end
 
 


### PR DESCRIPTION
### Description

**1.configure**

config.yaml

discovery:
  consul:
    servers:
       - "http://localhost:8500"
    keepalive: true

Version: 3.6.0


**2.situation**
Using the consul service, I found that there is a process leak. When reloading or quitting, there will be a nginx process shutting down and never exit.
When nginx reloads, the consul worker with keepalive turned on will not exit normally, will be in shutting down state, and will always access consul's health api.
You only need to make a judgment before creating a new timer to solve the process leak.
This problem does not exist when keepalive is false, but there will be an obvious memory leak.

htop -p $(pgrep -d',' -f "nginx")
<img width="831" alt="image" src="https://github.com/apache/apisix/assets/47879179/bb46a8cc-01ae-4fe6-9f66-a42ff66cfc5f">
process will not exit!

To process exit when testing, please change consul node state.

**3.testing**
start consul discovery, and try to `apisix reload && htop -p $(pgrep -d',' -f "nginx")`.  The process in shutting down, and nerver exit even if you set timeout.
after pull this commit, set shutting down timeout 300 seconds or change consul node info, the shutting down process will exit after node info changing or timeout.

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
