### PR TITLE
docs: fix usage of incorrect admin api port

### DIFF
--- a/docs/en/latest/plugins/degraphql.md
+++ b/docs/en/latest/plugins/degraphql.md
@@ -97,7 +97,7 @@ Now we can use RESTful API to query the same data that is proxy by APISIX.
 First, we need to create a route in APISIX, and enable the degreaph plugin on the route, we need to define the GraphQL query in the plugin's config.
 
 ```bash
-curl --location --request PUT 'http://localhost:9080/apisix/admin/routes/1' \
+curl --location --request PUT 'http://localhost:9180/apisix/admin/routes/1' \
 --header 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' \
 --header 'Content-Type: application/json' \
 --data-raw '{
@@ -210,7 +210,7 @@ we can execute it on `http://localhost:8080/playground`, and get the data as bel
 We convert the GraphQL query to JSON string like `"query($name: String!, $githubAccount: String!) {\n  persons(filter: { name: $name, githubAccount: $githubAccount }) {\n    id\n    name\n    blog\n    githubAccount\n    talks {\n      id\n      title\n    }\n  }\n}"`, so we create a route like this:
 
 ```bash
-curl --location --request PUT 'http://localhost:9080/apisix/admin/routes/1' \
+curl --location --request PUT 'http://localhost:9180/apisix/admin/routes/1' \
 --header 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' \
 --header 'Content-Type: application/json' \
 --data-raw '{

--- a/docs/en/latest/plugins/grpc-transcode.md
+++ b/docs/en/latest/plugins/grpc-transcode.md
@@ -238,7 +238,7 @@ If the gRPC service returns an error, there may be a `grpc-status-details-bin` f
 Upload the proto file：
 
 ```shell
-curl http://127.0.0.1:9080/apisix/admin/protos/1 \
+curl http://127.0.0.1:9180/apisix/admin/protos/1 \
 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "content" : "syntax = \"proto3\";
@@ -260,7 +260,7 @@ curl http://127.0.0.1:9080/apisix/admin/protos/1 \
 Enable the `grpc-transcode` plugin，and set the option `show_status_in_body` to `true`：
 
 ```shell
-curl http://127.0.0.1:9080/apisix/admin/routes/1 \
+curl http://127.0.0.1:9180/apisix/admin/routes/1 \
 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "methods": ["GET"],
@@ -308,7 +308,7 @@ Server: APISIX web server
 Note that there is an undecoded field in the return body. If you need to decode the field, you need to add the `message type` of the field in the uploaded proto file.
 
 ```shell
-curl http://127.0.0.1:9080/apisix/admin/protos/1 \
+curl http://127.0.0.1:9180/apisix/admin/protos/1 \
 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "content" : "syntax = \"proto3\";
@@ -335,7 +335,7 @@ curl http://127.0.0.1:9080/apisix/admin/protos/1 \
 Also configure the option `status_detail_type` to `helloworld.ErrorDetail`.
 
 ```shell
-curl http://127.0.0.1:9080/apisix/admin/routes/1 \
+curl http://127.0.0.1:9180/apisix/admin/routes/1 \
 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "methods": ["GET"],

--- a/docs/en/latest/tutorials/add-multiple-api-versions.md
+++ b/docs/en/latest/tutorials/add-multiple-api-versions.md
@@ -105,7 +105,7 @@ docker compose up -d
 You first need to [Route](https://apisix.apache.org/docs/apisix/terminology/route/) your HTTP requests from the gateway to an [Upstream](https://apisix.apache.org/docs/apisix/terminology/upstream/) (your API). With APISIX, you can create a route by sending an HTTP request to the gateway.
 
 ```shell
