### PR TITLE
fix(test/cli): add `set +e` when wait for control plane

### DIFF
--- a/t/cli/test_control.sh
+++ b/t/cli/test_control.sh
@@ -36,6 +36,7 @@ make run
 
 sleep 0.1
 
+set +e
 times=1
 code=000
 while [ $code -eq 000 ] && [ $times -lt 10 ]
@@ -44,6 +45,7 @@ do
   sleep 0.2
   times=$(($times+1))
 done
+set -e
 
 if [ ! $code -eq 200 ]; then
     echo "failed: access control server"
@@ -77,6 +79,7 @@ make run
 
 sleep 0.1
 
+set +e
 times=1
 code=000
 while [ $code -eq 000 ] && [ $times -lt 10 ]
@@ -85,6 +88,7 @@ do
   sleep 0.2
   times=$(($times+1))
 done
+set -e
 
 if [ ! $code -eq 200 ]; then
     echo "failed: access control server"
@@ -111,6 +115,7 @@ make run
 
 sleep 0.1
 
+set +e
 times=1
 code=000
 while [ $code -eq 000 ] && [ $times -lt 10 ]
@@ -119,6 +124,7 @@ do
   sleep 0.2
   times=$(($times+1))
 done
+set -e
 
 if [ ! $code -eq 200 ]; then
     echo "failed: access control server"


### PR DESCRIPTION
### Description

The commit won't work becase the shell option `set -e` in `t/cli/common.sh`

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

