### PR TITLE
docs: improve clarity for `ext-plugin-post-resp` plugin

### DIFF
--- a/docs/en/latest/plugins/ext-plugin-post-resp.md
+++ b/docs/en/latest/plugins/ext-plugin-post-resp.md
@@ -33,7 +33,7 @@ The `ext-plugin-post-resp` Plugin is for running specific external Plugins in th
 
 The `ext-plugin-post-resp` plugin will be executed after the request gets a response from the upstream.
 
-This plugin uses [lua-resty-http](https://github.com/api7/lua-resty-http) library under the hood to send requests to the upstream, due to which the[proxy-control](./proxy-control.md), [proxy-mirror](./proxy-mirror.md), and [proxy-cache](./proxy-cache.md) plugin are not available to be used alongside this plugin. Also, [mTLS Between APISIX and Upstream](../mtls.md#mtls-between-apisix-and-upstream) is not yet supported.
+This plugin uses [lua-resty-http](https://github.com/api7/lua-resty-http) library under the hood to send requests to the upstream, due to which the[proxy-control](./proxy-control.md), [proxy-mirror](./proxy-mirror.md), and [proxy-cache](./proxy-cache.md) plugins are not available to be used alongside this plugin. Also, [mTLS Between APISIX and Upstream](../mtls.md#mtls-between-apisix-and-upstream) is not yet supported.
 
 See [External Plugin](../external-plugin.md) to learn more.
 

--- a/docs/en/latest/plugins/ext-plugin-post-resp.md
+++ b/docs/en/latest/plugins/ext-plugin-post-resp.md
@@ -33,7 +33,7 @@ The `ext-plugin-post-resp` Plugin is for running specific external Plugins in th
 
 The `ext-plugin-post-resp` plugin will be executed after the request gets a response from the upstream.
 
-This plugin uses [lua-resty-http](https://github.com/api7/lua-resty-http) library under the hood to send requests to the upstream, due to which the[proxy-control](./proxy-control.md), [proxy-mirror](./proxy-mirror.md), and [proxy-cache](./proxy-cache.md) plugins are not available to be used alongside this plugin. Also, [mTLS Between APISIX and Upstream](../mtls.md#mtls-between-apisix-and-upstream) is not yet supported.
+This plugin uses [lua-resty-http](https://github.com/api7/lua-resty-http) library under the hood to send requests to the upstream, due to which the [proxy-control](./proxy-control.md), [proxy-mirror](./proxy-mirror.md), and [proxy-cache](./proxy-cache.md) plugins are not available to be used alongside this plugin. Also, [mTLS Between APISIX and Upstream](../mtls.md#mtls-between-apisix-and-upstream) is not yet supported.
 
 See [External Plugin](../external-plugin.md) to learn more.
 

--- a/docs/en/latest/plugins/ext-plugin-post-resp.md
+++ b/docs/en/latest/plugins/ext-plugin-post-resp.md
@@ -33,12 +33,7 @@ The `ext-plugin-post-resp` Plugin is for running specific external Plugins in th
 
 The `ext-plugin-post-resp` plugin will be executed after the request gets a response from the upstream.
 
-After enabling this plugin, APISIX will use the [lua-resty-http](https://github.com/api7/lua-resty-http) library to make requests to the upstream, this results in:
-
-- [proxy-control](./proxy-control.md) plugin is not available
-- [proxy-mirror](./proxy-mirror.md) plugin is not available
-- [proxy-cache](./proxy-cache.md) plugin is not available
-- [mTLS Between APISIX and Upstream](../mtls.md#mtls-between-apisix-and-upstream) function is not available yet
+This plugin uses [lua-resty-http](https://github.com/api7/lua-resty-http) library under the hood to send requests to the upstream, due to which the[proxy-control](./proxy-control.md), [proxy-mirror](./proxy-mirror.md), and [proxy-cache](./proxy-cache.md) plugin are not available to be used alongside this plugin. Also, [mTLS Between APISIX and Upstream](../mtls.md#mtls-between-apisix-and-upstream) is not yet supported.
 
 See [External Plugin](../external-plugin.md) to learn more.
 


### PR DESCRIPTION
### Description

The current state:
> After enabling this plugin, APISIX will use the lua-resty-http library to make requests to the upstream...

Leads to a confusion that APISIX would now use `lua-resty-http` to send requests to the upstream. The above statement can lead to some more misleading conclusions. Like this:
![image](https://github.com/apache/apisix/assets/61597896/be4a96c6-ffd3-4afd-8360-318a4da161f9)

![image](https://github.com/apache/apisix/assets/61597896/e4e94ceb-5ab8-41e0-89ac-cfbb67718e87)
https://the-asf.slack.com/archives/CUC5MN17A/p1708676667225869


### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
