### PR TITLE
fix(datadog): report consumer username tag

### DIFF
--- a/apisix/plugins/datadog.lua
+++ b/apisix/plugins/datadog.lua
@@ -88,8 +88,8 @@ local function generate_tag(entry, const_tags)
         core.table.insert(tags, "service_name:" .. entry.service_id)
     end
 
-    if entry.consumer and entry.consumer ~= "" then
-        core.table.insert(tags, "consumer:" .. entry.consumer)
+    if entry.consumer and entry.consumer.username then
+        core.table.insert(tags, "consumer:" .. entry.consumer.username)
     end
     if entry.balancer_ip ~= "" then
         core.table.insert(tags, "balancer_ip:" .. entry.balancer_ip)


### PR DESCRIPTION
### Description

When datadog tries to upload metrics containing the consumer username tag, it fails.
Basically the code there tries to splice a string with a table (without __tostring), which is completely wrong, and it has had this problem since the original version of the plugin, which went undetected because the original authors didn't write test cases related.

The previous author of PR #10934 was closed by bot for not adding test cases and no longer responding. Thanks to the issue reporter and the author of the previous PR.

Fixes #9269 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
