### PR TITLE
fix: confusion when substituting ENV in config file

### DIFF
--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -696,7 +696,7 @@ Please modify "admin_key" in conf/config.yaml .
 
         for name, value in pairs(exported_vars) do
             if value then
-                table_insert(sys_conf["envs"], name .. "=" .. value)
+                table_insert(sys_conf["envs"], name)
             end
         end
     end

--- a/t/cli/cli_envsubst_confusion.t
+++ b/t/cli/cli_envsubst_confusion.t
@@ -1,0 +1,111 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+
+$ENV{SOME_STRING_VALUE_BUT_DIFFERENT} = 'astringvaluebutdifferent';
+$ENV{SOME_STRING_VALUE} = 'astringvalue';
+
+our $yaml_config = <<_EOC_;
+apisix:
+  node_listen: 1984
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+_EOC_
+
+our $apisix_yaml = <<_EOC_;
+upstreams:
+  - id: 1
+    nodes:
+      - host: 127.0.0.1
+        port: 1980
+        weight: 1
+routes:
+  - uri: /hello
+    upstream_id: 1
+    plugins:
+      response-rewrite:
+        headers:
+          set:
+            X-Some-String-Value-But-Different: Different \${{SOME_STRING_VALUE_BUT_DIFFERENT}}
+            X-Some-String-Value: \${{SOME_STRING_VALUE}}
+#END
+_EOC_
+
+our $response_headers_correct = <<_EOC_;
+X-Some-String-Value-But-Different: Different astringvaluebutdifferent
+X-Some-String-Value: astringvalue
+_EOC_
+
+our $response_headers_INCORRECT = <<_EOC_;
+X-Some-String-Value-But-Different: Different astringvalue
+X-Some-String-Value: astringvalue
+_EOC_
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!$block->request) {
+        $block->set_value("request", "GET /hello");
+    }
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: assignment style, the PREFIX 1st - incorrect
+--- main_config
+env SOME_STRING_VALUE=astringvalue;
+env SOME_STRING_VALUE_BUT_DIFFERENT=astringvaluebutdifferent;
+--- yaml_config eval: $::yaml_config
+--- apisix_yaml eval: $::apisix_yaml
+--- response_headers eval: $::response_headers_INCORRECT
+
+
+
+=== TEST 2: assignment style, the DIFF 1st - correct
+--- main_config
+env SOME_STRING_VALUE_BUT_DIFFERENT=astringvaluebutdifferent;
+env SOME_STRING_VALUE=astringvalue;
+--- yaml_config eval: $::yaml_config
+--- apisix_yaml eval: $::apisix_yaml
+--- response_headers eval: $::response_headers_correct
+
+
+
+=== TEST 3: declaration style, the PREFIX 1st - correct
+--- main_config
+env SOME_STRING_VALUE;
+env SOME_STRING_VALUE_BUT_DIFFERENT;
+--- yaml_config eval: $::yaml_config
+--- apisix_yaml eval: $::apisix_yaml
+--- response_headers eval: $::response_headers_correct
+
+
+
+=== TEST 4: declaration style, the DIFF 1st - also correct
+--- main_config
+env SOME_STRING_VALUE_BUT_DIFFERENT;
+env SOME_STRING_VALUE;
+--- yaml_config eval: $::yaml_config
+--- apisix_yaml eval: $::apisix_yaml
+--- response_headers eval: $::response_headers_correct

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -348,7 +348,7 @@ deployment:
 
 ETCD_HOST=127.0.0.1 ETCD_PORT=2379 make init
 
-if ! grep "env ETCD_HOST=127.0.0.1;" conf/nginx.conf > /dev/null; then
+if ! grep "env ETCD_HOST;" conf/nginx.conf > /dev/null; then
     echo "failed: support environment variables in local_conf"
     exit 1
 fi
@@ -369,7 +369,7 @@ nginx_config:
 
 ETCD_HOST=127.0.0.1 ETCD_PORT=2379 make init
 
-if grep "env ETCD_HOST=127.0.0.1;" conf/nginx.conf > /dev/null; then
+if grep "env ETCD_HOST;" conf/nginx.conf > /dev/null; then
     echo "failed: support environment variables in local_conf"
     exit 1
 fi
@@ -394,12 +394,12 @@ nginx_config:
 
 ETCD_HOST=127.0.0.1 ETCD_PORT=2379 make init
 
-if grep "env ETCD_HOST=127.0.0.1;" conf/nginx.conf > /dev/null; then
+if grep "env ETCD_HOST;" conf/nginx.conf > /dev/null; then
     echo "failed: support environment variables in local_conf"
     exit 1
 fi
 
-if ! grep "env ETCD_HOST=1.1.1.1;" conf/nginx.conf > /dev/null; then
+if ! grep "env ETCD_HOST;" conf/nginx.conf > /dev/null; then
     echo "failed: support environment variables in local_conf"
     exit 1
 fi
@@ -414,7 +414,7 @@ tests:
 
 make init
 
-if ! grep "env TEST_ENV=1.1.1.1;" conf/nginx.conf > /dev/null; then
+if ! grep "env TEST_ENV;" conf/nginx.conf > /dev/null; then
     echo "failed: should use default value when environment not set"
     exit 1
 fi
@@ -426,7 +426,7 @@ tests:
 
 make init
 
-if ! grep "env TEST_ENV=very-long-domain-with-many-symbols.absolutely-non-exists-123ss.com:1234/path?param1=value1;" conf/nginx.conf > /dev/null; then
+if ! grep "env TEST_ENV;" conf/nginx.conf > /dev/null; then
     echo "failed: should use default value when environment not set"
     exit 1
 fi
@@ -438,7 +438,7 @@ tests:
 
 TEST_ENV=127.0.0.1 make init
 
