### PR TITLE
docs: Add #END to the `debug.yaml` basic snippet

### DIFF
--- a/docs/en/latest/debug-mode.md
+++ b/docs/en/latest/debug-mode.md
@@ -36,6 +36,7 @@ You can enable the basic debug mode by adding this line to your debug configurat
 ```yaml title="conf/debug.yaml"
 basic:
   enable: true
+#END
 ```
 
 APISIX loads the configurations of `debug.yaml` on startup and then checks if the file is modified on an interval of 1 second. If the file is changed, APISIX automatically applies the configuration changes.

--- a/docs/zh/latest/debug-mode.md
+++ b/docs/zh/latest/debug-mode.md
@@ -28,6 +28,7 @@ title: Debug Mode
 ```
 basic:
   enable: true
+#END
 ```
 
 注意：在 APISIX 2.10 之前，开启基本调试模式曾经是设置 `conf/config.yaml` 中的 `apisix.enable_debug` 为 `true`。


### PR DESCRIPTION
### Description

The debug.yaml needs a trailing #END (just like the routes.yaml)

The first sample misses it. This PR fixes it.

### Checklist

- [X] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [X] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)