### PR TITLE
docs: update the mysql docker example in stream proxy to use mysql_native_password

### DIFF
--- a/docs/en/latest/stream-proxy.md
+++ b/docs/en/latest/stream-proxy.md
@@ -115,7 +115,7 @@ Here is an example with MySQL:
 2. Now run a mysql docker container and expose port 3306 to the host
 
    ```shell
-   $ docker run --name mysql -e MYSQL_ROOT_PASSWORD=toor -p 3306:3306 -d mysql
+   $ docker run --name mysql -e MYSQL_ROOT_PASSWORD=toor -p 3306:3306 -d mysql mysqld --default-authentication-plugin=mysql_native_password
    # check it using a mysql client that it works
    $ mysql --host=127.0.0.1 --port=3306 -u root -p
    Enter password:

--- a/docs/zh/latest/stream-proxy.md
+++ b/docs/zh/latest/stream-proxy.md
@@ -101,7 +101,7 @@ curl http://127.0.0.1:9180/apisix/admin/stream_routes/1 -H 'X-API-KEY: edd1c9f03
 2. 现在运行一个 mysql docker 容器并将端口 3306 暴露给主机
 
    ```shell
-   $ docker run --name mysql -e MYSQL_ROOT_PASSWORD=toor -p 3306:3306 -d mysql
+   $ docker run --name mysql -e MYSQL_ROOT_PASSWORD=toor -p 3306:3306 -d mysql mysqld --default-authentication-plugin=mysql_native_password
    # check it using a mysql client that it works
    $ mysql --host=127.0.0.1 --port=3306 -u root -p
    Enter password:


### PR DESCRIPTION
### Description

Try with the current command in the doc and use `mysql` client to connect with the MySQL server, you will see an error: `Authentication plugin 'caching_sha2_password' cannot be loaded. The specific module can not be found`.

This is because MySQL 8.0 uses `caching_sha2_password` as the default authentication rather than `mysql_native_password`, which has been the default authentication in earlier versions.

For this docker example, an easy way to resort back to using `mysql_native_password` is to add `mysqld --default-authentication-plugin=mysql_native_password`:

![image](https://github.com/apache/apisix/assets/39619599/c2075d28-775a-4f7e-89d9-65d6b2a2ad45)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
