### PR TITLE
docs: fix request url error in certificate doc

### DIFF
--- a/docs/en/latest/certificate.md
+++ b/docs/en/latest/certificate.md
@@ -65,7 +65,7 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
 Send a request to verify:
 
 ```shell
-curl --resolve 'test.com:9443:127.0.0.1' https://test.com:9443/hello -k -vvv
+curl --resolve 'test.com:9443:127.0.0.1' https://test.com:9443/get -k -vvv
 
 * Added test.com:9443:127.0.0.1 to DNS cache
 * About to connect() to test.com port 9443 (#0)


### PR DESCRIPTION
### Description

The [certificate doc page](https://apisix.apache.org/docs/apisix/certificate/) has a test request

    curl --resolve 'test.com:9443:127.0.0.1' https://test.com:9443/hello -k -vvv

The request url has an error because the path should be `/get`, not `/hello`

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
