### PR TITLE
fix: authz_keycloak plugin giving 500 error 

### DIFF
--- a/apisix/plugins/authz-keycloak.lua
+++ b/apisix/plugins/authz-keycloak.lua
@@ -503,7 +503,7 @@ local function authz_keycloak_resolve_resource(conf, uri, sa_access_token)
     if not resource_registration_endpoint then
         local err = "Unable to determine registration endpoint."
         log.error(err)
-        return 503, err
+        return nil, err
     end
 
     log.debug("Resource registration endpoint: ", resource_registration_endpoint)

--- a/t/plugin/authz-keycloak2.t
+++ b/t/plugin/authz-keycloak2.t
@@ -654,3 +654,90 @@ true
 GET /t
 --- response_body
 true
+
+
+
+=== TEST 16: add plugin with lazy_load_paths when resource_registration_endpoint is neither in config not in the discovery doc
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "authz-keycloak": {
+                                "discovery": "http://127.0.0.1:8080/realms/University/.well-known/openid-configuration",
+                                "client_id": "course_management",
+                                "client_secret": "d1ec69e9-55d2-4109-a3ea-befa071579d5",
+                                "lazy_load_paths": true
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1982": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/course/foo"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 17: Get access token for student and access view course route.
+--- config
+    location /t {
+        content_by_lua_block {
+            local json_decode = require("toolkit.json").decode
+            local http = require "resty.http"
+            local httpc = http.new()
+            local uri = "http://127.0.0.1:8080/realms/University/protocol/openid-connect/token"
+            local res, err = httpc:request_uri(uri, {
+                    method = "POST",
+                    body = "grant_type=password&client_id=course_management&client_secret=d1ec69e9-55d2-4109-a3ea-befa071579d5&username=student@gmail.com&password=123456",
+                    headers = {
+                        ["Content-Type"] = "application/x-www-form-urlencoded"
+                    }
+                })
+
+            if res.status == 200 then
+                local body = json_decode(res.body)
+                local accessToken = body["access_token"]
+
+
+                uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/course/foo"
+                local res, err = httpc:request_uri(uri, {
+                    method = "GET",
+                    headers = {
+                        ["Authorization"] = "Bearer " .. accessToken,
+                    }
+                 })
+
+                if res.status == 503 then
+                    ngx.say(true)
+                else
+                    ngx.say(res.status)
+                end
+            else
+                ngx.say(false)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+true
+--- error_log
+Unable to determine registration endpoint.

--- a/t/plugin/authz-keycloak2.t
+++ b/t/plugin/authz-keycloak2.t
@@ -741,3 +741,4 @@ GET /t
 true
 --- error_log
 Unable to determine registration endpoint.
+

--- a/t/plugin/authz-keycloak2.t
+++ b/t/plugin/authz-keycloak2.t
@@ -657,7 +657,7 @@ true
 
 
 
-=== TEST 16: add plugin with lazy_load_paths when resource_registration_endpoint is neither in config not in the discovery doc
+=== TEST 16: add plugin with lazy_load_paths when resource_registration_endpoint is neither in config nor in the discovery doc
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/authz-keycloak2.t
+++ b/t/plugin/authz-keycloak2.t
@@ -741,4 +741,3 @@ GET /t
 true
 --- error_log
 Unable to determine registration endpoint.
-

--- a/t/plugin/authz-keycloak2.t
+++ b/t/plugin/authz-keycloak2.t
@@ -728,7 +728,7 @@ passed
                 if res.status == 503 then
                     ngx.say(true)
                 else
-                    ngx.say(res.status)
+                    ngx.say(false)
                 end
             else
                 ngx.say(false)


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

In the authz_keycloack plugin, when we set `lazy_load_paths` as true and do not provide `resource_registration_endpoint` either in the plugin config or in the discovery doc we get a 500 error code. 
This error code comes from here https://github.com/apache/apisix/blob/ab67b095bf7200274b37af5c589fc093858d98e8/apisix/plugins/authz-keycloak.lua#L580 when we try to get the length of `permission` because an integer value, 503, is passed to it from here https://github.com/apache/apisix/blob/ab67b095bf7200274b37af5c589fc093858d98e8/apisix/plugins/authz-keycloak.lua#L506

This PR changes the return value of `permission` to `nil`.  This will now return error 503 when this check runs:
https://github.com/apache/apisix/blob/ab67b095bf7200274b37af5c589fc093858d98e8/apisix/plugins/authz-keycloak.lua#L569

Fixes #10708 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
