### PR TITLE
docs: update xargs command in documentation

### DIFF
--- a/docs/en/latest/getting-started/load-balancing.md
+++ b/docs/en/latest/getting-started/load-balancing.md
@@ -85,7 +85,7 @@ From `mock.api7.ai`:
 Let's generate 100 requests to test the load-balancing effect:
 
 ```shell
-hc=$(seq 100 | xargs -i curl "http://127.0.0.1:9080/headers" -sL | grep "httpbin" | wc -l); echo httpbin.org: $hc, mock.api7.ai: $((100 - $hc))
+hc=$(seq 100 | xargs -I {} curl "http://127.0.0.1:9080/headers" -sL | grep "httpbin" | wc -l); echo httpbin.org: $hc, mock.api7.ai: $((100 - $hc))
 ```
 
 The result shows the requests were distributed over the two services almost equally:

--- a/docs/en/latest/getting-started/rate-limiting.md
+++ b/docs/en/latest/getting-started/rate-limiting.md
@@ -50,7 +50,7 @@ You will receive an `HTTP/1.1 201 OK` response if the plugin was added successfu
 Let's generate 100 simultaneous requests to see the rate limiting plugin in effect.
 
 ```shell
-count=$(seq 100 | xargs -i curl "http://127.0.0.1:9080/ip" -I -sL | grep "503" | wc -l); echo \"200\": $((100 - $count)), \"503\": $count
+count=$(seq 100 | xargs -I {} curl "http://127.0.0.1:9080/ip" -I -sL | grep "503" | wc -l); echo \"200\": $((100 - $count)), \"503\": $count
 ```
 
 The results are as expected: out of the 100 requests, 2 requests were sent successfully (status code `200`) while the others were rejected (status code `503`).

--- a/docs/zh/latest/getting-started/load-balancing.md
+++ b/docs/zh/latest/getting-started/load-balancing.md
@@ -85,7 +85,7 @@ curl -i "http://127.0.0.1:9180/apisix/admin/routes" -X PUT -d '
 我们生成 100 个请求来测试负载均衡的效果：
 
 ```shell
-hc=$(seq 100 | xargs -i curl "http://127.0.0.1:9080/headers" -sL | grep "httpbin" | wc -l); echo httpbin.org: $hc, mock.api7.ai: $((100 - $hc))
+hc=$(seq 100 | xargs -I {} curl "http://127.0.0.1:9080/headers" -sL | grep "httpbin" | wc -l); echo httpbin.org: $hc, mock.api7.ai: $((100 - $hc))
 ```
 
 结果显示，请求几乎平均分配给这两个上游服务：

--- a/docs/zh/latest/getting-started/rate-limiting.md
+++ b/docs/zh/latest/getting-started/rate-limiting.md
@@ -50,7 +50,7 @@ curl -i "http://127.0.0.1:9180/apisix/admin/routes/getting-started-ip" -X PATCH 
 我们同时生成 100 个请求来测试限速插件的效果。
 
 ```shell
-count=$(seq 100 | xargs -i curl "http://127.0.0.1:9080/ip" -I -sL | grep "503" | wc -l); echo \"200\": $((100 - $count)), \"503\": $count
+count=$(seq 100 | xargs -I {} curl "http://127.0.0.1:9080/ip" -I -sL | grep "503" | wc -l); echo \"200\": $((100 - $count)), \"503\": $count
 ```
 
 请求结果同预期一致：在这 100 个请求中，有 2 个请求发送成功（状态码为 `200`），其他请求均被拒绝（状态码为 `503`）。


### PR DESCRIPTION
### Description

In the current version of the APISIX documentation, there is a shell command intended for testing purposes:
`hc=$(seq 100 | xargs -i curl "http://127.0.0.1:9080/headers" -sL | grep "httpbin" | wc -l); echo httpbin.org: $hc, mock.api7.ai: $((100 - $hc))`
This command utilizes the -i option with xargs, which is deprecated in GNU xargs, particularly on newer GNU/Linux distributions. 
The updated command is as follows:
`hc=$(seq 100 | xargs -I {} curl "http://127.0.0.1:9080/headers" -sL | grep "httpbin" | wc -l); echo httpbin.org: $hc, mock.api7.ai: $((100 - $hc))`

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
