### PR TITLE
fix(brotli): brotli partial response fix

### DIFF
--- a/apisix/plugins/brotli.lua
+++ b/apisix/plugins/brotli.lua
@@ -239,7 +239,8 @@ function _M.body_filter(conf, ctx)
     end
 
     if eof then
-        ngx.arg[1] = ctx.compressor:finish()
+        -- overwriting the arg[1], results into partial response
+        ngx.arg[1] = ngx.arg[1] .. ctx.compressor:finish()
     end
 end
 


### PR DESCRIPTION
### Description
When there is a chunk in the `eof`, brotli plugin overwrite the response `arg[1]`. Which results into partial response.

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

- Fixes #11079 

### Checklist

- [X] I have explained the need for this PR and the problem it solves
- [X] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [X] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
