### PR TITLE
change: unify the keyring and key_encrypt_salt fields, remove ssl:key_encrypt_salt

### DIFF
--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -175,7 +175,7 @@ local function path_is_multi_type(path, type_val)
         return true
     end
 
-    if path == "apisix->ssl->key_encrypt_salt" then
+    if path == "apisix->data_encryption->keyring" then
         return true
     end
 

--- a/apisix/cli/schema.lua
+++ b/apisix/cli/schema.lua
@@ -224,24 +224,6 @@ local config_schema = {
                                 }
                             }
                         },
-                        key_encrypt_salt = {
-                            anyOf = {
-                                {
-                                    type = "array",
-                                    minItems = 1,
-                                    items = {
-                                        type = "string",
-                                        minLength = 16,
-                                        maxLength = 16
-                                    }
-                                },
-                                {
-                                    type = "string",
-                                    minLength = 16,
-                                    maxLength = 16
-                                }
-                            }
-                        },
                     }
                 },
             }

--- a/apisix/cli/schema.lua
+++ b/apisix/cli/schema.lua
@@ -248,7 +248,7 @@ local config_schema = {
                             }
                         },
                     }
-                }
+                },
             }
         },
         nginx_config = {

--- a/apisix/cli/schema.lua
+++ b/apisix/cli/schema.lua
@@ -226,6 +226,29 @@ local config_schema = {
                         },
                     }
                 },
