### PR TITLE
fix(prometheus): disable features when plugin is turned off

### DIFF
--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -97,6 +97,29 @@ local function check_disable(plugin_conf)
     return plugin_conf._meta.disable
 end
 
+--- check if the plugin is disabled with metatable
+--- if the plugin_conf is nil, return true
+--- if the plugin_conf._meta is nil, return true (enable default)
+--- if the plugin_conf._meta.disable is nil, return false
+--- true means plugin is disabled, false means plugin is enabled
+local function check_disable_with_metatable(plugin_conf)
+    if not plugin_conf then
+        return true
+    end
+
+    if not plugin_conf._meta then
+        return false
+    end
+
+    if type(plugin_conf._meta) ~= "table" then
+        return true
+    end
+
+    return plugin_conf._meta.disable
+end
+
+_M.check_disable_with_metatable = check_disable_with_metatable
+
 local PLUGIN_TYPE_HTTP = 1
 local PLUGIN_TYPE_STREAM = 2
 local PLUGIN_TYPE_HTTP_WASM = 3

--- a/apisix/utils/batch-processor.lua
+++ b/apisix/utils/batch-processor.lua
@@ -15,6 +15,7 @@
 -- limitations under the License.
 --
 local core = require("apisix.core")
+local plugin = require("apisix.plugin")
 local setmetatable = setmetatable
 local timer_at = ngx.timer.at
 local ipairs = ipairs
@@ -184,8 +185,9 @@ function batch_processor:push(entry)
         return
     end
 
-    if prometheus and prometheus.get_prometheus() and not batch_metrics and self.name
-       and self.route_id and self.server_addr then
+    if not plugin.check_disable_with_metatable(plugin.get("prometheus"))
+        and not batch_metrics and self.name
+        and self.route_id and self.server_addr then
         batch_metrics = prometheus.get_prometheus():gauge("batch_process_entries",
                                                           "batch process remaining entries",
                                                           {"name", "route_id", "server_addr"})

--- a/t/xrpc/prometheus.t
+++ b/t/xrpc/prometheus.t
@@ -271,3 +271,32 @@ passed
 GET /apisix/prometheus/metrics
 --- response_body eval
 qr/apisix_redis_commands_total\{route="1",command="hmset"\} 1/
+
+
+
+=== TEST 9: remove public API route and test route
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_DELETE
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 10: fetch the prometheus metric data while prometheus plugin is disabled
+--- yaml_config
+plugins:
+  - limit-count
+--- request
+GET /apisix/prometheus/metrics
+--- error_code: 404


### PR DESCRIPTION
### Description

The Prometheus plugin is a crucial component for observability within Apache APISIX. However, I've encountered an issue where, even after the Prometheus plugin is disabled, all features related to Prometheus are not entirely shut down. This behavior could lead to unexpected performance impacts and data leakage.

When the Prometheus plugin is disabled, all functionalities and metrics associated with Prometheus should be completely deactivated to ensure no unnecessary overhead or data exposure.
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # ([issue](https://github.com/apache/apisix/issues/11046))

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
