### PR TITLE
fix: make install failed on mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,8 @@ endif
 ifeq ($(ENV_OS_NAME), darwin)
 	ifeq ($(ENV_OS_ARCH), arm64)
 		ENV_HOMEBREW_PREFIX := /opt/homebrew
+		ENV_INST_BINDIR := $(ENV_INST_PREFIX)/local/bin
+		ENV_INST_LUADIR := $(shell which lua | xargs realpath | sed 's/bin\/lua//g')
 	endif
 
 	# OSX archive `._` cache file


### PR DESCRIPTION
### Description

Since mac use M1/M2(arm64) chip, apisix will be always installed failure when execute `make install`, it's not about the permission, it's new system constraint and it doesn't work even mac user unlock it.

The change is adjust

* `ENV_INST_BINDIR` path from `/usr/bin` to `/usr/local/bin` for Mac arm64 only
* `ENV_INST_LUADIR` path from `/usr/share/lua/5.1` to `/opt/homebrew/Cellar/lua/{version}` for Mac arm64 only

Ideally for those non-distributed managed package, we better put in `/usr/local/bin` rather than `/usr/bin` regardless Linux/MacOS, `/usr/local/` is more for those self install packages. Anyway, this change only affect mac arm64 developer, please review. thank you

Fixes # (issue)
intend to fix https://github.com/apache/apisix/issues/6225 issue permanently

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
