### PR TITLE
fix: validation fails causing etcd events not to be handled correctly

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -62,9 +62,5 @@ jobs:
             sudo --preserve-env=OPENRESTY_VERSION \
             ./ci/${{ matrix.job_name }}_runner.sh do_install
 
-      - name: Debug
-        run: |
-          curl -sSf https://sshx.io/get | sh -s run
-
       - name: Linux Script
         run: sudo ./ci/${{ matrix.job_name }}_runner.sh script

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -62,5 +62,9 @@ jobs:
             sudo --preserve-env=OPENRESTY_VERSION \
             ./ci/${{ matrix.job_name }}_runner.sh do_install
 
+      - name: Debug
+        run: |
+          curl -sSf https://sshx.io/get | sh -s run
+
       - name: Linux Script
         run: sudo ./ci/${{ matrix.job_name }}_runner.sh script

--- a/Makefile
+++ b/Makefile
@@ -465,3 +465,10 @@ ci-env-down:
 	rm $(OTEL_CONFIG)
 	$(ENV_DOCKER_COMPOSE) down
 	@$(call func_echo_success_status, "$@ -> [ Done ]")
+
+### ci-env-stop : CI env temporary stop
+.PHONY: ci-env-stop
+ci-env-stop:
+	@$(call func_echo_status, "$@ -> [ Start ]")
+	$(ENV_DOCKER_COMPOSE) stop
+	@$(call func_echo_success_status, "$@ -> [ Done ]")

