### PR TITLE
ci: trigger ci when the configuration file of current ci changes

### DIFF
--- a/.github/workflows/doc-lint.yml
+++ b/.github/workflows/doc-lint.yml
@@ -5,11 +5,13 @@ on:
     paths:
       - "docs/**"
       - "**/*.md"
+      - ".github/workflows/doc-lint.yml"
   pull_request:
     branches: [master, "release/**"]
     paths:
       - "docs/**"
       - "**/*.md"
+      - ".github/workflows/doc-lint.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -11,11 +11,13 @@ on:
     paths:
       - '**/*.md'
       - '**/link-check.yml'
+      - '.github/workflows/link-check.yml'
   pull_request:
     branches: [master, "release/**"]
     paths:
       - '**/*.md'
       - '**/link-check.yml'
+      - '.github/workflows/link-check.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
### Description
Now, for docs relevant ci will be triggered only when the docs have changed. But if the ci configuration file changes, it will not execute the ci. Like this [PR](https://github.com/apache/apisix/pull/10381), I can't ensure the change is well if the ci not be executed.
<!-- Please include a summary of the change and which issue is fixed. --> 
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
