### PR TITLE
fix: cache original_nodes with nodes

### DIFF
--- a/apisix/upstream.lua
+++ b/apisix/upstream.lua
@@ -221,8 +221,6 @@ local function fill_node_info(up_conf, scheme, is_stream)
         end
     end
 
-    up_conf.original_nodes = nodes
-
     if not need_filled then
         up_conf.nodes_ref = nodes
         return true

--- a/apisix/upstream.lua
+++ b/apisix/upstream.lua
@@ -291,6 +291,8 @@ function _M.set_by_route(route, api_ctx)
             end
 
             up_conf.nodes = new_nodes
+            up_conf.original_nodes = up_conf.nodes
+
             local new_up_conf = core.table.clone(up_conf)
             core.log.info("discover new upstream from ", up_conf.service_name, ", type ",
                           up_conf.discovery_type, ": ",

--- a/apisix/upstream.lua
+++ b/apisix/upstream.lua
@@ -221,6 +221,8 @@ local function fill_node_info(up_conf, scheme, is_stream)
         end
     end
 
+    up_conf.original_nodes = nodes
+
     if not need_filled then
         up_conf.nodes_ref = nodes
         return true

--- a/t/node/upstream-discovery-dynamic.t
+++ b/t/node/upstream-discovery-dynamic.t
@@ -1,0 +1,133 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+log_level('warn');
+no_root_location();
+no_shuffle();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: dynamic host based discovery
+--- extra_yaml_config
+nginx_config:
+    worker_processes: 1
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local discovery = require("apisix.discovery.init").discovery
+            local core = require("apisix.core")
+            discovery.demo_discover = {
+                nodes = function()
+                    local demo_nodes_tab = {
+                        a = { host = "127.0.0.1", port = 1111 },
+                        b = { host = "127.0.0.1", port = 2222 }
+                    }
+                    local host = ngx.var.host
+                    local service_id = host:match("([^.]+).myhost.com")
+                    local demo_node = demo_nodes_tab[service_id]
+
+                    local node_list = core.table.new(1, 0)
+                    core.table.insert(node_list, {
+                        host = demo_node.host,
+                        port = tonumber(demo_node.port),
+                        weight = 100,
+                    })
+
+                    return node_list
+                end
+            }
+
+            local code, body = t('/apisix/admin/services/',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "id": "demo_service",
+                    "name": "demo_service",
+                    "upstream": {
+                        "discovery_type": "demo_discover",
+                        "service_name": "demo_service",
+                        "type": "roundrobin"
+                    }
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+
+            ngx.sleep(0.5)
+
+            local code, body = t('/apisix/admin/routes/',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "id": "demo_route",
+                    "name": "demo_route",
+                    "uri": "/*",
+                    "hosts":[
+                    "*.myhost.com"
+                    ],
+                    "service_id": "demo_service"
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+
+            ngx.sleep(0.5)
+
+            local hosts = {
+                "a.myhost.com",
+                "a.myhost.com",
+                "b.myhost.com",
+                "b.myhost.com",
+                "a.myhost.com",
+                "b.myhost.com",
+                "b.myhost.com",
+                "a.myhost.com",
+                "b.myhost.com",
+                "a.myhost.com",
+            }
+
+            for i, url_host in ipairs(hosts) do
+                local http = require "resty.http"
+                local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/"
+                local httpc = http.new()
+                local res, err = httpc:request_uri(uri, {method = "GET", keepalive = false, headers = {
+                    ["Host"] = url_host
+                }})
+            end
+        }
+    }
+--- request
+GET /t
+--- grep_error_log eval
+qr/upstream: \S+, host: \S+/
+--- grep_error_log_out
+upstream: "http://127.0.0.1:1111/", host: "a.myhost.com"
+upstream: "http://127.0.0.1:1111/", host: "a.myhost.com"
+upstream: "http://127.0.0.1:2222/", host: "b.myhost.com"
+upstream: "http://127.0.0.1:2222/", host: "b.myhost.com"
+upstream: "http://127.0.0.1:1111/", host: "a.myhost.com"
+upstream: "http://127.0.0.1:2222/", host: "b.myhost.com"
+upstream: "http://127.0.0.1:2222/", host: "b.myhost.com"
+upstream: "http://127.0.0.1:1111/", host: "a.myhost.com"
+upstream: "http://127.0.0.1:2222/", host: "b.myhost.com"
+upstream: "http://127.0.0.1:1111/", host: "a.myhost.com"


### PR DESCRIPTION
### Description

upstream original_nodes is not updated when fill_node_info structure after cloning the nodes table. This PR stores the cloned nodes in the original nodes before fill_node_info

Fixes # (issue)

#9805 

### Checklist

- [X] I have explained the need for this PR and the problem it solves
- [X] I have explained the changes or the new features added to this PR
- [X] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
