### PR TITLE
fix: add post request headers only if auth request method is post

### DIFF
--- a/apisix/plugins/forward-auth.lua
+++ b/apisix/plugins/forward-auth.lua
@@ -89,10 +89,14 @@ function _M.access(conf, ctx)
         ["X-Forwarded-Host"] = core.request.get_host(ctx),
         ["X-Forwarded-Uri"] = ctx.var.request_uri,
         ["X-Forwarded-For"] = core.request.get_remote_client_ip(ctx),
-        ["Expect"] = core.request.header(ctx, "expect"),
-        ["Content-Length"] = core.request.header(ctx, "content-length"),
-        ["Transfer-Encoding"] = core.request.header(ctx, "transfer-encoding")
     }
+
+    if conf.request_method == "POST" then
+        auth_headers["Content-Length"] = core.request.header(ctx, "content-length")
+        auth_headers["Expect"] = core.request.header(ctx, "expect")
+        auth_headers["Transfer-Encoding"] = core.request.header(ctx, "transfer-encoding")
+        auth_headers["Content-Encoding"] = core.request.header(ctx, "content-encoding")
+    end
 
     -- append headers that need to be get from the client request header
     if #conf.request_headers > 0 then

--- a/t/plugin/forward-auth.t
+++ b/t/plugin/forward-auth.t
@@ -488,4 +488,3 @@ Authorization: 333
         }
     }
 --- error_code: 200
-

--- a/t/plugin/forward-auth.t
+++ b/t/plugin/forward-auth.t
@@ -143,24 +143,6 @@ property "request_method" validation failed: matches none of the enum values
                                                end
                                            end
                                         end
-                                    end]],
-                                    [[return function(conf, ctx)
-                                        local core = require("apisix.core");
-                                        if core.request.header(ctx, "Authorization") == "token-headers-test" then
-                                            if core.request.get_method() == "POST" then
-                                                if core.request.header(ctx, "Content-Length") or core.request.header(ctx, "Transfer-Encoding") or core.request.header(ctx, "Content-Encoding") then
-                                                    core.response.exit(200)
-                                                else
-                                                    core.response.exit(403)
-                                                end
-                                            else
-                                                if core.request.header(ctx, "Content-Length") or core.request.header(ctx, "Transfer-Encoding") or core.request.header(ctx, "Content-Encoding") then
-                                                    core.response.exit(403)
-                                                else
-                                                    core.response.exit(200)
-                                                end
-                                            end
-                                        end
                                     end]]
                                 }
                             }
@@ -323,40 +305,6 @@ property "request_method" validation failed: matches none of the enum values
                         "upstream_id": "u1",
                         "uri": "/onerror"
                     }]],
-                },
-                {
-                    url = "/apisix/admin/routes/9",
-                    data = [[{
-                        "plugins": {
-                            "forward-auth": {
-                                "uri": "http://127.0.0.1:1984/auth",
-                                "request_headers": ["Authorization"],
-                                "request_method": "POST"
-                            },
-                            "proxy-rewrite": {
-                                "uri": "/echo"
-                            }
-                        },
-                        "upstream_id": "u1",
-                        "uri": "/verify-auth-post"
-                    }]],
-                },
-                {
-                    url = "/apisix/admin/routes/10",
-                    data = [[{
-                        "plugins": {
-                            "forward-auth": {
-                                "uri": "http://127.0.0.1:1984/auth",
-                                "request_headers": ["Authorization"],
-                                "request_method": "GET"
-                            },
-                            "proxy-rewrite": {
-                                "uri": "/echo"
-                            }
-                        },
-                        "upstream_id": "u1",
-                        "uri": "/verify-auth-get"
-                    }]],
                 }
             }
 
@@ -369,7 +317,7 @@ property "request_method" validation failed: matches none of the enum values
         }
     }
 --- response_body eval
-"passed\n" x 13
+"passed\n" x 11
 
 
 
@@ -541,40 +489,3 @@ Authorization: 333
     }
 --- error_code: 200
 
-
-
-=== TEST 15: verify auth server forward headers for request_method=GET
---- request
-GET /verify-auth-get
---- more_headers
-Authorization: token-headers-test
---- error_code: 200
-
-
-
-=== TEST 16: verify auth server forward headers for request_method=POST for GET upstream
---- request
-GET /verify-auth-post
---- more_headers
-Authorization: token-headers-test
---- error_code: 200
-
-
-
-=== TEST 17: verify auth server forward headers for request_method=POST
---- request
-POST /verify-auth-post
-{"authorization": "token-headers-test"}
---- more_headers
-Authorization: token-headers-test
---- error_code: 200
-
-
-
-=== TEST 18: verify auth server forward headers for request_method=GET for POST upstream
---- request
-POST /verify-auth-get
-{"authorization": "token-headers-test"}
---- more_headers
-Authorization: token-headers-test
---- error_code: 200

