### PR TITLE
docs: update example in ua-restriction plugin doc

### DIFF
--- a/docs/en/latest/plugins/ua-restriction.md
+++ b/docs/en/latest/plugins/ua-restriction.md
@@ -39,11 +39,11 @@ A common scenario is to set crawler rules. `User-Agent` is the identity of the c
 | bypass_missing | boolean       | False    | false        |                         | When set to `true`, bypasses the check when the `User-Agent` header is missing. |
 | allowlist      | array[string] | False    |              |                         | List of allowed `User-Agent` headers.                                           |
 | denylist       | array[string] | False    |              |                         | List of denied `User-Agent` headers.                                            |
-| message        | string        | False    | "Not allowed" | [1, 1024] | Message with the reason for denial to be added to the response.                 |
+| message        | string        | False    | "Not allowed" |  | Message with the reason for denial to be added to the response.                 |
 
 :::note
 
-Both `allowlist` and `denylist` can't be used at the same time.
+`allowlist` and `denylist` can't be configured at the same time.
 
 :::
 
@@ -64,45 +64,25 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
     "plugins": {
         "ua-restriction": {
              "bypass_missing": true,
-             "allowlist": [
-                 "my-bot1",
-                 "(Baiduspider)/(\\d+)\\.(\\d+)"
-             ],
              "denylist": [
                  "my-bot2",
                  "(Twitterspider)/(\\d+)\\.(\\d+)"
-             ]
+             ],
+             "message": "Do you want to do something bad?"
         }
     }
 }'
 ```
 
-You can also configure the Plugin to respond with a custom rejection message:
-
-```json
-"plugins": {
-    "ua-restriction": {
-        "denylist": [
-            "my-bot2",
-            "(Twitterspider)/(\\d+)\\.(\\d+)"
-        ],
-        "message": "Do you want to do something bad?"
-    }
-}
-```
-
 ## Example usage
 
-After you have configured the Plugin as shown above, you can make a normal request which will get accepted:
+Send a request to the route:
 
 ```shell
 curl http://127.0.0.1:9080/index.html -i
 ```
 
-```shell
-HTTP/1.1 200 OK
-...
-```
+You should receive an `HTTP/1.1 200 OK` response.
 
 Now if the `User-Agent` header is in the `denylist` i.e the bot User-Agent:
 
@@ -110,10 +90,10 @@ Now if the `User-Agent` header is in the `denylist` i.e the bot User-Agent:
 curl http://127.0.0.1:9080/index.html --header 'User-Agent: Twitterspider/2.0'
 ```
 
-```shell
-HTTP/1.1 403 Forbidden
-...
-{"message":"Not allowed"}
+You should receive an `HTTP/1.1 403 Forbidden` response with the following message:
+
+```text
+{"message":"Do you want to do something bad?"}
 ```
 
 ## Delete Plugin

--- a/docs/zh/latest/plugins/ua-restriction.md
+++ b/docs/zh/latest/plugins/ua-restriction.md
@@ -38,7 +38,7 @@ description: 本文介绍了 Apache APISIX ua-restriction 插件的使用方法�
 | --------- | ------------- | ------ | ------ | ------ | -------------------------------- |
 | allowlist | array[string] | 否   |        |        | 加入白名单的 `User-Agent`。 |
 | denylist  | array[string] | 否   |        |        | 加入黑名单的 `User-Agent`。 |
-| message | string  | 否   | "Not allowed" | [1, 1024] | 当未允许的 `User-Agent` 访问时返回的信息。 |
+| message | string  | 否   | "Not allowed" |  | 当未允许的 `User-Agent` 访问时返回的信息。 |
 | bypass_missing | boolean       | 否    | false   |       | 当设置为 `true` 时，如果 `User-Agent` 请求头不存在或格式有误时，将绕过检查。 |
 
 :::note
@@ -64,31 +64,14 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
     "plugins": {
         "ua-restriction": {
             "bypass_missing": true,
-             "allowlist": [
-                 "my-bot1",
-                 "(Baiduspider)/(\\d+)\\.(\\d+)"
-             ],
              "denylist": [
                  "my-bot2",
                  "(Twitterspider)/(\\d+)\\.(\\d+)"
-             ]
+             ],
+             "message": "Do you want to do something bad?"
         }
     }
 }'
-```
-
-当未允许的 `User-Agent` 访问时，默认返回 `{"message":"Not allowed"}`。如果你想使用自定义的 `message`，可以在 `plugins` 部分进行配置：
-
-```json
-"plugins": {
-    "ua-restriction": {
-        "denylist": [
-            "my-bot2",
-            "(Twitterspider)/(\\d+)\\.(\\d+)"
-        ],
-        "message": "Do you want to do something bad?"
-    }
-}
 ```
 
 ## 测试插件
@@ -99,12 +82,7 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1 -H 'X-API-KEY: edd1c9f034335f13
 curl http://127.0.0.1:9080/index.html -i
 ```
 
-返回的 HTTP 响应头中带有 `200` 状态码，代表请求成功：
-
-```shell
-HTTP/1.1 200 OK
-...
-```
+你应当收到 `HTTP/1.1 200 OK` 的响应，表示请求成功。
 
 接下来，请求的同时指定处于 `denylist` 中的 `User-Agent`，如 `Twitterspider/2.0`：
 
@@ -112,12 +90,10 @@ HTTP/1.1 200 OK
 curl http://127.0.0.1:9080/index.html --header 'User-Agent: Twitterspider/2.0'
 ```
 
-返回的 HTTP 响应头中带有 `403` 状态码，请求失败，代表插件生效：
+你应当收到 `HTTP/1.1 403 Forbidden` 的响应和以下报错，表示请求失败，代表插件生效：
 
-```shell
-HTTP/1.1 403 Forbidden
-...
-{"message":"Not allowed"}
+```text
+{"message":"Do you want to do something bad?"}
 ```
 
 ## 删除插件


### PR DESCRIPTION
### Description

In ua-restriction plugin, the allowlist and denylist cannot be configured at the same time. Yet the example given configured both:

![image](https://github.com/apache/apisix/assets/39619599/97503def-e12b-4a23-9535-07f4796366b0)

This PR updates the example and improves writing.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
