### PR TITLE
change: use apisix.enable_http2 to enable HTTP/2 in APISIX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,13 @@ title: Changelog
 - [0.7.0](#070)
 - [0.6.0](#060)
 
+## Next Release Version
+
+### Breaking Changes
+
+- Change the configuration of HTTP/2. The original way is no longer supported: [#11032](https://github.com/apache/apisix/pull/11032)
+
+
 ## 3.8.0
 
 ### Core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,6 @@ title: Changelog
 
 - Change the configuration of HTTP/2. The original way is no longer supported: [#11032](https://github.com/apache/apisix/pull/11032)
 
-
 ## 3.8.0
 
 ### Core

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -380,7 +380,7 @@ Please modify "admin_key" in conf/config.yaml .
     local ip_port_to_check = {}
 
     local function listen_table_insert(listen_table, scheme, ip, port,
-                                enable_http2, enable_http3, enable_ipv6)
+                                enable_http3, enable_ipv6)
         if type(ip) ~= "string" then
             util.die(scheme, " listen ip format error, must be string", "\n")
         end
@@ -401,7 +401,6 @@ Please modify "admin_key" in conf/config.yaml .
                     {
                         ip = ip,
                         port = port,
-                        enable_http2 = enable_http2,
                         enable_http3 = enable_http3
                     })
             ip_port_to_check[addr] = scheme
@@ -416,7 +415,6 @@ Please modify "admin_key" in conf/config.yaml .
                         {
                             ip = ip,
                             port = port,
-                            enable_http2 = enable_http2,
                             enable_http3 = enable_http3
                         })
                 ip_port_to_check[addr] = scheme
@@ -424,17 +422,16 @@ Please modify "admin_key" in conf/config.yaml .
         end
     end
 
-    local enable_http2_global = false
     local node_listen = {}
     -- listen in http, support multiple ports and specific IP, compatible with the original style
     if type(yaml_conf.apisix.node_listen) == "number" then
         listen_table_insert(node_listen, "http", "0.0.0.0", yaml_conf.apisix.node_listen,
-                false, false, yaml_conf.apisix.enable_ipv6)
+                false, yaml_conf.apisix.enable_ipv6)
     elseif type(yaml_conf.apisix.node_listen) == "table" then
         for _, value in ipairs(yaml_conf.apisix.node_listen) do
             if type(value) == "number" then
                 listen_table_insert(node_listen, "http", "0.0.0.0", value,
-                        false, false, yaml_conf.apisix.enable_ipv6)
+                        false, yaml_conf.apisix.enable_ipv6)
             elseif type(value) == "table" then
                 local ip = value.ip
                 local port = value.port
@@ -452,15 +449,13 @@ Please modify "admin_key" in conf/config.yaml .
                     port = 9080
                 end
 
-                if enable_http2 == nil then
-                    enable_http2 = false
-                end
-                if enable_http2 == true then
-                    enable_http2_global = true
+                if enable_http2 ~= nil then
+                    util.die("ERROR: enable_http2 is deprecated,"
+                            .. " you should apisix.enable_http2.", "\n")
                 end
 
                 listen_table_insert(node_listen, "http", ip, port,
-                        enable_http2, false, enable_ipv6)
+                        false, enable_ipv6)
             end
         end
     end
@@ -487,11 +482,8 @@ Please modify "admin_key" in conf/config.yaml .
             port = 9443
         end
 
-        if enable_http2 == nil then
-            enable_http2 = false
-        end
-        if enable_http2 == true then
-            enable_http2_global = true
+        if enable_http2 ~= nil then
+            util.die("ERROR: enable_http2 is deprecated, you should use apisix.enable_http2.", "\n")
         end
 
         if enable_http3 == nil then
@@ -502,11 +494,10 @@ Please modify "admin_key" in conf/config.yaml .
         end
 
         listen_table_insert(ssl_listen, "https", ip, port,
-                enable_http2, enable_http3, enable_ipv6)
+                enable_http3, enable_ipv6)
     end
 
     yaml_conf.apisix.ssl.listen = ssl_listen
