### PR TITLE
fix:Solve the 403 problem caused by too large a request to upload the attachment body,error message"send() failed (32: Broken pipe)"

### DIFF
--- a/apisix/plugins/forward-auth.lua
+++ b/apisix/plugins/forward-auth.lua
@@ -117,7 +117,8 @@ function _M.access(conf, ctx)
 
     local httpc = http.new()
     httpc:set_timeout(conf.timeout)
-
+    local client_body_reader, err = httpc:get_client_body_reader()
+    params.body=client_body_reader
     local res, err = httpc:request_uri(conf.uri, params)
     if not res and conf.allow_degradation then
         return


### PR DESCRIPTION
… attachment body,error message"send() failed (32: Broken pipe)"

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (10375)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
