### PR TITLE
docs: fix wrong link in openid-connect docs

### DIFF
--- a/docs/en/latest/plugins/openid-connect.md
+++ b/docs/en/latest/plugins/openid-connect.md
@@ -245,7 +245,7 @@ You should also ensure that the `redirect_uri` include the scheme, such as `http
 
 #### 2. Missing Session Secret
 
-If you deploy APISIX in the [standalone mode](/apisix/production/deployment-modes#standalone-mode), make sure that `session.secret` is configured.
+If you deploy APISIX in the [standalone mode](../deployment-modes#standalone-mode), make sure that `session.secret` is configured.
 
 User sessions are stored in browser as cookies and encrypted with session secret. The secret is automatically generated and saved to etcd if no secret is configured through the `session.secret` attribute. However, in standalone mode, etcd is no longer the configuration center. Therefore, you should explicitly configure `session.secret` for this plugin in the YAML configuration center `apisix.yaml`.
 

--- a/docs/en/latest/plugins/openid-connect.md
+++ b/docs/en/latest/plugins/openid-connect.md
@@ -245,7 +245,7 @@ You should also ensure that the `redirect_uri` include the scheme, such as `http
 
 #### 2. Missing Session Secret
 
-If you deploy APISIX in the [standalone mode](../deployment-modes#standalone-mode), make sure that `session.secret` is configured.
+If you deploy APISIX in the [standalone mode](../deployment-modes.md#standalone), make sure that `session.secret` is configured.
 
 User sessions are stored in browser as cookies and encrypted with session secret. The secret is automatically generated and saved to etcd if no secret is configured through the `session.secret` attribute. However, in standalone mode, etcd is no longer the configuration center. Therefore, you should explicitly configure `session.secret` for this plugin in the YAML configuration center `apisix.yaml`.
 

--- a/docs/zh/latest/plugins/openid-connect.md
+++ b/docs/zh/latest/plugins/openid-connect.md
@@ -244,7 +244,7 @@ the error request to the redirect_uri path, but there's no session state found
 
 #### 2. 缺少 Session Secret
 
-如果您在[standalone 模式](/apisix/product/deployment-modes#standalone-mode)下部署 APISIX，请确保配置了 `session.secret`。
+如果您在[standalone 模式](../../../en/latest/deployment-modes#standalone-mode)下部署 APISIX，请确保配置了 `session.secret`。
 
 用户 session 作为 cookie 存储在浏览器中，并使用 session 密钥进行加密。如果没有通过 `session.secret` 属性配置机密，则会自动生成机密并将其保存到 etcd。然而，在独立模式下，etcd 不再是配置中心。因此，您应该在 YAML 配置中心 `apisix.yaml` 中为此插件显式配置 `session.secret`。
 

--- a/docs/zh/latest/plugins/openid-connect.md
+++ b/docs/zh/latest/plugins/openid-connect.md
@@ -244,7 +244,7 @@ the error request to the redirect_uri path, but there's no session state found
 
 #### 2. 缺少 Session Secret
 
-如果您在[standalone 模式](../../../en/latest/deployment-modes#standalone-mode)下部署 APISIX，请确保配置了 `session.secret`。
+如果您在[standalone 模式](../../../en/latest/deployment-modes.md#standalone)下部署 APISIX，请确保配置了 `session.secret`。
 
 用户 session 作为 cookie 存储在浏览器中，并使用 session 密钥进行加密。如果没有通过 `session.secret` 属性配置机密，则会自动生成机密并将其保存到 etcd。然而，在独立模式下，etcd 不再是配置中心。因此，您应该在 YAML 配置中心 `apisix.yaml` 中为此插件显式配置 `session.secret`。
 


### PR DESCRIPTION
### Description

Fixes #10876 

- Fix wrong link in openid-connect documentation. Due to the lack of Chinese documents, English documents are temporarily used instead.

### Checklist

- [X] I have explained the need for this PR and the problem it solves
- [X] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [X] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
