### PR TITLE
fix: make the message clearer when API key is missing

### DIFF
--- a/apisix/plugins/key-auth.lua
+++ b/apisix/plugins/key-auth.lua
@@ -77,7 +77,7 @@ function _M.rewrite(conf, ctx)
     end
 
     if not key then
-        return 401, {message = "Missing API key found in request"}
+        return 401, {message = "Missing API key in request"}
     end
 
     local consumer_conf = consumer_mod.plugin(plugin_name)

--- a/docs/en/latest/plugins/key-auth.md
+++ b/docs/en/latest/plugins/key-auth.md
@@ -141,7 +141,7 @@ curl http://127.0.0.2:9080/index.html -i
 ```
 HTTP/1.1 401 Unauthorized
 ...
-{"message":"Missing API key found in request"}
+{"message":"Missing API key in request"}
 ```
 
 ```shell

--- a/docs/zh/latest/plugins/key-auth.md
+++ b/docs/zh/latest/plugins/key-auth.md
@@ -148,7 +148,7 @@ curl http://127.0.0.2:9080/index.html -i
 ```shell
 HTTP/1.1 401 Unauthorized
 ...
-{"message":"Missing API key found in request"}
+{"message":"Missing API key in request"}
 ```
 
 ```shell

--- a/t/plugin/cors.t
+++ b/t/plugin/cors.t
@@ -454,7 +454,7 @@ ExternalHeader1: val
 ExternalHeader2: val
 ExternalHeader3: val
 --- response_body
-{"message":"Missing API key found in request"}
+{"message":"Missing API key in request"}
 --- error_code: 401
 --- response_headers
 Access-Control-Allow-Origin: https://sub.domain.com

--- a/t/plugin/key-auth.t
+++ b/t/plugin/key-auth.t
@@ -173,7 +173,7 @@ apikey: 123
 GET /hello
 --- error_code: 401
 --- response_body
-{"message":"Missing API key found in request"}
+{"message":"Missing API key in request"}
 
 
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

When the key is missing while accessing a route with the key-auth plugin enabled, we get the message, "Missing API key found in request," which isn't correct. How is something missing in the request, found in the request?

Instead, it should be phrased as "Missing API key in request," which is clearer.

While users may be able to make sense of the older message, it is an easy enough change.

This PR updates the message in the code, tests, and docs.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
