### PR TITLE
fix(prometheus): disable features when prometheus plugin is turned off

### DIFF
--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -347,15 +347,13 @@ function _M.load(config)
                 core.log.error("failed to load plugins: ", err)
             end
 
-            if ngx.config.subsystem == "http" then
-                local enabled = core.table.array_find(http_plugin_names, "prometheus") ~= nil
-                local active  = exporter.get_prometheus() ~= nil
-                if not enabled and active then
-                    exporter.destroy()
-                end
-                if enabled and not active then
-                    exporter.http_init()
-                end
+            local enabled = core.table.array_find(http_plugin_names, "prometheus") ~= nil
+            local active  = exporter.get_prometheus() ~= nil
+            if not enabled and active then
+                exporter.destroy()
+            end
+            if enabled and not active then
+                exporter.http_init()
             end
         end
     end
@@ -366,14 +364,6 @@ function _M.load(config)
         local ok, err = load_stream(stream_plugin_names)
         if not ok then
             core.log.error("failed to load stream plugins: ", err)
-        end
-
-        if ngx.config.subsystem == "stream" then
-            if not core.table.array_find(stream_plugin_names, "prometheus") then
-                exporter.destroy()
-            else
-                exporter.stream_init()
-            end
         end
     end
 

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -376,6 +376,8 @@ function _M.exit_worker()
     for name in pairs(stream_local_plugins_hash) do
         unload_plugin(name, PLUGIN_TYPE_STREAM)
     end
+
+    require("apisix.plugins.prometheus.exporter").destroy()
 end
 
 

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -350,13 +350,10 @@ function _M.load(config)
             if ngx.config.subsystem == "http" then
                 local enabled = core.table.array_find(http_plugin_names, "prometheus") ~= nil
                 local active  = exporter.get_prometheus() ~= nil
-                core.log.warn("inside subsystem: ", enabled, ". ", active, core.json.encode(http_plugin_names))
                 if not enabled and active then
-                    core.log.warn("disabled and active")
                     exporter.destroy()
                 end
                 if enabled and not active then
-                    core.log.warn("enabled and inactive")
                     exporter.http_init()
                 end
             end

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -349,7 +349,7 @@ function _M.load(config)
 
             local enabled = core.table.array_find(http_plugin_names, "prometheus") ~= nil
             local active  = exporter.get_prometheus() ~= nil
-            if not enabled and active then
+            if not enabled then
                 exporter.destroy()
             end
             if enabled and not active then

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -113,7 +113,7 @@ function _M.http_init(prometheus_enabled_in_stream)
     -- todo: support hot reload, we may need to update the lua-prometheus
     -- library
     if ngx.get_phase() ~= "init" and ngx.get_phase() ~= "init_worker"  then
-        if prometheus_bkp ~= nil then
+        if prometheus_bkp then
             prometheus = prometheus_bkp
         end
         return

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -231,83 +231,78 @@ end
 
 
 function _M.http_log(conf, ctx)
-    -- only record metrics when prometheus is enabled
-    if prometheus then
-        local vars = ctx.var
+    local vars = ctx.var
 
-        local route_id = ""
-        local balancer_ip = ctx.balancer_ip or ""
-        local service_id = ""
-        local consumer_name = ctx.consumer_name or ""
+    local route_id = ""
+    local balancer_ip = ctx.balancer_ip or ""
+    local service_id = ""
+    local consumer_name = ctx.consumer_name or ""
 
-        local matched_route = ctx.matched_route and ctx.matched_route.value
-        if matched_route then
-            route_id = matched_route.id
-            service_id = matched_route.service_id or ""
-            if conf.prefer_name == true then
-                route_id = matched_route.name or route_id
-                if service_id ~= "" then
-                    local service = service_fetch(service_id)
-                    service_id = service and service.value.name or service_id
-                end
+    local matched_route = ctx.matched_route and ctx.matched_route.value
+    if matched_route then
+        route_id = matched_route.id
+        service_id = matched_route.service_id or ""
+        if conf.prefer_name == true then
+            route_id = matched_route.name or route_id
+            if service_id ~= "" then
+                local service = service_fetch(service_id)
+                service_id = service and service.value.name or service_id
             end
         end
