### PR TITLE
fix(router/radixtree_uri_with_parameter): use encoded_uri for radixtree match

### DIFF
--- a/apisix/http/route.lua
+++ b/apisix/http/route.lua
@@ -111,7 +111,8 @@ function _M.match_uri(uri_router, api_ctx)
     match_opts.vars = api_ctx.var
     match_opts.matched = core.tablepool.fetch("matched_route_record", 0, 4)
 
-    local ok = uri_router:dispatch(api_ctx.var.uri, match_opts, api_ctx, match_opts)
+    local encoded_uri = core.utils.uri_safe_encode(api_ctx.var.uri)
+    local ok = uri_router:dispatch(encoded_uri, match_opts, api_ctx, match_opts)
     core.tablepool.release("route_match_opts", match_opts)
     return ok
 end

--- a/t/router/radixtree-uri-with-parameter-encoded.t
+++ b/t/router/radixtree-uri-with-parameter-encoded.t
@@ -41,7 +41,6 @@ run_tests();
 
 __DATA__
 
-
 === TEST 1: set route(id: 1)
 --- config
     location /t {
@@ -76,13 +75,16 @@ GET /t
 passed
 
 
-=== TEST 1: hit routes
+
+=== TEST 2: hit routes
 --- request
 GET /name/json/bar
 --- response_body
 hello world
 
-=== TEST 2: hit route: Chinese character
+
+
+=== TEST 3: hit route: Chinese character
 --- request
 GET /name/中文/bar
 --- response_body

--- a/t/router/radixtree-uri-with-parameter-encoded.t
+++ b/t/router/radixtree-uri-with-parameter-encoded.t
@@ -1,0 +1,89 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+log_level('info');
+worker_connections(256);
+no_root_location();
+no_shuffle();
+
+our $yaml_config = <<_EOC_;
+apisix:
+    node_listen: 1984
+    router:
+        http: 'radixtree_uri_with_parameter'
+_EOC_
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!$block->yaml_config) {
+        $block->set_value("yaml_config", $yaml_config);
+    }
+});
+
+run_tests();
+
+__DATA__
+
+
+=== TEST 1: set route(id: 1)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "methods": ["GET"],
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "plugins": {
+                            "proxy-rewrite":{"uri":"/hello"}
+                        },
+                        "uri": "/name/:name/bar"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+=== TEST 1: hit routes
+--- request
+GET /name/json/bar
+--- response_body
+hello world
+
+=== TEST 2: hit route: Chinese character
+--- request
+GET /name/中文/bar
+--- response_body
+hello world


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #10555 

the `resty/radixtree.lua` require a encoded uri for matching, while we pass a decoded uri, which will cause 404 if the `parameter` in path contains characters need to be encoded!


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
