### PR TITLE
fix(ssl): SSL key rotation caused request failure

### DIFF
--- a/apisix/ssl.lua
+++ b/apisix/ssl.lua
@@ -163,7 +163,7 @@ local function aes_decrypt_pkey(origin, field)
         end
 
         if C.ERR_peek_error() then
-            -- clean up the error queue of OpenSSL to prevent 
+            -- clean up the error queue of OpenSSL to prevent
             -- normal requests from being interfered with.
             C.ERR_clear_error()
         end

--- a/apisix/ssl.lua
+++ b/apisix/ssl.lua
@@ -159,10 +159,12 @@ local function aes_decrypt_pkey(origin, field)
     for _, aes_128_cbc_with_iv in ipairs(aes_128_cbc_with_iv_tbl) do
         local decrypted = aes_128_cbc_with_iv:decrypt(decoded_key)
         if decrypted then
-            if C.ERR_peek_error() then
-                C.ERR_clear_error()
-            end
             return decrypted
+        end
+
+        if C.ERR_peek_error() then
+            -- clean up the error queue of OpenSSL to prevent normal requests from being interfered with.
+            C.ERR_clear_error()
         end
     end
 

--- a/apisix/ssl.lua
+++ b/apisix/ssl.lua
@@ -163,7 +163,8 @@ local function aes_decrypt_pkey(origin, field)
         end
 
         if C.ERR_peek_error() then
-            -- clean up the error queue of OpenSSL to prevent normal requests from being interfered with.
+            -- clean up the error queue of OpenSSL to prevent 
+            -- normal requests from being interfered with.
             C.ERR_clear_error()
         end
     end

--- a/apisix/ssl.lua
+++ b/apisix/ssl.lua
@@ -18,7 +18,9 @@ local core           = require("apisix.core")
 local secret         = require("apisix.secret")
 local ngx_ssl        = require("ngx.ssl")
 local ngx_ssl_client = require("ngx.ssl.clienthello")
+local ffi            = require("ffi")
 
+local C = ffi.C
 local ngx_encode_base64 = ngx.encode_base64
 local ngx_decode_base64 = ngx.decode_base64
 local aes = require("resty.aes")
@@ -28,6 +30,10 @@ local assert = assert
 local type = type
 local ipairs = ipairs
 
+ffi.cdef[[
+unsigned long ERR_peek_error(void);
+void ERR_clear_error(void);
+]]
 
 local cert_cache = core.lrucache.new {
     ttl = 3600, count = 1024,
@@ -153,6 +159,9 @@ local function aes_decrypt_pkey(origin, field)
     for _, aes_128_cbc_with_iv in ipairs(aes_128_cbc_with_iv_tbl) do
         local decrypted = aes_128_cbc_with_iv:decrypt(decoded_key)
         if decrypted then
+            if C.ERR_peek_error() then
+                C.ERR_clear_error()
+            end
             return decrypted
         end
     end

--- a/t/admin/ssl4.t
+++ b/t/admin/ssl4.t
@@ -404,3 +404,108 @@ location /t {
 }
 --- response_body
 passed
+
+
+
+=== TEST 12: set ssl(sni: www.test.com), encrypt with the first keyring
+--- yaml_config
+apisix:
+    node_listen: 1984
+    data_encryption:
+        keyring:
+            - edd1c9f0985e76a1
+--- config
+location /t {
+    content_by_lua_block {
+        local core = require("apisix.core")
+        local t = require("lib.test_admin")
+
+        local ssl_cert = t.read_file("t/certs/apisix.crt")
+        local ssl_key =  t.read_file("t/certs/apisix.key")
+        local data = {cert = ssl_cert, key = ssl_key, sni = "test.com"}
+
+        local code, body = t.test('/apisix/admin/ssls/1',
+            ngx.HTTP_PUT,
+            core.json.encode(data),
+            [[{
+                "value": {
+                    "sni": "test.com"
+                },
+                "key": "/apisix/ssls/1"
+            }]]
+            )
+
+        ngx.status = code
+        ngx.say(body)
+    }
+}
+--- response_body
+passed
+
+
+
+=== TEST 13: update encrypt keyring, and set ssl(sni: test2.com)
+--- yaml_config
+apisix:
+    node_listen: 1984
+    data_encryption:
+        keyring:
+            - qeddd145sfvddff3
+            - edd1c9f0985e76a1
+--- config
+location /t {
+    content_by_lua_block {
+        local core = require("apisix.core")
+        local t = require("lib.test_admin")
+
+        local ssl_cert = t.read_file("t/certs/test2.crt")
+        local ssl_key =  t.read_file("t/certs/test2.key")
+        local data = {cert = ssl_cert, key = ssl_key, sni = "test2.com"}
+
+        local code, body = t.test('/apisix/admin/ssls/2',
+            ngx.HTTP_PUT,
+            core.json.encode(data),
+            [[{
+                "value": {
+                    "sni": "test2.com"
+                },
+                "key": "/apisix/ssls/2"
+            }]]
+            )
+
+        ngx.status = code
+        ngx.say(body)
+    }
+}
+--- response_body
+passed
+
+
+
+=== TEST 14: Successfully access test.com
+--- yaml_config
+apisix:
+    node_listen: 1984
+    data_encryption:
+        keyring:
+            - qeddd145sfvddff3
+            - edd1c9f0985e76a1
+--- exec
+curl -k -s --resolve "test2.com:1994:127.0.0.1" https://test2.com:1994/hello 2>&1 | cat
+--- response_body
+hello world
+
+
+
+=== TEST 15: Successfully access test2.com
+--- yaml_config
+apisix:
+    node_listen: 1984
+    data_encryption:
+        keyring:
+            - qeddd145sfvddff3
+            - edd1c9f0985e76a1
+--- exec
+curl -k -s --resolve "test2.com:1994:127.0.0.1" https://test2.com:1994/hello 2>&1 | cat
+--- response_body
+hello world

--- a/t/admin/ssl4.t
+++ b/t/admin/ssl4.t
@@ -242,7 +242,6 @@ apisix:
             - qeddd145sfvddff3
 --- error_log
 decrypt ssl key failed
-[alert]
 
 
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Due to the failure to handle the OpenSSL error generated during the AES decryption process, this error was caught by Nginx during the TLS handshake request, resulting in the request failure.

In the scenario of key rotation, due to the attempt to traverse all keys and attempt decryption, the error messages generated earlier should be ignored when decryption is successful.

reference：
* https://github.com/openresty/lua-resty-string/pull/65#issuecomment-1185765216
* https://segmentfault.com/a/1190000015326570


Fixes #11148 

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
