### PR TITLE
docs: mention env var support in `apisix.yaml`

### DIFF
--- a/docs/en/latest/profile.md
+++ b/docs/en/latest/profile.md
@@ -57,6 +57,12 @@ export APISIX_NODE_LISTEN=8132
 export DEPLOYMENT_ADMIN_ADMIN_LISTEN=9232
 ```
 
+:::caution
+
+You should set these variables with `export`. If you do not export, APISIX will fail to resolve for these variables.
+
+:::
+
 Now when you start APISIX, it will listen on port `8132` and expose the Admin API on port `9232`.
 
 To use default values if no environment variables are set, you can add it to your configuration file as shown below:
@@ -72,6 +78,30 @@ deployment:
 ```
 
 Now if you don't specify these environment variables when running APISIX, it will fall back to the default values and expose the Admin API on port `9180` and listen on port `9080`.
+
+Similarly, you can also use environment variables in `apisix.yaml` when deploying APISIX in standalone mode.
+
+For example, you can export the upstream address and port to environment variables:
+
+```shell
+export HOST_ADDR=httpbin.org
+export HOST_PORT=80
+```
+
+Then create a route as such:
+
+```yaml title="apisix.yaml"
+routes:
+  -
+    uri: "/anything"
+    upstream:
+      nodes:
+        "${{HOST_ADDR}}:${{HOST_PORT}}": 1
+      type: roundrobin
+#END
+```
+
+Initialize and start APISIX in standalone mode, requests to `/anything` should now be forwarded to `httpbin.org:80/anything`.
 
 ## Using the `APISIX_PROFILE` environment variable
 


### PR DESCRIPTION
### Description

Mention env var support in `apisix.yaml` and add a caution note for exporting vars.

See the below issues for more background info:

Closes #10509 
Closes #10530

The info is also mentioned in the [Admin API doc](https://apisix.apache.org/docs/apisix/admin-api/#using-environment-variables) but not easy to locate. Personally I only found out after looking for the PR that adds the feature.

From a user perspective, when I search for apisix config env var, this is the doc that comes up first.

![image](https://github.com/apache/apisix/assets/39619599/e1ec9aba-19af-40ed-8f55-2de11ac026c6)

_Though it seems from the doc title that this doc wasn't originally for this content._

There has been other user that recently mentioned the info could not be located:

![image](https://github.com/apache/apisix/assets/39619599/f9897147-03fa-45b8-a1af-40d27f07a3a9)

https://the-asf.slack.com/archives/CUC5MN17A/p1703518877003939

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
