### PR TITLE
refactor: add log after apisix.yml config reload in standalone mode

### DIFF
--- a/apisix/core/config_yaml.lua
+++ b/apisix/core/config_yaml.lua
@@ -115,6 +115,7 @@ local function read_apisix_yaml(premature, pre_mtime)
 
     apisix_yaml = apisix_yaml_new
     apisix_yaml_ctime = last_change_time
+    log.warn("config file ", apisix_yaml_path, " reloaded.")
 end
 
 


### PR DESCRIPTION
Fixes #10402

Please review. Not sure why is the log message printed multiple times and how to avoid it.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
