### PR TITLE
chore: the log level should be "error" when etcd compacts

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -227,7 +227,7 @@ local function do_run_watch(premature)
             log.warn("watch canceled by etcd, res: ", inspect(res))
             if res.result.compact_revision then
                 watch_ctx.rev = tonumber(res.result.compact_revision)
-                log.warn("etcd compacted, compact_revision=", watch_ctx.rev)
+                log.error("etcd compacted, compact_revision=", watch_ctx.rev)
                 produce_res(nil, "compacted")
             end
             cancel_watch(http_cli)
@@ -629,7 +629,7 @@ local function sync_data(self)
     if not dir_res then
         if err == "compacted" then
             self.need_reload = true
-            log.warn("waitdir [", self.key, "] err: ", err,
+            log.error("waitdir [", self.key, "] err: ", err,
                      ", will read the configuration again via readdir")
             return false
         end


### PR DESCRIPTION
### Description

The error_log level should be  when etcd compacts since we should avoid etcd compact

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

