### PR TITLE
fix: not saving etcd revision

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -139,6 +139,7 @@ local function do_run_watch(premature)
             error("no local conf: " .. err)
         end
         watch_ctx.prefix = local_conf.etcd.prefix .. "/"
+        watch_ctx.timeout = local_conf.etcd.watch_timeout
 
         watch_ctx.cli, err = get_etcd()
         if not watch_ctx.cli then
@@ -170,7 +171,7 @@ local function do_run_watch(premature)
         watch_ctx.rev = rev + 1
         watch_ctx.started = true
 
-        log.info("main etcd watcher started, revision=", watch_ctx.rev)
+        log.info("main etcd watcher initialised, revision=", watch_ctx.rev)
 
         if watch_ctx.wait_init then
             for _, sema in pairs(watch_ctx.wait_init) do
@@ -181,7 +182,7 @@ local function do_run_watch(premature)
     end
 
     local opts = {}
-    opts.timeout = 50 -- second
+    opts.timeout = watch_ctx.timeout or 50 -- second
     opts.need_cancel = true
     opts.start_revision = watch_ctx.rev
 

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -672,7 +672,8 @@ deployment:                    # Deployment configurations
     host:                         # Set etcd address(es) in the same etcd cluster.
       - "http://127.0.0.1:2379"   # If TLS is enabled for etcd, use https://127.0.0.1:2379.
     prefix: /apisix               # Set etcd prefix.
-    timeout: 30                   # Set timeout in seconds.
+    timeout: 30                   # The timeout when connect/read/write to etcd, Set timeout in seconds.
+    watch_timeout: 50             # The timeout when watch etcd
     # resync_delay: 5             # Set resync time in seconds after a sync failure.
                                   # The actual resync time would be resync_delay plus 50% random jitter.
     # health_check_timeout: 10    # Set timeout in seconds for etcd health check.

--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -486,3 +486,33 @@ passed
 hello world
 passed
 {"error_msg":"404 Route Not Found"}
+
+
+
+=== TEST 13: the main watcher should be initialised once
+--- yaml_config
+apisix:
+  node_listen: 1984
+deployment:
+  role: traditional
+  role_traditional:
+    config_provider: etcd
+  admin:
+    admin_key: null
+  etcd:
+    host:
+      - "http://127.0.0.1:2379"
+    watch_timeout: 1
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.sleep(1)
+        }
+    }
+--- request
+GET /t
+--- grep_error_log eval
+qr/main etcd watcher initialised, revision=/
+--- grep_error_log_out
+main etcd watcher initialised, revision=
+main etcd watcher initialised, revision=

--- a/t/core/etcd-sync.t
+++ b/t/core/etcd-sync.t
@@ -22,7 +22,6 @@ run_tests;
 
 __DATA__
 
-
 === TEST 1: using default timeout
 --- config
     location /t {

--- a/t/core/etcd-sync.t
+++ b/t/core/etcd-sync.t
@@ -22,6 +22,7 @@ run_tests;
 
 __DATA__
 
+
 === TEST 1: using default timeout
 --- config
     location /t {


### PR DESCRIPTION
### Description

Due to the [fix](https://github.com/apache/apisix/pull/10614), the saved etcd revision will be discarded when re-watch etcd, APISIX need to re-traverse all keys in etcd every time, that leads to high cpu usage

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

