### PR TITLE
feat: support hcv namespace

### DIFF
--- a/apisix/secret/vault.lua
+++ b/apisix/secret/vault.lua
@@ -65,6 +65,8 @@ local function make_request_to_vault(conf, method, key, data)
         ["X-Vault-Token"] = token
     }
     if conf.namespace then
+        -- The namespace rule is referenced in
+        -- https://developer.hashicorp.com/vault/docs/enterprise/namespaces#vault-api-and-namespaces
         headers["X-Vault-Namespace"] = conf.namespace
     end
 

--- a/apisix/secret/vault.lua
+++ b/apisix/secret/vault.lua
@@ -37,6 +37,9 @@ local schema = {
         token = {
             type = "string",
         },
+        namespace = {
+            type = "string",
+        },
     },
     required = {"uri", "prefix", "token"},
 }
@@ -58,11 +61,16 @@ local function make_request_to_vault(conf, method, key, data)
         token = conf.token
     end
 
+    local headers = {
+        ["X-Vault-Token"] = token
+    }
+    if conf.namespace then
+        headers["X-Vault-Namespace"] = conf.namespace
+    end
+
     local res, err = httpc:request_uri(req_addr, {
         method = method,
-        headers = {
-            ["X-Vault-Token"] = token
-        },
+        headers = headers,
         body = core.json.encode(data or {}, true)
     })
 

--- a/docs/en/latest/admin-api.md
+++ b/docs/en/latest/admin-api.md
@@ -1466,6 +1466,7 @@ When `{secretmanager}` is `vault`:
 | uri    | True     | URI        | URI of the vault server.                                                                                              |                                                  |
 | prefix    | True    | string        | key prefix
 | token     | True    | string      | vault token. |                                                  |
+| namespace | False   | string       | Vault namespace, no default value | `admin` |
 
 Example Configuration:
 

--- a/docs/en/latest/terminology/secret.md
+++ b/docs/en/latest/terminology/secret.md
@@ -170,7 +170,7 @@ secrets:
 
 :::tip
 
