### PR TITLE
fix: Solve the problem that the body-transfomer plug-in cannot convert xml…

### DIFF
--- a/apisix/plugins/body-transformer.lua
+++ b/apisix/plugins/body-transformer.lua
@@ -218,7 +218,8 @@ end
 function _M.body_filter(_, ctx)
     local conf = ctx.body_transformer_conf
     if conf.response then
-        local body = core.response.hold_body_chunk(ctx)
+        --local body = core.response.hold_body_chunk(ctx)
+        local body = tostring(ngx.arg[1])
         if ngx.arg[2] == false and not body then
             return
         end


### PR DESCRIPTION
Solve the problem that the body-transfomer plug-in cannot convert xml…

### Description

When using the body-transformer plug-in in the apisix3.2 version and configuring it according to the example provided in the demo, the returned xml data cannot be obtained. After replacing the body-transformer.lua corresponding to the master version, the problem still cannot be solved.

Fixes # (issue)

Changed the method of obtaining body in response from core.response.hold_body_chunk(ctx) to ngx.arg[1], the problem was solved
