### PR TITLE
feat(cas-auth): support logged-in user header

### DIFF
--- a/apisix/plugins/cas-auth.lua
+++ b/apisix/plugins/cas-auth.lua
@@ -35,6 +35,8 @@ local schema = {
         idp_uri = {type = "string"},
         cas_callback_uri = {type = "string"},
         logout_uri = {type = "string"},
+        set_user_header = {type = "boolean", default = true},
+        user_header = {type = "string", default = "X-Proxy-User"},
     },
     required = {
         "idp_uri", "cas_callback_uri", "logout_uri"
@@ -87,6 +89,9 @@ local function with_session_id(conf, ctx, session_id)
     else
         -- refresh the TTL
         store:set(session_id, user, SESSION_LIFETIME)
+        if conf.set_user_header then
+            core.request.set_header(conf.user_header, user)
+        end
     end
 end
 

--- a/docs/en/latest/plugins/cas-auth.md
+++ b/docs/en/latest/plugins/cas-auth.md
@@ -35,11 +35,13 @@ to do authentication, from the SP (service provider) perspective.
 
 ## Attributes
 
-| Name      | Type | Required      | Description |
-| ----------- | ----------- | ----------- | ----------- |
-| `idp_uri`      | string       | True      | URI of IdP.       |
-| `cas_callback_uri`      | string       | True      | redirect uri used to callback the SP from IdP after login or logout.       |
-| `logout_uri`      | string       | True      | logout uri to trigger logout.       |
+| Name               | Type    | Required | Default        | Description |
+| ------------------ | ------- | -------- | -------------- |
+| `idp_uri`          | string  | True     |                | URI of IdP.                                                                                                           |
+| `cas_callback_uri` | string  | True     |                | Redirect uri used to callback the SP from IdP after login or logout.                                                  |
+| `logout_uri`       | string  | True     |                | Logout uri to trigger logout.                                                                                         |
+| `set_user_header`  | boolean | False    | true           | When set to true, sets the logged-in user in a request header. By default, the `X-Proxy-User` request header is used. |
+| `user_header`      | string  | False    | "X-Proxy-User" | Overrides the header name used by the `set_user_header` attribute.                                                    |                                                                                        
 
 ## Enable Plugin
 


### PR DESCRIPTION
### Description

The cas-auth plugin is great, but does not currently support retrieving the logged-in user from upstreams, making it really hard to do any kind of access control appart from "a user is logged-in".

This PR adds the `set_user_header` and `user_header` attributes that enables setting the logged-in user in a header, and allows for the header's name customization.

Some users have already asked for it.

As far as backward compatibility is concerned:  The header is set by default, so one might experience issues if setting the header before reaching apisix... which would make little sense considering apisix handles the authentication.

Fixes #9524.


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
