### PR TITLE
fix: rectify the warning printed when `admin_key_required` == `false`

### DIFF
--- a/apisix/admin/init.lua
+++ b/apisix/admin/init.lua
@@ -463,7 +463,7 @@ function _M.init_worker()
         if local_conf.deployment.admin.admin_key_required == false then
             core.log.warn("Admin key is bypassed! ",
                 "If you are deploying APISIX in a production environment, ",
-                "please disable `admin_key_required` and set a secure admin key!")
+                "please enable `admin_key_required` and set a secure admin key!")
         end
 
         local ok, err = ngx_timer_at(0, function(premature)

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -193,7 +193,7 @@ local function init(env)
         checked_admin_key = true
         print("Warning! Admin key is bypassed! "
                 .. "If you are deploying APISIX in a production environment, "
-                .. "please disable `admin_key_required` and set a secure admin key!")
+                .. "please enable `admin_key_required` and set a secure admin key!")
     end
 
     if yaml_conf.apisix.enable_admin and not checked_admin_key then


### PR DESCRIPTION
### Description

Fixes #11091

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
