### PR TITLE
ci: fix "CLI Test" raise command not found info

### DIFF
--- a/t/cli/test_admin.sh
+++ b/t/cli/test_admin.sh
@@ -431,8 +431,8 @@ fi
 sleep 0.5
 
 # check http plugins load list
-if ! grep -E 'new plugins: {"public-api":true,"node-status":true}' logs/error.log; -o \
-   ! grep -E 'new plugins: {"node-status":true,"public-api":true}' logs/error.log; then
+if ! grep logs/error.log -E -e 'new plugins: {"public-api":true,"node-status":true}' \
+   -e 'new plugins: {"node-status":true,"public-api":true}'; then
     echo "failed: first time load http plugins list failed"
     exit 1
 fi
@@ -460,8 +460,8 @@ if [ ! $code -eq 200 ]; then
 fi
 
 # check http plugins load list
-if ! grep -E 'new plugins: {"public-api":true,"node-status":true}' logs/error.log; -o \
-   ! grep -E 'new plugins: {"node-status":true,"public-api":true}' logs/error.log; then
+if ! grep logs/error.log -E -e 'new plugins: {"public-api":true,"node-status":true}' \
+   -e 'new plugins: {"node-status":true,"public-api":true}'; then
     echo "failed: second time load http plugins list failed"
     exit 1
 fi


### PR DESCRIPTION
### Description

fix: ci "CLI Test" run will raise `/t/cli/test_admin.sh: line 435: -o: command not found`

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
