### PR TITLE
fix: Solve the 403 problem caused by too large a request to upload the attachment body,error message"send() failed (32: Broken pipe)"

### DIFF
--- a/apisix/plugins/forward-auth.lua
+++ b/apisix/plugins/forward-auth.lua
@@ -117,7 +117,8 @@ function _M.access(conf, ctx)
 
     local httpc = http.new()
     httpc:set_timeout(conf.timeout)
-
+    local client_body_reader, err = httpc:get_client_body_reader()
+    params.body=client_body_reader
     local res, err = httpc:request_uri(conf.uri, params)
     if not res and conf.allow_degradation then
         return


### PR DESCRIPTION
Solve the 403 problem caused by too large a request to upload the attachment body,error message"send() failed (32: Broken pipe)
#10375 