### PR TITLE
docs: update installation guide

### DIFF
--- a/docs/en/latest/building-apisix.md
+++ b/docs/en/latest/building-apisix.md
@@ -45,16 +45,10 @@ To build and package APISIX for a specific platform, see [apisix-build-tools](ht
 
 ## Building APISIX from source
 
-First of all, we need to specify the version `APISIX_VERSION` to be installed:
-
-```shell
-APISIX_VERSION='3.9.0'
-```
-
 Then, you can run the following command to clone the APISIX source code from Github:
 
 ```shell
-git clone --depth 1 --branch master https://github.com/apache/apisix.git apisix-${APISIX_VERSION}
+git clone --depth 1 --branch master https://github.com/apache/apisix.git
 ```
 
 Alternatively, you can also download the source package from the [Downloads](https://apisix.apache.org/downloads/) page. Note that source packages here are not distributed with test cases.

--- a/docs/en/latest/building-apisix.md
+++ b/docs/en/latest/building-apisix.md
@@ -54,7 +54,7 @@ APISIX_VERSION='3.9.0'
 Then, you can run the following command to clone the APISIX source code from Github:
 
 ```shell
-git clone --depth 1 --branch ${APISIX_VERSION} https://github.com/apache/apisix.git apisix-${APISIX_VERSION}
+git clone --depth 1 --branch master https://github.com/apache/apisix.git apisix-${APISIX_VERSION}
 ```
 
 Alternatively, you can also download the source package from the [Downloads](https://apisix.apache.org/downloads/) page. Note that source packages here are not distributed with test cases.

--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -32,6 +32,43 @@ This guide walks you through how you can install and run Apache APISIX in your e
 
 Refer to the [Getting Started](./getting-started/README.md) guide for a quick walk-through on running Apache APISIX.
 
+## Installing etcd
+
+APISIX uses [etcd](https://github.com/etcd-io/etcd) to save and synchronize configuration. Before installing APISIX, you need to install etcd on your machine.
+
+It would be installed automatically if you choose the Docker or Helm install method while installing APISIX. If you choose a different method or you need to install it manually, follow the steps shown below:
+
+<Tabs
+  groupId="os"
+  defaultValue="linux"
+  values={[
+    {label: 'Linux', value: 'linux'},
+    {label: 'macOS', value: 'mac'},
+  ]}>
+<TabItem value="linux">
+
+```shell
+ETCD_VERSION='3.5.4'
+wget https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz
+tar -xvf etcd-v${ETCD_VERSION}-linux-amd64.tar.gz && \
+  cd etcd-v${ETCD_VERSION}-linux-amd64 && \
+  sudo cp -a etcd etcdctl /usr/bin/
+nohup etcd >/tmp/etcd.log 2>&1 &
+```
+
+</TabItem>
+
+<TabItem value="mac">
+
+```shell
+brew install etcd
+brew services start etcd
+```
+
+</TabItem>
+</Tabs>
+
+
 ## Installing APISIX
 
 APISIX can be installed by the different methods listed below:
@@ -222,42 +259,6 @@ If you want to build APISIX from source, please refer to [Building APISIX from s
 </TabItem>
 </Tabs>
 
-## Installing etcd
-
-APISIX uses [etcd](https://github.com/etcd-io/etcd) to save and synchronize configuration. Before installing APISIX, you need to install etcd on your machine.
-
-It would be installed automatically if you choose the Docker or Helm install method while installing APISIX. If you choose a different method or you need to install it manually, follow the steps shown below:
-
-<Tabs
-  groupId="os"
-  defaultValue="linux"
-  values={[
-    {label: 'Linux', value: 'linux'},
-    {label: 'macOS', value: 'mac'},
-  ]}>
-<TabItem value="linux">
-
-```shell
-ETCD_VERSION='3.5.4'
-wget https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz
-tar -xvf etcd-v${ETCD_VERSION}-linux-amd64.tar.gz && \
-  cd etcd-v${ETCD_VERSION}-linux-amd64 && \
-  sudo cp -a etcd etcdctl /usr/bin/
-nohup etcd >/tmp/etcd.log 2>&1 &
-```
-
-</TabItem>
-
-<TabItem value="mac">
-
-```shell
-brew install etcd
-brew services start etcd
-```
-
-</TabItem>
-</Tabs>
-
 ## Next steps
 
 ### Configuring APISIX
@@ -271,9 +272,11 @@ You can configure your APISIX deployment in two ways:
    apisix start -c <path to config file>
    ```
 
-APISIX will use the configurations added in this configuration file and will fall back to the default configuration if anything is not configured.
+APISIX will use the configurations added in this configuration file and will fall back to the default configuration if anything is not configured. Generally, APISIX gets installed at `/usr/local/apisix/` directory, so your configuration file will be present at `/usr/local/apisix/conf/` path.
 
-For example, to configure the default listening port to be `8000` without changing other configurations, your configuration file could look like this:
+In case you get the Port binding logs when trying to run the APISIX server using `apisix start` command, it is most likely that the ports are being used by certain processes running on your machine. Try deleting the process using the port or configure the default listening port to other available port on your local machine.
+
+In order to configure the default listening port to be `8000` without changing other configurations, your configuration file could look like this:
 
 ```yaml title="conf/config.yaml"
 apisix:

--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -277,7 +277,7 @@ If you are unable to start APISIX and observe `Bind address already in use` in l
 
 Other way is to configure the default listening port to other available port on your local machine.
 
-In order to configure the default listening port to be `8000` without changing other configurations, your configuration file could look like this:
+In order to configure the default listening port to be `8000` without changing other configurations, your configuration file should look like this:
 
 ```yaml title="conf/config.yaml"
 apisix:

--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -273,7 +273,7 @@ You can configure your APISIX deployment in two ways:
 
 APISIX will use the configurations added in this configuration file and will fall back to the default configuration if anything is not configured. Generally, APISIX gets installed at `/usr/local/apisix/` directory, so your configuration file will be present at `/usr/local/apisix/conf/` path.
 
-In case you get the Port binding logs, that says `Bind address already in use` when trying to run the APISIX server using `apisix start` command, it is most likely that the ports are being used by certain processes running on your machine. Try killing the process which is using the port. You can find the PID of the process that is using the process by running the `sudo netstat -tulpn` command and later using `kill <process id>` command to kill the process.
+If you are unable to start APISIX and observe `Bind address already in use` in logs, it means the ports APISIX wants to use are already occupied by other running processes. Upon reviewing the use of these processes, you may decide to kill these processes or configure APISIX to use other non-conflicting ports.
 
 Other way is to configure the default listening port to other available port on your local machine.
 

--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -274,7 +274,9 @@ You can configure your APISIX deployment in two ways:
 
 APISIX will use the configurations added in this configuration file and will fall back to the default configuration if anything is not configured. Generally, APISIX gets installed at `/usr/local/apisix/` directory, so your configuration file will be present at `/usr/local/apisix/conf/` path.
 
-In case you get the Port binding logs when trying to run the APISIX server using `apisix start` command, it is most likely that the ports are being used by certain processes running on your machine. Try deleting the process using the port or configure the default listening port to other available port on your local machine.
+In case you get the Port binding logs, that says `Bind address already in use` when trying to run the APISIX server using `apisix start` command, it is most likely that the ports are being used by certain processes running on your machine. Try killing the process which is using the port. You can find the PID of the process that is using the process by running the `sudo netstat -tulpn` command and later using `kill <process id>` command to kill the process. 
+
+Other way is to configure the default listening port to other available port on your local machine.
 
 In order to configure the default listening port to be `8000` without changing other configurations, your configuration file could look like this:
 

--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -68,7 +68,6 @@ brew services start etcd
 </TabItem>
 </Tabs>
 
-
 ## Installing APISIX
 
 APISIX can be installed by the different methods listed below:
@@ -274,7 +273,7 @@ You can configure your APISIX deployment in two ways:
 
 APISIX will use the configurations added in this configuration file and will fall back to the default configuration if anything is not configured. Generally, APISIX gets installed at `/usr/local/apisix/` directory, so your configuration file will be present at `/usr/local/apisix/conf/` path.
 
-In case you get the Port binding logs, that says `Bind address already in use` when trying to run the APISIX server using `apisix start` command, it is most likely that the ports are being used by certain processes running on your machine. Try killing the process which is using the port. You can find the PID of the process that is using the process by running the `sudo netstat -tulpn` command and later using `kill <process id>` command to kill the process. 
+In case you get the Port binding logs, that says `Bind address already in use` when trying to run the APISIX server using `apisix start` command, it is most likely that the ports are being used by certain processes running on your machine. Try killing the process which is using the port. You can find the PID of the process that is using the process by running the `sudo netstat -tulpn` command and later using `kill <process id>` command to kill the process.
 
 Other way is to configure the default listening port to other available port on your local machine.
 


### PR DESCRIPTION
### Description

Generally, when you're trying to install the apisix from the [installation guide](https://apisix.apache.org/docs/apisix/installation-guide/), sometimes you come across the `Address Bind already in use` error logs when trying to start the apisix server. This is likely caused due to the unavailability of the port. Mostly, it happens if you've installed the apisix using docker due to which the ports get equipped. Hence, when you try installing the apisix locally, you get the error logs. 

This PR mentions this minor information with solution to this problem. There is a little refactoring of the docs as well. Since, it is required to install the `etcd` first, the installation part of etcd is moved first, followed by installation of `apisix` server installation.

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
