### PR TITLE
fix: linux-install-luarocks are not compatible with the openresty env…

### DIFF
--- a/utils/linux-install-luarocks.sh
+++ b/utils/linux-install-luarocks.sh
@@ -47,11 +47,15 @@ rm -rf luarocks-"$LUAROCKS_VER"
 
 mkdir ~/.luarocks || true
 
-OPENSSL_PREFIX=${OPENRESTY_PREFIX}/openssl3
-if [ ! -d ${OPENSSL_PREFIX} ]; then
-    echo "Error: ${OPENSSL_PREFIX} not found, please install openssl3 first."
-    exit 1
+# For old version OpenResty, we still need to install LuaRocks with Lua
+OPENSSL_PREFIX=${OPENRESTY_PREFIX}/openssl
+if [ -d ${OPENRESTY_PREFIX}/openssl3 ]; then
+    OPENSSL_PREFIX=${OPENRESTY_PREFIX}/openssl3
+elif [ -d ${OPENRESTY_PREFIX}/openssl111 ]; then
+    OPENSSL_PREFIX=${OPENRESTY_PREFIX}/openssl111
 fi
+
+[ ! -d ${OPENSSL_PREFIX} ] && echo "Warning: the path ${OPENSSL_PREFIX} is not found."
 
 FOUND_PATH=$(echo "${PATH}" | grep -oP '(?<=:|)/usr/local/bin(?=:|)') || true
 if [[ "${FOUND_PATH}" == "" ]]; then


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes https://github.com/api7/lua-resty-radixtree/issues/143

Due to the modification of openssl3, luarocks cannot be installed in the openresty environment and only supports the apisix-runtime environment. Consider using this script in multiple places and preserve its compatibility.





### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
