### PR TITLE
feat: support built-in variables in response_headers in mocking plugin

### DIFF
--- a/apisix/plugins/mocking.lua
+++ b/apisix/plugins/mocking.lua
@@ -229,6 +229,7 @@ function _M.access(conf, ctx)
 
     if conf.response_headers then
         for key, value in pairs(conf.response_headers) do
+            value = core.utils.resolve_var(value, ctx.var)
             core.response.add_header(key, value)
         end
     end

--- a/t/plugin/mocking.t
+++ b/t/plugin/mocking.t
@@ -465,3 +465,42 @@ GET /hello
 --- response_headers
 X-Apisix: is, cool
 X-Really: yes
+
+
+
+=== TEST 21: set route (return headers support built-in variables)
+--- config
+       location /t {
+           content_by_lua_block {
+               local t = require("lib.test_admin").test
+               local code, body = t('/apisix/admin/routes/1',
+                    ngx.HTTP_PUT,
+                    [[{
+                           "plugins": {
+                               "mocking": {
+                                   "response_example": "hello world",
+                                   "response_headers": {
+                                        "X-Route-Id": "$route_id"
+                                    }
+                               }
+                           },
+                           "uri": "/hello"
+                   }]]
+                   )
+
+               if code >= 300 then
+                   ngx.status = code
+               end
+               ngx.say(body)
+           }
+       }
+--- response_body
+passed
+
+
+
+=== TEST 22: hit route
+--- request
+GET /hello
+--- response_headers
+X-Route-Id: 1


### PR DESCRIPTION
### Description
support built-in variables in response_headers in mocking plugin
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #10868 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
