### PR TITLE
docs: update the default cache TTL to 300s for `proxy-cache` plugin

### DIFF
--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -48,7 +48,7 @@ apisix:
   # lua_module_hook: "my_project.my_hook"  # Hook module used to inject third-party code into APISIX.
 
   proxy_cache:      # Proxy Caching configuration
-    cache_ttl: 10s  # The default caching time on disk if the upstream does not specify a caching time.
+    cache_ttl: 300s  # The default caching time on disk if the upstream does not specify a caching time.
     zones:
       - name: disk_cache_one    # Name of the cache.
         memory_size: 50m        # Size of the memory to store the cache index.

--- a/docs/en/latest/plugins/proxy-cache.md
+++ b/docs/en/latest/plugins/proxy-cache.md
@@ -62,7 +62,7 @@ You can add your cache configuration in you APISIX configuration file (`conf/con
 ```yaml title="conf/config.yaml"
 apisix:
   proxy_cache:
-    cache_ttl: 10s  # default cache TTL for caching on disk
+    cache_ttl: 300s  # The default caching time on disk if the upstream does not specify a caching time.
     zones:
       - name: disk_cache_one
         memory_size: 50m

--- a/docs/en/latest/tutorials/cache-api-responses.md
+++ b/docs/en/latest/tutorials/cache-api-responses.md
@@ -89,7 +89,7 @@ You can add your cache configuration in the same file if you need to specify val
 
 ``` yaml
 proxy_cache:
- cache_ttl: 10s # default caching time if the upstream doesn't specify the caching time
+ cache_ttl: 300s # The default caching time on disk if the upstream does not specify a caching time.
  zones:
  - name: disk_cache_one # name of the cache. Admin can specify which cache to use in the Admin API by name
  memory_size: 50m # size of shared memory, used to store the cache index

--- a/docs/zh/latest/plugins/proxy-cache.md
+++ b/docs/zh/latest/plugins/proxy-cache.md
@@ -60,7 +60,7 @@ description: 本文介绍了 Apache APISIX proxy-cache 插件的相关操作，�
 ```yaml title="conf/config.yaml"
 apisix:
   proxy_cache:
-    cache_ttl: 10s  # 如果上游未指定缓存时间，则为默认磁盘缓存时间
+    cache_ttl: 300s  # 如果上游未指定缓存时间，则为默认磁盘缓存时间
     zones:
       - name: disk_cache_one
         memory_size: 50m


### PR DESCRIPTION
### Description

In the schema it is 300s:

https://github.com/apache/apisix/blob/3a87611f93fb2de9fb36b3f87d3bc7a530ca5f52/apisix/plugins/proxy-cache/init.lua#L101-L105

Despite

https://github.com/apache/apisix/blob/3a87611f93fb2de9fb36b3f87d3bc7a530ca5f52/apisix/cli/ngx_tpl.lua#L733

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
