### PR TITLE
fix: after updating the header, get the old value from the ctx.var

### DIFF
--- a/apisix/core/request.lua
+++ b/apisix/core/request.lua
@@ -144,6 +144,11 @@ local function modify_header(ctx, header_name, header_value, override)
         req_add_header(header_name, header_value)
     end
 
+    if ctx and ctx.var then
+        -- when the header is updated, clear cache of ctx.var
+        ctx.var["http_" .. str_lower(header_name)] = nil
+    end
+
     if is_apisix_or and not changed then
         -- if the headers are not changed before,
         -- we can only update part of the cache instead of invalidating the whole

--- a/t/core/request.t
+++ b/t/core/request.t
@@ -463,3 +463,30 @@ test
 test
 --- error_log
 DEPRECATED: use add_header(ctx, header_name, header_value) instead
+
+
+
+=== TEST 16: after setting the header, ctx.var can still access the correct value
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            ngx.ctx.api_ctx = {}
+            local ctx = ngx.ctx.api_ctx
+            core.ctx.set_vars_meta(ctx)
+
+            ctx.var.http_server = "ngx"
+            ngx.say(ctx.var.http_server)
+
+            core.request.set_header(ctx, "server",  "test")
+            ngx.say(ctx.var.http_server)
+
+            -- case-insensitive
+            core.request.set_header(ctx, "Server",  "apisix")
+            ngx.say(ctx.var.http_server)
+        }
+    }
+--- response_body
+ngx
+test
+apisix


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #11325

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
