### PR TITLE
fix(forward-auth): client body can not send to upstream after forwarding it to auth. service

### DIFF
--- a/apisix/plugins/forward-auth.lua
+++ b/apisix/plugins/forward-auth.lua
@@ -68,9 +68,9 @@ local schema = {
         keepalive = {type = "boolean", default = true},
         keepalive_timeout = {type = "integer", minimum = 1000, default = 60000},
         keepalive_pool = {type = "integer", minimum = 1, default = 5},
-	-- suggest adding this switch
+        -- suggest adding this switch
         forward_client_body = {type = "boolean", default = true},
-	-- test purpose, for covering the downloading fashion(core.request.get_body())
+        -- test purpose, for covering the downloading fashion(core.request.get_body())
         forward_by_streaming = {type = "boolean", default = true},
     },
     required = {"uri"}
@@ -102,7 +102,7 @@ function _M.access(conf, ctx)
     local forward_client_body = false
     local client_body_length = core.request.header(ctx, "content-length")
     if conf.request_method == "POST" and conf.forward_client_body and client_body_length then
-	forward_client_body = true
+        forward_client_body = true
         auth_headers["Content-Length"] = client_body_length
         auth_headers["Expect"] = core.request.header(ctx, "expect")
         auth_headers["Transfer-Encoding"] = core.request.header(ctx, "transfer-encoding")
@@ -131,40 +131,49 @@ function _M.access(conf, ctx)
     httpc:set_timeout(conf.timeout)
     if forward_client_body then
         params.body = co_wrap(
-	    function()
-		-- get_client_body_reader() -> ngx.req.socket()
-		-- once invoking ngx.req.socket() would stop NGX from reading client body causing 504 issue
-		-- why there is such a performance needs further clarification
-		-- delay the invoking in order to follow the normal proxy_pass flow rather than buffering
-		-- the client body by the plugin in case of client body has not started to read,
-		-- e.g. auth svc. is unable to connect and allow_degradation is true
+            function()
+                --[[ get_client_body_reader() -> ngx.req.socket()
+
+                    Once invoking ngx.req.socket() would stop NGX from
+                    reading client body, which causing 504 issue. Why
+                    there is such a performance needs further
+                    clarification.
+
+                    Delaying the invocation in order to follow the
+                    normal proxy_pass flow rather than buffering the
+                    client body by the plugin in case of client body
+                    has not started to read, e.g. auth svc. is unable
+                    to connect and allow_degradation is true.
+
+                ]]
+
                 if forward_by_streaming then
                     local client_body_reader, err = httpc:get_client_body_reader()
                     if client_body_reader then
                         ngx_req.init_body()
-			streaming_started = true
+                        streaming_started = true
                         repeat
                             local chunk, err, partial = client_body_reader()
                             if chunk then
                                 ngx_req.append_body(chunk)
                             elseif not err then
                                 ngx_req.finish_body()
-				streaming_finished = true
+                                streaming_finished = true
                             end
                             co_yield(chunk, err, partial)
                         until not chunk
                         return
-		    else
-			forward_by_streaming = false
-			core.log.warn("failed to get client_body_reader. err: ", err,
-				      " using core.request.get_body() instead")
+                    else
+                        forward_by_streaming = false
+                        core.log.warn("failed to get client_body_reader. err: ", err,
+                                      " using core.request.get_body() instead")
                     end
-		else
-		    core.log.warn("forward client body by downloading")
+                else
+                    core.log.warn("forward client body by downloading")
                 end
                 co_yield(core.request.get_body())
-	    end
-	)
+            end
+        )
     end
 
     if conf.keepalive then
@@ -175,17 +184,18 @@ function _M.access(conf, ctx)
     local res, err = httpc:request_uri(conf.uri, params)
     if not res and conf.allow_degradation then
         core.log.warn("allow_degradation, err: ", err)
