### PR TITLE
fix: wrong namespace related endpoint in k8s

### DIFF
--- a/apisix/discovery/kubernetes/informer_factory.lua
+++ b/apisix/discovery/kubernetes/informer_factory.lua
@@ -355,7 +355,7 @@ function _M.new(group, version, kind, plural, namespace)
     end
 
     if namespace and namespace ~= "" then
-        path = path .. "/namespace/" .. namespace
+        path = path .. "/namespaces/" .. namespace
     end
     path = path .. "/" .. plural
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

This PR fix url path splicing bug.

endpoints api url: /api/v1/`namespaces`/{namespace}/endpoints/{name}

ref: https://docs.openshift.com/container-platform/4.8/rest_api/network_apis/endpoints-core-v1.html#apiv1namespacesnamespaceendpointsname

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
