### PR TITLE
fix: add libyaml-dev dependency for apt

### DIFF
--- a/utils/install-dependencies.sh
+++ b/utils/install-dependencies.sh
@@ -78,7 +78,7 @@ function install_dependencies_with_apt() {
     sudo apt-get update
 
     # install some compilation tools
-    sudo apt-get install -y curl make gcc g++ cpanminus libpcre3 libpcre3-dev libldap2-dev unzip openresty-zlib-dev openresty-pcre-dev
+    sudo apt-get install -y curl make gcc g++ cpanminus libpcre3 libpcre3-dev libldap2-dev libyaml-dev unzip openresty-zlib-dev openresty-pcre-dev
 }
 
 # Identify the different distributions and call the corresponding function


### PR DESCRIPTION
was not installed during make deps on the ubuntu dev container for vscode. since this is definitely required for luarocks to work there shouldnt be any negative consequences on any system that already has it installed

### Description

Add a explicit dependency on `libyaml-dev` in the apt base systems, since it does not get installed on at least
some distributions (ubuntu 22 dev container in this case). Without this luarocks will not install any dependencies and fails saying it can't find the lib.

No changes to the performance_test.sh (the only test file that is relevant) need to be made

Fixes # (issue)

#11290 

### Checklist

- [x ] I have explained the need for this PR and the problem it solves
- [x ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
