### PR TITLE
fix: closing brace should not be a part of variable

### DIFF
--- a/apisix/core/utils.lua
+++ b/apisix/core/utils.lua
@@ -296,12 +296,9 @@ do
     local _escaper
 
     local function resolve(m)
-        local i = 1
-        -- if first capture's first char is "{" evaluate the second capture
-        if m[1]:byte(1) == 123 then
-            i = 2
-        end
-        local v = _ctx[m[i]]
+        local variable = m[2] or m[3]
+        local v = _ctx[variable]
+
         if v == nil then
             return ""
         end

--- a/apisix/core/utils.lua
+++ b/apisix/core/utils.lua
@@ -292,7 +292,7 @@ local resolve_var
 do
     local _ctx
     local n_resolved
-    local pat = [[(?<!\\)\$\{?(\w+)\}?]]
+    local pat = [[(?<!\\)\$(\{(\w+)\}|(\w+))]]
     local _escaper
 
     local function resolve(m)

--- a/apisix/core/utils.lua
+++ b/apisix/core/utils.lua
@@ -297,6 +297,7 @@ do
 
     local function resolve(m)
         local i = 1
+        -- if first capture's first char is "{" evaluate the second capture
         if m[1]:byte(1) == 123 then
             i = 2
         end

--- a/apisix/core/utils.lua
+++ b/apisix/core/utils.lua
@@ -296,7 +296,11 @@ do
     local _escaper
 
     local function resolve(m)
-        local v = _ctx[m[1]]
+        local i = 1
+        if m[1]:byte(1) == 123 then
+            i = 2
+        end
+        local v = _ctx[m[i]]
         if v == nil then
             return ""
         end

--- a/t/plugin/fault-injection2.t
+++ b/t/plugin/fault-injection2.t
@@ -143,7 +143,7 @@ h3: /hello
 
 
 
-=== TEST 4: closing curly brace not should not be a part of variable
+=== TEST 6: closing curly brace not should not be a part of variable
 --- config
  location /t {
            content_by_lua_block {
@@ -179,7 +179,7 @@ passed
 
 
 
-=== TEST 5: inject header
+=== TEST 7: test route
 --- request
 GET /hello?count=2
 --- response_body chomp

--- a/t/plugin/fault-injection2.t
+++ b/t/plugin/fault-injection2.t
@@ -140,3 +140,47 @@ GET /hello
 h1: v1
 h2: 2
 h3: /hello
+
+
+
+=== TEST 4: closing curly brace not should not be a part of variable
+--- config
+ location /t {
+           content_by_lua_block {
+               local t = require("lib.test_admin").test
+               local code, body = t('/apisix/admin/routes/1',
+                    ngx.HTTP_PUT,
+                    [=[{
+                            "plugins": {
+                               "fault-injection": {
+                                   "abort": {
+                                      "http_status": 200,
+                                      "body": "{\"count\": $arg_count}"
+                                   }
+                               }
+                            },
+                            "upstream": {
+                               "nodes": {
+                                   "127.0.0.1:1980": 1
+                               },
+                               "type": "roundrobin"
+                            },
+                            "uri": "/hello"
+                        }]=]
+                   )
+               if code >= 300 then
+                   ngx.status = code
+               end
+               ngx.say(body)
+           }
+       }
+--- response_body
+passed
+
+
+
+=== TEST 5: inject header
+--- request
+GET /hello?count=2
+--- response_body chomp
+{"count": 2}


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
Current regex for evaluating variables like: `$var`, `${var}`, etc. would also match `$var}` including the closing brace. This has been fixed.

Fixes #10478

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
