### PR TITLE
change(opentelemetry): make span name and attributes follow the standard spec

### DIFF
--- a/t/plugin/opentelemetry4-bugfix-pb-state.t
+++ b/t/plugin/opentelemetry4-bugfix-pb-state.t
@@ -105,10 +105,6 @@ passed
         local attributes = {}
         local span = spans[1]
         for _, attribute in ipairs(span.attributes) do
-            if attribute.key == "hostname" then
-                -- remove any randomness
-                goto skip
-            end
             table.insert(attributes_names, attribute.key)
             attributes[attribute.key] = attribute.value.string_value or ""
             ::skip::
@@ -167,9 +163,9 @@ GET /t
 --- no_error_log
 type 'opentelemetry.proto.trace.v1.TracesData' does not exists
 --- grep_error_log eval
-qr/attribute .+?:.[^,]*/
+qr/attribute (apisix|x-my).+?:.[^,]*/
 --- grep_error_log_out
-attribute route: "route_name"
-attribute service: ""
+attribute apisix.route_id: "1"
+attribute apisix.route_name: "route_name"
 attribute x-my-header-name: "william"
 attribute x-my-header-nick: "bill"

--- a/t/plugin/opentelemetry5.t
+++ b/t/plugin/opentelemetry5.t
@@ -1,0 +1,182 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!$block->extra_yaml_config) {
+        my $extra_yaml_config = <<_EOC_;
+plugins:
+    - opentelemetry
+    - proxy-rewrite
+plugin_attr:
+    opentelemetry:
+        trace_id_source: x-request-id
+        batch_span_processor:
+            max_export_batch_size: 1
+            inactive_timeout: 0.5
+        collector:
+            address: 127.0.0.1:4318
+            request_timeout: 3
+            request_headers:
+                foo: bar
+_EOC_
+        $block->set_value("extra_yaml_config", $extra_yaml_config);
+    }
+    if (!defined $block->response_body) {
+        $block->set_value("response_body", "passed\n");
+    }
+    $block;
+});
+repeat_each(1);
+no_long_string();
+no_root_location();
+log_level("debug");
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: add plugin
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "name": "route-name",
+                    "plugins": {
+                        "opentelemetry": {
+                            "sampler": {
+                                "name": "always_on"
+                            }
+                        },
+                        "proxy-rewrite": {"uri": "/opentracing"}
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/articles/*/comments"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 2: trigger opentelemetry
+--- request
+GET /articles/12345/comments?foo=bar
+--- more_headers
+User-Agent: test-client
+--- wait: 2
+--- response_body
+opentracing
+
+
+
+=== TEST 3: (resource) check service.name
+--- exec
+tail -n 1 ci/pod/otelcol-contrib/data-otlp.json
+--- response_body eval
+qr/\{"key":"service.name","value":\{"stringValue":"APISIX"\}\}/
+
+
+
+=== TEST 4: (span) check name
+--- exec
+tail -n 1 ci/pod/otelcol-contrib/data-otlp.json
+--- response_body eval
+qr/"name":"GET \/articles\/\*\/comments"/
+
+
+
+=== TEST 5: (span) check http.status_code
+--- exec
+tail -n 1 ci/pod/otelcol-contrib/data-otlp.json
+--- response_body eval
+qr/\{"key":"http.status_code","value":\{"intValue":"200"\}\}/
+
+
+
+=== TEST 6: (span) check http.method
+--- exec
+tail -n 1 ci/pod/otelcol-contrib/data-otlp.json
+--- response_body eval
+qr/\{"key":"http.method","value":\{"stringValue":"GET"\}\}/
+
+
+
+=== TEST 7: (span) check http.host
+--- exec
+tail -n 1 ci/pod/otelcol-contrib/data-otlp.json
+--- response_body eval
+qr/\{"key":"net.host.name","value":\{"stringValue":"localhost"\}\}/
+
+
+
+=== TEST 8: (span) check http.user_agent
+--- exec
+tail -n 1 ci/pod/otelcol-contrib/data-otlp.json
+--- response_body eval
+qr/\{"key":"http.user_agent","value":\{"stringValue":"test-client"\}\}/
+
+
+
+=== TEST 9: (span) check http.target
+--- exec
+tail -n 1 ci/pod/otelcol-contrib/data-otlp.json
+--- response_body eval
+qr/\{"key":"http.target","value":\{"stringValue":"\/articles\/12345\/comments\?foo=bar"\}\}/
+
+
+
+=== TEST 10: (span) check http.route
+--- exec
+tail -n 1 ci/pod/otelcol-contrib/data-otlp.json
+--- response_body eval
+qr/\{"key":"http.route","value":\{"stringValue":"\/articles\/\*\/comments"\}\}/
+
+
+
+=== TEST 11: (span) check apisix.route_id
+--- exec
+tail -n 1 ci/pod/otelcol-contrib/data-otlp.json
+--- response_body eval
+qr/\{"key":"apisix.route_id","value":\{"stringValue":"1"\}\}/
+
+
+
+=== TEST 12: (span) check apisix.route_name
+--- exec
+tail -n 1 ci/pod/otelcol-contrib/data-otlp.json
+--- response_body eval
+qr/\{"key":"apisix.route_name","value":\{"stringValue":"route-name"\}\}/


### PR DESCRIPTION
## Description

The previous implementation did not [follow the spec][1]. I'll list the reasoning below.

Span name:

> HTTP server span names SHOULD be {http.method} {http.route} if there
is a (low-cardinality) http.route available. HTTP server span names SHOULD be {http.method} if there is no (low-cardinality) http.route available. HTTP client spans have no http.route attribute since client-side instrumentation is not generally aware of the "route", and therefore HTTP client spans SHOULD use {http.method}. Instrumentation MUST NOT default to using URI path as span name, but MAY provide hooks to allow custom logic to override the default span name.

It's clearly mentioned that the span name MUST NOT use URI path, but the previous implementation did exactly that. Now it uses `http.method http.route` where the latter is added only when available.

`http.status_code`, `http.scheme`, `http.target`, `http.method`, and `net.host.name` are required according to the spec.

`http.route` is required if and only if it is available.

`http.user_agent` is recommended.

[1]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/semantic_conventions/http.md#http-server

## Motivation

The most important thing for us is the span name. The previous one had unlimited cardinality which would be a very bad idea in production (it can slow down the tracing platform and when using 3rd party services it could create huge bills).

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
  Not relevant.
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
  There obviously is a change, but I would consider it backward-compatible (or at least very low-risk one). I named this as `feat` but could also say it's a bug fix to make sure we are aligned with the OTel spec