-    yaml_conf.apisix.enable_http2 = enable_http2_global
     yaml_conf.apisix.enable_http3_in_server_context = enable_http3_in_server_context
 
 

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -451,7 +451,7 @@ Please modify "admin_key" in conf/config.yaml .
 
                 if enable_http2 ~= nil then
                     util.die("ERROR: enable_http2 is deprecated,"
-                            .. " you should apisix.enable_http2.", "\n")
+                            .. " you should use apisix.enable_http2.", "\n")
                 end
 
                 listen_table_insert(node_listen, "http", ip, port,

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -450,8 +450,9 @@ Please modify "admin_key" in conf/config.yaml .
                 end
 
                 if enable_http2 ~= nil then
-                    util.die("ERROR: enable_http2 is deprecated,"
-                            .. " you should use apisix.enable_http2.", "\n")
+                    util.die("ERROR: port level enable_http2 in node_listen is deprecated"
+                            .. "from 3.9 version, and you should use enable_http2 in "
+                            .. "apisix level.", "\n")
                 end
 
                 listen_table_insert(node_listen, "http", ip, port,
@@ -483,7 +484,9 @@ Please modify "admin_key" in conf/config.yaml .
         end
 
         if enable_http2 ~= nil then
-            util.die("ERROR: enable_http2 is deprecated, you should use apisix.enable_http2.", "\n")
+            util.die("ERROR: port level enable_http2 in ssl.listen is deprecated"
+                      .. "from 3.9 version, and you should use enable_http2 in "
+                      .. "apisix level.", "\n")
         end
 
         if enable_http3 == nil then

--- a/apisix/cli/schema.lua
+++ b/apisix/cli/schema.lua
@@ -199,6 +199,9 @@ local config_schema = {
                 dns_resolver_valid = {
                     type = "integer",
                 },
+                enable_http2 = {
+                    type = "boolean"
+                },
                 ssl = {
                     type = "object",
                     properties = {
@@ -217,9 +220,6 @@ local config_schema = {
                                         type = "integer",
                                         minimum = 1,
                                         maximum = 65535
-                                    },
-                                    enable_http2 = {
-                                        type = "boolean",
                                     },
                                     enable_http3 = {
                                         type = "boolean",

--- a/apisix/cli/schema.lua
+++ b/apisix/cli/schema.lua
@@ -200,7 +200,8 @@ local config_schema = {
                     type = "integer",
                 },
                 enable_http2 = {
-                    type = "boolean"
+                    type = "boolean",
+                    default = true
                 },
                 ssl = {
                     type = "object",

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -23,10 +23,8 @@ apisix:
   node_listen:                 # APISIX listening ports.
     - 9080
   #   - port: 9081
-  #     enable_http2: true     # If not set, default to `false`.
   #   - ip: 127.0.0.2          # If not set, default to `0.0.0.0`
   #     port: 9082
-  #     enable_http2: true
   enable_admin: true           # Admin API
   enable_dev_mode: false       # If true, set nginx `worker_processes` to 1.
   enable_reuseport: true       # If true, enable nginx SO_REUSEPORT option.
@@ -35,6 +33,7 @@ apisix:
                                                   # If false, show `X-APISIX-Upstream-Status` only if
                                                   # the upstream response code is 5xx.
   enable_ipv6: true
+  enable_http2: true
 
   # proxy_protocol:                    # PROXY Protocol configuration
   #   listen_http_port: 9181           # APISIX listening port for HTTP traffic with PROXY protocol.
@@ -96,11 +95,9 @@ apisix:
     enable: true
     listen:                                       # APISIX listening port for HTTPS traffic.
       - port: 9443
-        enable_http2: true
         enable_http3: false                       # Enable HTTP/3 (with QUIC). If not set default to `false`.
       # - ip: 127.0.0.3                           # If not set, default to `0.0.0.0`.
       #   port: 9445
-      #   enable_http2: true
       #   enable_http3: true
     # ssl_trusted_certificate: /path/to/ca-cert   # Set the path to CA certificates used to verify client
                                                   # certificates in the PEM format.

--- a/docs/en/latest/grpc-proxy.md
+++ b/docs/en/latest/grpc-proxy.md
@@ -78,9 +78,8 @@ By default, the APISIX only listens to `9443` for TLS‑encrypted HTTP/2. You ca
 apisix:
     node_listen:
         - port: 9080
-          enable_http2: false
         - port: 9081
-          enable_http2: true
+    enable_http2: true
 ```
 
 Invoking the route created before：

--- a/docs/zh/latest/grpc-proxy.md
+++ b/docs/zh/latest/grpc-proxy.md
@@ -78,9 +78,8 @@ grpcurl -insecure -import-path /pathtoprotos  -proto helloworld.proto  \
 apisix:
     node_listen:
         - port: 9080
-          enable_http2: false
         - port: 9081
-          enable_http2: true
+    enable_http2: true
 ```
 
 访问上面配置的 Route：

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -133,16 +133,14 @@ apisix:
       port: 9081
     - ip: 127.0.0.2
       port: 9082
-      enable_http2: true
   ssl:
-    enable_http2: false
     listen:
       - ip: 127.0.0.3
         port: 9444
       - ip: 127.0.0.4
         port: 9445
-        enable_http2: true
         enable_http3: true
+  enable_http2: true
 " > conf/config.yaml
 
 make init
@@ -153,21 +151,15 @@ if [ $count_http_specific_ip -ne 2 ]; then
     exit 1
 fi
 
-count_http_specific_ip_and_enable_http2=`grep -c "http2 on" conf/nginx.conf || true`
-if [ $count_http_specific_ip_and_enable_http2 -ne 1 ]; then
-    echo "failed: failed to support specific IP and enable http2 listen in http"
-    exit 1
-fi
-
 count_https_specific_ip=`grep -c "listen 127.0.0..:944. ssl" conf/nginx.conf || true`
 if [ $count_https_specific_ip -ne 2 ]; then
     echo "failed: failed to support specific IP listen in https"
     exit 1
 fi
 
-count_https_specific_ip_and_enable_http2=`grep -c "http2 on" conf/nginx.conf || true`
-if [ $count_https_specific_ip_and_enable_http2 -ne 1 ]; then
-    echo "failed: failed to support specific IP and enable http2 listen in https"
+count_enable_http2=`grep -c "http2 on" conf/nginx.conf || true`
+if [ $count_enable_http2 -ne 1 ]; then
+    echo "failed: failed to enable http2"
     exit 1
 fi
 

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -177,6 +177,46 @@ fi
 
 echo "passed: support specific IP listen in http and https"
 
+# check deprecated enable_http2 in node_listen
+echo "
+apisix:
+  node_listen:
+    - ip: 127.0.0.1
+      port: 9081
+      enable_http2: true
+" > conf/config.yaml
+
+out=$(make init 2>&1 || true)
+if ! echo "$out" | grep 'port level enable_http2 in node_listen is deprecated'; then
+    echo "failed: failed to detect deprecated enable_http2 in node_listen"
+    exit 1
+fi
+
+echo "passed: check deprecated enable_http2 in node_listen"
+
+
+# check deprecated enable_http2 in ssl.listen
+echo "
+apisix:
+  node_listen:
+    - ip: 127.0.0.1
+      port: 9081
+  ssl:
+    enable: true
+    listen:
+      - ip: 127.0.0.1
+        port: 9444
+        enable_http2: true
+" > conf/config.yaml
+
+out=$(make init 2>&1 || true)
+if ! echo "$out" | grep 'port level enable_http2 in ssl.listen is deprecated'; then
+    echo "failed: failed to detect deprecated enable_http2 in ssl.listen"
+    exit 1
+fi
+
+echo "passed: check deprecated enable_http2 in node_listen"
+
 # check default env
 echo "
 nginx_config:

--- a/t/core/config-default.t
+++ b/t/core/config-default.t
@@ -123,9 +123,8 @@ node_listen: [1985,1986]
 apisix:
   node_listen:
     - port: 1985
-      enable_http2: true
     - port: 1986
-      enable_http2: true
+  enable_http2: true
 --- config
   location /t {
     content_by_lua_block {
@@ -138,4 +137,4 @@ apisix:
 --- request
 GET /t
 --- response_body
-node_listen: [{"enable_http2":true,"port":1985},{"enable_http2":true,"port":1986}]
+node_listen: [{"port":1985},{"port":1986}]


### PR DESCRIPTION
### Description

**This PR is a Breaking Change.**

in https://github.com/apache/apisix/pull/10887, I upgrade openresty-1.25.3.1 for APISIX. There is a deprecation in nginx. The `http2` parameter in `listen` directive is deprecated.
> The parameter is deprecated, the [http2](https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2) directive should be used instead.

In https://github.com/apache/apisix/pull/10887, in order to maintain backward compatibility, I did not modify the method of `enable http2` in APISIX. But this will bring a breaking change to users.

for example.
`config.yaml`
```yaml
apisix:
  node_listen:
    - ip: 127.0.0.1
      port: 9081
      enable_http2: true  # enable HTTP/2 for 127.0.0.1:9081
    - ip: 127.0.0.2
      port: 9082
      enable_http2: false # disable HTTP/2 for 127.0.0.1:9082
```

generated `nginx.conf` which  `127.0.0.1:9081` and `127.0.0.2:9082` both can establish HTTP/2 connection. **This scenario is not what user want.**
```nginx
    server {
        http2 on;
        listen 127.0.0.1:9081 default_server reuseport;
        listen 127.0.0.2:9082 default_server reuseport;
```
So I want to make a breaking change for APISIX. Only support `apisix.enable_http2`.  eg.
```yaml
apisix:
  node_listen:
    - ip: 127.0.0.1
      port: 9081
    - ip: 127.0.0.2
      port: 9082
enable_http2: true # the new way to enable HTTP/2
```
it will generate following `nginx.conf` which  `127.0.0.1:9081` and `127.0.0.2:9082` both can establish HTTP/2 connection.
```nginx
    server {
        http2 on;
        listen 127.0.0.1:9081 default_server reuseport;
        listen 127.0.0.2:9082 default_server reuseport;
```

**The original method will no longer be supported. If you still use original way in `config.yaml`, APISIX will report an error to you.**

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