--- a/t/plugin/forward-auth2.t
+++ b/t/plugin/forward-auth2.t
@@ -31,6 +31,7 @@ add_block_preprocessor(sub {
 run_tests();
 
 __DATA__
+
 === TEST 1: setup route with plugin
 --- config
     location /t {
@@ -54,15 +55,20 @@ __DATA__
                                 functions =  {
                                     [[return function(conf, ctx)
                                         local core = require("apisix.core");
-                                        if core.request.header(ctx, "Authorization") == "token-headers-test" then
+                                        local token = "token-headers-test";
+                                        if core.request.header(ctx, "Authorization") == token then
                                             if core.request.get_method() == "POST" then
-                                                if core.request.header(ctx, "Content-Length") or core.request.header(ctx, "Transfer-Encoding") or core.request.header(ctx, "Content-Encoding") then
+                                                if core.request.header(ctx, "Content-Length") or
+                                                core.request.header(ctx, "Transfer-Encoding") or
+                                                core.request.header(ctx, "Content-Encoding") then
                                                     core.response.exit(200)
                                                 else
                                                     core.response.exit(403)
                                                 end
                                             else
-                                                if core.request.header(ctx, "Content-Length") or core.request.header(ctx, "Transfer-Encoding") or core.request.header(ctx, "Content-Encoding") then
+                                                if core.request.header(ctx, "Content-Length") or
+                                                core.request.header(ctx, "Transfer-Encoding") or
+                                                core.request.header(ctx, "Content-Encoding") then
                                                     core.response.exit(403)
                                                 else
                                                     core.response.exit(200)

--- a/t/plugin/forward-auth2.t
+++ b/t/plugin/forward-auth2.t
@@ -1,0 +1,179 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests();
+
+__DATA__
+=== TEST 1: setup route with plugin
+--- config
+    location /t {
+        content_by_lua_block {
+            local data = {
+                {
+                    url = "/apisix/admin/upstreams/u1",
+                    data = [[{
+                        "nodes": {
+                            "127.0.0.1:1984": 1
+                        },
+                        "type": "roundrobin"
+                    }]],
+                },
+                {
+                    url = "/apisix/admin/routes/auth",
+                    data = {
+                        plugins = {
+                            ["serverless-pre-function"] = {
+                                phase = "rewrite",
+                                functions =  {
+                                    [[return function(conf, ctx)
+                                        local core = require("apisix.core");
+                                        if core.request.header(ctx, "Authorization") == "token-headers-test" then
+                                            if core.request.get_method() == "POST" then
+                                                if core.request.header(ctx, "Content-Length") or core.request.header(ctx, "Transfer-Encoding") or core.request.header(ctx, "Content-Encoding") then
+                                                    core.response.exit(200)
+                                                else
+                                                    core.response.exit(403)
+                                                end
+                                            else
+                                                if core.request.header(ctx, "Content-Length") or core.request.header(ctx, "Transfer-Encoding") or core.request.header(ctx, "Content-Encoding") then
+                                                    core.response.exit(403)
+                                                else
+                                                    core.response.exit(200)
+                                                end
+                                            end
+                                        end
+                                    end]]
+                                }
+                            }
+                        },
+                        uri = "/auth"
+                    },
+                },
+                {
+                    url = "/apisix/admin/routes/echo",
+                    data = [[{
+                        "plugins": {
+                            "serverless-pre-function": {
+                                "phase": "rewrite",
+                                "functions": [
+                                    "return function (conf, ctx)
+                                        local core = require(\"apisix.core\");
+                                        core.response.exit(200, core.request.headers(ctx));
+                                    end"
+                                ]
+                            }
+                        },
+                        "uri": "/echo"
+                    }]],
+                },
+                {
+                    url = "/apisix/admin/routes/1",
+                    data = [[{
+                        "plugins": {
+                            "forward-auth": {
+                                "uri": "http://127.0.0.1:1984/auth",
+                                "request_headers": ["Authorization"],
+                                "request_method": "POST"
+                            },
+                            "proxy-rewrite": {
+                                "uri": "/echo"
+                            }
+                        },
+                        "upstream_id": "u1",
+                        "uri": "/verify-auth-post"
+                    }]],
+                },
+                {
+                    url = "/apisix/admin/routes/2",
+                    data = [[{
+                        "plugins": {
+                            "forward-auth": {
+                                "uri": "http://127.0.0.1:1984/auth",
+                                "request_headers": ["Authorization"],
+                                "request_method": "GET"
+                            },
+                            "proxy-rewrite": {
+                                "uri": "/echo"
+                            }
+                        },
+                        "upstream_id": "u1",
+                        "uri": "/verify-auth-get"
+                    }]],
+                }
+            }
+
+            local t = require("lib.test_admin").test
+
+            for _, data in ipairs(data) do
+                local code, body = t(data.url, ngx.HTTP_PUT, data.data)
+                ngx.say(body)
+            end
+        }
+    }
+--- response_body eval
+"passed\n" x 5
+
+
+
+=== TEST 2: verify auth server forward headers for request_method=GET
+--- request
+GET /verify-auth-get
+--- more_headers
+Authorization: token-headers-test
+--- error_code: 200
+
+
+
+=== TEST 3: verify auth server forward headers for request_method=POST for GET upstream
+--- request
+GET /verify-auth-post
+--- more_headers
+Authorization: token-headers-test
+--- error_code: 200
+
+
+
+=== TEST 4: verify auth server forward headers for request_method=POST
+--- request
+POST /verify-auth-post
+{"authorization": "token-headers-test"}
+--- more_headers
+Authorization: token-headers-test
+--- error_code: 200
+
+
+
+=== TEST 5: verify auth server forward headers for request_method=GET for POST upstream
+--- request
+POST /verify-auth-get
+{"authorization": "token-headers-test"}
+--- more_headers
+Authorization: token-headers-test
+--- error_code: 200


### PR DESCRIPTION
### Description
forward-auth plugin doesn't work if the request is POST and authservice api is GET. Its happening due to forwading the POST method request headers like content-type and expect. Moved these headers only if authserver api is also POST.

Fixes # (issue)
Fixes the issue with forward-auth plugin with POST headers. 
https://github.com/apache/apisix/issues/10927
https://github.com/apache/apisix/issues/11020

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