-
-        local matched_uri = ""
-        local matched_host = ""
-        if ctx.curr_req_matched then
-            matched_uri = ctx.curr_req_matched._path or ""
-            matched_host = ctx.curr_req_matched._host or ""
-        end
-
-        metrics.status:inc(1,
-            gen_arr(vars.status, route_id, matched_uri, matched_host,
-                    service_id, consumer_name, balancer_ip,
-                    unpack(extra_labels("http_status", ctx))))
-
-        local latency, upstream_latency, apisix_latency = latency_details(ctx)
-        local latency_extra_label_values = extra_labels("http_latency", ctx)
-
-        metrics.latency:observe(latency,
-            gen_arr("request", route_id, service_id, consumer_name, balancer_ip,
-            unpack(latency_extra_label_values)))
-
-        if upstream_latency then
-            metrics.latency:observe(upstream_latency,
-                gen_arr("upstream", route_id, service_id, consumer_name, balancer_ip,
-                unpack(latency_extra_label_values)))
-        end
-
-        metrics.latency:observe(apisix_latency,
-            gen_arr("apisix", route_id, service_id, consumer_name, balancer_ip,
-            unpack(latency_extra_label_values)))
-
-        local bandwidth_extra_label_values = extra_labels("bandwidth", ctx)
-
-        metrics.bandwidth:inc(vars.request_length,
-            gen_arr("ingress", route_id, service_id, consumer_name, balancer_ip,
-            unpack(bandwidth_extra_label_values)))
-
-        metrics.bandwidth:inc(vars.bytes_sent,
-            gen_arr("egress", route_id, service_id, consumer_name, balancer_ip,
-            unpack(bandwidth_extra_label_values)))
     end
+
+    local matched_uri = ""
+    local matched_host = ""
+    if ctx.curr_req_matched then
+        matched_uri = ctx.curr_req_matched._path or ""
+        matched_host = ctx.curr_req_matched._host or ""
+    end
+
+    metrics.status:inc(1,
+        gen_arr(vars.status, route_id, matched_uri, matched_host,
+                service_id, consumer_name, balancer_ip,
+                unpack(extra_labels("http_status", ctx))))
+
+    local latency, upstream_latency, apisix_latency = latency_details(ctx)
+    local latency_extra_label_values = extra_labels("http_latency", ctx)
+
+    metrics.latency:observe(latency,
+        gen_arr("request", route_id, service_id, consumer_name, balancer_ip,
+        unpack(latency_extra_label_values)))
+
+    if upstream_latency then
+        metrics.latency:observe(upstream_latency,
+            gen_arr("upstream", route_id, service_id, consumer_name, balancer_ip,
+            unpack(latency_extra_label_values)))
+    end
+
+    metrics.latency:observe(apisix_latency,
+        gen_arr("apisix", route_id, service_id, consumer_name, balancer_ip,
+        unpack(latency_extra_label_values)))
+
+    local bandwidth_extra_label_values = extra_labels("bandwidth", ctx)
+
+    metrics.bandwidth:inc(vars.request_length,
+        gen_arr("ingress", route_id, service_id, consumer_name, balancer_ip,
+        unpack(bandwidth_extra_label_values)))
+
+    metrics.bandwidth:inc(vars.bytes_sent,
+        gen_arr("egress", route_id, service_id, consumer_name, balancer_ip,
+        unpack(bandwidth_extra_label_values)))
 end
 
 
 function _M.stream_log(conf, ctx)
