### PR TITLE
feat(openid-connect): Add extra validation if audience claim exists in the Bearer token 

### DIFF
--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -382,7 +382,16 @@ local function introspect(ctx, conf)
         -- Token successfully validated.
         local method = (conf.public_key and "public_key") or (conf.use_jwks and "jwks")
         core.log.debug("token validate successfully by ", method)
+
+        -- Validate audience claim if it exists
+        if res.aud then
+            if res.aud ~= conf.client_id then
+                return ngx.HTTP_UNAUTHORIZED, "Audience does not match the client_id"
+            end
+        end
+
         return res, err, token, res
+
     else
         -- Validate token against introspection endpoint.
         -- TODO: Same as above for public key validation.
@@ -397,6 +406,14 @@ local function introspect(ctx, conf)
         -- Token successfully validated and response from the introspection
         -- endpoint contains the userinfo.
         core.log.debug("token validate successfully by introspection")
+
+        -- Validate audience claim if it exists
+        if res.aud then
+            if res.aud ~= conf.client_id then
+                return ngx.HTTP_UNAUTHORIZED, "Audience does not match the client_id"
+            end
+        end
+
         return res, err, token, res
     end
 end


### PR DESCRIPTION
### Description

>The "aud" (audience) claim identifies the recipients that the JWT is intended for.
>https://www.rfc-editor.org/rfc/rfc7519#section-4.1.3

Issue: `openid-connect` currently does not validate if the audience claim matches the client_id which means that every valid JWT can authenticate using this plugin, even if it was generated for a different client.

Solution: This MR enhances the `introspect` function by adding a simple validation that the audience claim `aud` is the same as the provided `client_id`. 

Note: There is no documentation that can be updated, unless a note should be added to explain this functionality in the page of the plugin. 

Fixes # (issue)
https://github.com/apache/apisix/issues/11018

### Checklist

- [X] I have explained the need for this PR and the problem it solves
- [X] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
