### PR TITLE
fix: post_arg match fails because content-type contains charset

### DIFF
--- a/apisix/core/ctx.lua
+++ b/apisix/core/ctx.lua
@@ -260,7 +260,9 @@ do
 
             elseif core_str.has_prefix(key, "post_arg_") then
                 -- only match default post form
-                if request.header(nil, "Content-Type") == "application/x-www-form-urlencoded" then
+                local content_type = request.header(nil, "Content-Type")
+                if content_type ~= nil and core_str.has_prefix(content_type,
+                        "application/x-www-form-urlencoded") then
                     local arg_key = sub_str(key, 10)
                     local args = request.get_post_args()[arg_key]
                     if args then

--- a/t/core/ctx2.t
+++ b/t/core/ctx2.t
@@ -292,7 +292,20 @@ find ctx.req_post_args.test: true
 
 
 
-=== TEST 13: missed (post_arg_test is missing)
+=== TEST 13: hit with charset
+--- request
+POST /hello
+test=test
+--- more_headers
+Content-Type: application/x-www-form-urlencoded;charset=utf-8
+--- response_body
+hello world
+--- error_log
+find ctx.req_post_args.test: true
+
+
+
+=== TEST 14: missed (post_arg_test is missing)
 --- request
 POST /hello
 --- more_headers
@@ -303,7 +316,7 @@ Content-Type: application/x-www-form-urlencoded
 
 
 
-=== TEST 14: missed (post_arg_test is mismatch)
+=== TEST 15: missed (post_arg_test is mismatch)
 --- request
 POST /hello
 test=tesy
@@ -315,7 +328,7 @@ Content-Type: application/x-www-form-urlencoded
 
 
 
-=== TEST 15: register custom variable
+=== TEST 16: register custom variable
 --- config
     location /t {
         content_by_lua_block {
@@ -351,7 +364,7 @@ Content-Type: application/x-www-form-urlencoded
 
 
 
-=== TEST 16: hit
+=== TEST 17: hit
 --- config
     location /t {
         content_by_lua_block {
@@ -375,7 +388,7 @@ find ctx.var.a6_labels_zone: Singapore
 
 
 
-=== TEST 17: register custom variable with no cacheable
+=== TEST 18: register custom variable with no cacheable
 --- config
     location /t {
         content_by_lua_block {
@@ -412,7 +425,7 @@ find ctx.var.a6_labels_zone: Singapore
 
 
 
-=== TEST 18: hit
+=== TEST 19: hit
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #10366

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
