### PR TITLE
feat: body-transformer plugin for other data formats without warnings

### DIFF
--- a/apisix/plugins/body-transformer.lua
+++ b/apisix/plugins/body-transformer.lua
@@ -34,7 +34,7 @@ local next              = next
 local transform_schema = {
     type = "object",
     properties = {
-        input_format = { type = "string", enum = {"xml", "json", "encoded", "args"} },
+        input_format = { type = "string", enum = {"xml", "json", "encoded", "args", "none"} },
         template = { type = "string" },
         template_is_base64 = { type = "boolean" },
     },
@@ -129,7 +129,7 @@ end
 local function transform(conf, body, typ, ctx, request_method)
     local out = {}
     local format = conf[typ].input_format
-    if body or request_method == "GET" then
+    if (body or request_method == "GET") and format ~= "none" then
         local err
         if format then
             out, err = decoders[format](body)

--- a/t/plugin/body-transformer.t
+++ b/t/plugin/body-transformer.t
@@ -1069,3 +1069,60 @@ location /demo {
             assert(res.status == 200)
         }
     }
+
+
+=== TEST 16: test for missing Content-Type and skip body parsing
+--- config
+    location /demo {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local body = core.request.get_body()
+            assert(body == "{\"message\": \"actually json\"}")
+        }
+    }
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin")
+            local core = require("apisix.core")
+
+            local code, body = t.test('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                string.format([[{
+                    "uri": "/foobar",
+                    "plugins": {
+                        "proxy-rewrite": {
+                            "uri": "/demo"
+                        },
+                        "body-transformer": {
+                            "request": {
+                                "input_format": "none",
+                                "template": "{\"message\": \"{* string.gsub(_body, 'not ', '') *}\"}"
+                            }
+                        }
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:%d": 1
+                        }
+                    }
+                }]], ngx.var.server_port)
+            )
+
+            if code >= 300 then
+                ngx.status = code
+                return
+            end
+            ngx.sleep(0.5)
+
+            local http = require("resty.http")
+            local httpc = http.new()
+            local res, err = httpc:request_uri("http://127.0.0.1:" .. ngx.var.server_port .. "/foobar", {
+                method = "POST",
+                body = "not actually json",
+            })
+            assert(res.status == 200)
+        }
+    }
+--- no_error_log
+no input format to parse


### PR DESCRIPTION
### Description

Fixes #10681

Adding another format to the input_format enum, none, that explicitly tells body-transformer to not try to parse or validate the body content and silences this warning would be convenient.

### Checklist

- [X] I have explained the need for this PR and the problem it solves
- [X] I have explained the changes or the new features added to this PR
- [X] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [X] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
