### PR TITLE
feat: Normalize OpenTelemetry configuration

### DIFF
--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -248,6 +248,11 @@ function _M.read_yaml_conf(apisix_home)
         return nil, "invalid config-default.yaml file"
     end
 
+    local ok, err = resolve_conf_var(default_conf)
+    if not ok then
+        return nil, err
+    end
+
     local_conf_path = profile:customized_yaml_path()
     if not local_conf_path then
         local_conf_path = profile:yaml_path("config")

--- a/conf/config-default.yaml
+++ b/conf/config-default.yaml
@@ -564,20 +564,20 @@ plugin_attr:          # Plugin attributes
   opentelemetry:      # Plugin: opentelemetry
     trace_id_source: x-request-id   # Specify the source of the trace ID for OpenTelemetry traces.
     resource:
-      service.name: APISIX          # Set the service name for OpenTelemetry traces.
+      service.name: ${{OTEL_SERVICE_NAME:=APISIX}}          # Set the service name for OpenTelemetry traces.
     collector:
-      address: 127.0.0.1:4318       # Set the address of the OpenTelemetry collector to send traces to.
+      address: ${{OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:=127.0.0.1:4318}}       # Set the address of the OpenTelemetry collector to send traces to.
       request_timeout: 3            # Set the timeout for requests to the OpenTelemetry collector in seconds.
       request_headers:              # Set the headers to include in requests to the OpenTelemetry collector.
         Authorization: token        # Set the authorization header to include an access token.
     batch_span_processor:
       drop_on_queue_full: false     # Drop spans when the export queue is full.
-      max_queue_size: 1024          # Set the maximum size of the span export queue.
+      max_queue_size: ${{OTEL_BSP_MAX_QUEUE_SIZE:=1024}}          # Set the maximum size of the span export queue.
       batch_timeout: 2              # Set the timeout for span batches to wait in the export queue before
                                     # being sent.
       inactive_timeout: 1           # Set the timeout for spans to wait in the export queue before being sent,
                                     # if the queue is not full.
-      max_export_batch_size: 16     # Set the maximum number of spans to include in each batch sent to the
+      max_export_batch_size: ${{OTEL_BSP_MAX_EXPORT_BATCH_SIZE:=16}}     # Set the maximum number of spans to include in each batch sent to the
                                     # OpenTelemetry collector.
     set_ngx_var: false              # Export opentelemetry variables to NGINX variables.
   prometheus:                               # Plugin: prometheus


### PR DESCRIPTION
### Description

Regular OpenTelemetry Tracing uses environment variable for configuration. This way, Ops don't need to understand the details of each stack to configure OTEL.

Here's a sample Docker Compose snippet where each stack is implemented on a different technology. Note that all abide by the [same environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/).

```yaml
  pricing:                      #python
    image: otel-pricing:1.1
    environment:
      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
      OTEL_RESOURCE_ATTRIBUTES: service.name=pricing
      OTEL_METRICS_EXPORTER: none
      OTEL_LOGS_EXPORTER: none
  inventory:                 #rust
    image: otel-inventory:1.0
    environment:
      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
      OTEL_RESOURCE_ATTRIBUTES: service.name=inventory
      OTEL_METRICS_EXPORTER: none
      OTEL_LOGS_EXPORTER: none
  warehouse-us:        #golang
    image: otel-warehouse-us:1.0
    environment:
      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
      OTEL_RESOURCE_ATTRIBUTES: service.name=stocks USA
      OTEL_METRICS_EXPORTER: none
      OTEL_LOGS_EXPORTER: none
  warehouse-jp:      #ruby
    image: otel-warehouse-jp:1.0
    environment:
      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318
      OTEL_RESOURCE_ATTRIBUTES: service.name=stocks Japan
      OTEL_METRICS_EXPORTER: none
      OTEL_LOGS_EXPORTER: none
```

This PR is a starting point to allow Apache APISIX to follow the same conventions.

Two things of note, that should be discussed in this PR:

* The default OTEL values defined in the spec are not the same as those defined by APISIX
* The units defined in the spec are not the same as those defined by APISIX

### Checklist

- [X] I have explained the need for this PR and the problem it solves
- [X] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [X] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
