### PR TITLE
fix(request.headers): no longer returns all http headers, but limited to the default 100. 

### DIFF
--- a/apisix/core/request.lua
+++ b/apisix/core/request.lua
@@ -55,17 +55,17 @@ local function _headers(ctx)
     end
 
     if not is_apisix_or then
-        return get_headers(0)
+        return get_headers()
     end
 
     if a6_request.is_request_header_set() then
         a6_request.clear_request_header()
-        ctx.headers = get_headers(0)
+        ctx.headers = get_headers()
     end
 
     local headers = ctx.headers
     if not headers then
-        headers = get_headers(0)
+        headers = get_headers()
         ctx.headers = headers
     end
 

--- a/t/core/request.t
+++ b/t/core/request.t
@@ -421,28 +421,7 @@ POST
 
 
 
-=== TEST 14: get header
---- config
-    location /t {
-        content_by_lua_block {
-            local core = require("apisix.core")
-            ngx.say(core.request.header(ngx.ctx, "X-101"))
-        }
-    }
---- more_headers eval
-my $i = 1;
-my $s;
-while ($i <= 101) {
-    $s .= "X-$i:$i\n";
-    $i++;
-}
-$s
---- response_body
-101
-
-
-
-=== TEST 15: add header
+=== TEST 14: add header
 --- config
     location /t {
         content_by_lua_block {
@@ -468,7 +447,7 @@ test
 
 
 
-=== TEST 16: call add_header with deprecated way
+=== TEST 15: call add_header with deprecated way
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #11139 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