-curl http://apisix:9080/apisix/admin/routes/1 -H 'X-API-KEY: xyz' -X PUT -d '
+curl http://apisix:9180/apisix/admin/routes/1 -H 'X-API-KEY: xyz' -X PUT -d '
 {
   "name": "Direct Route to Old API",
   "methods": ["GET"],
@@ -142,7 +142,7 @@ In the previous step, we created a route that wrapped an upstream inside its con
 Let's create the shared upstream by running below curl cmd:
 
 ```shell
-curl http://apisix:9080/apisix/admin/upstreams/1 -H 'X-API-KEY: xyz' -X PUT -d '
+curl http://apisix:9180/apisix/admin/upstreams/1 -H 'X-API-KEY: xyz' -X PUT -d '
 {
   "name": "Old API",
   "type": "roundrobin",
@@ -161,7 +161,7 @@ In the scope of this tutorial, we will use _URI path-based versioning_ because i
 Before introducing the new version, we also need to rewrite the query that comes to the API gateway before forwarding it to the upstream. Because both the old and new versions should point to the same upstream and the upstream exposes endpoint `/hello`, not `/v1/hello`. Let’s create a plugin configuration to rewrite the path:
 
 ```shell
-curl http://apisix:9080/apisix/admin/plugin_configs/1 -H 'X-API-KEY: xyz' -X PUT -d '
+curl http://apisix:9180/apisix/admin/plugin_configs/1 -H 'X-API-KEY: xyz' -X PUT -d '
 {
   "plugins": {
     "proxy-rewrite": {
@@ -176,7 +176,7 @@ We can now create the second versioned route that references the existing  upstr
 > Note that we can create routes for different API versions.
 
 ```shell
-curl http://apisix:9080/apisix/admin/routes/2 -H 'X-API-KEY: xyz' -X PUT -d '
+curl http://apisix:9180/apisix/admin/routes/2 -H 'X-API-KEY: xyz' -X PUT -d '
 {
   "name": "Versioned Route to Old API",
   "methods": ["GET"],
@@ -209,7 +209,7 @@ Hello world
 We have versioned our API, but our API consumers probably still use the legacy non-versioned API. We want them to migrate, but we cannot just delete the legacy route as our users are unaware of it. Fortunately, the `301 HTTP` status code is our friend: we can let users know that the resource has moved from `http://apisix.org/hello` to `http://apisix.org/v1/hello`. It requires configuring the [redirect plugin](https://apisix.apache.org/docs/apisix/plugins/redirect/) on the initial route:
 
 ```shell
-curl http://apisix:9080/apisix/admin/routes/1 -H 'X-API-KEY: xyz' -X PATCH -d '
+curl http://apisix:9180/apisix/admin/routes/1 -H 'X-API-KEY: xyz' -X PATCH -d '
 {
   "plugins": {
     "redirect": {

--- a/docs/zh/latest/plugins/grpc-transcode.md
+++ b/docs/zh/latest/plugins/grpc-transcode.md
@@ -239,7 +239,7 @@ Trailer: grpc-message
 上传 proto 文件：
 
 ```shell
-curl http://127.0.0.1:9080/apisix/admin/protos/1 \
+curl http://127.0.0.1:9180/apisix/admin/protos/1 \
 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "content" : "syntax = \"proto3\";
@@ -261,7 +261,7 @@ curl http://127.0.0.1:9080/apisix/admin/protos/1 \
 启用 `grpc-transcode` 插件，并设置选项 `show_status_in_body` 为 `true`：
 
 ```shell
-curl http://127.0.0.1:9080/apisix/admin/routes/1 \
+curl http://127.0.0.1:9180/apisix/admin/routes/1 \
 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "methods": ["GET"],
@@ -309,7 +309,7 @@ Server: APISIX web server
 注意返回体中还存在未解码的字段，如果需要解码该字段，需要在上传的 proto 文件中加上该字段对应的 `message type`。
 
 ```shell
-curl http://127.0.0.1:9080/apisix/admin/protos/1 \
+curl http://127.0.0.1:9180/apisix/admin/protos/1 \
 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "content" : "syntax = \"proto3\";
@@ -336,7 +336,7 @@ curl http://127.0.0.1:9080/apisix/admin/protos/1 \
 同时配置选项 `status_detail_type` 为 `helloworld.ErrorDetail`：
 
 ```shell
-curl http://127.0.0.1:9080/apisix/admin/routes/1 \
+curl http://127.0.0.1:9180/apisix/admin/routes/1 \
 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
 {
     "methods": ["GET"],


### PR DESCRIPTION
### Description

9080 is used as the admin port which is not the default and raises misconception/confusion among users:
[Example](https://the-asf.slack.com/archives/CUC5MN17A/p1698205230477449):

<img width="694" alt="image" src="https://github.com/apache/apisix/assets/61597896/6eab5776-e652-49cf-b93b-00c8be8a80a4">


### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
