### PR TITLE
fix(secret): rectify the way to fetch secret resource by id

### DIFF
--- a/apisix/secret.lua
+++ b/apisix/secret.lua
@@ -26,7 +26,6 @@ local byte      = string.byte
 local type      = type
 local pcall     = pcall
 local pairs     = pairs
-local ipairs    = ipairs
 
 local _M = {}
 


### PR DESCRIPTION
### Description

Instead of caching the secrets resource and iterating over all of them in a loop to find the correct secret resource, it's better to directly use the `get` function. This also maintains consistency with other parts of the apisix code.

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