-	if forward_client_body and forward_by_streaming and
-	    streaming_started and not streaming_finished then
-	    core.log.warn("allow_degradation, continue buffering the whole client body")
-	    repeat
-		local chunk, err = params.body()
-		if err then
-		    core.log.warn("allow_degradation, failed to buffer the whole client body, err: ", err)
-		    return conf.status_on_error
-		end
-	    until not chunk
-	end
+        if forward_client_body and forward_by_streaming and
+            streaming_started and not streaming_finished then
+            core.log.warn("allow_degradation, continue buffering the whole client body")
+            repeat
+                local chunk, err = params.body()
+                if err then
+                    core.log.warn("allow_degradation, " ..
+                                  "failed to buffer the whole client body, err: ", err)
+                    return conf.status_on_error
+                end
+            until not chunk
+        end
         return
     elseif not res then
         core.log.warn("failed to process forward auth, err: ", err)

--- a/apisix/plugins/forward-auth.lua
+++ b/apisix/plugins/forward-auth.lua
@@ -68,9 +68,7 @@ local schema = {
         keepalive = {type = "boolean", default = true},
         keepalive_timeout = {type = "integer", minimum = 1000, default = 60000},
         keepalive_pool = {type = "integer", minimum = 1, default = 5},
-        -- suggest adding this switch
         forward_client_body = {type = "boolean", default = true},
-        -- test purpose, for covering the downloading fashion(core.request.get_body())
         forward_by_streaming = {type = "boolean", default = true},
     },
     required = {"uri"}

--- a/docs/en/latest/plugins/forward-auth.md
+++ b/docs/en/latest/plugins/forward-auth.md
@@ -50,6 +50,8 @@ This Plugin moves the authentication and authorization logic to a dedicated exte
 | keepalive_pool    | integer       | False    | 5       | [1, ...]ms     | Connection pool limit.                                                                                                                           |
 | allow_degradation | boolean       | False    | false   |                | When set to `true`, allows authentication to be skipped when authentication server is unavailable. |
 | status_on_error   | integer       | False    | 403     | [200,...,599]  | Sets the HTTP status that is returned to the client when there is a network error to the authorization service. The default status is “403” (HTTP Forbidden). |
+| forward_client_body  | boolean       | False    | true     | [true,false]  | When set to `true`, allows forwarding client body to `auth` service. The forwarding takes effect must also meet the conditions: `request_method` set to "POST" and the client body is non-empty |
+| forward_by_streaming | boolean       | False    | true     | [true,false]  | When set to `true`, using the `streaming` way to forward client body. It's suitable for large client body. In case of `false`, the whole clien body is buffered(to memory or tempfile) first then start forwarding. |
 
 ## Data definition
 

--- a/docs/zh/latest/plugins/forward-auth.md
+++ b/docs/zh/latest/plugins/forward-auth.md
@@ -49,6 +49,8 @@ description: 本文介绍了关于 Apache APISIX `forward-auth` 插件的基本�
 | keepalive_pool    | integer       | 否    | 5       | [1, ...]ms     | 长连接池大小。                                                                                                        |
 | allow_degradation | boolean       | 否    | false   |                | 当设置为 `true` 时，允许在身份验证服务器不可用时跳过身份验证。 |
 | status_on_error   | boolean       | 否    | 403     | [200,...,599]   | 设置授权服务出现网络错误时返回给客户端的 HTTP 状态。默认状态为“403”。 |
+| forward_client_body    | boolean       | 否    | true     | [true,false]  | 是否转发客户端请求体到 `auth` 服务。注意，`request_method` 设置为 "POST" 并且请求体不为空时才会转发 |
+| forward_by_streaming   | boolean       | 否    | true     | [true,false]  | 是否使用`流`方式转发客户端请求体。适用于请求体较大的场景。设置为 `false` 时，会将整个请求体缓存（于内存或者临时文件）后再进行转发 |
 
 ## 数据定义
 

