### PR TITLE
fix: don't release healthchecker during etcd sync due to compaction

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -610,7 +610,7 @@ local function sync_data(self)
 
         if self.values then
             for i, val in ipairs(self.values) do
-                config_util.fire_all_clean_handlers(val)
+                config_util.fire_all_clean_handlers(val, self.compacted)
             end
 
             self.values = nil
@@ -629,6 +629,7 @@ local function sync_data(self)
     if not dir_res then
         if err == "compacted" then
             self.need_reload = true
+            self.compacted = true
             log.warn("waitdir [", self.key, "] err: ", err,
                      ", will read the configuration again via readdir")
             return false

--- a/apisix/core/config_util.lua
+++ b/apisix/core/config_util.lua
@@ -101,7 +101,7 @@ end
 
 
 -- fire all clean handlers added by add_clean_handler.
-function _M.fire_all_clean_handlers(item)
+function _M.fire_all_clean_handlers(item, is_compacted)
     -- When the key is deleted, the item will be set to false.
     if not item then
         return
@@ -111,7 +111,7 @@ function _M.fire_all_clean_handlers(item)
     end
 
     for _, clean_handler in ipairs(item.clean_handlers) do
-        clean_handler.f(item)
+        clean_handler.f(item, is_compacted)
     end
 
     item.clean_handlers = {}

--- a/apisix/upstream.lua
+++ b/apisix/upstream.lua
@@ -81,7 +81,11 @@ end
 _M.set = set_directly
 
 
-local function release_checker(healthcheck_parent)
+local function release_checker(healthcheck_parent, is_compacted)
+    if is_compacted then
+        core.log.info("need not release checker if reload is due to etcd compaction")
+        return
+    end
     local checker = healthcheck_parent.checker
     core.log.info("try to release checker: ", tostring(checker))
     checker:delayed_clear(3)


### PR DESCRIPTION
### Description

#### Root cause of the bug:
When APISIX tries to watch a revision that has been compacted by etcd compaction. This case is difficult to reproduce manually, so adding tests for this would be very unstable.

To reproduce this manually:
- Create an upstream where one node is available and another is not:
```shell
curl http://127.0.0.1:9180/apisix/admin/upstreams/1 \
-H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
  {
    "nodes": {
      "127.0.0.1:1980": 1,
      "127.0.0.1:1111": 1
    },
    "retries": 0,
    "name": "测试心跳",
    "type": "roundrobin",
    "timeout": {
      "connect": 60,
      "read": 60,
      "send": 60
    },
    "pass_host": "pass",
    "scheme": "http",
    "keepalive_pool": {
      "idle_timeout": 60,
      "requests": 1000,
      "size": 320
    },
    "checks": {
      "active": {
        "concurrency": 10,
        "healthy": {
          "http_statuses": [
            200,
            302
          ],
          "interval": 1,
          "successes": 2
        },
        "http_path": "/firstwork/healthcheck",
        "timeout": 5,
        "type": "http",
        "unhealthy": {
          "http_failures": 5,
          "http_statuses": [
            429,
            404,
            500,
            501,
            502,
            503,
            504,
            505
          ],
          "interval": 10,
          "tcp_failures": 2,
          "timeouts": 2
        }
      }
    }
  }'
```
- Create a route that references the above upstream:
```shell
curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
  -H "X-API-KEY: ${ADMIN_API_KEY}" \
  -d '
{
  "uri": "/*",
  "upstream_id": "1",
  "name": "测试心跳问题",
  "methods": [
    "GET",
    "HEAD",
    "POST",
    "PUT",
    "DELETE",
    "OPTIONS",
    "PATCH",
    "CONNECT",
    "TRACE"
  ],
  "priority": 0,
  "enable_websocket": false,
  "status": 1
}'
```
- send a couple of requests so that healthchecker kicks out the unhealthy node:
```shell
curl -i "http://127.0.0.1:9080/hello"
```
- use the following script that increases the latest revision number and performs compaction before apisix is able to watch the latest revision:
```shell
rev=$(etcdctl get --order=DESCEND --sort-by=MODIFY --limit=1 --prefix "" -w=json | jq '.kvs[0].mod_revision + 1')
ectl put key val; ectl compact $rev
```
- wait for the logs that say `err: compacted, will read the configuration again via readdir`
- after this the healthchecker will be released and unhealthy nodes will be added back. You can confirm this by sending requests to the route created previously some of them will result in 502.


Fixes #10500

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
