### PR TITLE
fix(brotli-plugin): Skip brotli compression for upstream compressed response

### DIFF
--- a/apisix/plugins/brotli.lua
+++ b/apisix/plugins/brotli.lua
@@ -163,6 +163,11 @@ function _M.header_filter(conf, ctx)
         return
     end
 
+    local content_encoded = ngx_header["Content-Encoding"]
+    if content_encoded then
+        -- Don't compress if Content-Encoding is present in upstream data
+        return
+    end
     local types = conf.types
     local content_type = ngx_header["Content-Type"]
     if not content_type then

--- a/apisix/plugins/brotli.lua
+++ b/apisix/plugins/brotli.lua
@@ -166,8 +166,10 @@ function _M.header_filter(conf, ctx)
     local content_encoded = ngx_header["Content-Encoding"]
     if content_encoded then
         -- Don't compress if Content-Encoding is present in upstream data
+        core.log.info("content-encoding")
         return
     end
+    core.log.info(content_encoded)
     local types = conf.types
     local content_type = ngx_header["Content-Type"]
     if not content_type then

--- a/apisix/plugins/brotli.lua
+++ b/apisix/plugins/brotli.lua
@@ -168,6 +168,7 @@ function _M.header_filter(conf, ctx)
         -- Don't compress if Content-Encoding is present in upstream data
         return
     end
+    
     local types = conf.types
     local content_type = ngx_header["Content-Type"]
     if not content_type then

--- a/apisix/plugins/brotli.lua
+++ b/apisix/plugins/brotli.lua
@@ -168,7 +168,6 @@ function _M.header_filter(conf, ctx)
         -- Don't compress if Content-Encoding is present in upstream data
         return
     end
-    
     local types = conf.types
     local content_type = ngx_header["Content-Type"]
     if not content_type then

--- a/apisix/plugins/brotli.lua
+++ b/apisix/plugins/brotli.lua
@@ -168,6 +168,7 @@ function _M.header_filter(conf, ctx)
         -- Don't compress if Content-Encoding is present in upstream data
         return
     end
+
     local types = conf.types
     local content_type = ngx_header["Content-Type"]
     if not content_type then

--- a/apisix/plugins/brotli.lua
+++ b/apisix/plugins/brotli.lua
@@ -166,10 +166,8 @@ function _M.header_filter(conf, ctx)
     local content_encoded = ngx_header["Content-Encoding"]
     if content_encoded then
         -- Don't compress if Content-Encoding is present in upstream data
-        core.log.info("content-encoding")
         return
     end
-    core.log.info(content_encoded)
     local types = conf.types
     local content_type = ngx_header["Content-Type"]
     if not content_type then

--- a/docs/en/latest/plugins/brotli.md
+++ b/docs/en/latest/plugins/brotli.md
@@ -49,7 +49,7 @@ sudo ldconfig
 
 :::caution
 
-If the upstream is returning a compressed response, then the Brotli plugin won't be able to compress it. 
+If the upstream is returning a compressed response, then the Brotli plugin won't be able to compress it.
 
 :::
 

--- a/docs/en/latest/plugins/brotli.md
+++ b/docs/en/latest/plugins/brotli.md
@@ -49,7 +49,7 @@ sudo ldconfig
 
 :::caution
 
-If the upstream is returning compressed response, than brotli plugin won't be able to compress. 
+If the upstream is returning a compressed response, then the Brotli plugin won't be able to compress it. 
 
 :::
 

