### PR TITLE
docs: fix broken example in body-transformer

### DIFF
--- a/docs/en/latest/plugins/body-transformer.md
+++ b/docs/en/latest/plugins/body-transformer.md
@@ -138,6 +138,7 @@ curl http://127.0.0.1:9180/apisix/admin/routes/test_ws \
     "plugins": {
         "body-transformer": {
             "request": {
+                "template_is_base64": true,
                 "template": "'"$(base64 -w0 /path/to/my_template_file)"'"
             }
         }


### PR DESCRIPTION
### Description

The base64 example was missing `template_is_base64`

### Checklist

- [X] I have explained the need for this PR and the problem it solves
- [X] I have explained the changes or the new features added to this PR
- [X] I have updated the documentation to reflect this change
- [X] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)