### PR TITLE
chore: restore release/3.9 branch protection 

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -53,6 +53,10 @@ github:
           dismiss_stale_reviews: true
           require_code_owner_reviews: true
           required_approving_review_count: 2
+      release/3.9:
+        required_pull_request_reviews:
+          require_code_owner_reviews: true
+          required_approving_review_count: 2
       release/3.8:
         required_pull_request_reviews:
           require_code_owner_reviews: true


### PR DESCRIPTION

This reverts commit 005281c13278db16e2a2070854428481b585f0c6.