### PR TITLE
fix: do not invoke add_header if value resolved as nil

### DIFF
--- a/apisix/plugins/proxy-rewrite.lua
+++ b/apisix/plugins/proxy-rewrite.lua
@@ -365,8 +365,11 @@ function _M.rewrite(conf, ctx)
             local val = core.utils.resolve_var_with_captures(hdr_op.add[i + 1],
                                             ctx.proxy_rewrite_regex_uri_captures)
             val = core.utils.resolve_var(val, ctx.var)
-            local header = hdr_op.add[i]
-            core.request.add_header(ctx, header, val)
+            -- A nil or empty table value will cause add_header function to throw an error.
+            if val then
+                local header = hdr_op.add[i]
+                core.request.add_header(ctx, header, val)
+            end
         end
 
         local field_cnt = #hdr_op.set


### PR DESCRIPTION
### Description

If header_value is resolved to nil or empty table, `add_header` will throw an error https://github.com/openresty/lua-resty-core/blob/master/lib/resty/core/request.lua#L364

It's better to do nothing.

ref: https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/req.md#add_header

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

