### PR TITLE
fix: etcd sync data checker should work

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -677,7 +677,7 @@ local function sync_data(self)
             data_valid, err = self.checker(res.value)
             if not data_valid then
                 log.error("failed to check item data of [", self.key,
-                            "] err:", err, " ,val: ", json.delay_encode(res.value))
+                          "] err:", err, " ,val: ", json.delay_encode(res.value))
             end
         end
 

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -671,13 +671,13 @@ local function sync_data(self)
                 log.error("failed to check item data of [", self.key,
                           "] err:", err, " ,val: ", json.encode(res.value))
             end
+        end
 
-            if data_valid and self.checker then
-                data_valid, err = self.checker(res.value)
-                if not data_valid then
-                    log.error("failed to check item data of [", self.key,
-                              "] err:", err, " ,val: ", json.delay_encode(res.value))
-                end
+        if data_valid and res.value and self.checker then
+            data_valid, err = self.checker(res.value)
+            if not data_valid then
+                log.error("failed to check item data of [", self.key,
+                            "] err:", err, " ,val: ", json.delay_encode(res.value))
             end
         end
 

--- a/t/plugin/error-log-logger-clickhouse.t
+++ b/t/plugin/error-log-logger-clickhouse.t
@@ -98,7 +98,7 @@ done
 --- error_log
 this is a warning message for test2
 clickhouse body: INSERT INTO t FORMAT JSONEachRow
-clickhouse headers: x-clickhouse-key:dpwomMlEsHH2L7wSUi6YiQ==
+clickhouse headers: x-clickhouse-key:a
 clickhouse headers: x-clickhouse-user:default
 clickhouse headers: x-clickhouse-database:default
 --- wait: 3
@@ -133,7 +133,7 @@ clickhouse headers: x-clickhouse-database:default
 --- error_log
 this is a warning message for test3
 clickhouse body: INSERT INTO t FORMAT JSONEachRow
-clickhouse headers: x-clickhouse-key:dpwomMlEsHH2L7wSUi6YiQ==
+clickhouse headers: x-clickhouse-key:a
 clickhouse headers: x-clickhouse-user:default
 clickhouse headers: x-clickhouse-database:default
 --- wait: 5

--- a/t/plugin/sls-logger.t
+++ b/t/plugin/sls-logger.t
@@ -472,3 +472,60 @@ hello world
     }
 --- error_log
 "body":"hello world\n"
+
+
+
+=== TEST 16: set incorrect plugin metadata, should have error log
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local key = "/plugin_metadata/sls-logger"
+            local val = {
+                id = "sls-logger",
+                log_format = "bad plugin metadata"
+            }
+            local _, err = core.etcd.set(key, val)
+            if err then
+                ngx.say(err)
+                return
+            end
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+--- error_log
+sync_data(): failed to check item data of [/apisix/plugin_metadata]
+failed to check the configuration of plugin sls-logger
+
+
+
+=== TEST 17: set correct plugin metadata, should no error log
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local key = "/plugin_metadata/sls-logger"
+            local val = {
+                id = "sls-logger",
+                log_format = {
+                    host = "$host",
+                    client_ip = "$remote_addr"
+                }
+            }
+            local _, err = core.etcd.set(key, val)
+            if err then
+                ngx.say(err)
+                return
+            end
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+--- no_error_log


### PR DESCRIPTION
Signed-off-by: ashing <axingfly@gmail.com>

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes https://github.com/apache/apisix/issues/11216

fix part 2 of this issue

## Background

the `load_full_data` function in the file `config_etcd.lua`(load all exist data from etcd when apisix start), `checker` does not depend on `item_schema` to have a value

https://github.com/apache/apisix/blob/507df1262de88c4ed3ee8a637de46c4f4d2412f8/apisix/core/config_etcd.lua#L540-L546

But in the `sync_data` function (watch new events from etcd when apisix running), `checker` relies on `item_schema` should have value.

https://github.com/apache/apisix/blob/507df1262de88c4ed3ee8a637de46c4f4d2412f8/apisix/core/config_etcd.lua#L668

As a result, the plugin metadata resource cannot reach the checker logic when etcd watch.

https://github.com/apache/apisix/blob/507df1262de88c4ed3ee8a637de46c4f4d2412f8/apisix/plugin.lua#L816-L821

So we need to fix it.

###  about the test case:

The admin api is not used for the operation, because the admin api will directly fail to verify the schema and cannot go to the etcd checker logic.

error-log-logger-clickhouse.t: The request header sent to clickhouse should be decrypted to be correct. 
There was a problem with the previous modification of this PR 
https://github.com/apache/apisix/pull/11076/files#diff-2974594095136be865db5d415f3da92d2a435211e30f93f693f1ed46a4a90037


PS: This PR is a partial fork of https://github.com/apache/apisix/pull/11430.

### about failed CI

My PR changes have nothing to do with this CI error. The reason for the error is a problem with the image version used by the github runner.

<img width="453" alt="image" src="https://github.com/user-attachments/assets/23907f33-e9c2-47e3-a9db-d2abb73e4c26">

ref: https://github.com/apache/apisix/actions/runs/10193727573/job/28202213850?pr=11457

- The correct github runner image version is as follows,

<img width="453" alt="image" src="https://github.com/user-attachments/assets/32cb1316-36e2-49a6-81ec-b8227dfa2ab5">

ref: https://github.com/apache/apisix/actions/runs/10193727573/job/28202215238?pr=11457

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