--- a/t/plugin/forward-auth-client-body.t
+++ b/t/plugin/forward-auth-client-body.t
@@ -60,24 +60,24 @@ __DATA__
                                 phase = "rewrite",
                                 functions = {
                                     [[
-				    return function(conf, ctx)
+                                    return function(conf, ctx)
                                         local core = require("apisix.core")
                                         if core.request.get_method() == "POST" then
                                             if core.request.header(ctx, "Authorization") == "read-whole-client-body" then
-					        local body = core.request.get_body()
-						local content_length = tonumber(ngx.var.content_length)
-						if content_length > 0 then
-						    assert(#body == content_length)
-						end
+                                                local body = core.request.get_body()
+                                                local content_length = tonumber(ngx.var.content_length)
+                                                if content_length > 0 then
+                                                    assert(#body == content_length)
+                                                end
                                                 core.response.exit(200)
                                             end
                                             if core.request.header(ctx, "Authorization") == "simulate-partially-read-client-body" then
-					        ngx.sleep(1)
+                                                ngx.sleep(1)
                                                 ngx.exit(ngx.ERROR)
                                             end
                                         end
                                     end
-				    ]]
+                                    ]]
                                 }
                             }
                         },
@@ -92,19 +92,19 @@ __DATA__
                                 phase = "rewrite",
                                 functions = {
                                     [[
-				    return function(conf, ctx)
+                                    return function(conf, ctx)
                                         local core = require("apisix.core")
-					local resty_md5 = require("resty.md5")
-					local resty_str = require("resty.string")
-					local body = core.request.get_body()
-					assert(#body == tonumber(ngx.var.content_length))
-					local md5 = resty_md5:new()
-					md5:update(body)
-					local digest = md5:final()
-					local body_md5 = resty_str.to_hex(digest)
+                                        local resty_md5 = require("resty.md5")
+                                        local resty_str = require("resty.string")
+                                        local body = core.request.get_body()
+                                        assert(#body == tonumber(ngx.var.content_length))
+                                        local md5 = resty_md5:new()
+                                        md5:update(body)
+                                        local digest = md5:final()
+                                        local body_md5 = resty_str.to_hex(digest)
                                         core.response.exit(200, body_md5)
                                     end
-				    ]]
+                                    ]]
                                 }
                             }
                         },
@@ -120,15 +120,15 @@ __DATA__
                                 "request_headers": ["Authorization"],
                                 "request_method": "POST"
                         },
-  			"proxy-rewrite": {
+                        "proxy-rewrite": {
                                 "uri": "/echo"
-			    }
-			},			
-			"upstream_id": "u1",
+                            }
+                        },
+                        "upstream_id": "u1",
                         "uri": "/sanity"
                     }]],
                 },
-		{
+                {
                     url = "/apisix/admin/routes/11",
                     data = [[{
                         "plugins": {
@@ -136,17 +136,17 @@ __DATA__
                                 "uri": "http://127.0.0.1:1984/auth",
                                 "request_headers": ["Authorization"],
                                 "request_method": "POST",
-				"forward_by_streaming": false
+                                "forward_by_streaming": false
                         },
-  			"proxy-rewrite": {
+                        "proxy-rewrite": {
                                 "uri": "/echo"
-			    }
-			},			
-			"upstream_id": "u1",
+                            }
+                        },
+                        "upstream_id": "u1",
                         "uri": "/sanity_download"
                     }]],
                 },
-		{
+                {
                     url = "/apisix/admin/routes/12",
                     data = [[{
                         "plugins": {
@@ -154,13 +154,13 @@ __DATA__
                                 "uri": "http://127.0.0.1:1984/auth",
                                 "request_headers": ["Authorization"],
                                 "request_method": "POST",
-				"forward_client_body": false
+                                "forward_client_body": false
                         },
-  			"proxy-rewrite": {
+                        "proxy-rewrite": {
                                 "uri": "/echo"
-			    }
-			},			
-			"upstream_id": "u1",
+                            }
+                        },
+                        "upstream_id": "u1",
                         "uri": "/sanity_not_forward"
                     }]],
                 },
@@ -174,15 +174,15 @@ __DATA__
                                 "request_method": "POST",
                                 "allow_degradation": true
                         },
-  			"proxy-rewrite": {
+                        "proxy-rewrite": {
                                 "uri": "/echo"
-			    }
-			},			
-			"upstream_id": "u1",
+                            }
+                        },
+                        "upstream_id": "u1",
                         "uri": "/partially_forwarded"
                     }]],
                 },
