### PR TITLE
perf(ssl): replace 'string.len' with '#'

### DIFF
--- a/apisix/ssl.lua
+++ b/apisix/ssl.lua
@@ -24,7 +24,6 @@ local ngx_decode_base64 = ngx.decode_base64
 local aes = require("resty.aes")
 local str_lower = string.lower
 local str_byte = string.byte
-local str_len = string.len
 local assert = assert
 local type = type
 local ipairs = ipairs
@@ -299,7 +298,7 @@ function _M.get_status_request_ext()
         core.log.debug("no contains status request extension")
         return false
     end
-    local total_len = str_len(ext)
+    local total_len = #ext
     -- 1-byte for CertificateStatusType
     -- 2-byte for zero-length "responder_id_list"
     -- 2-byte for zero-length "request_extensions"


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
