### PR TITLE
chore: release/3.9 branch is invalid and the protection should be removed

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -53,10 +53,6 @@ github:
           dismiss_stale_reviews: true
           require_code_owner_reviews: true
           required_approving_review_count: 2
-      release/3.9:
-        required_pull_request_reviews:
-          require_code_owner_reviews: true
-          required_approving_review_count: 2
       release/3.8:
         required_pull_request_reviews:
           require_code_owner_reviews: true


### PR DESCRIPTION
release/3.9 branch is invalid and the protection should be removed. 

I will rebuild the correct release/3.9 branch ASAP, and then we can restore the release/3.9 branch protection.

After this PR was merge, we will do:

1. delete `release/3.9` branch
2. rename branch `release/3.9.0` to `release/3.9` 
3. submit new PR to protect branch `release/3.9`