### PR TITLE
Add configure-routes.md of admin api key 

### DIFF
--- a/docs/en/latest/getting-started/configure-routes.md
+++ b/docs/en/latest/getting-started/configure-routes.md
@@ -36,10 +36,19 @@ In this section, you will create a route that forwards client requests to [httpb
 
 The following command creates a route, which should forward all requests sent to `http://127.0.0.1:9080/ip` to [httpbin.org/ip](http://httpbin.org/ip):
 
-[//]: <TODO: Add the link to the authorization of Admin API>
+[the Admin API key](https://apisix.apache.org/docs/apisix/installation-guide/#updating-admin-api-key)
+```
+deployment:
+  admin:
+    admin_key
+      -
+        name: "admin"
+        key: newsupersecurekey
+        role: admin
+```
 
 ```shell
-curl -i "http://127.0.0.1:9180/apisix/admin/routes" -X PUT -d '
+curl -i "http://127.0.0.1:9180/apisix/admin/routes" -X PUT -H 'X-API-KEY: <admin api key>' -d '
 {
   "id": "getting-started-ip",
   "uri": "/ip",


### PR DESCRIPTION
### Description

When using APISIX based on the provided documentation, I found that the given examples were not functional. The main issue was the absence of the X-API-KEY in the headers, which is required for proper usage.

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
