### PR TITLE
fix(zipkin): avoid getting a nil value in log phase(#10590)

### DIFF
--- a/apisix/plugins/zipkin.lua
+++ b/apisix/plugins/zipkin.lua
@@ -283,6 +283,15 @@ end
 
 
 function _M.log(conf, ctx)
+    if ctx.zipkin then
+        core.tablepool.release("zipkin_ctx", ctx.zipkin)
+        ctx.zipkin = nil
+    end
+
+    if not ctx.opentracing_sample then
+        return
+    end
+
     local opentracing = ctx.opentracing
 
     local log_end_time = opentracing.tracer:time()
@@ -302,11 +311,6 @@ function _M.log(conf, ctx)
     opentracing.request_span:set_tag("http.status_code", upstream_status)
 
     opentracing.request_span:finish(log_end_time)
-
-    if ctx.zipkin then
-        core.tablepool.release("zipkin_ctx", ctx.zipkin)
-        ctx.zipkin = nil
-    end
 end
 
 return _M

--- a/t/plugin/zipkin.t
+++ b/t/plugin/zipkin.t
@@ -467,3 +467,13 @@ GET /t
 --- response_body
 1
 0
+
+
+
+=== TEST 23: no error in log phase while b3 header invalid
+--- request
+GET /echo
+--- more_headers
+b3: abc
+--- no_error_log
+[error]

--- a/t/plugin/zipkin.t
+++ b/t/plugin/zipkin.t
@@ -474,6 +474,11 @@ GET /t
 --- request
 GET /echo
 --- more_headers
-b3: abc
+b3: 80f198ee56343ba864fe8b2a57d3eff7
+--- response_headers
+x-b3-sampled:
+--- error_code: 400
+--- error_log
+invalid b3 header
 --- no_error_log
-[error]
+attempt to index local 'opentracing' (a nil value)


### PR DESCRIPTION
### Description
An error(attempt to index local 'opentracing' (a nil value))  occurs in the following situations:

- failed to parse b3 header and return 400.
- plugins with higher priority return or throw exceptions.

All of the above result in a not being assigned value to ctx.opentracing. so got a error in log phase. this pr will fix it.

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #10590

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