+                data_encryption = {
+                    type = "object",
+                    properties = {
+                        keyring = {
+                            anyOf = {
+                                {
+                                    type = "array",
+                                    minItems = 1,
+                                    items = {
+                                        type = "string",
+                                        minLength = 16,
+                                        maxLength = 16
+                                    }
+                                },
+                                {
+                                    type = "string",
+                                    minLength = 16,
+                                    maxLength = 16
+                                }
+                            }
+                        },
+                    }
+                }
             }
         },
         nginx_config = {

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -906,7 +906,8 @@ local enable_data_encryption
 local function enable_gde()
     if enable_data_encryption == nil then
         enable_data_encryption =
-            core.table.try_read_attr(local_conf, "apisix", "data_encryption", "enable_encrypt_fields")
+            core.table.try_read_attr(local_conf, "apisix", "data_encryption",
+                    "enable_encrypt_fields")
         _M.enable_data_encryption = enable_data_encryption
     end
 
@@ -946,7 +947,7 @@ local function decrypt_conf(name, conf, schema_type)
     if schema.encrypt_fields and not core.table.isempty(schema.encrypt_fields) then
         for _, key in ipairs(schema.encrypt_fields) do
             if conf[key] then
-                local decrypted, err = apisix_ssl.aes_decrypt_pkey(conf[key], "data_encrypt")
+                local decrypted, err = apisix_ssl.aes_decrypt_pkey(conf[key])
                 if not decrypted then
                     core.log.warn("failed to decrypt the conf of plugin [", name,
                                   "] key [", key, "], err: ", err)
@@ -963,8 +964,7 @@ local function decrypt_conf(name, conf, schema_type)
 
                 -- we only support two levels
                 if conf[res[1]] and conf[res[1]][res[2]] then
-                    local decrypted, err = apisix_ssl.aes_decrypt_pkey(
-                                           conf[res[1]][res[2]], "data_encrypt")
+                    local decrypted, err = apisix_ssl.aes_decrypt_pkey(conf[res[1]][res[2]])
                     if not decrypted then
                         core.log.warn("failed to decrypt the conf of plugin [", name,
                                       "] key [", key, "], err: ", err)
@@ -992,7 +992,7 @@ local function encrypt_conf(name, conf, schema_type)
     if schema.encrypt_fields and not core.table.isempty(schema.encrypt_fields) then
         for _, key in ipairs(schema.encrypt_fields) do
             if conf[key] then
-                local encrypted, err = apisix_ssl.aes_encrypt_pkey(conf[key], "data_encrypt")
+                local encrypted, err = apisix_ssl.aes_encrypt_pkey(conf[key])
                 if not encrypted then
                     core.log.warn("failed to encrypt the conf of plugin [", name,
                                   "] key [", key, "], err: ", err)
@@ -1009,8 +1009,7 @@ local function encrypt_conf(name, conf, schema_type)
 
                 -- we only support two levels
                 if conf[res[1]] and conf[res[1]][res[2]] then
-                    local encrypted, err = apisix_ssl.aes_encrypt_pkey(
-                                           conf[res[1]][res[2]], "data_encrypt")
+                    local encrypted, err = apisix_ssl.aes_encrypt_pkey(conf[res[1]][res[2]])
                     if not encrypted then
                         core.log.warn("failed to encrypt the conf of plugin [", name,
                                       "] key [", key, "], err: ", err)

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -947,7 +947,7 @@ local function decrypt_conf(name, conf, schema_type)
     if schema.encrypt_fields and not core.table.isempty(schema.encrypt_fields) then
         for _, key in ipairs(schema.encrypt_fields) do
             if conf[key] then
-                local decrypted, err = apisix_ssl.aes_decrypt_pkey(conf[key])
+                local decrypted, err = apisix_ssl.aes_decrypt_pkey(conf[key], "data_encrypt")
                 if not decrypted then
                     core.log.warn("failed to decrypt the conf of plugin [", name,
                                   "] key [", key, "], err: ", err)
@@ -964,7 +964,8 @@ local function decrypt_conf(name, conf, schema_type)
 
                 -- we only support two levels
                 if conf[res[1]] and conf[res[1]][res[2]] then
-                    local decrypted, err = apisix_ssl.aes_decrypt_pkey(conf[res[1]][res[2]])
+                    local decrypted, err = apisix_ssl.aes_decrypt_pkey(
+                                           conf[res[1]][res[2]], "data_encrypt")
                     if not decrypted then
                         core.log.warn("failed to decrypt the conf of plugin [", name,
                                       "] key [", key, "], err: ", err)
@@ -992,7 +993,7 @@ local function encrypt_conf(name, conf, schema_type)
     if schema.encrypt_fields and not core.table.isempty(schema.encrypt_fields) then
         for _, key in ipairs(schema.encrypt_fields) do
             if conf[key] then
-                local encrypted, err = apisix_ssl.aes_encrypt_pkey(conf[key])
+                local encrypted, err = apisix_ssl.aes_encrypt_pkey(conf[key], "data_encrypt")
                 if not encrypted then
                     core.log.warn("failed to encrypt the conf of plugin [", name,
                                   "] key [", key, "], err: ", err)
@@ -1009,7 +1010,8 @@ local function encrypt_conf(name, conf, schema_type)
 
                 -- we only support two levels
                 if conf[res[1]] and conf[res[1]][res[2]] then
-                    local encrypted, err = apisix_ssl.aes_encrypt_pkey(conf[res[1]][res[2]])
+                    local encrypted, err = apisix_ssl.aes_encrypt_pkey(
+                                           conf[res[1]][res[2]], "data_encrypt")
                     if not encrypted then
                         core.log.warn("failed to encrypt the conf of plugin [", name,
                                       "] key [", key, "], err: ", err)

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -992,7 +992,7 @@ local function encrypt_conf(name, conf, schema_type)
     if schema.encrypt_fields and not core.table.isempty(schema.encrypt_fields) then
         for _, key in ipairs(schema.encrypt_fields) do
             if conf[key] then
-                local encrypted, err = apisix_ssl.aes_encrypt_pkey(conf[key], "data_encrypt")
+                local encrypted, err = apisix_ssl.aes_encrypt_pkey(conf[key])
                 if not encrypted then
                     core.log.warn("failed to encrypt the conf of plugin [", name,
                                   "] key [", key, "], err: ", err)
@@ -1009,8 +1009,7 @@ local function encrypt_conf(name, conf, schema_type)
 
                 -- we only support two levels
                 if conf[res[1]] and conf[res[1]][res[2]] then
-                    local encrypted, err = apisix_ssl.aes_encrypt_pkey(
-                                           conf[res[1]][res[2]], "data_encrypt")
+                    local encrypted, err = apisix_ssl.aes_encrypt_pkey(conf[res[1]][res[2]])
                     if not encrypted then
                         core.log.warn("failed to encrypt the conf of plugin [", name,
                                       "] key [", key, "], err: ", err)

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -906,7 +906,7 @@ local enable_data_encryption
 local function enable_gde()
     if enable_data_encryption == nil then
         enable_data_encryption =
-            core.table.try_read_attr(local_conf, "apisix", "data_encryption", "enable")
+            core.table.try_read_attr(local_conf, "apisix", "data_encryption", "enable_encrypt_fields")
         _M.enable_data_encryption = enable_data_encryption
     end
 
@@ -992,7 +992,7 @@ local function encrypt_conf(name, conf, schema_type)
     if schema.encrypt_fields and not core.table.isempty(schema.encrypt_fields) then
         for _, key in ipairs(schema.encrypt_fields) do
             if conf[key] then
-                local encrypted, err = apisix_ssl.aes_encrypt_pkey(conf[key])
+                local encrypted, err = apisix_ssl.aes_encrypt_pkey(conf[key], "data_encrypt")
                 if not encrypted then
                     core.log.warn("failed to encrypt the conf of plugin [", name,
                                   "] key [", key, "], err: ", err)
@@ -1009,7 +1009,8 @@ local function encrypt_conf(name, conf, schema_type)
 
                 -- we only support two levels
                 if conf[res[1]] and conf[res[1]][res[2]] then
-                    local encrypted, err = apisix_ssl.aes_encrypt_pkey(conf[res[1]][res[2]])
+                    local encrypted, err = apisix_ssl.aes_encrypt_pkey(
+                                           conf[res[1]][res[2]], "data_encrypt")
                     if not encrypted then
                         core.log.warn("failed to encrypt the conf of plugin [", name,
                                       "] key [", key, "], err: ", err)

--- a/apisix/ssl.lua
+++ b/apisix/ssl.lua
@@ -90,17 +90,6 @@ local function init_iv_tbl(ivs)
 end
 
 
-local _aes_128_cbc_with_iv_tbl_ssl
-local function get_aes_128_cbc_with_iv_ssl(local_conf)
-    if _aes_128_cbc_with_iv_tbl_ssl == nil then
-        local ivs = core.table.try_read_attr(local_conf, "apisix", "ssl", "key_encrypt_salt")
-        _aes_128_cbc_with_iv_tbl_ssl = init_iv_tbl(ivs)
-    end
-
-    return _aes_128_cbc_with_iv_tbl_ssl
-end
-
-
 local _aes_128_cbc_with_iv_tbl_gde
 local function get_aes_128_cbc_with_iv_gde(local_conf)
     if _aes_128_cbc_with_iv_tbl_gde == nil then
@@ -123,44 +112,26 @@ local function encrypt(aes_128_cbc_with_iv, origin)
     return ngx_encode_base64(encrypted)
 end
 
-function _M.aes_encrypt_pkey(origin, field)
+function _M.aes_encrypt_pkey(origin)
     local local_conf = core.config.local_conf()
 
-    if not field then
-        -- default used by ssl
-        local aes_128_cbc_with_iv_tbl_ssl = get_aes_128_cbc_with_iv_ssl(local_conf)
-        local aes_128_cbc_with_iv_ssl = aes_128_cbc_with_iv_tbl_ssl[1]
-        if aes_128_cbc_with_iv_ssl ~= nil and core.string.has_prefix(origin, "---") then
-            return encrypt(aes_128_cbc_with_iv_ssl, origin)
-        end
-    else
-        if field == "data_encrypt" then
-            local aes_128_cbc_with_iv_tbl_gde = get_aes_128_cbc_with_iv_gde(local_conf)
-            local aes_128_cbc_with_iv_gde = aes_128_cbc_with_iv_tbl_gde[1]
-            if aes_128_cbc_with_iv_gde ~= nil then
-                return encrypt(aes_128_cbc_with_iv_gde, origin)
-            end
-        end
+    local aes_128_cbc_with_iv_tbl_gde = get_aes_128_cbc_with_iv_gde(local_conf)
+    local aes_128_cbc_with_iv_gde = aes_128_cbc_with_iv_tbl_gde[1]
+    if aes_128_cbc_with_iv_gde ~= nil and core.string.has_prefix(origin, "---") then
+        return encrypt(aes_128_cbc_with_iv_gde, origin)
     end
 
     return origin
 end
 
 
-local function aes_decrypt_pkey(origin, field)
+local function aes_decrypt_pkey(origin)
     local local_conf = core.config.local_conf()
-    local aes_128_cbc_with_iv_tbl
 
-    if not field then
-        if core.string.has_prefix(origin, "---") then
-            return origin
-        end
-        aes_128_cbc_with_iv_tbl = get_aes_128_cbc_with_iv_ssl(local_conf)
-    else
-        if field == "data_encrypt" then
-            aes_128_cbc_with_iv_tbl = get_aes_128_cbc_with_iv_gde(local_conf)
-        end
+    if core.string.has_prefix(origin, "---") then
+        return origin
     end
+    local aes_128_cbc_with_iv_tbl = get_aes_128_cbc_with_iv_gde(local_conf)
 
     if #aes_128_cbc_with_iv_tbl == 0 then
         return origin

--- a/apisix/ssl.lua
+++ b/apisix/ssl.lua
@@ -112,27 +112,34 @@ local function encrypt(aes_128_cbc_with_iv, origin)
     return ngx_encode_base64(encrypted)
 end
 
-function _M.aes_encrypt_pkey(origin)
+function _M.aes_encrypt_pkey(origin, field)
     local local_conf = core.config.local_conf()
-
     local aes_128_cbc_with_iv_tbl_gde = get_aes_128_cbc_with_iv_gde(local_conf)
     local aes_128_cbc_with_iv_gde = aes_128_cbc_with_iv_tbl_gde[1]
-    if aes_128_cbc_with_iv_gde ~= nil and core.string.has_prefix(origin, "---") then
+
+    if aes_128_cbc_with_iv_gde == nil then
+        return origin
+    end
+
+    if not field and core.string.has_prefix(origin, "---") then
         return encrypt(aes_128_cbc_with_iv_gde, origin)
+    else
+        if field == "data_encrypt" then
+            return encrypt(aes_128_cbc_with_iv_gde, origin)
+        end
     end
 
     return origin
 end
 
 
-local function aes_decrypt_pkey(origin)
-    local local_conf = core.config.local_conf()
-
-    if core.string.has_prefix(origin, "---") then
+local function aes_decrypt_pkey(origin, field)
+    if not field and core.string.has_prefix(origin, "---") then
         return origin
     end
-    local aes_128_cbc_with_iv_tbl = get_aes_128_cbc_with_iv_gde(local_conf)
 
+    local local_conf = core.config.local_conf()
+    local aes_128_cbc_with_iv_tbl = get_aes_128_cbc_with_iv_gde(local_conf)
     if #aes_128_cbc_with_iv_tbl == 0 then
         return origin
     end

--- a/apisix/ssl.lua
+++ b/apisix/ssl.lua
@@ -112,20 +112,28 @@ local function encrypt(aes_128_cbc_with_iv, origin)
     return ngx_encode_base64(encrypted)
 end
 
-function _M.aes_encrypt_pkey(origin)
+function _M.aes_encrypt_pkey(origin, field)
     local local_conf = core.config.local_conf()
     local aes_128_cbc_with_iv_tbl_gde = get_aes_128_cbc_with_iv_gde(local_conf)
     local aes_128_cbc_with_iv_gde = aes_128_cbc_with_iv_tbl_gde[1]
 
-    if aes_128_cbc_with_iv_gde == nil then
-        return origin
+    if not field then
+        if aes_128_cbc_with_iv_gde ~= nil and core.string.has_prefix(origin, "---") then
+            return encrypt(aes_128_cbc_with_iv_gde, origin)
+        end
+    else
+        if field == "data_encrypt" then
+            if aes_128_cbc_with_iv_gde ~= nil then
+                return encrypt(aes_128_cbc_with_iv_gde, origin)
+            end
+        end
     end
-    return encrypt(aes_128_cbc_with_iv_gde, origin)
+    return origin
 end
 
 
-local function aes_decrypt_pkey(origin)
-    if core.string.has_prefix(origin, "---") then
+local function aes_decrypt_pkey(origin, field)
+    if not field and core.string.has_prefix(origin, "---") then
         return origin
     end
 

--- a/apisix/ssl.lua
+++ b/apisix/ssl.lua
@@ -112,7 +112,7 @@ local function encrypt(aes_128_cbc_with_iv, origin)
     return ngx_encode_base64(encrypted)
 end
 
-function _M.aes_encrypt_pkey(origin, field)
+function _M.aes_encrypt_pkey(origin)
     local local_conf = core.config.local_conf()
     local aes_128_cbc_with_iv_tbl_gde = get_aes_128_cbc_with_iv_gde(local_conf)
     local aes_128_cbc_with_iv_gde = aes_128_cbc_with_iv_tbl_gde[1]
@@ -120,21 +120,12 @@ function _M.aes_encrypt_pkey(origin, field)
     if aes_128_cbc_with_iv_gde == nil then
         return origin
     end
-
-    if not field and core.string.has_prefix(origin, "---") then
-        return encrypt(aes_128_cbc_with_iv_gde, origin)
-    else
-        if field == "data_encrypt" then
-            return encrypt(aes_128_cbc_with_iv_gde, origin)
-        end
-    end
-
-    return origin
+    return encrypt(aes_128_cbc_with_iv_gde, origin)
 end
 
 
-local function aes_decrypt_pkey(origin, field)
-    if not field and core.string.has_prefix(origin, "---") then
+local function aes_decrypt_pkey(origin)
+    if core.string.has_prefix(origin, "---") then
         return origin
     end
 

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -108,16 +108,6 @@ apisix:
                                 # Disabled by default because it renders Perfect Forward Secrecy (FPS)
                                 # useless. See https://github.com/mozilla/server-side-tls/issues/135.
 
-    key_encrypt_salt:           # This field is only used to encrypt the private key of SSL.
-      - edd1c9f0985e76a2        # Set the encryption key for AES-128-CBC. It should be a
-                                # hexadecimal string of length 16.
-                                # If not set, APISIX saves the original data into etcd.
-                                # CAUTION: If you would like to update the key, add the new key as the
-                                # first item in the array and keep the older keys below the newly added
-                                # key, so that data can be decrypted with the older keys and encrypted
-                                # with the new key. Removing the old keys directly can render the data
-                                # unrecoverable.
-
     # fallback_sni: "my.default.domain"      # Fallback SNI to be used if the client does not send SNI during
     #                                        # the handshake.
 
@@ -132,7 +122,7 @@ apisix:
     enable: false
     keyring:                      # Set the encryption key for AES-128-CBC. It should be a
       - qeddd145sfvddff3          # hexadecimal string of length 16.
-                                  # If not set, APISIX saves the original data into etcd.
+      - edd1c9f0985e76a2          # If not set, APISIX saves the original data into etcd.
                                   # CAUTION: If you would like to update the key, add the new key as the
                                   # first item in the array and keep the older keys below the newly added
                                   # key, so that data can be decrypted with the older keys and encrypted

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -118,10 +118,12 @@ apisix:
 
   disable_sync_configuration_during_start: false  # Safe exit. TO BE REMOVED.
 
-  data_encryption:                # Encrypt fields specified in `encrypt_fields` in plugin schema.
-    enable: false
-    keyring:                      # Set the encryption key for AES-128-CBC. It should be a
-      - qeddd145sfvddff3          # hexadecimal string of length 16.
+  data_encryption:                # Data encryption settings.
+    enable_encrypt_fields: false  # Whether enable encrypt fields specified in `encrypt_fields` in plugin schema.
+    keyring:                      # This field is used to encrypt the private key of SSL and the `encrypt_fields`
+                                  # in plugin schema.
+      - qeddd145sfvddff3          # Set the encryption key for AES-128-CBC. It should be a hexadecimal string
+                                  # of length 16.
       - edd1c9f0985e76a2          # If not set, APISIX saves the original data into etcd.
                                   # CAUTION: If you would like to update the key, add the new key as the
                                   # first item in the array and keep the older keys below the newly added

--- a/t/admin/ssl2.t
+++ b/t/admin/ssl2.t
@@ -431,8 +431,8 @@ qr/"snis":\["update1.com","update2.com"\]/
 --- yaml_config
 apisix:
     node_listen: 1984
-    ssl:
-        key_encrypt_salt: "edd1c9f0985e76a2"
+    data_encryption:
+        keyring: "qeddd145sfvddff3"
 --- config
     location /t {
         content_by_lua_block {
@@ -468,8 +468,8 @@ false
 --- yaml_config
 apisix:
     node_listen: 1984
-    ssl:
-        key_encrypt_salt: "edd1c9f0985e76a2"
+    data_encryption:
+        keyring: "qeddd145sfvddff3"
 --- config
     location /t {
         content_by_lua_block {

--- a/t/admin/ssl4.t
+++ b/t/admin/ssl4.t
@@ -110,14 +110,14 @@ run_tests;
 
 __DATA__
 
-=== TEST 1: set ssl(sni: www.test.com), encrypt with the first key_encrypt_salt
+=== TEST 1: set ssl(sni: www.test.com), encrypt with the first keyring
 --- yaml_config
 apisix:
     node_listen: 1984
-    ssl:
-        key_encrypt_salt:
+    data_encryption:
+        keyring:
             - edd1c9f0985e76a1
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
 location /t {
     content_by_lua_block {
@@ -152,8 +152,8 @@ passed
 --- yaml_config
 apisix:
     node_listen: 1984
-    ssl:
-        key_encrypt_salt: "edd1c9f0985e76a1"
+    data_encryption:
+        keyring: "edd1c9f0985e76a1"
 --- config
     location /t {
         content_by_lua_block {
@@ -182,12 +182,12 @@ passed
 
 
 
-=== TEST 3: client request with the old style key_encrypt_salt
+=== TEST 3: client request with the old style keyring
 --- yaml_config
 apisix:
     node_listen: 1984
-    ssl:
-        key_encrypt_salt: "edd1c9f0985e76a1"
+    data_encryption:
+        keyring: "edd1c9f0985e76a1"
 --- response_body eval
 qr{connected: 1
 ssl handshake: true
@@ -207,12 +207,12 @@ server name: "www.test.com"
 
 
 
-=== TEST 4: client request with the new style key_encrypt_salt
+=== TEST 4: client request with the new style keyring
 --- yaml_config
 apisix:
     node_listen: 1984
-    ssl:
-        key_encrypt_salt:
+    data_encryption:
+        keyring:
             - edd1c9f0985e76a1
 --- response_body eval
 qr{connected: 1
@@ -233,26 +233,26 @@ server name: "www.test.com"
 
 
 
-=== TEST 5: client request failed with the wrong key_encrypt_salt
+=== TEST 5: client request failed with the wrong keyring
 --- yaml_config
 apisix:
     node_listen: 1984
-    ssl:
-        key_encrypt_salt:
-            - edd1c9f0985e76a2
+    data_encryption:
+        keyring:
+            - qeddd145sfvddff3
 --- error_log
 decrypt ssl key failed
 [alert]
 
 
 
-=== TEST 6: client request successfully, use the two key_encrypt_salt to decrypt in turn
+=== TEST 6: client request successfully, use the two keyring to decrypt in turn
 --- yaml_config
 apisix:
     node_listen: 1984
-    ssl:
-        key_encrypt_salt:
-            - edd1c9f0985e76a2
+    data_encryption:
+        keyring:
+            - qeddd145sfvddff3
             - edd1c9f0985e76a1
 --- response_body eval
 qr{connected: 1
@@ -273,8 +273,8 @@ close: 1 nil}
 --- yaml_config
 apisix:
     node_listen: 1984
-    ssl:
-        key_encrypt_salt:
+    data_encryption:
+        keyring:
             - edd1c9f0985e76a1
 --- config
 location /t {
@@ -292,8 +292,8 @@ location /t {
 --- yaml_config
 apisix:
     node_listen: 1984
-    ssl:
-        key_encrypt_salt: null
+    data_encryption:
+        keyring: null
 --- config
 location /t {
     content_by_lua_block {
@@ -324,12 +324,12 @@ passed
 
 
 
-=== TEST 9: client request without key_encrypt_salt
+=== TEST 9: client request without keyring
 --- yaml_config
 apisix:
     node_listen: 1984
-    ssl:
-        key_encrypt_salt: null
+    data_encryption:
+        keyring: null
 --- response_body eval
 qr{connected: 1
 ssl handshake: true
@@ -353,8 +353,8 @@ server name: "www.test.com"
 --- yaml_config
 apisix:
     node_listen: 1984
-    ssl:
-        key_encrypt_salt: null
+    data_encryption:
+        keyring: null
 --- config
 location /t {
     content_by_lua_block {
@@ -371,8 +371,8 @@ location /t {
 --- yaml_config
 apisix:
     node_listen: 1984
-    ssl:
-        key_encrypt_salt: null
+    data_encryption:
+        keyring: null
 --- config
 location /t {
     content_by_lua_block {

--- a/t/node/data_encrypt.t
+++ b/t/node/data_encrypt.t
@@ -41,7 +41,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {
@@ -131,7 +131,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- request
 GET /hello
 --- more_headers
@@ -147,7 +147,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {
@@ -232,7 +232,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- request
 GET /hello
 --- more_headers
@@ -249,7 +249,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: false
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {
@@ -293,7 +293,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {
@@ -346,7 +346,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {
@@ -404,7 +404,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- request
 GET /hello
 --- more_headers
@@ -415,13 +415,13 @@ hello world
 
 
 
-=== TEST 11: keyring rotate, encrypt with qeddd145sfvddff3
+=== TEST 11: keyring rotate, encrypt with edd1c9f0985e76a2
 --- yaml_config
 apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {
@@ -474,14 +474,14 @@ passed
 
 
 
-=== TEST 12: keyring rotate, decrypt with qeddd145sfvddff3 would fail, but encrypt with qeddd145sfvddff3 would success
+=== TEST 12: keyring rotate, decrypt with edd1c9f0985e76a2 would fail, but encrypt with edd1c9f0985e76a2 would success
 --- yaml_config
 apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
             - qeddd145sfvddff3
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- request
 GET /hello
 --- more_headers
@@ -497,7 +497,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {

--- a/t/node/data_encrypt.t
+++ b/t/node/data_encrypt.t
@@ -474,7 +474,7 @@ passed
 
 
 
-=== TEST 12: keyring rotate, decrypt with edd1c9f0985e76a2 would fail, but encrypt with edd1c9f0985e76a2 would success
+=== TEST 12: keyring rotate, decrypt with qeddd145sfvddff3 would fail, but encrypt with edd1c9f0985e76a2 would success
 --- yaml_config
 apisix:
     data_encryption:

--- a/t/node/data_encrypt.t
+++ b/t/node/data_encrypt.t
@@ -39,9 +39,9 @@ __DATA__
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {
@@ -129,9 +129,9 @@ passed
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- request
 GET /hello
 --- more_headers
@@ -145,9 +145,9 @@ hello world
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {
@@ -230,9 +230,9 @@ passed
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- request
 GET /hello
 --- more_headers
@@ -247,9 +247,9 @@ hello world
 --- yaml_config
 apisix:
     data_encryption:
-        enable: false
+        enable_encrypt_fields: false
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {
@@ -291,9 +291,9 @@ bar
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {
@@ -344,9 +344,9 @@ failed to decrypt the conf of plugin [basic-auth] key [password], err: decrypt s
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {
@@ -402,9 +402,9 @@ failed to decrypt the conf of plugin [basic-auth] key [password], err: decrypt s
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- request
 GET /hello
 --- more_headers
@@ -415,13 +415,13 @@ hello world
 
 
 
-=== TEST 11: keyring rotate, encrypt with edd1c9f0985e76a2
+=== TEST 11: keyring rotate, encrypt with qeddd145sfvddff3
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {
@@ -474,14 +474,14 @@ passed
 
 
 
-=== TEST 12: keyring rotate, decrypt with qeddd145sfvddff3 would fail, but encrypt with edd1c9f0985e76a2 would success
+=== TEST 12: keyring rotate, decrypt with qeddd145sfvddff3 would fail, but encrypt with qeddd145sfvddff3 would success
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
             - qeddd145sfvddff3
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- request
 GET /hello
 --- more_headers
@@ -495,9 +495,9 @@ hello world
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {

--- a/t/node/data_encrypt2.t
+++ b/t/node/data_encrypt2.t
@@ -38,9 +38,9 @@ __DATA__
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {
@@ -101,9 +101,9 @@ abc123
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- request
 GET /opentracing
 --- response_body
@@ -121,9 +121,9 @@ clickhouse headers: x-clickhouse-database:default
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {
@@ -189,9 +189,9 @@ abc123
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {
@@ -268,9 +268,9 @@ def456
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {
@@ -345,9 +345,9 @@ abc123
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- request
 GET /opentracing
 --- response_body
@@ -365,9 +365,9 @@ clickhouse headers: x-clickhouse-database:default
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {
@@ -443,9 +443,9 @@ abc123
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- request
 GET /opentracing
 --- response_body
@@ -463,9 +463,9 @@ clickhouse headers: x-clickhouse-database:default
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {
@@ -567,9 +567,9 @@ passed
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {
@@ -645,9 +645,9 @@ vU/ZHVJw7b0XscDJ1Fhtig==
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {
@@ -704,7 +704,7 @@ apisix:
 --- yaml_config
 apisix:
     data_encryption:
-        enable: false
+        enable_encrypt_fields: false
 --- config
     location /t {
         content_by_lua_block {

--- a/t/node/data_encrypt2.t
+++ b/t/node/data_encrypt2.t
@@ -40,7 +40,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {
@@ -103,7 +103,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- request
 GET /opentracing
 --- response_body
@@ -123,7 +123,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {
@@ -191,7 +191,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {
@@ -270,7 +270,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {
@@ -347,7 +347,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- request
 GET /opentracing
 --- response_body
@@ -367,7 +367,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {
@@ -445,7 +445,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- request
 GET /opentracing
 --- response_body
@@ -465,7 +465,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {
@@ -569,7 +569,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {
@@ -647,7 +647,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {

--- a/t/node/upstream-mtls.t
+++ b/t/node/upstream-mtls.t
@@ -337,8 +337,8 @@ GET /t
 --- yaml_config
 apisix:
     node_listen: 1984
-    ssl:
-        key_encrypt_salt: null
+    data_encryption:
+        keyring: null
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/authz-casdoor.t
+++ b/t/plugin/authz-casdoor.t
@@ -450,7 +450,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/authz-casdoor.t
+++ b/t/plugin/authz-casdoor.t
@@ -448,9 +448,9 @@ failed when accessing token: invalid access_token
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/authz-keycloak3.t
+++ b/t/plugin/authz-keycloak3.t
@@ -113,9 +113,9 @@ Location: http://127.0.0.1/test
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/authz-keycloak3.t
+++ b/t/plugin/authz-keycloak3.t
@@ -115,7 +115,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/csrf.t
+++ b/t/plugin/csrf.t
@@ -334,7 +334,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/csrf.t
+++ b/t/plugin/csrf.t
@@ -332,9 +332,9 @@ hello world
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/elasticsearch-logger.t
+++ b/t/plugin/elasticsearch-logger.t
@@ -456,7 +456,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/elasticsearch-logger.t
+++ b/t/plugin/elasticsearch-logger.t
@@ -454,9 +454,9 @@ check elasticsearch custom body success
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/error-log-logger-clickhouse.t
+++ b/t/plugin/error-log-logger-clickhouse.t
@@ -218,9 +218,9 @@ passed
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {
@@ -280,7 +280,7 @@ apisix:
     data_encryption:
         enable: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/error-log-logger-clickhouse.t
+++ b/t/plugin/error-log-logger-clickhouse.t
@@ -220,7 +220,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {
@@ -280,7 +280,7 @@ apisix:
     data_encryption:
         enable: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/error-log-logger-clickhouse.t
+++ b/t/plugin/error-log-logger-clickhouse.t
@@ -278,7 +278,7 @@ bar
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
             - edd1c9f0985e76a2
 --- config

--- a/t/plugin/google-cloud-logging2.t
+++ b/t/plugin/google-cloud-logging2.t
@@ -75,9 +75,9 @@ passed
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/google-cloud-logging2.t
+++ b/t/plugin/google-cloud-logging2.t
@@ -77,7 +77,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/hmac-auth3.t
+++ b/t/plugin/hmac-auth3.t
@@ -706,7 +706,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/hmac-auth3.t
+++ b/t/plugin/hmac-auth3.t
@@ -704,9 +704,9 @@ passed
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/jwt-auth3.t
+++ b/t/plugin/jwt-auth3.t
@@ -326,9 +326,9 @@ passed
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {
@@ -384,7 +384,7 @@ apisix:
     data_encryption:
         enable: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/jwt-auth3.t
+++ b/t/plugin/jwt-auth3.t
@@ -328,7 +328,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {
@@ -384,7 +384,7 @@ apisix:
     data_encryption:
         enable: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/jwt-auth3.t
+++ b/t/plugin/jwt-auth3.t
@@ -382,7 +382,7 @@ IRWpPjbDq5BCgHyIllnOMA==
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
             - edd1c9f0985e76a2
 --- config

--- a/t/plugin/kafka-proxy.t
+++ b/t/plugin/kafka-proxy.t
@@ -62,9 +62,9 @@ property "sasl" validation failed: property "password" validation failed: wrong 
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/kafka-proxy.t
+++ b/t/plugin/kafka-proxy.t
@@ -64,7 +64,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/openid-connect2.t
+++ b/t/plugin/openid-connect2.t
@@ -85,9 +85,9 @@ __DATA__
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/openid-connect2.t
+++ b/t/plugin/openid-connect2.t
@@ -87,7 +87,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/rocketmq-logger2.t
+++ b/t/plugin/rocketmq-logger2.t
@@ -447,9 +447,9 @@ done
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/rocketmq-logger2.t
+++ b/t/plugin/rocketmq-logger2.t
@@ -449,7 +449,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/sls-logger.t
+++ b/t/plugin/sls-logger.t
@@ -266,7 +266,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/sls-logger.t
+++ b/t/plugin/sls-logger.t
@@ -264,9 +264,9 @@ passed
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/tencent-cloud-cls.t
+++ b/t/plugin/tencent-cloud-cls.t
@@ -348,7 +348,7 @@ apisix:
     data_encryption:
         enable_encrypt_fields: true
         keyring:
-            - qeddd145sfvddff3
+            - edd1c9f0985e76a2
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/tencent-cloud-cls.t
+++ b/t/plugin/tencent-cloud-cls.t
@@ -346,9 +346,9 @@ passed
 --- yaml_config
 apisix:
     data_encryption:
-        enable: true
+        enable_encrypt_fields: true
         keyring:
-            - edd1c9f0985e76a2
+            - qeddd145sfvddff3
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
### Description

This is a fix for issue 10484, the field ssl:key_encrypt_salt has been removed, all the encrypt and decrypt operations are using data_encryption:keyring field now.

key_encrypt_salt and keyring are all used for data encrypt and decrypt, but in fact the are doing the same thing, this change remove key_encrypt_salt only field keyring need to be reserved.

Fixes #10484 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
