### PR TITLE
fix(request.header): core.request.header return string instead of table

### DIFF
--- a/apisix/core/request.lua
+++ b/apisix/core/request.lua
@@ -107,7 +107,9 @@ function _M.header(ctx, name)
     if not ctx then
         ctx = ngx.ctx.api_ctx
     end
-    return _headers(ctx)[name]
+
+    local value = _headers(ctx)[name]
+    return type(value) == "table" and value[1] or value
 end
 
 local function modify_header(ctx, header_name, header_value, override)

--- a/apisix/plugins/real-ip.lua
+++ b/apisix/plugins/real-ip.lua
@@ -90,7 +90,7 @@ end
 local function get_addr(conf, ctx)
     if conf.source == "http_x_forwarded_for" then
         -- use the last address from X-Forwarded-For header
-        -- after core.request.header function changed, we need to get orginal header value by using core.request.headers
+        -- after core.request.header function changed, we need to get original header value by using core.request.headers
         local addrs = core.request.headers(ctx)["X-Forwarded-For"]
         if not addrs then
             return nil

--- a/apisix/plugins/real-ip.lua
+++ b/apisix/plugins/real-ip.lua
@@ -90,7 +90,8 @@ end
 local function get_addr(conf, ctx)
     if conf.source == "http_x_forwarded_for" then
         -- use the last address from X-Forwarded-For header
-        -- after core.request.header function changed, we need to get original header value by using core.request.headers
+        -- after core.request.header function changed
+        -- we need to get original header value by using core.request.headers
         local addrs = core.request.headers(ctx)["X-Forwarded-For"]
         if not addrs then
             return nil

--- a/apisix/plugins/real-ip.lua
+++ b/apisix/plugins/real-ip.lua
@@ -90,7 +90,8 @@ end
 local function get_addr(conf, ctx)
     if conf.source == "http_x_forwarded_for" then
         -- use the last address from X-Forwarded-For header
-        local addrs = core.request.header(ctx, "X-Forwarded-For")
+        -- after core.request.header function changed, we need to get orginal header value by using core.request.headers
+        local addrs = core.request.headers(ctx)["X-Forwarded-For"]
         if not addrs then
             return nil
         end

--- a/apisix/plugins/ua-restriction.lua
+++ b/apisix/plugins/ua-restriction.lua
@@ -150,7 +150,7 @@ end
 
 
 function _M.access(conf, ctx)
-    -- after core.request.header function changed, we need to get orginal header value by using core.request.headers
+    -- after core.request.header function changed, we need to get original header value by using core.request.headers
     local user_agent = core.request.headers(ctx)["User-Agent"]
 
     if not user_agent then

--- a/apisix/plugins/ua-restriction.lua
+++ b/apisix/plugins/ua-restriction.lua
@@ -150,7 +150,8 @@ end
 
 
 function _M.access(conf, ctx)
-    local user_agent = core.request.header(ctx, "User-Agent")
+    -- after core.request.header function changed, we need to get orginal header value by using core.request.headers
+    local user_agent = core.request.headers(ctx)["User-Agent"]
 
     if not user_agent then
         if conf.bypass_missing then

--- a/apisix/plugins/ua-restriction.lua
+++ b/apisix/plugins/ua-restriction.lua
@@ -150,7 +150,8 @@ end
 
 
 function _M.access(conf, ctx)
-    -- after core.request.header function changed, we need to get original header value by using core.request.headers
+    -- after core.request.header function changed
+    -- we need to get original header value by using core.request.headers
     local user_agent = core.request.headers(ctx)["User-Agent"]
 
     if not user_agent then

--- a/t/core/request.t
+++ b/t/core/request.t
@@ -454,10 +454,10 @@ $s
             local h = core.request.header(ctx, "test_header")
             ngx.say(h)
             core.request.add_header(ctx, "test_header", "t2")
-            local h2 = core.request.header(ctx, "test_header")
+            local h2 = core.request.headers(ctx)["test_header"]
             ngx.say(json.encode(h2))
             core.request.add_header(ctx, "test_header", "t3")
-            local h3 = core.request.header(ctx, "test_header")
+            local h3 = core.request.headers(ctx)["test_header"]
             ngx.say(json.encode(h3))
         }
     }


### PR DESCRIPTION
Signed-off-by: ashing <axingfly@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #11126

In order to prevent the caller from judging the data type by itself.

notice: After `core.request.header` function changed, we need to get original header value by using `core.request.headers` in file `real-ip.lua` and `ua-restriction.lua`

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