-    if prometheus then
-        local route_id = ""
-        local matched_route = ctx.matched_route and ctx.matched_route.value
-        if matched_route then
-            route_id = matched_route.id
-            if conf.prefer_name == true then
-                route_id = matched_route.name or route_id
-            end
+    local route_id = ""
+    local matched_route = ctx.matched_route and ctx.matched_route.value
+    if matched_route then
+        route_id = matched_route.id
+        if conf.prefer_name == true then
+            route_id = matched_route.name or route_id
         end
-
-        metrics.stream_connection_total:inc(1, gen_arr(route_id))
     end
+
+    metrics.stream_connection_total:inc(1, gen_arr(route_id))
 end
 
 

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -522,6 +522,9 @@ _M.get_api = get_api
 
 
 function _M.export_metrics(stream_only)
+    if not prometheus then
+        core.response.exit(200, "")
+    end
     local api = get_api(false)
     local uri = ngx.var.uri
     local method = ngx.req.get_method()
@@ -544,5 +547,11 @@ end
 function _M.get_prometheus()
     return prometheus
 end
+
+
+function _M.destroy()
+    prometheus = nil
+end
+
 
 return _M

--- a/t/cli/test_prometheus_reload.sh
+++ b/t/cli/test_prometheus_reload.sh
@@ -91,31 +91,3 @@ if curl -i http://127.0.0.1:9091/apisix/prometheus/metrics | grep "{}" > /dev/nu
     echo "failed: metrics should not contain '{}' when prometheus is enabled"
     exit 1
 fi
-
-echo "disable http prometheus and enable stream prometheus and call reload"
-
-exit_if_not_customed_nginx
-
-echo "
-apisix:
-    proxy_mode: http&stream
-    enable_admin: true
-    stream_proxy:
-        tcp:
-            - addr: 9100
-plugins:
-    - example-plugin
-stream_plugins:
-    - prometheus
-" > conf/config.yaml
-
-curl -i http://127.0.0.1:9090/v1/plugins/reload -XPUT
-
-sleep 2
-
-echo "fetching metrics should actually work demonstrating hot reload"
-
-if ! curl -i http://127.0.0.1:9091/apisix/prometheus/metrics | grep "{}" > /dev/null; then
-    echo "failed: metrics should not contain '{}' when prometheus is enabled"
-    exit 1
-fi

--- a/t/cli/test_prometheus_reload.sh
+++ b/t/cli/test_prometheus_reload.sh
@@ -91,3 +91,31 @@ if curl -i http://127.0.0.1:9091/apisix/prometheus/metrics | grep "{}" > /dev/nu
     echo "failed: metrics should not contain '{}' when prometheus is enabled"
     exit 1
 fi
+
+echo "disable http prometheus and enable stream prometheus and call reload"
+
+exit_if_not_customed_nginx
+
+echo "
+apisix:
+    proxy_mode: http&stream
+    enable_admin: true
+    stream_proxy:
+        tcp:
+            - addr: 9100
+plugins:
+    - example-plugin
+stream_plugins:
+    - prometheus
+" > conf/config.yaml
+
+curl -i http://127.0.0.1:9090/v1/plugins/reload -XPUT
+
+sleep 2
+
+echo "fetching metrics should actually work demonstrating hot reload"
+
+if ! curl -i http://127.0.0.1:9091/apisix/prometheus/metrics | grep "{}" > /dev/null; then
+    echo "failed: metrics should not contain '{}' when prometheus is enabled"
+    exit 1
+fi

--- a/t/cli/test_prometheus_reload.sh
+++ b/t/cli/test_prometheus_reload.sh
@@ -21,8 +21,6 @@
 
 git checkout conf/config.yaml
 
-sleep 1
-
 make run
 
 sleep 2

