### PR TITLE
fix: mostly_healthy is healthy

### DIFF
--- a/apisix/control/v1.lua
+++ b/apisix/control/v1.lua
@@ -130,7 +130,7 @@ local HTML_TEMPLATE = [[
 {% for _, stat in ipairs(stats) do %}
 {% for _, node in ipairs(stat.nodes) do %}
 {% i = i + 1 %}
-  {% if node.status == "healthy" then %}
+  {% if node.status == "healthy" or node.status == "mostly_healthy" then %}
   <tr>
   {% else %}
   <tr bgcolor="#FF0000">

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -475,8 +475,10 @@ local function collect(ctx, stream_only)
     local stats = control.get_health_checkers()
     for _, stat in ipairs(stats) do
         for _, node in ipairs(stat.nodes) do
-            metrics.upstream_status:set((node.status == "healthy") and 1 or 0,
-                gen_arr(stat.name, node.ip, node.port))
+            metrics.upstream_status:set(
+                    (node.status == "healthy" or node.status == "mostly_healthy") and 1 or 0,
+                    gen_arr(stat.name, node.ip, node.port)
+            )
         end
     end
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

fix: #10664

![WeChatWorkScreenshot_8548b234-7416-469a-9b45-4ddf05c50c1f](https://github.com/apache/apisix/assets/2706161/272481a2-654b-410d-944d-eeea9fcf23fb)

build a `mostly_healthy` test case based on test-nginx is too difficult for me.  so this PR not include test case

I will add the test case form this metric at the next PR


### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
