### PR TITLE
fix: stream route matcher is nil after first match

### DIFF
--- a/apisix/stream/router/ip_port.lua
+++ b/apisix/stream/router/ip_port.lua
@@ -110,8 +110,6 @@ do
                     for _, route in ipairs(items) do
                         local hit = match_addrs(route, vars)
                         if hit then
-                            route.value.remote_addr_matcher = nil
-                            route.value.server_addr_matcher = nil
                             ctx.matched_route = route
                             return true
                         end
@@ -177,8 +175,6 @@ do
         for _, route in ipairs(other_routes) do
             local hit = match_addrs(route, api_ctx.var)
             if hit then
-                route.value.remote_addr_matcher = nil
-                route.value.server_addr_matcher = nil
                 api_ctx.matched_route = route
                 return true
             end

--- a/t/stream-node/sanity-repeat.t
+++ b/t/stream-node/sanity-repeat.t
@@ -1,0 +1,133 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+log_level('info');
+no_root_location();
+workers(1);
+repeat_each(2);
+
+run_tests();
+
+__DATA__
+=== TEST 1: set stream route(id: 1) -> service(id: 1)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/services/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1995": 1
+                        },
+                        "type": "roundrobin"
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            code, body = t('/apisix/admin/stream_routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "remote_addr": "127.0.0.1",
+                    "service_id": 1
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 2: hit route
+--- stream_request eval
+mmm
+--- stream_response
+hello world
+
+
+
+=== TEST 3: set stream / ssl
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local t = require("lib.test_admin")
+
+            local ssl_cert = t.read_file("t/certs/apisix.crt")
+            local ssl_key =  t.read_file("t/certs/apisix.key")
+            local data = {
+                cert = ssl_cert, key = ssl_key,
+                sni = "*.test.com",
+            }
+            local code, body = t.test('/apisix/admin/ssls/1',
+                ngx.HTTP_PUT,
+                core.json.encode(data)
+            )
+
+            if code >= 300 then
+                ngx.status = code
+                return
+            end
+
+            local code, body = t.test('/apisix/admin/stream_routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "sni": "a.test.com",
+                    "remote_addr": "127.0.0.1",
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1995": 1
+                        },
+                        "type": "roundrobin"
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+                return
+            end
+
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 4: hit route
+--- stream_tls_request
+mmm
+--- stream_sni: a.test.com
+--- response_body
+hello world
+--- error_log
+proxy request to 127.0.0.1:1995

--- a/t/stream-node/sanity-repeat.t
+++ b/t/stream-node/sanity-repeat.t
@@ -24,6 +24,7 @@ repeat_each(2);
 run_tests();
 
 __DATA__
+
 === TEST 1: set stream route(id: 1) -> service(id: 1)
 --- config
     location /t {


### PR DESCRIPTION
### Description
Fix https://github.com/apache/apisix/issues/11259

this bug introduced in https://github.com/apache/apisix/pull/10298/files#diff-0234dd467ed66c3dffbef844397e9e7e018c287aab324ba8dd0b5a9e03b89360, I have no idea why made those changes,
set `route.value.xxx_matcher`  to nil is insane, the stream route only working in first matched request now, after first match, all requests to same stream route will be panic with nil matcher:
<img width="1672" alt="image" src="https://github.com/apache/apisix/assets/22141303/dc21c62a-a689-4f0e-994d-acb1713d5c44">
<img width="1935" alt="image" src="https://github.com/apache/apisix/assets/22141303/0373f3cd-8697-4acf-944a-b48342b5732d">
### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