--- a/t/cli/test_prometheus_reload.sh
+++ b/t/cli/test_prometheus_reload.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+. ./t/cli/common.sh
+
+git checkout conf/config.yaml
+
+sleep 1
+
+make run
+
+sleep 2
+
+echo "removing prometheus from the plugins list"
+echo '
+deployment:
+  role: traditional
+  role_traditional:
+    config_provider: etcd
+  admin:
+    admin_key: null
+apisix:
+  node_listen: 1984
+plugins:
+  - ip-restriction' > conf/config.yaml
+
+echo "fetch metrics, should not contain {}"
+
+if curl -i http://127.0.0.1:9091/apisix/prometheus/metrics | grep "{}" > /dev/null; then
+    echo "failed: metrics should not contain '{}' when prometheus is enabled"
+    exit 1
+fi
+
+echo "calling reload API to actually disable prometheus"
+
+curl -i http://127.0.0.1:9090/v1/plugins/reload -XPUT
+
+sleep 2
+
+echo "fetch metrics after reload should contain {}"
+
+if ! curl -i http://127.0.0.1:9091/apisix/prometheus/metrics | grep "{}" > /dev/null; then
+    echo "failed: metrics should contain '{}' when prometheus is disabled"
+    exit 1
+fi
+
+echo "re-enable prometheus"
+
+echo '
+deployment:
+  role: traditional
+  role_traditional:
+    config_provider: etcd
+  admin:
+    admin_key: null
+apisix:
+  node_listen: 1984
+plugins:
+  - prometheus' > conf/config.yaml
+
+echo "fetching metrics without reloading should give same result as before"
+
+if ! curl -i http://127.0.0.1:9091/apisix/prometheus/metrics | grep "{}" > /dev/null; then
+    echo "failed: metrics should contain '{}' when prometheus is disabled"
+    exit 1
+fi
+
+echo "calling reload API to actually enable prometheus"
+
+curl -i http://127.0.0.1:9090/v1/plugins/reload -XPUT
+
+sleep 2
+
+if curl -i http://127.0.0.1:9091/apisix/prometheus/metrics | grep "{}" > /dev/null; then
+    echo "failed: metrics should not contain '{}' when prometheus is enabled"
+    exit 1
+fi

