### PR TITLE
chore: move events sock path to conf

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -202,7 +202,7 @@ stream {
     {% if (events.module or "") == "lua-resty-events" then %}
     # the server block for lua-resty-events
     server {
-        listen unix:{*apisix_lua_home*}/logs/stream_worker_events.sock;
+        listen unix:{*apisix_lua_home*}/conf/stream_worker_events.sock;
         access_log off;
         content_by_lua_block {
             require("resty.events.compat").run()
@@ -497,7 +497,7 @@ http {
     {% if (events.module or "") == "lua-resty-events" then %}
     # the server block for lua-resty-events
     server {
-        listen unix:{*apisix_lua_home*}/logs/worker_events.sock;
+        listen unix:{*apisix_lua_home*}/conf/worker_events.sock;
         access_log off;
         location / {
             content_by_lua_block {

--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -64,6 +64,7 @@ env {*name*};
 thread_pool grpc-client-nginx-module threads=1;
 
 lua {
+    lua_shared_dict apisix 1m;
     {% if enabled_stream_plugins["prometheus"] then %}
     lua_shared_dict prometheus-metrics {* meta.lua_shared_dict["prometheus-metrics"] *};
     {% end %}
@@ -202,7 +203,7 @@ stream {
     {% if (events.module or "") == "lua-resty-events" then %}
     # the server block for lua-resty-events
     server {
-        listen unix:{*apisix_lua_home*}/conf/stream_worker_events.sock;
+        listen unix:{*apisix_lua_home*}/tmp/stream_worker_events.sock;
         access_log off;
         content_by_lua_block {
             require("resty.events.compat").run()
@@ -497,7 +498,7 @@ http {
     {% if (events.module or "") == "lua-resty-events" then %}
     # the server block for lua-resty-events
     server {
-        listen unix:{*apisix_lua_home*}/conf/worker_events.sock;
+        listen unix:{*apisix_lua_home*}/tmp/worker_events.sock;
         access_log off;
         location / {
             content_by_lua_block {

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -158,7 +158,7 @@ local function cleanup_unix_sockets(env)
     if pl_path.exists(events_http_sock_path) then
         local ok, err = os_remove(events_http_sock_path)
         if not ok then
-            util.die("failed to remove stale conf server sock file, error: ", err)
+            util.die("failed to remove stale worker events sock file, error: ", err)
         end
     end
 
@@ -166,7 +166,7 @@ local function cleanup_unix_sockets(env)
     if pl_path.exists(events_stream_sock_path) then
         local ok, err = os_remove(events_stream_sock_path)
         if not ok then
-            util.die("failed to remove stale conf server sock file, error: ", err)
+            util.die("failed to remove stale stream worker events sock file, error: ", err)
         end
     end
 end

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -153,6 +153,25 @@ local function get_lua_path(conf)
 end
 
 
+local function cleanup_unix_sockets(env)
+    local events_http_sock_path = env.apisix_home .. "/conf/worker_events.sock"
+    if pl_path.exists(events_http_sock_path) then
+        local ok, err = os_remove(events_http_sock_path)
+        if not ok then
+            util.die("failed to remove stale conf server sock file, error: ", err)
+        end
+    end
+
+    local events_stream_sock_path = env.apisix_home .. "/conf/stream_worker_events.sock"
+    if pl_path.exists(events_stream_sock_path) then
+        local ok, err = os_remove(events_stream_sock_path)
+        if not ok then
+            util.die("failed to remove stale conf server sock file, error: ", err)
+        end
+    end
+end
+
+
 local function init(env)
     if env.is_root_path then
         print('Warning! Running apisix under /root is only suitable for '
@@ -750,6 +769,8 @@ Please modify "admin_key" in conf/config.yaml .
     if not ok then
         util.die("failed to update nginx.conf: ", err, "\n")
     end
+
+    cleanup_unix_sockets(env)
 end
 
 

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -153,25 +153,6 @@ local function get_lua_path(conf)
 end
 
 
-local function cleanup_unix_sockets(env)
-    local events_http_sock_path = env.apisix_home .. "/conf/worker_events.sock"
-    if pl_path.exists(events_http_sock_path) then
-        local ok, err = os_remove(events_http_sock_path)
-        if not ok then
-            util.die("failed to remove stale worker events sock file, error: ", err)
-        end
-    end
-
-    local events_stream_sock_path = env.apisix_home .. "/conf/stream_worker_events.sock"
-    if pl_path.exists(events_stream_sock_path) then
-        local ok, err = os_remove(events_stream_sock_path)
-        if not ok then
-            util.die("failed to remove stale stream worker events sock file, error: ", err)
-        end
-    end
-end
-
-
 local function init(env)
     if env.is_root_path then
         print('Warning! Running apisix under /root is only suitable for '
@@ -769,8 +750,6 @@ Please modify "admin_key" in conf/config.yaml .
     if not ok then
         util.die("failed to update nginx.conf: ", err, "\n")
     end
-
-    cleanup_unix_sockets(env)
 end
 
 

--- a/apisix/core/utils.lua
+++ b/apisix/core/utils.lua
@@ -276,7 +276,7 @@ function _M.gethostname()
 end
 
 
--- Clean up and make sure the tmp folder exists, for code base internal use only 
+-- Clean up and make sure the tmp folder exists, for code base internal use only
 function _M.init_tmp_directory()
     local initialized_flag = "tmp_directory_initialized"
     -- skip initialize when reload
@@ -294,7 +294,7 @@ function _M.init_tmp_directory()
                 local abs_path = tmp_path..file
                 local ok, err = os_remove(abs_path)
                 if not ok then
-                    ngx.log(ngx.ERR, err)
+                    log.error("failed to cleanup files in tmp directory, error: ", err)
                 end
             end
         end

--- a/apisix/events.lua
+++ b/apisix/events.lua
@@ -129,10 +129,8 @@ end
 
 function _M.get_healthcheck_events_modele(self)
     if self.events_module == _M.EVENTS_MODULE_LUA_RESTY_EVENTS then
-        ngx.log(ngx.WARN, "resty.events")
         return "resty.events"
     else
-        ngx.log(ngx.WARN, "resty.worker.events")
         return "resty.worker.events"
     end
 end

--- a/apisix/events.lua
+++ b/apisix/events.lua
@@ -51,7 +51,7 @@ end
 local function init_resty_events()
     _M.events_module = _M.EVENTS_MODULE_LUA_RESTY_EVENTS
 
-    local listening = "unix:" .. ngx.config.prefix() .. "logs/"
+    local listening = "unix:" .. ngx.config.prefix() .. "conf/"
     if ngx.config.subsystem == "http" then
         listening = listening .. "worker_events.sock"
     else
@@ -129,8 +129,10 @@ end
 
 function _M.get_healthcheck_events_modele(self)
     if self.events_module == _M.EVENTS_MODULE_LUA_RESTY_EVENTS then
+        ngx.log(ngx.WARN, "resty.events")
         return "resty.events"
     else
+        ngx.log(ngx.WARN, "resty.worker.events")
         return "resty.worker.events"
     end
 end

--- a/apisix/events.lua
+++ b/apisix/events.lua
@@ -51,7 +51,7 @@ end
 local function init_resty_events()
     _M.events_module = _M.EVENTS_MODULE_LUA_RESTY_EVENTS
 
-    local listening = "unix:" .. ngx.config.prefix() .. "conf/"
+    local listening = "unix:" .. ngx.config.prefix() .. "tmp/"
     if ngx.config.subsystem == "http" then
         listening = listening .. "worker_events.sock"
     else

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -82,6 +82,7 @@ local _M = {version = 0.4}
 
 
 function _M.http_init(args)
+    core.utils.init_tmp_directory()
     core.resolver.init_resolver(args)
     core.id.init()
     core.env.init()

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -440,7 +440,7 @@ _EOC_
     $extra_stream_config
 
     server {
-        listen unix:$apisix_home/t/servroot/logs/stream_worker_events.sock;
+        listen unix:$apisix_home/t/servroot/conf/stream_worker_events.sock;
         access_log off;
         content_by_lua_block {
             require("resty.events.compat").run()
@@ -701,7 +701,7 @@ _EOC_
 
     $http_config .= <<_EOC_;
     server {
-        listen unix:$apisix_home/t/servroot/logs/worker_events.sock;
+        listen unix:$apisix_home/t/servroot/conf/worker_events.sock;
         access_log off;
         location / {
             content_by_lua_block {

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -271,6 +271,7 @@ _EOC_
 thread_pool grpc-client-nginx-module threads=1;
 
 lua {
+    lua_shared_dict apisix 1m;
     lua_shared_dict prometheus-metrics 15m;
 }
 _EOC_
@@ -440,7 +441,7 @@ _EOC_
     $extra_stream_config
 
     server {
-        listen unix:$apisix_home/t/servroot/conf/stream_worker_events.sock;
+        listen unix:$apisix_home/t/servroot/tmp/stream_worker_events.sock;
         access_log off;
         content_by_lua_block {
             require("resty.events.compat").run()
@@ -701,7 +702,7 @@ _EOC_
 
     $http_config .= <<_EOC_;
     server {
-        listen unix:$apisix_home/t/servroot/conf/worker_events.sock;
+        listen unix:$apisix_home/t/servroot/tmp/worker_events.sock;
         access_log off;
         location / {
             content_by_lua_block {


### PR DESCRIPTION
### Description

In my last PR #10550, I place the unix socket files in `logs` directory. It may be inappropriate because if we use a container environment with log-rotate turned on, we may mount the `logs` folder to an external volume, and I think we may run into communication and permissions issues.

So this PR moves the sock files to the conf folder, which is probably a better choice because that's where we're generating our nginx.conf right now, and the same way we used to create conf_server sock file there previously.

In addition, this PR adds some code for cleaning up the sock file to ensure that when an Nginx process crashes or is killed, the sock file can be cleaned up before the next startup, preventing such errors (this is because the file already exists):

```
✗ bin/apisix start
/usr/local/openresty//luajit/bin/luajit ./apisix/cli/apisix.lua start
nginx.pid exists but there's no corresponding process with pid  1860232 , the file will be overwritten
nginx: [emerg] bind() to unix:/home/bzp/code/apisix/conf/worker_events.sock failed (98: Address already in use)
nginx: [emerg] bind() to unix:/home/bzp/code/apisix/conf/worker_events.sock failed (98: Address already in use)
```

This often occurs when using containers, and we have to be able to handle it correctly.

This feature has not yet been released, so fixing it now is timely and involves no compatibility issues. In the meantime, no test cases themselves need to be changed.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
