### PR TITLE
fix: remove 0 from required_acks allowed values for kafka-logger

### DIFF
--- a/apisix/plugins/kafka-logger.lua
+++ b/apisix/plugins/kafka-logger.lua
@@ -95,7 +95,7 @@ local schema = {
         required_acks = {
             type = "integer",
             default = 1,
-            enum = { 0, 1, -1 },
+            enum = { 1, -1 },
         },
         key = {type = "string"},
         timeout = {type = "integer", minimum = 1, default = 3},

--- a/t/plugin/kafka-logger2.t
+++ b/t/plugin/kafka-logger2.t
@@ -57,7 +57,7 @@ done
 
 
 
-=== TEST 2: report log to kafka, with required_acks(1, 0, -1)
+=== TEST 2: report log to kafka, with required_acks(1, -1)
 --- config
 location /t {
     content_by_lua_block {
@@ -98,30 +98,6 @@ location /t {
                             timeout = 1,
                             batch_max_size = 1,
                             required_acks = -1,
-                            meta_format = "origin",
-                        }
-                    },
-                    upstream = {
-                        nodes = {
-                            ["127.0.0.1:1980"] = 1
-                        },
-                        type = "roundrobin"
-                    },
-                    uri = "/hello",
-                },
-            },
-            {
-                input = {
-                    plugins = {
-                        ["kafka-logger"] = {
-                            broker_list = {
-                                ["127.0.0.1"] = 9092
-                            },
-                            kafka_topic = "test2",
-                            producer_type = "sync",
-                            timeout = 1,
-                            batch_max_size = 1,
-                            required_acks = 0,
                             meta_format = "origin",
                         }
                     },


### PR DESCRIPTION
### Description

While the doc was updated in #10126, the code was not. As a user, it could be confusing to see the doc mentions `required_acks` doesn't support 0, yet the schema and test say otherwise.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)