### PR TITLE
fix(api-breaker):The actual number of failures of the circuit breaker is inconsistent with the set number of failures

### DIFF
--- a/apisix/plugins/api-breaker.lua
+++ b/apisix/plugins/api-breaker.lua
@@ -179,7 +179,7 @@ function _M.access(conf, ctx)
     core.log.info("breaker_time: ", breaker_time)
 
     -- breaker
-    if lasttime + breaker_time >= ngx.time() then
+    if lasttime + breaker_time >= ngx.time() and unhealthy_count % conf.unhealthy.failures == 0 then
         if conf.break_response_body then
             if conf.break_response_headers then
                 for _, value in ipairs(conf.break_response_headers) do

--- a/t/plugin/api-breaker.t
+++ b/t/plugin/api-breaker.t
@@ -652,3 +652,53 @@ phase_func(): breaker_time: 10
 GET /t
 --- response_body eval
 qr/failed to check the configuration of plugin api-breaker err: property \"break_response_headers\" validation failed: failed to validate item 1: property \"(key|value)\" is required/
+
+
+
+=== TEST 21: continuous trigger break, The number of unhealthy instances is uncertain 
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local json = require("toolkit.json")
+
+        -- trigger to unhealth
+        for i = 1, 4 do
+            local code = t('/api_breaker?code=500', ngx.HTTP_GET)
+            ngx.say("code: ", code)
+        end
+
+        -- break for 2 seconds
+        ngx.sleep(2)
+
+        -- trigger to unhealth
+        for i = 1, 4 do
+            local code = t('/api_breaker?code=500', ngx.HTTP_GET)
+            ngx.say("code: ", code)
+        end
+
+        -- break for 2 seconds
+        ngx.sleep(4)
+        
+        -- trigger to unhealth
+        for i = 1, 4 do
+            local code = t('/api_breaker?code=500', ngx.HTTP_GET)
+            ngx.say("code: ", code)
+        end
+    }
+}
+--- request
+GET /t
+--- response_body
+code: 500
+code: 500
+code: 500
+code: 599
+code: 500
+code: 599
+code: 599
+code: 599
+code: 500
+code: 500
+code: 599
+code: 599


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
###### api-breaker plug-in configuration
![设置](https://github.com/user-attachments/assets/6c7af188-a940-461f-8eec-4813264fd15a)
###### Actual test result
![QQ图片20240718100029](https://github.com/user-attachments/assets/581ed161-b403-47d2-ba31-62e47d3d4b13)
*You can see from the picture, in the test picture,The actual number of failures did not reach 3 times on the fuse.so that,In the access phase, it is not only necessary to judge the time problem, but also to determine whether the current total number of unhealthy times is equal to the number of unhealthy failures*







