### PR TITLE
fix: use proxy_protocol_addr instead of remote_addr in proxy-protocol case

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -715,7 +715,7 @@ http {
             proxy_set_header   Host              $upstream_host;
             proxy_set_header   Upgrade           $upstream_upgrade;
             proxy_set_header   Connection        $upstream_connection;
-            proxy_set_header   X-Real-IP         $proxy_protocol_addr;
+            proxy_set_header   X-Real-IP         {% if proxy_protocol then %} $proxy_protocol_addr {% else %} $remote_addr {% end %};
             proxy_pass_header  Date;
 
             ### the following x-forwarded-* headers is to send to upstream server

--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -715,7 +715,7 @@ http {
             proxy_set_header   Host              $upstream_host;
             proxy_set_header   Upgrade           $upstream_upgrade;
             proxy_set_header   Connection        $upstream_connection;
-            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Real-IP         $proxy_protocol_addr;
             proxy_pass_header  Date;
 
             ### the following x-forwarded-* headers is to send to upstream server


### PR DESCRIPTION
Hello to APISIX maintainers ✋🏻 

### Description

We are currently using APISIX API Gateway and Ingress Controller on an Kubernetes infrastructure and we had some hard time to configure properly the way `X-Real-IP` is set in `proxy-protocol`.

By default, the APISIX Ingress Controller will use `$remote_addr` as value for `X-Real-IP` header.
But IMHO, the value should be `$proxy_protocol_addr` in proxy-protocol context.

Currently, in order to get the visitor IP address, we have to : 
 - Enable `proxy-rewrite` plugin on instance level with this configuration : 
   ```
   {
     "headers": {
       "set": {
         "X-Forwarded-For": "$proxy_protocol_addr",
         "X-Forwarded-Port": "$proxy_protocol_port"
       }
     },
     "use_real_request_uri_unsafe": false
   }
   ```
 - Enable `real-ip` plugin on each `APISIXRoute` we declare : 
   ```
        - name: real-ip
          enable: true
          config:
            source: http_x_forwarded_for
   ```

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
  => not covered by current tests
- [ ] I have updated the documentation to reflect this change
  => not covered by current documentation
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