--- a/docs/en/latest/plugins/brotli.md
+++ b/docs/en/latest/plugins/brotli.md
@@ -47,6 +47,12 @@ sudo sh -c "echo /usr/local/brotli/lib >> /etc/ld.so.conf.d/brotli.conf"
 sudo ldconfig
 ```
 
+:::caution
+
+If the upstream is returning compressed response, than brotli plugin won't be able to compress. 
+
+:::
+
 ## Attributes
 
 | Name           | Type                 | Required | Default       | Valid values | Description                                                                             |

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -591,4 +591,11 @@ function _M.clickhouse_logger_server()
 end
 
 
+function _M.mock_compressed_upstream_response()
+    local s = "compressed_response"
+    ngx.header['Content-Encoding'] = 'gzip'
+    ngx.say(s)
+end
+
+
 return _M

--- a/t/plugin/brotli.t
+++ b/t/plugin/brotli.t
@@ -755,7 +755,7 @@ passed
 
 
 
-=== TEST 31: hit - skip brotli compression of compressed upsteam response
+=== TEST 31: hit - skip brotli compression of compressed upstream response
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/brotli.t
+++ b/t/plugin/brotli.t
@@ -718,3 +718,31 @@ passed
     }
 --- response_body
 ok
+
+
+
+=== TEST 30: hit - skip brotli compression of compressed response, return the same upstream response
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port
+                        .. "/mock_compressed_upstream_response"
+            local httpc = http.new()
+            local req_body = ("abcdf01234"):rep(1024)
+            local res, err = httpc:request_uri(uri,
+                {method = "POST", headers = {["Accept-Encoding"] = "gzip, br"}, body = req_body})
+            if not res then
+                ngx.say(err)
+                return
+            end
+        }
+    }
+--- request
+GET /t
+--- more_headers
+Accept-Encoding: gzip, br
+Vary: upstream
+Content-Type: text/html
+--- response_headers
+Content-Encoding: gzip

--- a/t/plugin/brotli.t
+++ b/t/plugin/brotli.t
@@ -770,7 +770,7 @@ passed
                 ngx.say(err)
                 return
             end
-            if res.headers["Content-Encoding"] ~= 'gzip' then
+            if res.headers["Content-Encoding"] == 'gzip' then
                 ngx.say("ok")
             end
         }

--- a/t/plugin/brotli.t
+++ b/t/plugin/brotli.t
@@ -770,6 +770,7 @@ passed
                 ngx.say(err)
                 return
             end
+            ngx.say(res)
         }
     }
 --- request

--- a/t/plugin/brotli.t
+++ b/t/plugin/brotli.t
@@ -770,7 +770,9 @@ passed
                 ngx.say(err)
                 return
             end
-            ngx.say(res)
+            if res.headers["Content-Encoding"] ~= 'gzip' then
+                ngx.say("ok")
+            end
         }
     }
 --- request
@@ -779,5 +781,5 @@ GET /t
 Accept-Encoding: gzip, br
 Vary: upstream
 Content-Type: text/html
---- response_headers
-Content-Encoding: gzip
+--- response_body
+ok

--- a/t/plugin/brotli.t
+++ b/t/plugin/brotli.t
@@ -721,7 +721,41 @@ ok
 
 
 
-=== TEST 30: hit - skip brotli compression of compressed response, return the same upstream response
+=== TEST 30: mock upstream compressed response
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/mock_compressed_upstream_response",
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        }
+                    },
+                    "plugins": {
+                        "brotli": {
+                            "types": "*"
+                        }
+                    }
+            }]]
+            )
+
+        if code >= 300 then
+            ngx.status = code
+        end
+        ngx.say(body)
+    }
+}
+--- response_body
+passed
+
+
+
+=== TEST 31: hit - skip brotli compression of compressed upsteam response
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
- Fixes #10739 (issue)
---
Skipping the `brotli` compression if the upstream response is already compressed.

## The Problem
The problem occurs when the upstream service sends compressed data/response either in `gzip` or `deflate`. Apisix tries to compress data in `brotli` which is already compressed and, in turn, returns encoded data that can not be used by the browser or application.

## Possible Solutions
There are two options to solve the problem first to skip the further compression and return with the upstream compressed response. The second is to decompress the upstream response and then compress using `brotli`, which is not viable on apisix gateway, it increases the overhead of the gateway and results in increasing latency and computation requirements.

This PR solves the Issue by skipping the `brotli` compression if the upstream response is compressed.


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
