### PR TITLE
fix: plugins cors allow_origins is "**" work does not meet expectations

### DIFF
--- a/apisix/plugins/cors.lua
+++ b/apisix/plugins/cors.lua
@@ -248,7 +248,8 @@ end
 local function process_with_allow_origins(allow_origin_type, allow_origins, ctx, req_origin,
                                           cache_key, cache_version)
     if allow_origins == "**" then
-        allow_origins = '*'
+        allow_origins = req_origin or '*'
+        return allow_origins
     end
 
     local multiple_origin, err

--- a/apisix/plugins/cors.lua
+++ b/apisix/plugins/cors.lua
@@ -248,7 +248,7 @@ end
 local function process_with_allow_origins(allow_origin_type, allow_origins, ctx, req_origin,
                                           cache_key, cache_version)
     if allow_origins == "**" then
-        allow_origins = req_origin or '*'
+        allow_origins = '*'
     end
 
     local multiple_origin, err


### PR DESCRIPTION
### Description

Resolved an issue where the cross-origin plugin did not function correctly when the plugin configuration allow_origins = "**" and an exceptional request header Origin contained a comma (",").

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
