### PR TITLE
chore: deprecate the pacakge `io/ioutil`

### DIFF
--- a/ci/pod/openfunction/function-example/test-body/hello.go
+++ b/ci/pod/openfunction/function-example/test-body/hello.go
@@ -21,8 +21,9 @@ package hello
 
 import (
 	"fmt"
+	"io"
 	"net/http"
-	"io/ioutil"
+
 	"github.com/OpenFunction/functions-framework-go/functions"
 )
 
@@ -31,6 +32,6 @@ func init() {
 }
 
 func HelloWorld(w http.ResponseWriter, r *http.Request) {
-	body,_ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	fmt.Fprintf(w, "Hello, %s!\n", string(body))
 }

--- a/t/grpc_server_example/main.go
+++ b/t/grpc_server_example/main.go
@@ -30,10 +30,7 @@ import (
 	"crypto/x509"
 	"flag"
 	"fmt"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -42,6 +39,9 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -112,7 +112,6 @@ func (s *server) GetErrResp(ctx context.Context, in *pb.HelloRequest) (*pb.Hello
 		Message: "The server is out of service",
 		Type:    "service",
 	})
-
 	if err != nil {
 		panic(fmt.Sprintf("Unexpected error attaching metadata: %v", err))
 	}
@@ -121,7 +120,6 @@ func (s *server) GetErrResp(ctx context.Context, in *pb.HelloRequest) (*pb.Hello
 }
 
 func (s *server) SayHelloAfterDelay(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
-
 	select {
 	case <-time.After(1 * time.Second):
 		fmt.Println("overslept")
@@ -318,7 +316,7 @@ func main() {
 			}
 
 			certPool := x509.NewCertPool()
-			ca, err := ioutil.ReadFile(caFilePath)
+			ca, err := os.ReadFile(caFilePath)
 			if err != nil {
 				log.Fatalf("could not read ca certificate: %s", err)
 			}


### PR DESCRIPTION
### Description

"io/ioutil" has been deprecated since Go 1.16

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
