### PR TITLE
fix(ci): foo.com is no longer a bad gateway

### DIFF
--- a/t/plugin/traffic-split3.t
+++ b/t/plugin/traffic-split3.t
@@ -285,7 +285,6 @@ passed
 === TEST 8: domain name resolved successfully
 --- request
 GET /server_port
---- error_code: 502
 --- error_log eval
 qr/dns resolver domain: foo.com to \d+.\d+.\d+.\d+/
 

--- a/t/plugin/traffic-split3.t
+++ b/t/plugin/traffic-split3.t
@@ -287,7 +287,7 @@ passed
 GET /server_port
 --- error_code: 502
 --- error_log eval
-qr/dns resolver domain: foo.com to \d+.\d+.\d+.\d+/
+qr/dns resolver domain: test.com to \d+.\d+.\d+.\d+/
 
 
 

--- a/t/plugin/traffic-split3.t
+++ b/t/plugin/traffic-split3.t
@@ -251,7 +251,7 @@ location /t {
                                         name = "upstream_A",
                                         type = "roundrobin",
                                         nodes = {
-                                            {host = "foo.com", port = 80, weight = 0}
+                                            {host = "test.com", port = 80, weight = 0}
                                         }
                                     },
                                     weight = 2
@@ -285,7 +285,7 @@ passed
 === TEST 8: domain name resolved successfully
 --- request
 GET /server_port
---- error_code: 302
+--- error_code: 502
 --- error_log eval
 qr/dns resolver domain: foo.com to \d+.\d+.\d+.\d+/
 

--- a/t/plugin/traffic-split3.t
+++ b/t/plugin/traffic-split3.t
@@ -285,6 +285,7 @@ passed
 === TEST 8: domain name resolved successfully
 --- request
 GET /server_port
+--- error_code: 302
 --- error_log eval
 qr/dns resolver domain: foo.com to \d+.\d+.\d+.\d+/
 


### PR DESCRIPTION
### Description

foo.com used in traffic split test is a valid domain now and sending plain http request will yield `302` status code instead of `502`.
https://github.com/apache/apisix/actions/runs/10823712557/job/30029684940?pr=11499#step:21:380

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
