### PR TITLE
chore: Remove the shell and docs for build/install APISIX on MacOS

### DIFF
--- a/apisix-master-0.rockspec
+++ b/apisix-master-0.rockspec
@@ -17,7 +17,7 @@
 
 package = "apisix"
 version = "master-0"
-supported_platforms = {"linux", "macosx"}
+supported_platforms = {"linux"}
 
 source = {
     url = "git://github.com/apache/apisix",

--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -57,15 +57,9 @@ do
     fi
 done
 
-if [[ "$(uname)" == "Darwin" ]]; then
-    sed  -i "" "s/\- proxy-mirror .*/#\- proxy-mirror/g" conf/config-default.yaml
-    sed  -i "" "s/\- proxy-cache .*/#\- proxy-cache/g" conf/config-default.yaml
-    sed  -i "" "s/listen .*;/$nginx_listen/g" benchmark/server/conf/nginx.conf
-else
-    sed  -i "s/\- proxy-mirror/#\- proxy-mirror/g" conf/config-default.yaml
-    sed  -i "s/\- proxy-cache/#\- proxy-cache/g" conf/config-default.yaml
-    sed  -i "s/listen .*;/$nginx_listen/g" benchmark/server/conf/nginx.conf
-fi
+sed  -i "s/\- proxy-mirror/#\- proxy-mirror/g" conf/config-default.yaml
+sed  -i "s/\- proxy-cache/#\- proxy-cache/g" conf/config-default.yaml
+sed  -i "s/listen .*;/$nginx_listen/g" benchmark/server/conf/nginx.conf
 
 echo "
 nginx_config:
@@ -144,11 +138,7 @@ echo -e "\n\nfake empty apisix server: $worker_cnt worker"
 
 sleep 1
 
-if [[ "$(uname)" == "Darwin" ]]; then
-    sed  -i "" "s/worker_processes [0-9]*/worker_processes $worker_cnt/g" benchmark/fake-apisix/conf/nginx.conf
-else
-    sed  -i "s/worker_processes [0-9]*/worker_processes $worker_cnt/g" benchmark/fake-apisix/conf/nginx.conf
-fi
+sed  -i "s/worker_processes [0-9]*/worker_processes $worker_cnt/g" benchmark/fake-apisix/conf/nginx.conf
 
 sudo ${fake_apisix_cmd} || exit 1
 

--- a/docs/en/latest/building-apisix.md
+++ b/docs/en/latest/building-apisix.md
@@ -254,12 +254,6 @@ For the error `Error unknown directive "lua_package_path" in /API_ASPIX/apisix/t
   export PATH=/usr/local/openresty/nginx/sbin:$PATH
   ```
 
-- macOS default installation path (view homebrew):
-
-  ```shell
-  export PATH=/usr/local/opt/openresty/nginx/sbin:$PATH
-  ```
-
 #### Running a specific test case
 
 To run a specific test case, use the command below:

--- a/docs/en/latest/install-dependencies.md
+++ b/docs/en/latest/install-dependencies.md
@@ -37,7 +37,7 @@ title: Install Dependencies
 
 Run the following command to install Apache APISIX's dependencies on a supported operating system.
 
-Supported OS versions: CentOS7, Fedora31 & 32, Ubuntu 16.04 & 18.04, Debian 9 & 10, Arch Linux, Mac OSX
+Supported OS versions: CentOS7, Fedora31 & 32, Ubuntu 16.04 & 18.04, Debian 9 & 10, Arch Linux.
 
 Note that in the case of Arch Linux, we use `openresty` from the AUR, thus requiring a AUR helper. For now `yay` and `pacaur` are supported.
 

--- a/docs/zh/latest/building-apisix.md
+++ b/docs/zh/latest/building-apisix.md
@@ -252,12 +252,6 @@ APISIX 的一些特性需要在 OpenResty 中引入额外的 NGINX 模块。
   export PATH=/usr/local/openresty/nginx/sbin:$PATH
   ```
 
-- macOS 通过 `homebrew` 的默认安装路径：
-
-  ```shell
-  export PATH=/usr/local/opt/openresty/nginx/sbin:$PATH
-  ```
-
 ### 运行指定的测试用例
 
 使用以下命令运行指定的测试用例：

--- a/docs/zh/latest/install-dependencies.md
+++ b/docs/zh/latest/install-dependencies.md
@@ -37,7 +37,7 @@ title: 安装依赖
 
 在支持的操作系统上运行以下指令即可安装 Apache APISIX dependencies。
 
-支持的操作系统版本：CentOS 7, Fedora 31 & 32, Ubuntu 16.04 & 18.04, Debian 9 & 10, Arch Linux, Mac OSX。
+支持的操作系统版本：CentOS 7, Fedora 31 & 32, Ubuntu 16.04 & 18.04, Debian 9 & 10, Arch Linux。
 
 注意，对于 Arch Linux 来说，我们使用 AUR 源中的 `openresty`，所以需要 AUR Helper 才能正常安装。目前支持 `yay` 和 `pacaur`。
 

--- a/utils/install-dependencies.sh
+++ b/utils/install-dependencies.sh
@@ -96,7 +96,7 @@ function multi_distro_installation() {
     elif grep -Eqi "Arch" /etc/issue || grep -Eqi "EndeavourOS" /etc/issue || grep -Eq "Arch" /etc/*-release; then
         install_dependencies_with_aur
     else
-        echo "Non-supported operating system version"
+        echo "Non-supported distribution, APISIX is only supported on Linux-based systems"
         exit 1
     fi
     install_apisix_runtime
@@ -114,7 +114,7 @@ function multi_distro_uninstallation() {
     elif grep -Eqi "Ubuntu" /etc/issue || grep -Eq "Ubuntu" /etc/*-release; then
         sudo apt-get autoremove -y openresty-zlib-dev openresty-pcre-dev
     else
-        echo "Non-supported operating system version"
+        echo "Non-supported distribution, APISIX is only supported on Linux-based systems"
         exit 1
     fi
 }
@@ -148,7 +148,7 @@ function main() {
             install_luarocks
             return
         else
-            echo "Non-supported distribution"
+            echo "Non-supported distribution, APISIX is only supported on Linux-based systems"
             exit 1
         fi
     fi
@@ -162,7 +162,7 @@ function main() {
             if [[ "${OS_NAME}" == "linux" ]]; then
                 multi_distro_uninstallation
             else
-                echo "Non-supported distribution"
+                echo "Non-supported distribution, APISIX is only supported on Linux-based systems"
             fi
         ;;
         *)

--- a/utils/install-dependencies.sh
+++ b/utils/install-dependencies.sh
@@ -81,12 +81,6 @@ function install_dependencies_with_apt() {
     sudo apt-get install -y curl make gcc g++ cpanminus libpcre3 libpcre3-dev libldap2-dev unzip openresty-zlib-dev openresty-pcre-dev
 }
 
-# Install dependencies on mac osx
-function install_dependencies_on_mac_osx() {
-    # install OpenResty, etcd and some compilation tools
-    brew install openresty/brew/openresty luarocks lua@5.1 wget curl git pcre openldap
-}
-
 # Identify the different distributions and call the corresponding function
 function multi_distro_installation() {
     if grep -Eqi "CentOS" /etc/issue || grep -Eq "CentOS" /etc/*-release; then
@@ -152,8 +146,6 @@ function main() {
         if [[ "${OS_NAME}" == "linux" ]]; then
             multi_distro_installation
             install_luarocks
-        elif [[ "${OS_NAME}" == "darwin" ]]; then
-            install_dependencies_on_mac_osx
         else
             echo "Non-supported distribution"
         fi

--- a/utils/install-dependencies.sh
+++ b/utils/install-dependencies.sh
@@ -146,10 +146,11 @@ function main() {
         if [[ "${OS_NAME}" == "linux" ]]; then
             multi_distro_installation
             install_luarocks
+            return
         else
             echo "Non-supported distribution"
+            exit 1
         fi
-        return
     fi
 
     case_opt=$1


### PR DESCRIPTION
### Description
Remove the sh and docs for build/install `APISIX` on MacOS, it will be not supported

Fixes #
Part of: https://github.com/apache/apisix/issues/10784

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
