### PR TITLE
feat(chaitin-waf): update lua-resty-t1k to 1.1.1

### DIFF
--- a/apisix-master-0.rockspec
+++ b/apisix-master-0.rockspec
@@ -79,7 +79,7 @@ dependencies = {
     "nanoid = 0.1-1",
     "lua-resty-mediador = 0.1.2-1",
     "lua-resty-ldap = 0.1.0-0",
-    "lua-resty-t1k = 1.1.0",
+    "lua-resty-t1k = 1.1.1",
     "brotli-ffi = 0.3-1",
     "lua-ffi-zlib = 0.6-0"
 }


### PR DESCRIPTION
### Description

Full changelog: https://github.com/chaitin/lua-resty-t1k/compare/v1.1.0...v1.1.1

The primary modification involves correcting a bug that triggers a warning-level log when executing `sock:setkeepalive` in `request.lua` .

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
