### PR TITLE
fix: ext-plugin request header cannot be override

### DIFF
--- a/apisix/plugins/ext-plugin/init.lua
+++ b/apisix/plugins/ext-plugin/init.lua
@@ -647,10 +647,10 @@ local rpc_handlers = {
             if len > 0 then
                 for i = 1, len do
                     local entry = rewrite:Headers(i)
-                    local name = entry:Name()
+                    local name = str_lower(entry:Name())
                     core.request.set_header(ctx, name, entry:Value())
 
-                    if str_lower(name) == "host" then
+                    if name == "host" then
                         var.upstream_host = entry:Value()
                     end
                 end
@@ -809,8 +809,9 @@ local rpc_handlers = {
         else
             -- Filter out origin headeres
             for k, v in pairs(res.headers) do
-                if not exclude_resp_header[str_lower(k)] then
-                    core.response.set_header(k, v)
+                local name = str_lower(k)
+                if not exclude_resp_header[name] then
+                    core.response.set_header(name, v)
                 end
             end
         end

--- a/t/plugin/ext-plugin/init.t
+++ b/t/plugin/ext-plugin/init.t
@@ -1,0 +1,70 @@
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    $block->set_value("stream_conf_enable", 1);
+
+    if (!defined $block->extra_stream_config) {
+        my $stream_config = <<_EOC_;
+    server {
+        listen unix:\$TEST_NGINX_HTML_DIR/nginx.sock;
+
+        content_by_lua_block {
+            local ext = require("lib.ext-plugin")
+            ext.go({})
+        }
+    }
+
+_EOC_
+        $block->set_value("extra_stream_config", $stream_config);
+    }
+
+    my $unix_socket_path = $ENV{"TEST_NGINX_HTML_DIR"} . "/nginx.sock";
+    my $cmd = $block->ext_plugin_cmd // "['sleep', '5s']";
+    my $extra_yaml_config = <<_EOC_;
+ext-plugin:
+    path_for_test: $unix_socket_path
+    cmd: $cmd
+_EOC_
+
+    $block->set_value("extra_yaml_config", $extra_yaml_config);
+
+    if (!$block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+    if (!$block->error_log) {
+        $block->set_value("no_error_log", "[error]\n[alert]");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: rewrite header
+--- extra_stream_config
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+
+        content_by_lua_block {
+            local ext = require("lib.ext-plugin")
+            ext.go({rewrite = true})
+            local headers = ngx.req.get_headers()
+            ngx.say(headers["x-change"])
+            headers["x-change"] == "bar"
+        }
+    }
+--- request
+GET /hello
+--- more_headers
+x-change: foo
+--- response_body chomp
+cat
+--- error_code: 405


### PR DESCRIPTION
### Description

When I use go plugin runner to set the request header, such as `content-type`, in apisix lua, it will become `Content-Type`.

And due to case sensitivity, the request header cannot be correctly replicated.


By printing the `params` through the log


https://github.com/apache/apisix/blob/2d47b4b3b33730b1de92c91c4fbe2b239ee339af/apisix/plugins/ext-plugin-post-resp.lua#L80-L85

 it can be observed that both `Content-Type` and `content-type` can be observed simultaneously in the `headers`.




Fixes # (issue)
https://github.com/apache/apisix-go-plugin-runner/issues/155

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