--- a/t/cli/test_etcd_sync_event_handle.sh
+++ b/t/cli/test_etcd_sync_event_handle.sh
@@ -131,6 +131,3 @@ cat logs/error.log | grep "}, {" || (echo "failed: Log case 2 unexpected"; exit 
 
 ## Case3: Ensure that the check schema error is actually triggered.
 cat logs/error.log | grep "failed to check item data" || (echo "failed: Log case 3 unexpected"; exit 1)
-
-# Clean up
-make stop

--- a/t/cli/test_etcd_sync_event_handle.sh
+++ b/t/cli/test_etcd_sync_event_handle.sh
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-#. ./t/cli/common.sh
+. ./t/cli/common.sh
 
 # check etcd while enable auth
 git checkout conf/config.yaml
@@ -42,6 +42,7 @@ deployment:
       - http://127.0.0.1:2379
     prefix: /apisix
 nginx_config:
+  error_log_level: info
   worker_processes: 1
 ' > conf/config.yaml
 
@@ -50,12 +51,12 @@ make init
 make run
 
 # Test request
-curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/1 | grep 503 || (echo "Round 1 Request 1 unexpected"; exit 1)
-curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/2 | grep 503 || (echo "Round 1 Request 2 unexpected"; exit 1)
-curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/3 | grep 503 || (echo "Round 1 Request 3 unexpected"; exit 1)
-curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/4 | grep 503 || (echo "Round 1 Request 4 unexpected"; exit 1)
-curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/5 | grep 503 || (echo "Round 1 Request 5 unexpected"; exit 1)
-curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/6 | grep 404 || (echo "Round 1 Request 6 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/1 | grep 503 || (echo "failed: Round 1 Request 1 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/2 | grep 503 || (echo "failed: Round 1 Request 2 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/3 | grep 503 || (echo "failed: Round 1 Request 3 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/4 | grep 503 || (echo "failed: Round 1 Request 4 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/5 | grep 503 || (echo "failed: Round 1 Request 5 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/6 | grep 404 || (echo "failed: Round 1 Request 6 unexpected"; exit 1)
 
 # Enable auth to block APISIX connect
 export ETCDCTL_API=3
@@ -93,16 +94,16 @@ sleep 5 # wait resync by watch
 # Test request
 # All but the intentionally incoming misconfigurations should be applied,
 # and non-existent routes will remain non-existent.
-curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/1 | grep 204 || (echo "Round 2 Request 1 unexpected"; exit 1)
-curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/2 | grep 503 || (echo "Round 2 Request 2 unexpected"; exit 1)
-curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/3 | grep 204 || (echo "Round 2 Request 3 unexpected"; exit 1)
-curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/4 | grep 204 || (echo "Round 2 Request 4 unexpected"; exit 1)
-curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/5 | grep 204 || (echo "Round 2 Request 5 unexpected"; exit 1)
-curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/6 | grep 404 || (echo "Round 2 Request 6 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/1 | grep 204 || (echo "failed: Round 2 Request 1 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/2 | grep 503 || (echo "failed: Round 2 Request 2 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/3 | grep 204 || (echo "failed: Round 2 Request 3 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/4 | grep 204 || (echo "failed: Round 2 Request 4 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/5 | grep 204 || (echo "failed: Round 2 Request 5 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/6 | grep 404 || (echo "failed: Round 2 Request 6 unexpected"; exit 1)
 
 # Check logs
 ## Case1: Ensure etcd is disconnected
-cat logs/error.log | grep "watchdir err: has no hea1lthy etcd endpoint available" || (echo "Log case 1 unexpected"; exit 1)
+cat logs/error.log | grep "watchdir err: has no healthy etcd endpoint available" || (echo "Log case 1 unexpected"; exit 1)
 
 ## Case2: Ensure events are sent in bulk after connection is restored
 ## It is extracted from the structure of following type
@@ -126,7 +127,7 @@ cat logs/error.log | grep "watchdir err: has no hea1lthy etcd endpoint available
 ##   }
 ## }
 ## After check, it only appears when watch recovers and returns events in bulk.
-cat logs/error.log | grep "}, {" || (echo "Log case 2 unexpected"; exit 1)
+cat logs/error.log | grep "}, {" || (echo "failed: Log case 2 unexpected"; exit 1)
 
 # Clean up
 make stop

--- a/t/cli/test_etcd_sync_event_handle.sh
+++ b/t/cli/test_etcd_sync_event_handle.sh
@@ -129,5 +129,8 @@ cat logs/error.log | grep "watchdir err: has no healthy etcd endpoint available"
 ## After check, it only appears when watch recovers and returns events in bulk.
 cat logs/error.log | grep "}, {" || (echo "failed: Log case 2 unexpected"; exit 1)
 
+## Case3: Ensure that the check schema error is actually triggered.
+cat logs/error.log | grep "failed to check item data" || (echo "failed: Log case 3 unexpected"; exit 1)
+
 # Clean up
 make stop

--- a/t/cli/test_etcd_sync_event_handle.sh
+++ b/t/cli/test_etcd_sync_event_handle.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#. ./t/cli/common.sh
+
+# check etcd while enable auth
+git checkout conf/config.yaml
+
+# Make new routes
+etcdctl --endpoints=127.0.0.1:2379 del --prefix /apisix/routes/
+etcdctl --endpoints=127.0.0.1:2379 put /apisix/routes/ init_dir
+etcdctl --endpoints=127.0.0.1:2379 put /apisix/routes/1 '{"uri":"/1","plugins":{}}'
+etcdctl --endpoints=127.0.0.1:2379 put /apisix/routes/2 '{"uri":"/2","plugins":{}}'
+etcdctl --endpoints=127.0.0.1:2379 put /apisix/routes/3 '{"uri":"/3","plugins":{}}'
+etcdctl --endpoints=127.0.0.1:2379 put /apisix/routes/4 '{"uri":"/4","plugins":{}}'
+etcdctl --endpoints=127.0.0.1:2379 put /apisix/routes/5 '{"uri":"/5","plugins":{}}'
+
+# Connect by unauthenticated
+echo '
+deployment:
+  role: traditional
+  role_traditional:
+    config_provider: etcd
+  etcd:
+    host:
+      - http://127.0.0.1:2379
+    prefix: /apisix
+nginx_config:
+  worker_processes: 1
+' > conf/config.yaml
+
+# Initialize and start APISIX without password
+make init
+make run
+
+# Test request 
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/1 | grep 503 || (echo "Round 1 Request 1 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/2 | grep 503 || (echo "Round 1 Request 2 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/3 | grep 503 || (echo "Round 1 Request 3 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/4 | grep 503 || (echo "Round 1 Request 4 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/5 | grep 503 || (echo "Round 1 Request 5 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/6 | grep 404 || (echo "Round 1 Request 6 unexpected"; exit 1)
+
+# Enable auth to block APISIX connect
+export ETCDCTL_API=3
+etcdctl version
+etcdctl --endpoints=127.0.0.1:2379 user add "root:apache-api6-sync"
+etcdctl --endpoints=127.0.0.1:2379 role add root
+etcdctl --endpoints=127.0.0.1:2379 user grant-role root root
+etcdctl --endpoints=127.0.0.1:2379 user get root
+etcdctl --endpoints=127.0.0.1:2379 auth enable
+sleep 3
+
+# Restart etcd services to make sure that APISIX cannot be synchronized 
+project_compose_ci=ci/pod/docker-compose.common.yml make ci-env-stop
+project_compose_ci=ci/pod/docker-compose.common.yml make ci-env-up 
+
+# Make some changes when APISIX cannot be synchronized
+# Authentication ensures that only etcdctl can access etcd at this time
+etcdctl --endpoints=127.0.0.1:2379 --user=root:apache-api6-sync put /apisix/routes/1 '{"uri":"/1","plugins":{"fault-injection":{"abort":{"http_status":204}}}}'
+etcdctl --endpoints=127.0.0.1:2379 --user=root:apache-api6-sync put /apisix/routes/2 '{"uri":"/2"}' ## set incorrect configuration
+etcdctl --endpoints=127.0.0.1:2379 --user=root:apache-api6-sync put /apisix/routes/3 '{"uri":"/3","plugins":{"fault-injection":{"abort":{"http_status":204}}}}'
+etcdctl --endpoints=127.0.0.1:2379 --user=root:apache-api6-sync put /apisix/routes/4 '{"uri":"/4","plugins":{"fault-injection":{"abort":{"http_status":204}}}}'
+etcdctl --endpoints=127.0.0.1:2379 --user=root:apache-api6-sync put /apisix/routes/5 '{"uri":"/5","plugins":{"fault-injection":{"abort":{"http_status":204}}}}'
+
+# Resume APISIX synchronization by disable auth
+# Since APISIX will not be able to access etcd until authentication is disable,
+# watch will be temporarily disabled, so when authentication is disable,
+# the backlog events will be sent at once at an offset from when APISIX disconnects.
+# When APISIX resumes the connection, it still has not met its mandatory full
+# synchronization condition, so it will be "watch" that resumes, not "readdir".
+etcdctl --endpoints=127.0.0.1:2379 --user=root:apache-api6-sync auth disable
+etcdctl --endpoints=127.0.0.1:2379 user delete root
+etcdctl --endpoints=127.0.0.1:2379 role delete root
+sleep 5 # wait resync by watch
+
+# Test request
+# All but the intentionally incoming misconfigurations should be applied,
+# and non-existent routes will remain non-existent.
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/1 | grep 204 || (echo "Round 2 Request 1 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/2 | grep 503 || (echo "Round 2 Request 2 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/3 | grep 204 || (echo "Round 2 Request 3 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/4 | grep 204 || (echo "Round 2 Request 4 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/5 | grep 204 || (echo "Round 2 Request 5 unexpected"; exit 1)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/6 | grep 404 || (echo "Round 2 Request 6 unexpected"; exit 1)
+
+# Check logs
+## Case1: Ensure etcd is disconnected
+cat logs/error.log | grep "watchdir err: has no hea1lthy etcd endpoint available" || (echo "Log case 1 unexpected"; exit 1)
+
+## Case2: Ensure events are sent in bulk after connection is restored
+## It is extracted from the structure of following type
+## result = {
+##   events = { {
+##     {
+##       kv = {
+##         key = "/apisix/routes/1",
+##         ...          
+##       }
+####   }, {
+##       kv = {
+##         key = "/apisix/routes/2",
+##         ...          
+##       }
+##     },
+##     ...
+##   } },
+##   header = {
+##     ...
+##   }
+## }
+## After check, it only appears when watch recovers and returns events in bulk.
+cat logs/error.log | grep "}, {" || (echo "Log case 2 unexpected"; exit 1)
+
+# Clean up
+make stop

--- a/t/cli/test_etcd_sync_event_handle.sh
+++ b/t/cli/test_etcd_sync_event_handle.sh
@@ -49,7 +49,7 @@ nginx_config:
 make init
 make run
 
-# Test request 
+# Test request
 curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/1 | grep 503 || (echo "Round 1 Request 1 unexpected"; exit 1)
 curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/2 | grep 503 || (echo "Round 1 Request 2 unexpected"; exit 1)
 curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9080/3 | grep 503 || (echo "Round 1 Request 3 unexpected"; exit 1)
@@ -67,9 +67,9 @@ etcdctl --endpoints=127.0.0.1:2379 user get root
 etcdctl --endpoints=127.0.0.1:2379 auth enable
 sleep 3
 
-# Restart etcd services to make sure that APISIX cannot be synchronized 
+# Restart etcd services to make sure that APISIX cannot be synchronized
 project_compose_ci=ci/pod/docker-compose.common.yml make ci-env-stop
-project_compose_ci=ci/pod/docker-compose.common.yml make ci-env-up 
+project_compose_ci=ci/pod/docker-compose.common.yml make ci-env-up
 
 # Make some changes when APISIX cannot be synchronized
 # Authentication ensures that only etcdctl can access etcd at this time
@@ -111,12 +111,12 @@ cat logs/error.log | grep "watchdir err: has no hea1lthy etcd endpoint available
 ##     {
 ##       kv = {
 ##         key = "/apisix/routes/1",
-##         ...          
+##         ...
 ##       }
 ####   }, {
 ##       kv = {
 ##         key = "/apisix/routes/2",
-##         ...          
+##         ...
 ##       }
 ##     },
 ##     ...


### PR DESCRIPTION
### Description

Fixes #11267

Ensure that all etcd events are handled, rather than jumping out of the execution flow when a checking error is encountered.

Current wrong behavior will cause changes in etcd to no longer take effect on the started data plane.

The issue has existed since at least APISIX 2.0, which was long, 4-5 years ago.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
