### PR TITLE
docs: update dubbo-proxy doc

### DIFF
--- a/docs/en/latest/plugins/dubbo-proxy.md
+++ b/docs/en/latest/plugins/dubbo-proxy.md
@@ -93,7 +93,45 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1  -H 'X-API-KEY: edd1c9f034335f1
 
 You can follow the [Quick Start](https://github.com/alibaba/tengine/tree/master/modules/mod_dubbo#quick-start) guide in Tengine with the configuration above for testing.
 
-Dubbo returns data in the form `Map<String, String>`.
+APISIX dubbo plugin uses `hessian2` as the serialization protocol. It supports only `Map<String, Object>` as the request and response data type.
+
+### Application
+
+Your dubbo config should be configured to use `hessian2` as the serialization protocol.
+
+```xml
+dubbo:
+  ...
+  protocol:
+    ...
+    serialization: hessian2
+```
+
+Your application should implement the interface with the request and response data type as `Map<String, Object>`.
+
+```java
+public interface DemoService {
+    Map<String, Object> sayHello(Map<String, Object> context);
+}
+```
+
+### Request and Response
+
+If you need to pass request data, you can add the data to the HTTP request header. The plugin will convert the HTTP request header to the request data of the Dubbo service. Here is a sample HTTP request that passes `user` information:
+
+```curl
+curl -i -X POST 'http://localhost:9080/hello' \
+                    --header 'user: apisix'
+
+
+HTTP/1.1 200 OK
+Date: Mon, 15 Jan 2024 10:15:57 GMT
+Content-Type: text/plain; charset=utf-8
+...
+hello: apisix
+...
+Server: APISIX/3.8.0
+```
 
 If the returned data is:
 

--- a/docs/en/latest/plugins/dubbo-proxy.md
+++ b/docs/en/latest/plugins/dubbo-proxy.md
@@ -99,7 +99,7 @@ APISIX dubbo plugin uses `hessian2` as the serialization protocol. It supports o
 
 Your dubbo config should be configured to use `hessian2` as the serialization protocol.
 
-```xml
+```yml
 dubbo:
   ...
   protocol:
@@ -119,7 +119,7 @@ public interface DemoService {
 
 If you need to pass request data, you can add the data to the HTTP request header. The plugin will convert the HTTP request header to the request data of the Dubbo service. Here is a sample HTTP request that passes `user` information:
 
-```curl
+```bash
 curl -i -X POST 'http://localhost:9080/hello' \
                     --header 'user: apisix'
 


### PR DESCRIPTION
### Description

Fixes #10648 

The PR update the docs for dubbo-proxy with the following information :
- Only Map<String, Object> is supported
- Only hessian2 is supported for serialization, so the user must set this in dubbo config of their applications
- The data to the user program can be passed as header

### Checklist

- [X] I have explained the need for this PR and the problem it solves
- [] I have explained the changes or the new features added to this PR
- [] I have added tests corresponding to this change
- [X] I have updated the documentation to reflect this change
- [X] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
