### PR TITLE
fix: memory leak caused by timer that never quit

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -286,7 +286,9 @@ local function run_watch(premature)
     ngx_thread_kill(run_watch_th)
     ngx_thread_kill(check_worker_th)
 
-    ngx_timer_at(0, run_watch)
+    if not exiting() then
+        ngx_timer_at(0, run_watch)
+    end
 end
 
 

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -288,6 +288,9 @@ local function run_watch(premature)
 
     if not exiting() then
         ngx_timer_at(0, run_watch)
+    else
+        -- notify child watchers
+        produce_res(nil, "worker exited")
     end
 end
 
@@ -843,6 +846,9 @@ local function _automatic_fetch(premature, self)
                                        .. backoff_duration .. "s")
                         end
                     end
+                elseif err == "worker exited" then
+                    log.info("worker exited.")
+                    return
                 elseif err ~= "timeout" and err ~= "Key not found"
                     and self.last_err ~= err then
                     log.error("failed to fetch data from etcd: ", err, ", ",


### PR DESCRIPTION
### Description

The [etcd related pr](https://github.com/apache/apisix/pull/9456) imported a timer that never quits.
According to [the official recommendation](recommendations), the timer will cause memory leak.
![image](https://github.com/apache/apisix/assets/9354193/4a755077-a08b-4bb8-a11a-8cf186511ffb)

It will affect all versions between 3.4.0 and 3.7.0, including 3.2.2

Fixes #10392 #10349

### steps to reproduce

Frequent configuration changes can cause memory to keep going up.

The memory goes from 0.2% to 1.7% in few hours
<img width="609" alt="094497d0e3ae84914ab41af1f0f6383" src="https://github.com/apache/apisix/assets/9354193/e5827d10-e8fe-4877-90bb-0020e81edbfc">
![image](https://github.com/apache/apisix/assets/9354193/dc94543c-8ec4-4f17-a027-3f5d807127c2)

And the memory keeps stable after fixed
![image](https://github.com/apache/apisix/assets/9354193/4cc2f8e0-fbd6-43e7-98e1-8fc5aa617b8c)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)