-if ! grep "env TEST_ENV=127.0.0.1;" conf/nginx.conf > /dev/null; then
+if ! grep "env TEST_ENV;" conf/nginx.conf > /dev/null; then
     echo "failed: should use environment variable when environment is set"
     exit 1
 fi

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -394,12 +394,12 @@ nginx_config:
 
 ETCD_HOST=127.0.0.1 ETCD_PORT=2379 make init
 
-if grep "env ETCD_HOST=.*;" conf/nginx.conf > /dev/null; then
+if grep "env ETCD_HOST;" conf/nginx.conf > /dev/null; then
     echo "failed: support environment variables in local_conf"
     exit 1
 fi
 
-if ! grep "env ETCD_HOST;" conf/nginx.conf > /dev/null; then
+if ! grep "env ETCD_HOST=1.1.1.1;" conf/nginx.conf > /dev/null; then
     echo "failed: support environment variables in local_conf"
     exit 1
 fi

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -369,7 +369,7 @@ nginx_config:
 
 ETCD_HOST=127.0.0.1 ETCD_PORT=2379 make init
 
-if grep "env ETCD_HOST;" conf/nginx.conf > /dev/null; then
+if grep "env ETCD_HOST=.*;" conf/nginx.conf > /dev/null; then
     echo "failed: support environment variables in local_conf"
     exit 1
 fi
@@ -394,7 +394,7 @@ nginx_config:
 
 ETCD_HOST=127.0.0.1 ETCD_PORT=2379 make init
 
-if grep "env ETCD_HOST;" conf/nginx.conf > /dev/null; then
+if grep "env ETCD_HOST=.*;" conf/nginx.conf > /dev/null; then
     echo "failed: support environment variables in local_conf"
     exit 1
 fi

--- a/t/cli/test_standalone.sh
+++ b/t/cli/test_standalone.sh
@@ -54,7 +54,7 @@ routes:
 # check for resolve variables
 var_test_path=/test make init
 
-if ! grep "env var_test_path=/test;" conf/nginx.conf > /dev/null; then
+if ! grep "env var_test_path;" conf/nginx.conf > /dev/null; then
     echo "failed: failed to resolve variables"
     exit 1
 fi


### PR DESCRIPTION
### Description

Fixes #11121
Fixes #11239

1. Import environment variables with the same prefix to Nginx using assignment style
2. In the `init_by_lua` phase
3. There will be confusion issues

```
use Test::Nginx::Socket 'no_plan';

master_on();
repeat_each(1);

our $prefix = "prefix";
our $longer = "longer";
$ENV{TEST_ENV_SAME_PREFIX} = $prefix;
$ENV{TEST_ENV_SAME_PREFIX_LONGER} = $longer;

add_block_preprocessor(sub {
    my ($block) = @_;

    if (!$block->request) {
        $block->set_value("request", "GET /t");
    }

    my $config = $block->config // "";
    $config .= <<_EOC_;
    location = /t {
    	content_by_lua_block {
            local prefix = os.getenv("TEST_ENV_SAME_PREFIX")                 
            local longer = os.getenv("TEST_ENV_SAME_PREFIX_LONGER")
            assert(prefix == "$::prefix" and longer == "$::longer")
        }
	}
_EOC_

    $block->set_value("config", $config);
});

run_tests();

__DATA__

=== TEST 1: assignment style, the PREFIX 1st - incorrect
--- main_config eval
qq/
env TEST_ENV_SAME_PREFIX=$::prefix;
env TEST_ENV_SAME_PREFIX_LONGER=$::longer;
/
--- http_config eval
qq/
    init_by_lua_block {
        local prefix = os.getenv("TEST_ENV_SAME_PREFIX")                 
        local longer = os.getenv("TEST_ENV_SAME_PREFIX_LONGER")
        assert(prefix == "$::prefix" and longer == "$::prefix")
    }
/



=== TEST 2: assignment style, the LONGER 1st - correct
--- main_config eval
qq/
env TEST_ENV_SAME_PREFIX_LONGER=$::longer;
env TEST_ENV_SAME_PREFIX=$::prefix;
/
--- http_config eval
qq/
    init_by_lua_block {
        local prefix = os.getenv("TEST_ENV_SAME_PREFIX")                 
        local longer = os.getenv("TEST_ENV_SAME_PREFIX_LONGER")
        assert(prefix == "$::prefix" and longer == "$::longer")
    }
/

    

=== TEST 3: declaration style, the LONGER 1st - correct
--- main_config
env TEST_ENV_SAME_PREFIX_LONGER;
env TEST_ENV_SAME_PREFIX;
--- http_config eval
qq/
    init_by_lua_block {
        local prefix = os.getenv("TEST_ENV_SAME_PREFIX")                 
        local longer = os.getenv("TEST_ENV_SAME_PREFIX_LONGER")
        assert(prefix == "$::prefix" and longer == "$::longer")
    }
/
    


=== TEST 4: declaration style, the PREFIX 1st - also correct
--- main_config
env TEST_ENV_SAME_PREFIX;
env TEST_ENV_SAME_PREFIX_LONGER;
--- http_config eval    
qq/
    init_by_lua_block {
        local prefix = os.getenv("TEST_ENV_SAME_PREFIX")                 
        local longer = os.getenv("TEST_ENV_SAME_PREFIX_LONGER")
        assert(prefix == "$::prefix" and longer == "$::longer")
    }
/
```


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
4. Always update the documentation to reflect the changes made in the PR.
5. Make a new commit to resolve conversations instead of `push -f`.
6. To resolve merge conflicts, merge master instead of rebasing.
7. Use "request review" to notify the reviewer after making changes.
8. Only a reviewer can mark a conversation as resolved.

-->
