### PR TITLE
fix: close session in case of error to avoid blocked session

### DIFF
--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -546,6 +546,9 @@ function _M.rewrite(plugin_conf, ctx)
         response, err, _, session  = openidc.authenticate(conf, nil, unauth_action, conf.session)
 
         if err then
+            if session then
+                session:close()
+            end
             if err == "unauthorized request" then
                 if conf.unauth_action == "pass" then
                     return nil

--- a/t/plugin/openid-connect5.t
+++ b/t/plugin/openid-connect5.t
@@ -144,18 +144,7 @@ hello world
 === TEST 2: Call to route with locking session storage, no authentication and unauth_action 'deny' should not block subsequent requests on same session
 --- config
     set $session_storage redis;
-    set $session_redis_prefix                   sessions;
-    set $session_redis_database                 0;
-    set $session_redis_connect_timeout          1000; # (in milliseconds)
-    set $session_redis_send_timeout             1000; # (in milliseconds)
-    set $session_redis_read_timeout             1000; # (in milliseconds)
-    set $session_redis_host                     127.0.0.1;
-    set $session_redis_port                     6379;
-    set $session_redis_ssl                      off;
-    set $session_redis_ssl_verify               off;
     set $session_redis_uselocking               on;
-    set $session_redis_spinlockwait             150;  # (in milliseconds)
-    set $session_redis_maxlockwait              30;   # (in seconds)
 
     location /t {
         content_by_lua_block {

--- a/t/plugin/openid-connect5.t
+++ b/t/plugin/openid-connect5.t
@@ -175,15 +175,6 @@ hello world
                                 "client_secret": "d1ec69e9-55d2-4109-a3ea-befa071579d5",
                                 "redirect_uri": "http://127.0.0.1:]] .. ngx.var.server_port .. [[/authenticated",
                                 "ssl_verify": false,
-                                "bearer_only" : false,
-                                "timeout": 10,
-                                "introspection_endpoint_auth_method": "client_secret_post",
-                                "introspection_endpoint": "http://127.0.0.1:8080/realms/University/protocol/openid-connect/token/introspect",
-                                "set_access_token_header": true,
-                                "access_token_in_authorization_header": false,
-                                "set_id_token_header": true,
-                                "set_userinfo_header": true,
-                                "set_refresh_token_header": true,
                                 "unauth_action": "deny"
                             }
                         },

--- a/t/plugin/openid-connect5.t
+++ b/t/plugin/openid-connect5.t
@@ -138,3 +138,97 @@ __DATA__
     }
 --- response_body_like
 hello world
+
+
+
+=== TEST 2: Call to route with locking session storage, no authentication and unauth_action 'deny' should not block subsequent requests on same session
+--- config
+    set $session_storage redis;
+    set $session_redis_prefix                   sessions;
+    set $session_redis_database                 0;
+    set $session_redis_connect_timeout          1000; # (in milliseconds)
+    set $session_redis_send_timeout             1000; # (in milliseconds)
+    set $session_redis_read_timeout             1000; # (in milliseconds)
+    set $session_redis_host                     127.0.0.1;
+    set $session_redis_port                     6379;
+    set $session_redis_ssl                      off;
+    set $session_redis_ssl_verify               off;
+    set $session_redis_uselocking               on;
+    set $session_redis_spinlockwait             150;  # (in milliseconds)
+    set $session_redis_maxlockwait              30;   # (in seconds)
+
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local http = require "resty.http"
+            local login_keycloak = require("lib.keycloak").login_keycloak
+            local concatenate_cookies = require("lib.keycloak").concatenate_cookies
+
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "openid-connect": {
+                                "discovery": "http://127.0.0.1:8080/realms/University/.well-known/openid-configuration",
+                                "realm": "University",
+                                "client_id": "course_management",
+                                "client_secret": "d1ec69e9-55d2-4109-a3ea-befa071579d5",
+                                "redirect_uri": "http://127.0.0.1:]] .. ngx.var.server_port .. [[/authenticated",
+                                "ssl_verify": false,
+                                "bearer_only" : false,
+                                "timeout": 10,
+                                "introspection_endpoint_auth_method": "client_secret_post",
+                                "introspection_endpoint": "http://127.0.0.1:8080/realms/University/protocol/openid-connect/token/introspect",
+                                "set_access_token_header": true,
+                                "access_token_in_authorization_header": false,
+                                "set_id_token_header": true,
+                                "set_userinfo_header": true,
+                                "set_refresh_token_header": true,
+                                "unauth_action": "deny"
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/*"
+                }]]
+                )
+
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/hello"
+
+            -- Make the final call to protected route WITHOUT cookie
+            local httpc = http.new()
+            local res, err = httpc:request_uri(uri, {method = "GET"})
+
+            -- Extract cookie which is not authenticated
+            local cookie_str = concatenate_cookies(res.headers['Set-Cookie'])
+
+            -- Make the call to protected route cookie
+            local function firstRequest()
+               local httpc = http.new()
+               httpc:request_uri(uri, {
+                        method = "GET",
+                        headers = {
+                            ["Cookie"] = cookie_str
+                        }
+                    })
+            end
+            ngx.thread.spawn(firstRequest)
+
+            -- Make second call to protected route and same cookie which should not timeout due ton a blocked session
+            local httpc = http.new()
+            httpc:set_timeout(2000)
+
+            res, err = httpc:request_uri(uri, {
+                    method = "GET",
+                     headers = {
+                        ["Cookie"] = cookie_str
+                     }
+            })
+            ngx.status = res.status
+        }
+    }
+--- error_code: 401


### PR DESCRIPTION
…session on locking session storage (example unauth_action=deny)

### Description

This PR is fixing a bug where sessions are blocked until ttl is expired in case of an authentication error. For example unauthenticated session and `unauth_action='deny'` and locking session storage is configured.

Basically the same problem as in https://github.com/apache/apisix/pull/10788 but in case of error.

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