-It now supports the use of the `namespace` field to set the multi-tenant namespace concepts supported by HashiCorp Vault Enterprise and HCP Vault.
+It now supports the use of the [`namespace` field](../admin-api.md#request-body-parameters-11) to set the multi-tenant namespace concepts supported by [HashiCorp Vault Enterprise](https://developer.hashicorp.com/vault/docs/enterprise/namespaces#vault-api-and-namespaces) and HCP Vault.
 
 :::
 

--- a/docs/en/latest/terminology/secret.md
+++ b/docs/en/latest/terminology/secret.md
@@ -123,9 +123,9 @@ curl http://127.0.0.1:9180/apisix/admin/consumers \
 
 Through the above steps, the `key` configuration in the `key-auth` plugin can be saved in the environment variable instead of being displayed in plain text when configuring the plugin.
 
-## Use Vault to manage secrets
+## Use HashiCorp Vault to manage secrets
 
-Using Vault to manage secrets means that you can store secrets information in the Vault service and refer to it through variables in a specific format when configuring plugins. APISIX currently supports [Vault KV engine version V1](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v1).
+Using HashiCorp Vault to manage secrets means that you can store secrets information in the Vault service and refer to it through variables in a specific format when configuring plugins. APISIX currently supports [Vault KV engine version V1](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v1).
 
 ### Usage
 
@@ -133,7 +133,7 @@ Using Vault to manage secrets means that you can store secrets information in th
 $secret://$manager/$id/$secret_name/$key
 ```
 
-- manager: secrets management service, could be the Vault, AWS, etc.
+- manager: secrets management service, could be the HashiCorp Vault, AWS, etc.
 - id: APISIX Secrets resource ID, which needs to be consistent with the one specified when adding the APISIX Secrets resource
 - secret_name: the secret name in the secrets management service
 - key: the key corresponding to the secret in the secrets management service
@@ -167,6 +167,12 @@ secrets:
     token: root
     uri: 127.0.0.1:8200
 ```
+
+:::tip
+
+It now supports the use of the `namespace` field to set the multi-tenant namespace concepts supported by HashiCorp Vault Enterprise and HCP Vault.
+
+:::
 
 Step 3: Reference the APISIX Secrets resource in the `key-auth` plugin and fill in the key information:
 

--- a/docs/zh/latest/admin-api.md
+++ b/docs/zh/latest/admin-api.md
@@ -358,7 +358,7 @@ Route 对象 JSON 配置示例：
     "desc": "hello world",
     "remote_addrs": ["127.0.0.1"],        # 一组客户端请求 IP 地址
     "vars": [["http_user", "==", "ios"]], # 由一个或多个 [var, operator, val] 元素组成的列表
-    "upstream_id": "1",                   # upstream 对象在 etcd 中的 id ，建议使用此值
+    "upstream_id": "1",                   # upstream 对象在 etcd 中的 id，建议使用此值
     "upstream": {},                       # upstream 信息对象，建议尽量不要使用
     "timeout": {                          # 为 route 设置 upstream 的连接、发送消息、接收消息的超时时间。
         "connect": 3,
@@ -652,7 +652,7 @@ Service 对象 JSON 配置示例：
 {
     "id": "1",                # id
     "plugins": {},            # 指定 service 绑定的插件
-    "upstream_id": "1",       # upstream 对象在 etcd 中的 id ，建议使用此值
+    "upstream_id": "1",       # upstream 对象在 etcd 中的 id，建议使用此值
     "upstream": {},           # upstream 信息对象，不建议使用
     "name": "test svc",       # service 名称
     "desc": "hello world",    # service 描述
@@ -1476,6 +1476,7 @@ Secret 资源请求地址：/apisix/admin/secrets/{secretmanager}/{id}
 | uri    | 是     | URI        |  Vault 服务器的 URI                                                 |                                                  |
 | prefix    | 是    | 字符串       | 密钥前缀
 | token     | 是    | 字符串       | Vault 令牌 |                                                  |
+| namespace | 否    | 字符串       | Vault 命名空间，该字段无默认值 | `admin` |
 
 配置示例：
 

--- a/docs/zh/latest/terminology/secret.md
+++ b/docs/zh/latest/terminology/secret.md
@@ -169,6 +169,12 @@ secrets:
     uri: 127.0.0.1:8200
 ```
 
+:::tip
+
+它现在支持使用 `namespace` 字段设置 HashiCorp Vault Enterprise 和 HCP Vault 所支持的多租户命名空间概念。
+
+:::
+
 第三步：在 `key-auth` 插件中引用 APISIX Secret 资源，填充秘钥信息：
 
 ```shell

--- a/docs/zh/latest/terminology/secret.md
+++ b/docs/zh/latest/terminology/secret.md
@@ -171,7 +171,7 @@ secrets:
 
 :::tip
 
-它现在支持使用 `namespace` 字段设置 HashiCorp Vault Enterprise 和 HCP Vault 所支持的多租户命名空间概念。
+它现在支持使用 [`namespace` 字段](../admin-api.md#secret-config-body-requset-parameters]设置 [HashiCorp Vault Enterprise](https://developer.hashicorp.com/vault/docs/enterprise/namespaces#vault-api-and-namespaces) 和 HCP Vault 所支持的多租户命名空间概念。
 
 :::
 

--- a/docs/zh/latest/terminology/secret.md
+++ b/docs/zh/latest/terminology/secret.md
@@ -171,7 +171,7 @@ secrets:
 
 :::tip
 
-它现在支持使用 [`namespace` 字段](../admin-api.md#secret-config-body-requset-parameters]设置 [HashiCorp Vault Enterprise](https://developer.hashicorp.com/vault/docs/enterprise/namespaces#vault-api-and-namespaces) 和 HCP Vault 所支持的多租户命名空间概念。
+它现在支持使用 [`namespace` 字段](../admin-api.md#secret-config-body-requset-parameters] 设置 [HashiCorp Vault Enterprise](https://developer.hashicorp.com/vault/docs/enterprise/namespaces#vault-api-and-namespaces) 和 HCP Vault 所支持的多租户命名空间概念。
 
 :::
 


### PR DESCRIPTION
### Description

HashiCorp Cloud and Enterprise editions support multi-tenancy based on the namespace concept. By using a specific HTTP Header, we can get the key from a specific namespace.

This makes sense, for HashiCorp Cloud it looks like namespaces are turned on by default and its default namespace is admin, which will not work when the client (APISIX) does not specify a namespace.

This PR adds namespace support on HCV (HashiCorp Vault).

### Addition

**In addition to this, I would suggest to rename the `vault` module in APISIX to `hcv`, based on the fact that `vault` itself is a neutral term that stands for some kind of component used to store keys. `HashiCorp Vault` is the name of that software, so it should be written `hcv` and not `vault`.**

**I would suggest renaming it, and in the meantime, we could add some sort of aliasing mechanism to continue to support users who use `vault` until APISIX 4.0, when we can remove support for the old name.**

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
