### PR TITLE
docs: allow to use environment variables for limit-count plugin settings

### DIFF
--- a/docs/zh/latest/plugins/limit-count.md
+++ b/docs/zh/latest/plugins/limit-count.md
@@ -250,6 +250,37 @@ curl -i http://127.0.0.1:9180/apisix/admin/routes/1 \
 }'
 ```
 
+此外, 插件中的属性值可以引用 APISIX 中的密钥. APISIX 当前支持两种存储密钥的方式 - [环境变量和 HashiCorp Vault](../terminology/secret.md)。
+如果您设置了环境变量 `REDIS_HOST` 和 `REDIS_PASSWORD` ， 如下所示，您可以在插件配置中使用它们：
+
+```shell
+curl -i http://127.0.0.1:9180/apisix/admin/routes/1 \
+-H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+{
+    "uri": "/index.html",
+    "plugins": {
+        "limit-count": {
+            "count": 2,
+            "time_window": 60,
+            "rejected_code": 503,
+            "key": "remote_addr",
+            "policy": "redis",
+            "redis_host": "$ENV://REDIS_HOST",
+            "redis_port": 6379,
+            "redis_password": "$ENV://REDIS_PASSWORD",
+            "redis_database": 1,
+            "redis_timeout": 1001
+        }
+    },
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "127.0.0.1:1980": 1
+        }
+    }
+}'
+```
+
 ## 测试插件
 
 在上文提到的配置中，其限制了 60 秒内请求只能访问 2 次，可通过如下 `curl` 命令测试请求访问：

--- a/docs/zh/latest/plugins/limit-count.md
+++ b/docs/zh/latest/plugins/limit-count.md
@@ -250,7 +250,7 @@ curl -i http://127.0.0.1:9180/apisix/admin/routes/1 \
 }'
 ```
 
-此外, 插件中的属性值可以引用 APISIX 中的密钥. APISIX 当前支持两种存储密钥的方式 - [环境变量和 HashiCorp Vault](../terminology/secret.md)。
+此外, 插件中的属性值可以引用 APISIX 中的密钥。 APISIX 当前支持两种存储密钥的方式 - [环境变量和 HashiCorp Vault](../terminology/secret.md)。
 如果您设置了环境变量 `REDIS_HOST` 和 `REDIS_PASSWORD` ， 如下所示，您可以在插件配置中使用它们：
 
 ```shell

--- a/docs/zh/latest/plugins/limit-count.md
+++ b/docs/zh/latest/plugins/limit-count.md
@@ -250,8 +250,8 @@ curl -i http://127.0.0.1:9180/apisix/admin/routes/1 \
 }'
 ```
 
-此外, 插件中的属性值可以引用 APISIX 中的密钥。 APISIX 当前支持两种存储密钥的方式 - [环境变量和 HashiCorp Vault](../terminology/secret.md)。
-如果您设置了环境变量 `REDIS_HOST` 和 `REDIS_PASSWORD` ， 如下所示，您可以在插件配置中使用它们：
+此外，插件中的属性值可以引用 APISIX 中的密钥。APISIX 当前支持两种存储密钥的方式 - [环境变量和 HashiCorp Vault](../terminology/secret.md)。
+如果您设置了环境变量 `REDIS_HOST` 和 `REDIS_PASSWORD` ，如下所示，您可以在插件配置中使用它们：
 
 ```shell
 curl -i http://127.0.0.1:9180/apisix/admin/routes/1 \


### PR DESCRIPTION
### Description

Fixes #10798 

add Chinese translation of using variables for secrets in limit-count plugin

### Checklist

- [X] I have explained the need for this PR and the problem it solves
- [X] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [X] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