--- a/t/plugin/prometheus4.t
+++ b/t/plugin/prometheus4.t
@@ -292,21 +292,21 @@ apisix_http_latency_bucket\{type="upstream",route="1",service="",consumer="",nod
                         "plugins": {
                             "prometheus": {},
                             "syslog": {
-			                    "host": "127.0.0.1",
-			                    "include_req_body": false,
-			                    "max_retry_times": 1,
-			                    "tls": false,
-			                    "retry_interval": 1,
-			                    "batch_max_size": 1000,
-			                    "buffer_duration": 60,
-			                    "port": 1000,
-			                    "name": "sys-logger",
-			                    "flush_limit": 4096,
-			                    "sock_type": "tcp",
-			                    "timeout": 3,
-			                    "drop_limit": 1048576,
-			                    "pool_size": 5
-		                    }                        
+                                "host": "127.0.0.1",
+                                "include_req_body": false,
+                                "max_retry_times": 1,
+                                "tls": false,
+                                "retry_interval": 1,
+                                "batch_max_size": 1000,
+                                "buffer_duration": 60,
+                                "port": 1000,
+                                "name": "sys-logger",
+                                "flush_limit": 4096,
+                                "sock_type": "tcp",
+                                "timeout": 3,
+                                "drop_limit": 1048576,
+                                "pool_size": 5
+                            }
                         },
                         "upstream": {
                             "nodes": {
@@ -361,7 +361,7 @@ plugin_attr:
             local code, body = t('/batch-process-metrics',
                  ngx.HTTP_GET
                 )
-            
+
             ngx.status = code
             ngx.say(body)
 

--- a/t/plugin/prometheus4.t
+++ b/t/plugin/prometheus4.t
@@ -340,7 +340,7 @@ passed
             local httpc = http.new()
 
             local t = require("lib.test_admin").test
-                    ngx.sleep(0.1)
+            ngx.sleep(0.1)
             local data = [[
 deployment:
   role: traditional
@@ -364,7 +364,6 @@ plugin_attr:
 
             ngx.status = code
             ngx.say(body)
-
 
             local data = [[
 deployment:

--- a/t/plugin/prometheus4.t
+++ b/t/plugin/prometheus4.t
@@ -277,3 +277,140 @@ apisix_http_latency_bucket\{type="upstream",route="1",service="",consumer="",nod
 apisix_http_latency_bucket\{type="upstream",route="1",service="",consumer="",node="127.0.0.1",le="105"\} \d+
 apisix_http_latency_bucket\{type="upstream",route="1",service="",consumer="",node="127.0.0.1",le="205"\} \d+
 apisix_http_latency_bucket\{type="upstream",route="1",service="",consumer="",node="127.0.0.1",le="505"\} \d+/
+
+
+
+=== TEST 10: set sys plugins
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/9',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "methods": ["GET"],
+                        "plugins": {
+                            "prometheus": {},
+                            "syslog": {
+			                    "host": "127.0.0.1",
+			                    "include_req_body": false,
+			                    "max_retry_times": 1,
+			                    "tls": false,
+			                    "retry_interval": 1,
+			                    "batch_max_size": 1000,
+			                    "buffer_duration": 60,
+			                    "port": 1000,
+			                    "name": "sys-logger",
+			                    "flush_limit": 4096,
+			                    "sock_type": "tcp",
+			                    "timeout": 3,
+			                    "drop_limit": 1048576,
+			                    "pool_size": 5
+		                    }                        
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/batch-process-metrics"
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 11: remove prometheus -> reload -> send batch request -> add prometheus for next tests
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+
+            local t = require("lib.test_admin").test
+                    ngx.sleep(0.1)
+            local data = [[
+deployment:
+  role: traditional
+  role_traditional:
+    config_provider: etcd
+  admin:
+    admin_key: null
+apisix:
+  node_listen: 1984
+plugins:
+    - example-plugin
+plugin_attr:
+    example-plugin:
+        val: 1
+        ]]
+            require("lib.test_admin").set_config_yaml(data)
+            local code, _, org_body = t('/v1/plugins/reload', ngx.HTTP_PUT)
+            local code, body = t('/batch-process-metrics',
+                 ngx.HTTP_GET
+                )
+            
+            ngx.status = code
+            ngx.say(body)
+
+
+            local data = [[
+deployment:
+  role: traditional
+  role_traditional:
+    config_provider: etcd
+  admin:
+    admin_key: null
+apisix:
+  node_listen: 1984
+plugins:
+    - prometheus
+plugin_attr:
+    example-plugin:
+        val: 1
+        ]]
+            require("lib.test_admin").set_config_yaml(data)
+        }
+    }
+--- request
+GET /t
+--- error_code: 404
+--- response_body_like eval
+qr/404 Not Found/
+
+
+
+=== TEST 12: fetch prometheus metrics -> batch_process_entries metrics should not be present
+--- request
+GET /apisix/prometheus/metrics
+--- error_code: 200
+--- response_body_unlike eval
+qr/apisix_batch_process_entries\{name="sys-logger",route_id="9",server_addr="127.0.0.1"\} \d+/
+
+
+
+=== TEST 13: hit batch-process-metrics with prometheus enabled from TEST 11
+--- request
+GET /batch-process-metrics
+--- error_code: 404
+
+
+
+=== TEST 14: batch_process_entries metrics should be present now
+--- request
+GET /apisix/prometheus/metrics
+--- error_code: 200
+--- response_body_like eval
+qr/apisix_batch_process_entries\{name="sys-logger",route_id="9",server_addr="127.0.0.1"\} \d+/


### PR DESCRIPTION
### Description

This PR allows disabling the export server when prometheus is removed from plugins list in config.yaml and then the plugin reload api is called.

Fixes #11046 

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
