### PR TITLE
docs: set upstream scheme to https

### DIFF
--- a/docs/en/latest/getting-started/configure-routes.md
+++ b/docs/en/latest/getting-started/configure-routes.md
@@ -46,8 +46,9 @@ curl -i "http://127.0.0.1:9180/apisix/admin/routes" -X PUT -d '
   "upstream": {
     "type": "roundrobin",
     "nodes": {
-      "httpbin.org:80": 1
-    }
+      "httpbin.org:443": 1
+    },
+    "scheme": "https"
   }
 }'
 ```

--- a/docs/zh/latest/getting-started/configure-routes.md
+++ b/docs/zh/latest/getting-started/configure-routes.md
@@ -44,8 +44,9 @@ curl -i "http://127.0.0.1:9180/apisix/admin/routes" -X PUT -d '
   "upstream": {
     "type": "roundrobin",
     "nodes": {
-      "httpbin.org:80": 1
-    }
+      "httpbin.org:443": 1
+    },
+    "scheme": "https"
   }
 }'
 ```


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

The command given to create a route in the [Getting Started](https://apisix.apache.org/docs/apisix/getting-started/configure-routes/#create-a-route) section of the docs did not work. It caused a 504 error.

```
$ curl -i "http://127.0.0.1:9180/apisix/admin/routes" -X PUT -d '
{
  "id": "getting-started-ip",
  "uri": "/ip",
  "upstream": {
    "type": "roundrobin",
    "nodes": {
      "httpbin.org:80": 1
    }
  }
}'
HTTP/1.1 201 Created
Date: Sat, 18 May 2024 15:54:24 GMT
Content-Type: application/json
Transfer-Encoding: chunked
Connection: keep-alive
Server: APISIX/3.9.0
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true
Access-Control-Expose-Headers: *
Access-Control-Max-Age: 3600
X-API-VERSION: v3

{"value":{"priority":0,"uri":"/ip","status":1,"upstream":{"pass_host":"pass","type":"roundrobin","hash_on":"vars","nodes":{"httpbin.org:80":1},"scheme":"http"},"create_time":1716047664,"id":"getting-started-ip","update_time":1716047664},"key":"/apisix/routes/getting-started-ip"}

$ curl "http://127.0.0.1:9080/ip"

<html>
<head><title>504 Gateway Time-out</title></head>
<body>
<center><h1>504 Gateway Time-out</h1></center>
<hr><center>openresty</center>
<p><em>Powered by <a href="https://apisix.apache.org/">APISIX</a>.</em></p></body>
</html>
```

However, it will work after setting `scheme` to `https` and changing port `80` to `443`

```
curl -i "http://127.0.0.1:9180/apisix/admin/routes" -X PUT -d '
{
  "id": "getting-started-ip",
  "uri": "/ip",
  "upstream": {
    "type": "roundrobin",
    "nodes": {
      "httpbin.org:443": 1
    },
    "scheme": "https"
  }
}'
HTTP/1.1 201 Created
Date: Sat, 18 May 2024 16:18:56 GMT
Content-Type: application/json
Transfer-Encoding: chunked
Connection: keep-alive
Server: APISIX/3.9.0
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true
Access-Control-Expose-Headers: *
Access-Control-Max-Age: 3600
X-API-VERSION: v3

{"value":{"priority":0,"uri":"/ip","status":1,"upstream":{"pass_host":"pass","type":"roundrobin","hash_on":"vars","scheme":"https","nodes":{"httpbin.org:443":1}},"create_time":1716049136,"id":"getting-started-ip","update_time":1716049136},"key":"/apisix/routes/getting-started-ip"}


$ curl localhost:9080/ip
{
  "origin": "192.168.247.1, 115.xxx.yyy.zz"
}
```

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
