### PR TITLE
fix(nacos discovery): up_apps is empty fault tolerance

### DIFF
--- a/apisix/discovery/nacos/init.lua
+++ b/apisix/discovery/nacos/init.lua
@@ -353,6 +353,9 @@ local function fetch_full_registry(premature)
     end
     local new_apps_md5sum = ngx.md5(core.json.encode(up_apps))
     local old_apps_md5sum = ngx.md5(core.json.encode(applications))
+    if next(up_apps) == nil then
+        return
+    end
     if new_apps_md5sum == old_apps_md5sum then
         return
     end


### PR DESCRIPTION
### Description

fix: up_apps is empty fault tolerance

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list]