-		{
+                {
                     url = "/apisix/admin/routes/21",
                     data = [[{
                         "plugins": {
@@ -191,13 +191,13 @@ __DATA__
                                 "request_headers": ["Authorization"],
                                 "request_method": "POST",
                                 "allow_degradation": true,
-				"forward_by_streaming": false
+                                "forward_by_streaming": false
                         },
-  			"proxy-rewrite": {
+                        "proxy-rewrite": {
                                 "uri": "/echo"
-			    }
-			},			
-			"upstream_id": "u1",
+                            }
+                        },
+                        "upstream_id": "u1",
                         "uri": "/partially_forwarded_download"
                     }]],
                 },
@@ -210,7 +210,7 @@ __DATA__
                                 "request_headers": ["Authorization"],
                                 "request_method": "POST",
                                 "allow_degradation": true,
-				"timeout": 100
+                                "timeout": 100
                             },
                             "proxy-rewrite": {
                                 "uri": "/echo"
@@ -220,7 +220,7 @@ __DATA__
                         "uri": "/connect_auth_svc_not_exists"
                     }]],
                 },
-		{
+                {
                     url = "/apisix/admin/routes/31",
                     data = [[{
                         "plugins": {
@@ -229,8 +229,8 @@ __DATA__
                                 "request_headers": ["Authorization"],
                                 "request_method": "POST",
                                 "allow_degradation": true,
-				"timeout": 100,
-				"forward_by_streaming": false
+                                "timeout": 100,
+                                "forward_by_streaming": false
                             },
                             "proxy-rewrite": {
                                 "uri": "/echo"

--- a/t/plugin/forward-auth-client-body.t
+++ b/t/plugin/forward-auth-client-body.t
@@ -1,0 +1,339 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+use Digest;
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+our $tempfile_body = 'a' x (1024*1024*11);
+our $memory_body = 'b' x 1024;
+our $tempfile_body_md5 = Digest->new("MD5")->add($tempfile_body)->hexdigest;
+our $memory_body_md5 = Digest->new("MD5")->add($memory_body)->hexdigest;
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: setup route with plugin
+--- config
+    location /t {
+        content_by_lua_block {
+            local data = {
+                {
+                    url = "/apisix/admin/upstreams/u1",
+                    data = [[{
+                        "nodes": {
+                            "127.0.0.1:1984": 1
+                        },
+                        "type": "roundrobin"
+                    }]],
+                },
+                {
+                    url = "/apisix/admin/routes/auth",
+                    data = {
+                        plugins = {
+                            ["serverless-pre-function"] = {
+                                phase = "rewrite",
+                                functions = {
+                                    [[
+				    return function(conf, ctx)
+                                        local core = require("apisix.core")
+                                        if core.request.get_method() == "POST" then
+                                            if core.request.header(ctx, "Authorization") == "read-whole-client-body" then
+					        local body = core.request.get_body()
+						local content_length = tonumber(ngx.var.content_length)
+						if content_length > 0 then
+						    assert(#body == content_length)
+						end
+                                                core.response.exit(200)
+                                            end
+                                            if core.request.header(ctx, "Authorization") == "simulate-partially-read-client-body" then
+					        ngx.sleep(1)
+                                                ngx.exit(ngx.ERROR)
+                                            end
+                                        end
+                                    end
+				    ]]
+                                }
+                            }
+                        },
+                        uri = "/auth"
+                    }
+                },
+                {
+                    url = "/apisix/admin/routes/echo",
+                    data = {
+                        plugins = {
+                            ["serverless-pre-function"] = {
+                                phase = "rewrite",
+                                functions = {
+                                    [[
+				    return function(conf, ctx)
+                                        local core = require("apisix.core")
+					local resty_md5 = require("resty.md5")
+					local resty_str = require("resty.string")
+					local body = core.request.get_body()
+					assert(#body == tonumber(ngx.var.content_length))
+					local md5 = resty_md5:new()
+					md5:update(body)
+					local digest = md5:final()
+					local body_md5 = resty_str.to_hex(digest)
+                                        core.response.exit(200, body_md5)
+                                    end
+				    ]]
+                                }
+                            }
+                        },
+                        uri = "/echo"
+                    }
+                },
+                {
+                    url = "/apisix/admin/routes/1",
+                    data = [[{
+                        "plugins": {
+                        "forward-auth": {
+                                "uri": "http://127.0.0.1:1984/auth",
+                                "request_headers": ["Authorization"],
+                                "request_method": "POST"
+                        },
+  			"proxy-rewrite": {
+                                "uri": "/echo"
+			    }
+			},			
+			"upstream_id": "u1",
+                        "uri": "/sanity"
+                    }]],
+                },
+		{
+                    url = "/apisix/admin/routes/11",
+                    data = [[{
+                        "plugins": {
+                        "forward-auth": {
+                                "uri": "http://127.0.0.1:1984/auth",
+                                "request_headers": ["Authorization"],
+                                "request_method": "POST",
+				"forward_by_streaming": false
+                        },
+  			"proxy-rewrite": {
+                                "uri": "/echo"
+			    }
+			},			
+			"upstream_id": "u1",
+                        "uri": "/sanity_download"
+                    }]],
+                },
+		{
+                    url = "/apisix/admin/routes/12",
+                    data = [[{
+                        "plugins": {
+                        "forward-auth": {
+                                "uri": "http://127.0.0.1:1984/auth",
+                                "request_headers": ["Authorization"],
+                                "request_method": "POST",
+				"forward_client_body": false
+                        },
+  			"proxy-rewrite": {
+                                "uri": "/echo"
+			    }
+			},			
+			"upstream_id": "u1",
+                        "uri": "/sanity_not_forward"
+                    }]],
+                },
+                {
+                    url = "/apisix/admin/routes/2",
+                    data = [[{
+                        "plugins": {
+                        "forward-auth": {
+                                "uri": "http://127.0.0.1:1984/auth",
+                                "request_headers": ["Authorization"],
+                                "request_method": "POST",
+                                "allow_degradation": true
+                        },
+  			"proxy-rewrite": {
+                                "uri": "/echo"
+			    }
+			},			
+			"upstream_id": "u1",
+                        "uri": "/partially_forwarded"
+                    }]],
+                },
+		{
+                    url = "/apisix/admin/routes/21",
+                    data = [[{
+                        "plugins": {
+                        "forward-auth": {
+                                "uri": "http://127.0.0.1:1984/auth",
+                                "request_headers": ["Authorization"],
+                                "request_method": "POST",
+                                "allow_degradation": true,
+				"forward_by_streaming": false
+                        },
+  			"proxy-rewrite": {
+                                "uri": "/echo"
+			    }
+			},			
+			"upstream_id": "u1",
+                        "uri": "/partially_forwarded_download"
+                    }]],
+                },
+                {
+                    url = "/apisix/admin/routes/3",
+                    data = [[{
+                        "plugins": {
+                            "forward-auth": {
+                                "uri": "http://127.39.40.1:9999/auth",
+                                "request_headers": ["Authorization"],
+                                "request_method": "POST",
+                                "allow_degradation": true,
+				"timeout": 100
+                            },
+                            "proxy-rewrite": {
+                                "uri": "/echo"
+                            }
+                        },
+                        "upstream_id": "u1",
+                        "uri": "/connect_auth_svc_not_exists"
+                    }]],
+                },
+		{
+                    url = "/apisix/admin/routes/31",
+                    data = [[{
+                        "plugins": {
+                            "forward-auth": {
+                                "uri": "http://127.39.40.1:9999/auth",
+                                "request_headers": ["Authorization"],
+                                "request_method": "POST",
+                                "allow_degradation": true,
+				"timeout": 100,
+				"forward_by_streaming": false
+                            },
+                            "proxy-rewrite": {
+                                "uri": "/echo"
+                            }
+                        },
+                        "upstream_id": "u1",
+                        "uri": "/connect_auth_svc_not_exists_download"
+                    }]],
+                }
+            }
+
+            local t = require("lib.test_admin").test
+
+            for _, data in ipairs(data) do
+                local code, body = t(data.url, ngx.HTTP_PUT, data.data)
+                ngx.say(body)
+            end
+        }
+    }
+--- response_body eval
+"passed\n" x 10
+
+
+
+=== TEST 2: sanity - forward to auth. service then proxy_psss to upstream
+--- pipelined_requests eval
+[
+"POST /sanity\n" . $::tempfile_body,
+"POST /sanity\n" . $::memory_body,
+"POST /sanity_download\n" . $::tempfile_body,
+"POST /sanity_download\n" . $::memory_body,
+]
+--- more_headers
+Authorization: read-whole-client-body
+--- error_code eval
+[200, 200, 200, 200]
+--- response_body eval
+[
+$::tempfile_body_md5,
+$::memory_body_md5,
+$::tempfile_body_md5,
+$::memory_body_md5,
+]
+
+
+
+=== TEST 3: sanity - not forward to auth. service
+--- pipelined_requests eval
+[
+"POST /sanity_not_forward\n" . $::tempfile_body,
+"POST /sanity_not_forward\n" . $::memory_body,
+]
+--- more_headers
+Authorization: read-whole-client-body
+--- error_code eval
+[200, 200]
+--- response_body eval
+[
+$::tempfile_body_md5,
+$::memory_body_md5,
+]
+
+
+
+=== TEST 4: [allow_degradation=true] client body has partially forwarded to auth. service
+--- pipelined_requests eval
+[
+"POST /partially_forwarded\n" . $::tempfile_body,
+"POST /partially_forwarded\n" . $::memory_body,
+"POST /partially_forwarded_download\n" . $::tempfile_body,
+"POST /partially_forwarded_download\n" . $::memory_body,
+]
+--- more_headers
+Authorization: simulate-partially-read-client-body
+--- error_code eval
+[200, 200, 200, 200]
+--- ignore_error_log
+--- response_body eval
+[
+$::tempfile_body_md5,
+$::memory_body_md5,
+$::tempfile_body_md5,
+$::memory_body_md5,
+]
+
+
+
+=== TEST 5: [allow_degradation=true] client body has not started to forward to auth. service
+--- pipelined_requests eval
+[
+"POST /connect_auth_svc_not_exists\n" . $::tempfile_body,
+"POST /connect_auth_svc_not_exists\n" . $::memory_body,
+"POST /connect_auth_svc_not_exists_download\n" . $::tempfile_body,
+"POST /connect_auth_svc_not_exists_download\n" . $::memory_body,
+]
+--- more_headers
+Authorization: read-whole-client-body
+--- error_code eval
+[200, 200, 200, 200]
+--- response_body eval
+[
+$::tempfile_body_md5,
+$::memory_body_md5,
+$::tempfile_body_md5,
+$::memory_body_md5,
+]


### PR DESCRIPTION
fix(forward-auth): client body can not send to upstream after forwarding it to auth. service

### Description

Fixes https://github.com/apache/apisix/issues/11050
Fixes https://github.com/apache/apisix/issues/11200
Fixes #11537

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

1. sync. with Nginx using ngx.req.<init|append|finish>_body APIs while forwarding/streaming to auth. svc
2. consider the case of conf.allow_degradation == true
3. delay invoking "get_client_body_reader() -> ngx.req.socket()"
> 		-- once invoking ngx.req.socket() would stop NGX from reading client body causing 504 issue
> 		-- why there is such a performance needs further clarification
> 		-- delay the invoking in order to follow the normal proxy_pass flow rather than buffering
> 		-- the client body by the plugin in case of client body has not started to read,
> 		-- e.g. auth svc. is unable to connect and allow_degradation is true
4. suggest adding the following config field
> 	-- suggest adding this switch
>         forward_client_body = {type = "boolean", default = true},



### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
6. Always add/update tests for any changes unless you have a good reason.
7. Always update the documentation to reflect the changes made in the PR.
8. Make a new commit to resolve conversations instead of `push -f`.
9. To resolve merge conflicts, merge master instead of rebasing.
10. Use "request review" to notify the reviewer after making changes.
11. Only a reviewer can mark a conversation as resolved.

-->
