### PR TITLE
feat: Remove lua-resty-worker-events library

### DIFF
--- a/apisix/admin/init.lua
+++ b/apisix/admin/init.lua
@@ -453,7 +453,7 @@ function _M.init_worker()
     end
 
     router = route.new(uri_route)
-    events = require("resty.worker.events")
+    events = require("resty.events.compat")
 
     events.register(reload_plugins, reload_event, "PUT")
 

--- a/apisix/discovery/consul/init.lua
+++ b/apisix/discovery/consul/init.lua
@@ -579,7 +579,7 @@ function _M.init_worker()
         end
     end
 
-    events = require("resty.worker.events")
+    events = require("resty.events.compat")
     events_list = events.event_list(
             "discovery_consul_update_all_services",
             "updating"

--- a/apisix/discovery/consul_kv/init.lua
+++ b/apisix/discovery/consul_kv/init.lua
@@ -369,7 +369,7 @@ function _M.init_worker()
       end
     end
 
-    events = require("resty.worker.events")
+    events = require("resty.events.compat")
     events_list = events.event_list(
         "discovery_consul_update_application",
         "updating"

--- a/apisix/discovery/nacos/init.lua
+++ b/apisix/discovery/nacos/init.lua
@@ -371,7 +371,7 @@ end
 
 
 function _M.init_worker()
-    events = require("resty.worker.events")
+    events = require("resty.events.compat")
     events_list = events.event_list("discovery_nacos_update_application",
                                     "updating")
 

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -123,7 +123,7 @@ function _M.http_init_worker()
         core.grpc = nil
     end
 
-    local we = require("resty.worker.events")
+    local we = require("resty.events.compat")
     local ok, err = we.configure({shm = "worker-events", interval = 0.1})
     if not ok then
         error("failed to init worker event: " .. err)
@@ -1024,7 +1024,7 @@ function _M.stream_init_worker()
     require("apisix.http.service").init_worker()
     apisix_upstream.init_worker()
 
-    local we = require("resty.worker.events")
+    local we = require("resty.events.compat")
     local ok, err = we.configure({shm = "worker-events-stream", interval = 0.1})
     if not ok then
         error("failed to init worker event: " .. err)

--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -42,7 +42,7 @@ local process, ngx_pipe, events
 if is_http then
     process = require("ngx.process")
     ngx_pipe = require("ngx.pipe")
-    events = require("resty.worker.events")
+    events = require("resty.events.compat")
 end
 local resty_lock = require("resty.lock")
 local resty_signal = require "resty.signal"

--- a/apisix/upstream.lua
+++ b/apisix/upstream.lua
@@ -114,6 +114,7 @@ local function create_checker(upstream)
         name = get_healthchecker_name(healthcheck_parent),
         shm_name = "upstream-healthcheck",
         checks = upstream.checks,
+        events_module = "resty.events",
     })
 
     if not checker then

--- a/rockspec/apisix-master-0.rockspec
+++ b/rockspec/apisix-master-0.rockspec
@@ -39,7 +39,6 @@ dependencies = {
     "lua-resty-balancer = 0.04",
     "lua-resty-ngxvar = 0.5.2",
     "lua-resty-jit-uuid = 0.0.7",
-    "lua-resty-worker-events = 1.0.0",
     "lua-resty-healthcheck-api7 = 3.2.0",
     "api7-lua-resty-jwt = 0.2.5",
     "lua-resty-hmac-ffi = 0.06-1",


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

NOTE: This PR is a breaking change.
This PR requires APISIX to be built and run on the version of apisix-base which has this change - https://github.com/api7/apisix-build-tools/pull/323
The events library will no longer be installed with luarocks. But instead compiled from source while building apisix-base.

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
