### PR TITLE
feat: aws-auth plugin

### DIFF
--- a/apisix/cli/config.lua
+++ b/apisix/cli/config.lua
@@ -198,6 +198,7 @@ local _M = {
     "multi-auth",
     "openid-connect",
     "cas-auth",
+    "aws-auth",
     "authz-casbin",
     "authz-casdoor",
     "wolf-rbac",

--- a/apisix/plugins/aws-auth.lua
+++ b/apisix/plugins/aws-auth.lua
@@ -1,0 +1,530 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+local require              = require
+local ngx                  = ngx
+local ngx_time             = ngx.time
+local ngx_re               = require("ngx.re")
+local ngx_re_split         = ngx_re.split
+local ngx_re_match         = ngx.re.match
+local abs                  = math.abs
+local core                 = require("apisix.core")
+local core_schema          = require("apisix.core.schema")
+local consumer             = require("apisix.consumer")
+local pairs                = pairs
+local ipairs               = ipairs
+
+local utils                = require("apisix.plugins.aws-auth.utils")
+
+local HOST_KEY             = "Host"
+local ALGORITHM_KEY        = "X-Amz-Algorithm"
+local CREDENTIAL_KEY       = "X-Amz-Credential"
+local DATE_KEY             = "X-Amz-Date"
+local SIGNED_HEADERS_KEY   = "X-Amz-SignedHeaders"
+local SIGNATURE_KEY        = "X-Amz-Signature"
+local EXPIRES_KEY          = "X-Amz-Expires"
+local plugin_name          = "aws-auth"
+local DEFAULT_MAX_REQ_BODY = 1024 * 512
+local DEFAULT_CLOCK_SKEW   = 60 * 15
+local DEFAULT_MAX_EXPIRES  = 60 * 60 * 24 * 7
+local ALGO                 = "AWS4-HMAC-SHA256"
+
+
+--- @class Config
+--- @field host string?
+--- @field region string?
+--- @field service string?
+--- @field clock_skew integer?
+--- @field extra_must_sign_headers string[]?
+--- @field max_req_body integer?
+--- @field enable_header_method boolean?
+--- @field enable_query_string_method boolean?
+--- @field max_expires integer?
+--- @field keep_unsigned_headers boolean?
+
+local schema = {
+    type = "object",
+    properties = {
+        host                       = {
+            type = "string",
+            title = "Host to validate. Without validate if not provided.",
+            default = nil,
+        },
+        region                     = {
+            type = "string",
+            title = "Region to validate. Without validate if not provided.",
+            default = nil,
+        },
+        service                    = {
+            type    = "string",
+            title   = "Service to validate. Without validate if not provided.",
+            default = nil,
+        },
+        clock_skew                 = {
+            type    = "integer",
+            title   = "Clock skew allowed by the signature in seconds. "
+                .. "The default value is 900 seconds (15 minutes). "
+                .. "If `X-Amz-Date` is not in `must_sign_headers` parameter, an error will occur. "
+                .. "Setting it to 0 will skip checking the date (UNSAFE).",
+            default = DEFAULT_CLOCK_SKEW
+        },
+        extra_must_sign_headers    = {
+            type    = "array",
+            items   = {
+                type = "string"
+            },
+            title   = "The Request Headers that must be signed. "
+                .. "Case insensitive.",
+            default = nil
+        },
+        max_req_body               = {
+            type    = "integer",
+            title   = "Max request body size. "
+                .. "The default value is 512 KB.",
+            default = DEFAULT_MAX_REQ_BODY,
+        },
+        enable_header_method       = {
+            type    = "boolean",
+            title   =
+                "Enable [HTTP authorization header](https://docs.aws.amazon.com/IAM/latest/UserGuide/aws-signing-authentication-methods.html#aws-signing-authentication-methods-http) method. "
+                .. "The default is true.",
+            default = true,
+        },
+        enable_query_string_method = {
+            type    = "boolean",
+            title   =
+                "Enable [Query string parameters](https://docs.aws.amazon.com/IAM/latest/UserGuide/aws-signing-authentication-methods.html#aws-signing-authentication-methods-query) method. "
+                .. "The default is true.",
+            default = true,
+        },
+        max_expires                = {
+            type    = "integer",
+            title   = "Sets the maximum value allowed for the `X-Amz-Expires` parameter. "
+                .. "The default value is 604800 seconds (7 days). "
+                .. "Setting it to 0 will skip checking exprires limit (UNSAFE).",
+            default = DEFAULT_MAX_EXPIRES,
+        },
+        keep_unsigned_headers      = {
+            type    = "boolean",
+            title   = "Whether to keep the Unsigned Request Header. "
+                .. "The default is false.",
+            default = false,
+        },
+    },
+}
+
+
+--- @class ConsumerConfig
+--- @field access_key string?
+--- @field secret_key string?
+
+local consumer_schema = {
+    type           = "object",
+    properties     = {
+        access_key = {
+            type = "string",
+        },
+        secret_key = {
+            type = "string",
+        },
+    },
+    encrypt_fields = { "access_key", "secret_key" },
+    required       = { "access_key", "secret_key" },
+}
+
+
+local _M = {
+    version         = 0.1,
+    priority        = 50,
+    type            = 'auth',
+    name            = plugin_name,
+    schema          = schema,
+    consumer_schema = consumer_schema,
+}
+
+
+--- check_schema
+---
+--- @param conf Config|ConsumerConfig|unknown
+--- @param schema_type integer
+--- @return boolean ok, string? err
+function _M.check_schema(conf, schema_type)
+    core.log.info("input conf: ", core.json.delay_encode(conf))
+
+    if schema_type == core_schema.TYPE_CONSUMER then
+        return core_schema.check(consumer_schema, conf)
+    else
+        return core_schema.check(schema, conf)
+    end
+end
+
+--- parse_credential
+---
+--- @param cred_str string e.g. AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request
+--- @return Credential|nil credential, string|nil err
+local function parse_credential(cred_str)
+    local credential_data = ngx_re_split(cred_str, "/")
+    if (not credential_data) or #credential_data ~= 5 then
+        return nil, "Bad Credential"
+    end
+
+    --- @class Credential
+    --- @field access_key string e.g. AKIAIOSFODNN7EXAMPLE
+    --- @field date string e.g. 20130524
+    --- @field region string e.g. us-east-1
+    --- @field service string e.g. s3
+    local credential = {
+        access_key = credential_data[1],
+        date       = credential_data[2],
+        region     = credential_data[3],
+        service    = credential_data[4],
+    }
+
+    if (not credential.access_key) or #credential.access_key == 0 then
+        return nil, "access key missing"
+    end
+
+    if (not credential.date) or #credential.date == 0 then
+        return nil, "date missing"
+    end
+
+    if (not credential.region) or #credential.region == 0 then
+        return nil, "region missing"
+    end
+
+    if (not credential.service) or #credential.service == 0 then
+        return nil, "service missing"
+    end
+
+    local credential_aws4_request = credential_data[5]
+    if (not credential_aws4_request) or credential_aws4_request ~= "aws4_request" then
+        return nil, "Credential should be scoped with a valid terminator: 'aws4_request'"
+    end
+
+    return credential
+end
+
+
+--- get_params
+---
+--- @param ctx unknown
+--- @param conf unknown
+--- @return Parameters?, string? err
+local function get_params(ctx, conf)
+    --- @class Parameters
+    --- @field host string the request host
+    --- @field method string the request method
+    --- @field uri string the request uri
+    --- @field query_string table<string, string?> the request query string
+    --- @field headers table<string, string?> the request headers
+    --- @field body string|nil the request body
+    --- @field algorithm string X-Amz-Algorithm, must be "AWS4-HMAC-SHA256"
+    --- @field credential Credential
+    --- @field signed_headers string[] X-Amz-SignedHeaders, Header is Lowercase
+    --- @field signed_headers_map table<string, string> X-Amz-SignedHeaders, Key is Lowercase
+    --- @field signature string X-Amz-Signature
+    --- @field expires integer? X-Amz-Expires
+    --- @field is_query_string_method boolean
+    --- @field date string X-Amz-Date
+    local params = {
+        host         = core.request.get_host(),
+        method       = core.request.get_method(ctx),
+        uri          = ctx.var.uri,
+        query_string = core.request.get_uri_args(ctx),
+        headers      = core.request.headers(ctx),
+    }
+
+    if conf.max_req_body and conf.max_req_body > 0 then
+        local err
+        params.body, err = core.request.get_body(conf.max_req_body, ctx)
+        if err then
+            return nil, "Exceed body limit size"
+        end
+    end
+
+    local signed_headers_str -- e.g. host;range;x-amz-content-sha256;x-amz-date
+    local credential_str     -- e.g. AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,
+    if conf.enable_header_method and params.headers["Authorization"] then
+        -- Using the Authorization Header
+        -- e.g. AWS4-HMAC-SHA256
+        --      Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,
+        --      SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,
+        --      Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+        local auth_header_str = params.headers["Authorization"]
+        if #auth_header_str == 0 then
+            return nil, "Authorization header cannot be empty: '" .. auth_header_str .. "'"
+        end
+        local auth_data = ngx_re_match(auth_header_str,
+            [[([\w\-]+) (?:(?:Credential=([\w\-\/]+)|SignedHeaders=([\w;\-]+)|Signature=([\w\d]+))[, ]*)+]], "oj")
+        if (not auth_data) or #auth_data ~= 4 then
+            return nil, "Bad Authorization Header"
+        end
+
+        params.algorithm              = auth_data[1]
+        credential_str                = auth_data[2]
+        signed_headers_str            = auth_data[3]
+        params.signature              = auth_data[4]
+
+        params.is_query_string_method = false
+    elseif conf.enable_query_string_method and params.query_string[ALGORITHM_KEY] then
+        -- Using Query Parameters
+        params.algorithm   = params.query_string[ALGORITHM_KEY]
+        credential_str     = params.query_string[CREDENTIAL_KEY]
+        signed_headers_str = params.query_string[SIGNED_HEADERS_KEY]
+        params.signature   = params.query_string[SIGNATURE_KEY]
+
+        core.log.info("params.expires: ", params.expires)
+
+        params.expires                = tonumber(params.query_string[EXPIRES_KEY])
+        params.is_query_string_method = true
+    else
+        return nil, "Missing Authentication Token"
+    end
+
+    if (not credential_str) or #credential_str == 0 then
+        return nil, "Authorization header requires 'Credential' parameter"
+    end
+    local credential, err = parse_credential(credential_str)
+    if err then
+        return nil, err
+    end
+    assert(credential)
+    params.credential = credential
+
+    if (not signed_headers_str) or #signed_headers_str == 0 then
+        return nil, "Authorization header requires 'SignedHeaders' parameter"
+    end
+    local signed_headers, err = ngx_re_split(signed_headers_str, ";")
+    if err then
+        error(err)
+    end
+    assert(signed_headers)
+    params.signed_headers = signed_headers
+    params.signed_headers_map = {}
+    for _, header_name in pairs(params.signed_headers) do
+        params.signed_headers_map[header_name] = params.headers[header_name] or ""
+    end
+
+    if (not params.signature) or #params.signature == 0 then
+        return nil, "Authorization header requires 'Signature' parameter"
+    end
+
+    local date = params.headers[DATE_KEY] or params.query_string[DATE_KEY]
+    if not date then
+        return nil, "Missing header '" .. DATE_KEY .. "'"
+    end
+    params.date = date
+
+    return params, nil
+end
+
+
+--- get_consumer
+---
+--- @param access_key string
+--- @return unknown? consumer, string? error
+local function get_consumer(access_key)
+    if not access_key then
+        return nil, "missing access key"
+    end
+
+    local consumer_conf = consumer.plugin(plugin_name)
+    if not consumer_conf then
+        return nil, "Missing related consumer"
+    end
+
+    local consumers = consumer.consumers_kv(plugin_name, consumer_conf, "access_key")
+    if not consumers then
+        return nil, "The security token included in the request is invalid."
+    end
+    local consumer = consumers[access_key]
+    if not consumer then
+        return nil, "The security token included in the request is invalid."
+    end
+
+    core.log.info("consumer: ", core.json.delay_encode(consumer))
+
+    return consumer, nil
+end
+
+
+--- validate
+---
+--- @param conf Config
+--- @param params Parameters
+--- @return unknown? consumer
+--- @return string? error
+local function validate(conf, params)
+    if params.algorithm ~= ALGO then
+        return nil, "algorithm '" .. params.algorithm .. "' is not supported"
+    end
+
+    if conf.host and #conf.host > 0 then
+        if (not params.host) or params.host ~= conf.host then
+            return nil, "Host dismatch, '" .. params.host .. "'"
+        end
+    end
+
+    if conf.region and #conf.region > 0 then
+        if (not params.credential.region) or params.credential.region ~= conf.region then
+            return nil, "Credential should be scoped to a valid Region, not '" .. params.credential.region .. "'"
+        end
+    end
+
+    if conf.service and #conf.service > 0 then
+        if (not params.credential.service) or params.credential.service ~= conf.service then
+            return nil, "Credential should be scoped to correct service: '" .. params.credential.service .. "'"
+        end
+    end
+
+    -- check headers
+    if not params.signed_headers_map[HOST_KEY:lower()] then
+        return nil, "header '" .. HOST_KEY .. "' is not signed"
+    end
+    if not params.signed_headers_map[DATE_KEY:lower()] then
+        if params.headers[DATE_KEY] then -- When X-Amz-Date is from Header (not from Query String)
+            return nil, "header '" .. DATE_KEY .. "' is not signed"
+        end
+    end
+    if conf.extra_must_sign_headers and #conf.extra_must_sign_headers > 0 then
+        for _, must in pairs(conf.extra_must_sign_headers) do
+            if not params.signed_headers_map[must:lower()] then
+                return nil, "extra header '" .. must .. "' must be signed"
+            end
+        end
+    end
+
+    -- check clock skew
+    local now = ngx_time()
+    local time_to_validate = utils.iso8601_to_timestamp(params.date)
+    local skew = now - time_to_validate
+    core.log.info("conf.clock_skew: ", conf.clock_skew)
+    if (conf.clock_skew and conf.clock_skew > 0) then
+        if params.date:sub(1, 8) ~= params.credential.date then
+            return nil, "Date in Credential scope does not match YYYYMMDD from ISO-8601 version of date from HTTP"
+        end
+
+        core.log.info("Clock skew: ", skew .. "=" .. now .. "-" .. time_to_validate)
+        if skew > conf.clock_skew then
+            return nil, "Signature expired: '" .. params.date .. "' is now earlier than '" .. now .. "'"
+        elseif skew < 0 then
+            return nil, "Signature not yet current: '" .. params.date .. "' is still later than '" .. now .. "'"
+        end
+    end
+
+    -- check X-Amz-Expires
+    if params.is_query_string_method then
+        if not params.expires then
+            return nil, "'X-Amz-Expires' is not present"
+        end
+
+        if conf.max_expires and conf.max_expires > 0 then
+            if params.expires > conf.max_expires then
+                return nil, "max_expires limited"
+            end
+        end
+
+        if abs(skew) > params.expires then
+            return nil, "Signature expired: '" .. params.date .. "' is now earlier than '" .. now .. "'"
+        end
+    end
+
+    -- get consumer
+    local consumer, err = get_consumer(params.credential.access_key)
+    if err or (not consumer) then
+        return nil, err
+    end
+
+    -- calc signature
+    local qs_to_signature = {}
+    if params.is_query_string_method then
+        qs_to_signature = {}
+        for _, qs_name in ipairs(params.query_string) do
+            if qs_name ~= ALGORITHM_KEY
+                and qs_name ~= CREDENTIAL_KEY
+                and qs_name ~= DATE_KEY
+                and qs_name ~= EXPIRES_KEY
+                and qs_name ~= SIGNED_HEADERS_KEY
+                and qs_name ~= SIGNATURE_KEY then
+                qs_to_signature[qs_name] = params.headers[qs_name]
+            end
+        end
+    end
+
+    --- @type ConsumerConfig
+    local consumer_auth_conf = consumer.auth_conf
+    local secret_key         = consumer_auth_conf and consumer_auth_conf.secret_key
+    assert(secret_key)
+    local request_signature   = params.signature
+    local generated_signature = utils.generate_signature(
+        params.method,
+        params.uri,
+        qs_to_signature,
+        params.signed_headers_map,
+        params.body,
+        secret_key,
+        time_to_validate,
+        params.credential.region,
+        params.credential.service
+    )
+
+    core.log.info("request_signature: ", request_signature,
+        " generated_signature: ", generated_signature)
+
+    if request_signature ~= generated_signature then
+        return nil, "The request signature we calculated does not match the signature you provided."
+    end
+
+    return consumer
+end
+
+
+--- rewrite
+---
+--- @param conf Config
+--- @param ctx unknown
+--- @return integer? code, table? body
+function _M.rewrite(conf, ctx)
+    local params, err = get_params(ctx, conf)
+    if err then
+        core.log.warn("client request can't be validated: ", err)
+        return 403, { message = err }
+    end
+    assert(params)
+
+    local validated_consumer, err = validate(conf, params)
+    if not validated_consumer then
+        core.log.warn("client request can't be validated: ", err)
+        return 403, { message = err }
+    end
+    core.log.info("validated_consumer: ", core.json.delay_encode(validated_consumer))
+
+    local consumer_conf = consumer.plugin(plugin_name)
+    consumer.attach_consumer(ctx, validated_consumer, consumer_conf)
+    core.log.info("hit aws-auth rewrite")
+
+    -- remove unsigned headers
+    if not conf.keep_unsigned_headers then
+        for key, _ in pairs(params.headers) do
+            if not params.signed_headers_map[key] then
+                core.request.set_header(ctx, key, nil)
+            end
+        end
+    end
+end
+
+return _M

--- a/apisix/plugins/aws-auth.lua
+++ b/apisix/plugins/aws-auth.lua
@@ -150,7 +150,7 @@ local consumer_schema = {
 
 local _M = {
     version         = 0.1,
-    priority        = 50,
+    priority        = 2570,
     type            = 'auth',
     name            = plugin_name,
     schema          = schema,

--- a/apisix/plugins/aws-auth.lua
+++ b/apisix/plugins/aws-auth.lua
@@ -269,11 +269,11 @@ local function get_params(ctx, conf)
         if #auth_header_str == 0 then
             return nil, "Authorization header cannot be empty: '" .. auth_header_str .. "'"
         end
-        local signed_headers_regexp = "SignedHeaders=([\\w;\\-]+)"
         local credential_regexp = "Credential=([\\w\\-\\/]+)"
+        local signed_headers_regexp = "SignedHeaders=([\\w;\\-]+)"
         local signature_regexp = "Signature=([\\w\\d]+)"
-        local regexps = signed_headers_regexp .. "|"
-            .. credential_regexp .. "|"
+        local regexps = credential_regexp .. "|"
+            .. signed_headers_regexp .. "|"
             .. signature_regexp
         local auth_data = ngx_re_match(auth_header_str,
             "([\\w\\-]+) (?:(?:" .. regexps .. ")[, ]*)+",

--- a/apisix/plugins/aws-auth.lua
+++ b/apisix/plugins/aws-auth.lua
@@ -27,6 +27,9 @@ local core_schema          = require("apisix.core.schema")
 local consumer             = require("apisix.consumer")
 local pairs                = pairs
 local ipairs               = ipairs
+local tonumber             = tonumber
+local assert               = assert
+local error                = error
 
 local utils                = require("apisix.plugins.aws-auth.utils")
 

--- a/apisix/plugins/aws-auth/utils.lua
+++ b/apisix/plugins/aws-auth/utils.lua
@@ -28,6 +28,10 @@ local ngx_escape_uri = ngx.escape_uri
 local ngx_re_match   = ngx.re.match
 local ngx_re_gmatch  = ngx.re.gmatch
 local str_strip      = require("pl.stringx").strip
+local assert         = assert
+local error          = error
+local tonumber       = tonumber
+local os             = os
 
 local ALGO           = "AWS4-HMAC-SHA256"
 

--- a/apisix/plugins/aws-auth/utils.lua
+++ b/apisix/plugins/aws-auth/utils.lua
@@ -1,0 +1,305 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+local require        = require
+local hmac           = require("resty.hmac")
+local resty_sha256   = require("resty.sha256")
+local hex_encode     = require("resty.string").to_hex
+local pairs          = pairs
+local tab_concat     = table.concat
+local tab_sort       = table.sort
+local tab_insert     = table.insert
+local ngx            = ngx
+local ngx_escape_uri = ngx.escape_uri
+local ngx_re_match   = ngx.re.match
+local ngx_re_gmatch  = ngx.re.gmatch
+local str_strip      = require("pl.stringx").strip
+
+local ALGO           = "AWS4-HMAC-SHA256"
+
+local _M             = {}
+
+
+--- hmac256_bin
+---
+--- @param key string specifies the key to use when calculating the message authentication code (MAC).
+--- @param msg string
+--- @return string hash_binary
+function _M.hmac256_bin(key, msg)
+    return hmac:new(key, hmac.ALGOS.SHA256):final(msg)
+end
+
+--- sha256
+---
+--- @param msg string
+--- @return string hex lowercase e.g. 2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae
+function _M.sha256(msg)
+    local hash = resty_sha256:new()
+    assert(hash)
+    hash:update(msg)
+    local digest = hash:final()
+    return hex_encode(digest)
+end
+
+--- iso8601_to_timestamp
+---
+--- yyyyMMddTHHmmssZ
+---
+--- e.g. 20160801T223241Z
+--- @param iso8601 string
+--- @return integer timestamp utc
+function _M.iso8601_to_timestamp(iso8601)
+    -- Extract date and time components from the ISO 8601 string
+    local match, err = ngx_re_match(iso8601, [[(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z]], "oj")
+    if err then
+        error(err)
+    end
+
+    -- Create a table compatible with os.time
+    local datetime = {
+        year = tonumber(match[1]),
+        month = tonumber(match[2]),
+        day = tonumber(match[3]),
+        hour = tonumber(match[4]),
+        min = tonumber(match[5]),
+        sec = tonumber(match[6])
+    }
+
+    -- Convert to Unix timestamp
+    local offset = os.time() - os.time(os.date("!*t"))
+    local timestamp = os.time(datetime) + offset
+
+    return timestamp
+end
+
+--- aws_uri_encode
+---
+--- Encode a string for use in the path of a URL; uses URLEncoder.encode,
+--- (which encodes a string for use in the query portion of a URL), then
+--- applies some postfilters to fix things up per the RFC. Can optionally
+--- handle strings which are meant to encode a path (ie include '/'es
+--- which should NOT be escaped).
+--- @param value string the value to encode
+--- @param path boolean true if the value is intended to represent a path
+--- @return string encoded the encoded value
+function _M.aws_uri_encode(value, path)
+    if (not value) or #value == 0 then
+        return ""
+    end
+
+    local encoded = ngx_escape_uri(value)
+
+    -- match
+    -- !
+    -- *
+    -- (
+    -- )
+    -- '
+    -- %2F                 / when path encode
+    --
+    -- other to pass
+    -- (%[A-Z0-9]{2})      uri encoded
+    -- [A-Za-z0-9\-\._\~]  reserved characters
+    local iterator, err = ngx_re_gmatch(encoded, "!|\\*|\\(|\\)|'|%2F|(%[A-Z0-9]{2})|[A-Za-z0-9\\-\\._\\~]", "oj")
+    if not iterator then
+        error(err)
+    end
+
+    local replacement = {}
+
+    while true do
+        local m, err = iterator()
+        if err then
+            error(err)
+        end
+
+        if not m then
+            -- no match found (any more)
+            break
+        end
+
+        -- found a match
+        if m[0] == "!" then
+            tab_insert(replacement, "%21")
+        elseif m[0] == "*" then
+            tab_insert(replacement, "%2A")
+        elseif m[0] == "(" then
+            tab_insert(replacement, "%28")
+        elseif m[0] == ")" then
+            tab_insert(replacement, "%29")
+        elseif m[0] == "'" then
+            tab_insert(replacement, "%27")
+        elseif path and m[0] == "%2F" then
+            tab_insert(replacement, "/")
+        else
+            tab_insert(replacement, m[0])
+        end
+    end
+
+    return tab_concat(replacement)
+end
+
+--- build_canonical_uri
+---
+--- e.g. input "foo///bar" output "/foo/bar"
+--- @param uri string
+--- @return string canonical_uri
+function _M.build_canonical_uri(uri)
+    if uri == "" then
+        return "/"
+    end
+
+    if uri ~= "/" then
+        -- rm suffix slash
+        if uri:sub(-1, -1) == "/" then
+            uri = uri:sub(1, -2)
+        end
+        -- add prefix slash
+        if uri:sub(1, 1) ~= "/" then
+            uri = "/" .. uri
+        end
+    end
+
+    return _M.aws_uri_encode(uri, true)
+end
+
+--- build_canonical_query_string
+---
+--- @param query_string table<string, string>
+--- @return string canonical_query_string
+function _M.build_canonical_query_string(query_string)
+    local canonical_qs_table = {}
+    local canonical_qs_i = 0
+    for k, v in pairs(query_string) do
+        canonical_qs_i = canonical_qs_i + 1
+        canonical_qs_table[canonical_qs_i] = _M.aws_uri_encode(k, false)
+            .. "=" .. _M.aws_uri_encode(v, false)
+    end
+
+    tab_sort(canonical_qs_table)
+    local canonical_qs = tab_concat(canonical_qs_table, "&")
+
+    return canonical_qs
+end
+
+--- build_canonical_headers
+---
+--- @param headers table<string, string>
+--- @return string canonical_headers, string signed_headers
+function _M.build_canonical_headers(headers)
+    local canonical_headers_table, signed_headers_list = {}, {}
+    local signed_headers_i = 0
+    for k, v in pairs(headers) do
+        k = k:lower()
+
+        signed_headers_i = signed_headers_i + 1
+        signed_headers_list[signed_headers_i] = k
+        -- strip starting and trailing spaces including strip multiple spaces into single space
+        canonical_headers_table[k] = str_strip(v)
+    end
+    tab_sort(signed_headers_list)
+
+    for i = 1, #signed_headers_list do
+        local k = signed_headers_list[i]
+        canonical_headers_table[i] = k .. ":" .. canonical_headers_table[k] .. "\n"
+    end
+
+    local canonical_headers = tab_concat(canonical_headers_table, nil)
+    local signed_headers = tab_concat(signed_headers_list, ";")
+
+    return canonical_headers, signed_headers
+end
+
+--- create_signing_key
+--- @param secret_key string
+--- @param datestamp string
+--- @param region string
+--- @param service string
+--- @return string binary
+function _M.create_signing_key(secret_key, datestamp, region, service)
+    local date_key                = _M.hmac256_bin("AWS4" .. secret_key, datestamp)
+    local date_region_key         = _M.hmac256_bin(date_key, region)
+    local date_region_service_key = _M.hmac256_bin(date_region_key, service)
+    local signing_key             = _M.hmac256_bin(date_region_service_key, "aws4_request")
+    return signing_key
+end
+
+--- generate_signature
+---
+--- @param method string
+--- @param uri string
+--- @param query_string table<string, string>? The Request Query String should not include Signature like 'X-Amz-Signature'
+--- @param headers table<string, string>? The Request Headers should not include Signature like 'X-Amz-Signature'
+--- @param body string?
+--- @param secret_key string
+--- @param time integer UTC seconds timestamp
+--- @param region string
+--- @param service string
+--- @return string signature
+function _M.generate_signature(method, uri, query_string, headers, body, secret_key, time, region, service)
+    -- Step 1: Create a canonical request
+
+    -- computing canonical uri
+    local canonical_uri = _M.build_canonical_uri(uri)
+
+    -- computing canonical query string
+    local canonical_qs = ""
+    if query_string then
+        canonical_qs = _M.build_canonical_query_string(query_string)
+    end
+
+    -- computing canonical headers
+    local canonical_headers, signed_headers = "", ""
+    if headers then
+        canonical_headers, signed_headers = _M.build_canonical_headers(headers)
+    end
+
+    -- default no body hash
+    local body_hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    if body and body ~= "" then
+        body_hash = _M.sha256(body)
+    end
+
+    local canonical_request        = method:upper() .. "\n"
+        .. canonical_uri .. "\n"
+        .. (canonical_qs or "") .. "\n"
+        .. canonical_headers .. "\n"
+        .. signed_headers .. "\n"
+        .. body_hash
+
+    -- Step 2: Create a hash of the canonical request
+    local hashed_canonical_request = _M.sha256(canonical_request)
+
+    -- Step 3: Create a string to sign
+    local amzdate                  = os.date("!%Y%m%dT%H%M%SZ", time) -- ISO 8601 20130524T000000Z
+    local datestamp                = os.date("!%Y%m%d", time)         -- Date w/o time, used in credential scope
+
+    local credential_scope         = datestamp .. "/" .. region .. "/" .. service .. "/aws4_request"
+    local string_to_sign           = ALGO .. "\n"
+        .. amzdate .. "\n"
+        .. credential_scope .. "\n"
+        .. hashed_canonical_request
+
+    -- Step 4: Calculate the signature
+    ---@cast datestamp string
+    local signing_key              = _M.create_signing_key(secret_key, datestamp, region, service)
+    local signature                = hex_encode(_M.hmac256_bin(signing_key, string_to_sign))
+
+    return signature
+end
+
+return _M

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -460,6 +460,7 @@ plugins:                           # plugin list (sorted by priority)
   - multi-auth                     # priority: 2600
   - openid-connect                 # priority: 2599
   - cas-auth                       # priority: 2597
+  - aws-auth                       # priority: 2570
   - authz-casbin                   # priority: 2560
   - authz-casdoor                  # priority: 2559
   - wolf-rbac                      # priority: 2555

--- a/t/admin/plugins.t
+++ b/t/admin/plugins.t
@@ -78,6 +78,7 @@ chaitin-waf
 multi-auth
 openid-connect
 cas-auth
+aws-auth
 authz-casbin
 authz-casdoor
 wolf-rbac
@@ -319,7 +320,7 @@ qr/\{"metadata_schema":\{"properties":\{"ikey":\{"minimum":0,"type":"number"\},"
         }
     }
 --- response_body eval
-qr/\[\{"name":"multi-auth","priority":2600\},\{"name":"wolf-rbac","priority":2555\},\{"name":"ldap-auth","priority":2540\},\{"name":"hmac-auth","priority":2530\},\{"name":"basic-auth","priority":2520\},\{"name":"jwt-auth","priority":2510\},\{"name":"jwe-decrypt","priority":2509\},\{"name":"key-auth","priority":2500\}\]/
+qr/\[\{"name":"multi-auth","priority":2600\},{"name":"aws-auth","priority":2570\},\{"name":"wolf-rbac","priority":2555\},\{"name":"ldap-auth","priority":2540\},\{"name":"hmac-auth","priority":2530\},\{"name":"basic-auth","priority":2520\},\{"name":"jwt-auth","priority":2510\},\{"name":"jwe-decrypt","priority":2509\},\{"name":"key-auth","priority":2500\}\]/
 
 
 

--- a/t/plugin/aws-auth.t
+++ b/t/plugin/aws-auth.t
@@ -1,0 +1,484 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+repeat_each(2);
+no_long_string();
+no_root_location();
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: Utils Test: hmac256_bin
+--- config
+location /t {
+    content_by_lua_block {
+        local utils        = require("apisix.plugins.aws-auth.utils")
+        local hex_encode   = require("resty.string").to_hex
+
+        local body = hex_encode(utils.hmac256_bin("foo", "bar"))
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317
+
+
+
+=== TEST 2: Utils Test: sha256
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local body = utils.sha256("Welcome to Amazon S3.")
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072
+
+
+
+=== TEST 3: Utils Test: iso8601_to_timestamp
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local body = utils.iso8601_to_timestamp("20160801T223241Z")
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+1470090761
+
+
+
+=== TEST 4: Utils Test: aws_uri_encode: reserved characters
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local body = utils.aws_uri_encode([[AZaz09-._~]], false)
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+AZaz09-._~
+
+
+
+=== TEST 5: Utils Test: aws_uri_encode: space is reserved characters
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local body = utils.aws_uri_encode(" ", false)
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+%20
+
+
+
+=== TEST 6: Utils Test: aws_uri_encode: expect reserved characters
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local body = utils.aws_uri_encode([[`!@#$%^&*()+=[]\{}|;':",/<>?]] .. "\r" .. "\n", false)
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+%60%21%40%23%24%25%5E%26%2A%28%29%2B%3D%5B%5D%5C%7B%7D%7C%3B%27%3A%22%2C%2F%3C%3E%3F%0D%0A
+
+
+
+=== TEST 7: Utils Test: aws_uri_encode: encode path
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local body = utils.aws_uri_encode("/amzn-s3-demo-bucket/myphoto.jpg", true)
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+/amzn-s3-demo-bucket/myphoto.jpg
+
+
+
+=== TEST 8: Utils Test: build_canonical_uri: mixed (un)reserved characters
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local body = utils.build_canonical_uri("test$file.text")
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+/test%24file.text
+
+
+
+=== TEST 9: Utils Test: build_canonical_uri: empty uri string
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local body = utils.build_canonical_uri("")
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+/
+
+
+
+=== TEST 10: Utils Test: build_canonical_uri: test slash
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local body = utils.build_canonical_uri("hello/")
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+/hello
+
+
+
+=== TEST 11: Utils Test: build_canonical_query_string
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local query_string = {}
+        query_string["prefix"]   = "somePrefix"
+        query_string["marker"]   = "someMarker"
+        query_string["max-keys"] = "20"
+
+        local body = utils.build_canonical_query_string(query_string)
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+marker=someMarker&max-keys=20&prefix=somePrefix
+
+
+
+=== TEST 12: Utils Test: build_canonical_query_string: with empty string value
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local query_string = {}
+        query_string["acl"] = ""
+
+        local body = utils.build_canonical_query_string(query_string)
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+acl=
+
+
+
+=== TEST 13: Utils Test: build_canonical_query_string: with UriEncode
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local query_string = {}
+        query_string["AZaz09-._~"] = " %/="
+
+        local body = utils.build_canonical_query_string(query_string)
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+AZaz09-._~=%20%25%2F%3D
+
+
+
+=== TEST 14: Utils Test: build_canonical_headers: return canonical_headers
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local headers = {}
+        headers["Host"] = "examplebucket.s3.amazonaws.com"
+        headers["Date"] = "Fri, 24 May 2013 00:00:00 GMT"
+        headers["x-amz-date"] = "20130524T000000Z"
+        headers["x-amz-storage-class"] = "REDUCED_REDUNDANCY"
+        headers["x-amz-content-sha256"] = "44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072"
+
+        local r1, r2 = utils.build_canonical_headers(headers)
+        ngx.say(r1)
+    }
+}
+--- request
+GET /t
+--- response_body eval
+"date:Fri, 24 May 2013 00:00:00 GMT
+host:examplebucket.s3.amazonaws.com
+x-amz-content-sha256:44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072
+x-amz-date:20130524T000000Z
+x-amz-storage-class:REDUCED_REDUNDANCY
+
+"
+
+
+
+=== TEST 15: Utils Test: build_canonical_headers: return signed_headers
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local headers = {}
+        headers["Host"] = "examplebucket.s3.amazonaws.com"
+        headers["Date"] = "Fri, 24 May 2013 00:00:00 GMT"
+        headers["x-amz-date"] = "20130524T000000Z"
+        headers["x-amz-storage-class"] = "REDUCED_REDUNDANCY"
+        headers["x-amz-content-sha256"] = "44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072"
+
+        local r1, r2 = utils.build_canonical_headers(headers)
+        ngx.say(r2)
+    }
+}
+--- request
+GET /t
+--- response_body
+date;host;x-amz-content-sha256;x-amz-date;x-amz-storage-class
+
+
+
+=== TEST 16: Utils Test: create_signing_key
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+        local hex_encode   = require("resty.string").to_hex
+
+        local headers = {}
+        headers["Host"] = "examplebucket.s3.amazonaws.com"
+        headers["Date"] = "Fri, 24 May 2013 00:00:00 GMT"
+        headers["x-amz-date"] = "20130524T000000Z"
+        headers["x-amz-storage-class"] = "REDUCED_REDUNDANCY"
+        headers["x-amz-content-sha256"] = "44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072"
+
+        local body = utils.create_signing_key(
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "20130524",
+            "us-east-1",
+            "s3"
+        )
+        body = hex_encode(body)
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+dbb893acc010964918f1fd433add87c70e8b0db6be30c1fbeafefa5ec6ba8378
+
+
+
+=== TEST 17: Utils Test: generate_signature: GET Object
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+        local hex_encode   = require("resty.string").to_hex
+
+        local headers = {}
+        headers["Host"] = "examplebucket.s3.amazonaws.com"
+        headers["Range"] = "bytes=0-9"
+        headers["x-amz-content-sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        headers["x-amz-date"] = "20130524T000000Z"
+
+        local body = utils.generate_signature(
+            "GET",
+            "/test.txt",
+            nil,
+            headers,
+            nil,
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            1369353600,    -- "20130524T000000Z"
+            "us-east-1",
+            "s3"
+        )
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+
+
+
+=== TEST 18: Utils Test: generate_signature: PUT Object
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+        local hex_encode   = require("resty.string").to_hex
+
+        local headers = {}
+        headers["Host"] = "examplebucket.s3.amazonaws.com"
+        headers["Date"] = "Fri, 24 May 2013 00:00:00 GMT"
+        headers["x-amz-date"] = "20130524T000000Z"
+        headers["x-amz-storage-class"] = "REDUCED_REDUNDANCY"
+        headers["x-amz-content-sha256"] = "44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072"
+
+        local body = utils.generate_signature(
+            "PUT",
+            "test$file.text",
+            nil,
+            headers,
+            "Welcome to Amazon S3.",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            1369353600,    -- "20130524T000000Z"
+            "us-east-1",
+            "s3"
+        )
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+98ad721746da40c64f1a55b78f14c238d841ea1380cd77a1b5971af0ece108bd
+
+
+
+=== TEST 19: Utils Test: generate_signature: GET Bucket Lifecycle
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+        local hex_encode   = require("resty.string").to_hex
+
+        local headers = {}
+        headers["Host"] = "examplebucket.s3.amazonaws.com"
+        headers["x-amz-date"] = "20130524T000000Z"
+        headers["x-amz-content-sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+        local query_string = {}
+        query_string["lifecycle"] = ""
+
+        local body = utils.generate_signature(
+            "GET",
+            "",
+            query_string,
+            headers,
+            "",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            1369353600,    -- "20130524T000000Z"
+            "us-east-1",
+            "s3"
+        )
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+fea454ca298b7da1c68078a5d1bdbfbbe0d65c699e0f91ac7a200a0136783543
+
+
+
+=== TEST 20: Utils Test: generate_signature: Get Bucket (List Objects)
+--- config
+location /t {
+    content_by_lua_block {
+        local utils = require("apisix.plugins.aws-auth.utils")
+        local hex_encode   = require("resty.string").to_hex
+
+        local headers = {}
+        headers["Host"] = "examplebucket.s3.amazonaws.com"
+        headers["x-amz-date"] = "20130524T000000Z"
+        headers["x-amz-content-sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+        local query_string = {}
+        query_string["max-keys"] = "2"
+        query_string["prefix"]   = "J"
+
+        local body = utils.generate_signature(
+            "GET",
+            "",
+            query_string,
+            headers,
+            "",
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            1369353600,    -- "20130524T000000Z"
+            "us-east-1",
+            "s3"
+        )
+        ngx.say(body)
+    }
+}
+--- request
+GET /t
+--- response_body
+34b48302e7b5fa45bde8084f4b7868a86f0a534bc59db6670ed5711ef69dc6f7

--- a/t/plugin/aws-auth2.t
+++ b/t/plugin/aws-auth2.t
@@ -1,0 +1,179 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+repeat_each(2);
+no_long_string();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    my $user_yaml_config = <<_EOC_;
+apisix:
+  data_encryption:
+    enable_encrypt_fields: false
+_EOC_
+    $block->set_value("yaml_config", $user_yaml_config);
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: Config Test: sanity
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local plugin = require("apisix.plugins.aws-auth")
+            local ok, err = plugin.check_schema(
+                {
+                    access_key= 'AKIAIOSFODNN7EXAMPLE',
+                    secret_key = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+                },
+                core.schema.TYPE_CONSUMER
+            )
+            if not ok then
+                ngx.say(err)
+            else
+                ngx.say("done")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+
+
+
+=== TEST 2: Config Test: access_key missing
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local plugin = require("apisix.plugins.aws-auth")
+            local ok, err = plugin.check_schema(
+                {
+                    secret_key = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+                },
+                core.schema.TYPE_CONSUMER
+            )
+            if not ok then
+                ngx.say(err)
+            else
+                ngx.say("done")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+property "access_key" is required
+
+
+
+=== TEST 3: Config Test: secret_key missing
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local plugin = require("apisix.plugins.aws-auth")
+            local ok, err = plugin.check_schema(
+                {
+                    access_key= 'AKIAIOSFODNN7EXAMPLE'
+                },
+                core.schema.TYPE_CONSUMER
+            )
+            if not ok then
+                ngx.say(err)
+            else
+                ngx.say("done")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+property "secret_key" is required
+
+
+
+=== TEST 4: Config Test: add consumer with plugin aws-auth
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack",
+                    "plugins": {
+                        "aws-auth": {
+                            "access_key": "AKIAIOSFODNN7EXAMPLE",
+                            "secret_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 5: Config Test: add aws auth plugin using admin api
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "aws-auth": {}
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed

--- a/t/plugin/aws-auth3.t
+++ b/t/plugin/aws-auth3.t
@@ -421,7 +421,7 @@ location /t {
 
         local httpc = http.new()
         local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
-          .. ":" .. ngx.var.server_port .. path
+        .. ":" .. ngx.var.server_port .. path
         local res, err = httpc:request_uri(uri,
             {
                 method = method,
@@ -474,7 +474,7 @@ location /t {
         headers["Host"]                 = "examplebucket.s3.amazonaws.com"
         headers["x-amz-date"]           = amzdate
         headers["x-amz-content-sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-       
+
 
         local signature = utils.generate_signature(
             method,
@@ -505,7 +505,7 @@ location /t {
 
         local httpc = http.new()
         local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
-          .. ":" .. ngx.var.server_port .. path
+        .. ":" .. ngx.var.server_port .. path
         local res, err = httpc:request_uri(uri,
             {
                 method = method,
@@ -588,7 +588,7 @@ location /t {
 
         local httpc = http.new()
         local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
-          .. ":" .. ngx.var.server_port .. path
+        .. ":" .. ngx.var.server_port .. path
         local res, err = httpc:request_uri(uri,
             {
                 method = method,
@@ -666,7 +666,7 @@ location /t {
 
         local httpc = http.new()
         local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
-          .. ":" .. ngx.var.server_port .. path
+        .. ":" .. ngx.var.server_port .. path
         local res, err = httpc:request_uri(uri,
             {
                 method = method,
@@ -749,7 +749,7 @@ location /t {
 
         local httpc = http.new()
         local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
-          .. ":" .. ngx.var.server_port .. path
+        .. ":" .. ngx.var.server_port .. path
         local res, err = httpc:request_uri(uri,
             {
                 method = method,
@@ -833,7 +833,7 @@ location /t {
 
         local httpc = http.new()
         local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
-          .. ":" .. ngx.var.server_port .. path
+        .. ":" .. ngx.var.server_port .. path
         local res, err = httpc:request_uri(uri,
             {
                 method = method,

--- a/t/plugin/aws-auth3.t
+++ b/t/plugin/aws-auth3.t
@@ -1,0 +1,859 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    my $user_yaml_config = <<_EOC_;
+apisix:
+  data_encryption:
+    enable_encrypt_fields: false
+_EOC_
+    $block->set_value("yaml_config", $user_yaml_config);
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: Verify by Header: add consumer with plugin aws-auth
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack",
+                    "plugins": {
+                        "aws-auth": {
+                            "access_key": "AKIAIOSFODNN7EXAMPLE",
+                            "secret_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 2: Verify by Header: add aws auth plugin using admin api
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "aws-auth": {
+                            "region": "us-east-1",
+                            "service": "s3"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 3: Verify by Header: missing header Authentication
+--- request
+GET /hello
+--- error_code: 403
+--- response_body
+{"message":"Missing Authentication Token"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: Missing Authentication Token
+
+
+
+=== TEST 4: Verify by Header: empty Authentication header
+--- request
+GET /hello
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Authorization:
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20130524T000000Z
+--- error_code: 403
+--- response_body
+{"message":"Authorization header cannot be empty: ''"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: Authorization header cannot be empty: ''
+
+
+
+=== TEST 5: Verify by Header: Bad Authorization Header
+--- request
+GET /hello
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Authorization: Bearer XXXXXXXXXXXXXXXXXXX
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20130524T000000Z
+--- error_code: 403
+--- response_body
+{"message":"Bad Authorization Header"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: Bad Authorization Header
+
+
+
+=== TEST 6: Verify by Header: Credential: algorithm mistake
+--- request
+GET /hello
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Authorization: FAKE-ALGO Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20130524T000000Z
+--- error_code: 403
+--- response_body
+{"message":"algorithm 'FAKE-ALGO' is not supported"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: algorithm 'FAKE-ALGO' is not supported
+
+
+
+=== TEST 7: Verify by Header: Credential: access key missing
+--- request
+GET /hello
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Authorization: AWS4-HMAC-SHA256 Credential=/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20130524T000000Z
+--- error_code: 403
+--- response_body
+{"message":"access key missing"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: access key missing
+
+
+
+=== TEST 8: Verify by Header: Credential: date missing
+--- request
+GET /hello
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE//us-east-1/s3/aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20130524T000000Z
+--- error_code: 403
+--- response_body
+{"message":"date missing"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: date missing
+
+
+
+=== TEST 9: Verify by Header: Credential: region missing
+--- request
+GET /hello
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524//s3/aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20130524T000000Z
+--- error_code: 403
+--- response_body
+{"message":"region missing"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: region missing
+
+
+
+=== TEST 10: Verify by Header: Credential: invalid region
+--- request
+GET /hello
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/fake-region/s3/aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20130524T000000Z
+--- error_code: 403
+--- response_body
+{"message":"Credential should be scoped to a valid Region, not 'fake-region'"}
+--- grep_error_log eval
+qr/client request can't be validated: Credential should be scoped to a valid Region, not [^,]+/
+--- grep_error_log_out
+client request can't be validated: Credential should be scoped to a valid Region, not 'fake-region'
+
+
+
+=== TEST 11: Verify by Header: Credential: service missing
+--- request
+GET /hello
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1//aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20130524T000000Z
+--- error_code: 403
+--- response_body
+{"message":"service missing"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: service missing
+
+
+
+=== TEST 12: Verify by Header: Credential: invalid service
+--- request
+GET /hello
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/fake-service/aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20130524T000000Z
+--- error_code: 403
+--- response_body
+{"message":"Credential should be scoped to correct service: 'fake-service'"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: Credential should be scoped to correct service: 'fake-service'
+
+
+
+=== TEST 13: Verify by Header: Credential: invalid terminator
+--- request
+GET /hello
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/not_aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20130524T000000Z
+--- error_code: 403
+--- response_body
+{"message":"Credential should be scoped with a valid terminator: 'aws4_request'"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: Credential should be scoped with a valid terminator: 'aws4_request'
+
+
+
+=== TEST 14: Verify by Header: signed_header: Host missing
+--- request
+GET /hello
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=range;x-amz-content-sha256;x-amz-date,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20130524T000000Z
+--- error_code: 403
+--- response_body
+{"message":"header 'Host' is not signed"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: header 'Host' is not signed
+
+
+
+=== TEST 15: Verify by Header: signed_header: X-Amz-Date missing
+--- request
+GET /hello
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;range;x-amz-content-sha256,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20130524T000000Z
+--- error_code: 403
+--- response_body
+{"message":"header 'X-Amz-Date' is not signed"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: header 'X-Amz-Date' is not signed
+
+
+
+=== TEST 16: Verify by Header: clock_skew: Date in Credential scope is dismatch X-Amz-Date parameter
+--- request
+GET /hello
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+x-amz-date: 20000101T000000Z
+--- error_code: 403
+--- response_body
+{"message":"Date in Credential scope does not match YYYYMMDD from ISO-8601 version of date from HTTP"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: Date in Credential scope does not match YYYYMMDD from ISO-8601 version of date from HTTP
+
+
+
+=== TEST 17: Verify by Header: clock_skew: Signature expired
+--- config
+location /t {
+    content_by_lua_block {
+        local http  = require("resty.http")
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local now       = os.time() - 100000
+        local amzdate   = os.date("!%Y%m%dT%H%M%SZ", now) -- ISO 8601 20130524T000000Z
+        local datestamp = os.date("!%Y%m%d", now)         -- Date w/o time, used in credential scope
+
+        local method     = "GET"
+        local path       = "/hello"
+        local body       = nil
+        local access_key = "AKIAIOSFODNN7EXAMPLE"
+        local secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        local region     = "us-east-1"
+        local service    = "s3"
+        local credential = table.concat({access_key, datestamp, region, service, "aws4_request"}, "/")
+
+        local query_string = {}
+
+        local headers = {}
+        headers["Host"]                 = "examplebucket.s3.amazonaws.com"
+        headers["x-amz-date"]           = amzdate
+        headers["x-amz-content-sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+        local signature = utils.generate_signature(
+            method,
+            path,
+            query_string,
+            headers,
+            body,
+            secret_key,
+            now,
+            region,
+            service
+        )
+
+        local _, signed_headers = utils.build_canonical_headers(headers)
+        headers["Authorization"] = "AWS4-HMAC-SHA256 "
+        .. "Credential=" .. credential .. ","
+        .. "SignedHeaders=" .. signed_headers .. ","
+        .. "Signature=" .. signature
+
+        local query_string_list = {}
+        for k,v in ipairs(query_string) do
+            table.insert(query_string_list, k .. "=" .. v)
+        end
+        local query_string_str = ""
+        if #query_string_list > 0 then
+            query_string_str = "?" .. table.concat(query_string_list, "&")
+        end
+
+        local httpc = http.new()
+        local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
+          .. ":" .. ngx.var.server_port .. path
+        local res, err = httpc:request_uri(uri,
+            {
+                method = method,
+                body = body,
+                keepalive = false,
+                headers = headers,
+                query = query_string
+            }
+        )
+
+        ngx.status = res.status
+        ngx.print(res.body)
+    }
+}
+--- request
+GET /t
+--- error_code: 403
+--- response_body eval
+qr/{"message":"Signature expired: '.+' is now earlier than '.+'"}/
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out eval
+qr/Signature expired: '.+' is now earlier than '.+'/
+
+
+
+=== TEST 18: Verify by Header: clock_skew: Signature in the future
+--- config
+location /t {
+    content_by_lua_block {
+        local http  = require("resty.http")
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local now       = os.time() + 100000
+        local amzdate   = os.date("!%Y%m%dT%H%M%SZ", now) -- ISO 8601 20130524T000000Z
+        local datestamp = os.date("!%Y%m%d", now)         -- Date w/o time, used in credential scope
+
+        local method     = "GET"
+        local path       = "/hello"
+        local body       = nil
+        local access_key = "AKIAIOSFODNN7EXAMPLE"
+        local secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        local region     = "us-east-1"
+        local service    = "s3"
+        local credential = table.concat({access_key, datestamp, region, service, "aws4_request"}, "/")
+
+        local query_string = {}
+
+        local headers = {}
+        headers["Host"]                 = "examplebucket.s3.amazonaws.com"
+        headers["x-amz-date"]           = amzdate
+        headers["x-amz-content-sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+       
+
+        local signature = utils.generate_signature(
+            method,
+            path,
+            query_string,
+            headers,
+            body,
+            secret_key,
+            now,
+            region,
+            service
+        )
+
+        local _, signed_headers = utils.build_canonical_headers(headers)
+        headers["Authorization"] = "AWS4-HMAC-SHA256 "
+        .. "Credential=" .. credential .. ","
+        .. "SignedHeaders=" .. signed_headers .. ","
+        .. "Signature=" .. signature
+
+        local query_string_list = {}
+        for k,v in ipairs(query_string) do
+            table.insert(query_string_list, k .. "=" .. v)
+        end
+        local query_string_str = ""
+        if #query_string_list > 0 then
+            query_string_str = "?" .. table.concat(query_string_list, "&")
+        end
+
+        local httpc = http.new()
+        local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
+          .. ":" .. ngx.var.server_port .. path
+        local res, err = httpc:request_uri(uri,
+            {
+                method = method,
+                body = body,
+                keepalive = false,
+                headers = headers,
+                query = query_string
+            }
+        )
+
+        ngx.status = res.status
+        ngx.print(res.body)
+    }
+}
+--- request
+GET /t
+--- error_code: 403
+--- response_body eval
+qr/{"message":"Signature not yet current: '.+' is still later than '.+'"}/
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out eval
+qr/Signature not yet current: '.+' is still later than '.+'/
+
+
+
+=== TEST 19: Verify by Header: Success
+--- config
+location /t {
+    content_by_lua_block {
+        local http  = require("resty.http")
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local now       = os.time()
+        local amzdate   = os.date("!%Y%m%dT%H%M%SZ", now) -- ISO 8601 20130524T000000Z
+        local datestamp = os.date("!%Y%m%d", now)         -- Date w/o time, used in credential scope
+
+        local method     = "GET"
+        local path       = "/hello"
+        local body       = nil
+        local access_key =  "AKIAIOSFODNN7EXAMPLE"
+        local secret_key =  "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        local region     = "us-east-1"
+        local service    = "s3"
+        local credential = table.concat({access_key, datestamp, region, service, "aws4_request"}, "/")
+
+        local query_string = {}
+
+        local headers = {}
+        headers["Host"] = "examplebucket.s3.amazonaws.com"
+        headers["x-amz-date"] = amzdate
+        headers["x-amz-content-sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+        local signature = utils.generate_signature(
+            method,
+            path,
+            query_string,
+            headers,
+            body,
+            secret_key,
+            now,
+            region,
+            service
+        )
+
+        local _, signed_headers = utils.build_canonical_headers(headers)
+        headers["Authorization"] = "AWS4-HMAC-SHA256 "
+        .. "Credential=" .. credential .. ","
+        .. "SignedHeaders=" .. signed_headers .. ","
+        .. "Signature=" .. signature
+
+        local query_string_list = {}
+        for k,v in ipairs(query_string) do
+            table.insert(query_string_list, k .. "=" .. v)
+        end
+        local query_string_str = ""
+        if #query_string_list > 0 then
+            query_string_str = "?" .. table.concat(query_string_list, "&")
+        end
+
+        local httpc = http.new()
+        local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
+          .. ":" .. ngx.var.server_port .. path
+        local res, err = httpc:request_uri(uri,
+            {
+                method = method,
+                body = body,
+                keepalive = false,
+                headers = headers,
+                query = query_string
+            }
+        )
+
+        ngx.status = res.status
+        ngx.print(res.body)
+    }
+}
+--- request
+GET /t
+--- response_body
+hello world
+
+
+
+=== TEST 20: Verify by Header: Consumer not found
+--- config
+location /t {
+    content_by_lua_block {
+        local http  = require("resty.http")
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local now       = os.time()
+        local amzdate   = os.date("!%Y%m%dT%H%M%SZ", now) -- ISO 8601 20130524T000000Z
+        local datestamp = os.date("!%Y%m%d", now)         -- Date w/o time, used in credential scope
+
+        local method     = "GET"
+        local path       = "/hello"
+        local body       = nil
+        local access_key = "FAKE_ACCESS_KEY"
+        local secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        local region     = "us-east-1"
+        local service    = "s3"
+        local credential = table.concat({access_key, datestamp, region, service, "aws4_request"}, "/")
+
+        local query_string = {}
+
+        local headers = {}
+        headers["Host"] = "examplebucket.s3.amazonaws.com"
+        headers["x-amz-date"] = amzdate
+        headers["x-amz-content-sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+        local signature = utils.generate_signature(
+            method,
+            path,
+            query_string,
+            headers,
+            body,
+            secret_key,
+            now,
+            region,
+            service
+        )
+
+        local _, signed_headers = utils.build_canonical_headers(headers)
+        headers["Authorization"] = "AWS4-HMAC-SHA256 "
+        .. "Credential=" .. credential .. ","
+        .. "SignedHeaders=" .. signed_headers .. ","
+        .. "Signature=" .. signature
+
+        local query_string_list = {}
+        for k,v in ipairs(query_string) do
+            table.insert(query_string_list, k .. "=" .. v)
+        end
+        local query_string_str = ""
+        if #query_string_list > 0 then
+            query_string_str = "?" .. table.concat(query_string_list, "&")
+        end
+
+        local httpc = http.new()
+        local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
+          .. ":" .. ngx.var.server_port .. path
+        local res, err = httpc:request_uri(uri,
+            {
+                method = method,
+                body = body,
+                keepalive = false,
+                headers = headers,
+                query = query_string
+            }
+        )
+
+        ngx.status = res.status
+        ngx.print(res.body)
+    }
+}
+--- request
+GET /t
+--- error_code: 403
+--- response_body
+{"message":"The security token included in the request is invalid."}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: The security token included in the request is invalid.
+
+
+
+=== TEST 21: Verify by Header: Signature Dismatch
+--- config
+location /t {
+    content_by_lua_block {
+        local http  = require("resty.http")
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local now       = os.time()
+        local amzdate   = os.date("!%Y%m%dT%H%M%SZ", now) -- ISO 8601 20130524T000000Z
+        local datestamp = os.date("!%Y%m%d", now)         -- Date w/o time, used in credential scope
+
+        local method     = "GET"
+        local path       = "/hello"
+        local body       = nil
+        local access_key = "AKIAIOSFODNN7EXAMPLE"
+        local secret_key = "FAKE_SECRET_KEY"
+        local region     = "us-east-1"
+        local service    = "s3"
+        local credential = table.concat({access_key, datestamp, region, service, "aws4_request"}, "/")
+
+        local query_string = {}
+
+        local headers = {}
+        headers["Host"] = "examplebucket.s3.amazonaws.com"
+        headers["x-amz-date"] = amzdate
+        headers["x-amz-content-sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+        local signature = utils.generate_signature(
+            method,
+            path,
+            query_string,
+            headers,
+            body,
+            secret_key,
+            now,
+            region,
+            service
+        )
+
+        local _, signed_headers = utils.build_canonical_headers(headers)
+        headers["Authorization"] = "AWS4-HMAC-SHA256 "
+        .. "Credential=" .. credential .. ","
+        .. "SignedHeaders=" .. signed_headers .. ","
+        .. "Signature=" .. signature
+
+        local query_string_list = {}
+        for k,v in ipairs(query_string) do
+            table.insert(query_string_list, k .. "=" .. v)
+        end
+        local query_string_str = ""
+        if #query_string_list > 0 then
+            query_string_str = "?" .. table.concat(query_string_list, "&")
+        end
+
+        local httpc = http.new()
+        local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
+          .. ":" .. ngx.var.server_port .. path
+        local res, err = httpc:request_uri(uri,
+            {
+                method = method,
+                body = body,
+                keepalive = false,
+                headers = headers,
+                query = query_string
+            }
+        )
+
+        ngx.status = res.status
+        ngx.print(res.body)
+    }
+}
+--- request
+GET /t
+--- error_code: 403
+--- response_body
+{"message":"The request signature we calculated does not match the signature you provided."}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: The request signature we calculated does not match the signature you provided.
+
+
+
+=== TEST 22: Verify by Header: Exceed body limit size
+--- config
+location /t {
+    content_by_lua_block {
+        local http  = require("resty.http")
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local now       = os.time()
+        local amzdate   = os.date("!%Y%m%dT%H%M%SZ", now) -- ISO 8601 20130524T000000Z
+        local datestamp = os.date("!%Y%m%d", now)         -- Date w/o time, used in credential scope
+
+        local method     = "GET"
+        local path       = "/hello"
+        local body       = string.rep("A", 1024*1024)
+        local access_key = "AKIAIOSFODNN7EXAMPLE"
+        local secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        local region     = "us-east-1"
+        local service    = "s3"
+        local credential = table.concat({access_key, datestamp, region, service, "aws4_request"}, "/")
+
+        local query_string = {}
+
+        local headers = {}
+        headers["Host"] = "examplebucket.s3.amazonaws.com"
+        headers["x-amz-date"] = amzdate
+        headers["x-amz-content-sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+
+        local signature = utils.generate_signature(
+            method,
+            path,
+            query_string,
+            headers,
+            body,
+            secret_key,
+            now,
+            region,
+            service
+        )
+
+        local _, signed_headers = utils.build_canonical_headers(headers)
+        headers["Authorization"] = "AWS4-HMAC-SHA256 "
+        .. "Credential=" .. credential .. ","
+        .. "SignedHeaders=" .. signed_headers .. ","
+        .. "Signature=" .. signature
+
+        local query_string_list = {}
+        for k,v in ipairs(query_string) do
+            table.insert(query_string_list, k .. "=" .. v)
+        end
+        local query_string_str = ""
+        if #query_string_list > 0 then
+            query_string_str = "?" .. table.concat(query_string_list, "&")
+        end
+
+        local httpc = http.new()
+        local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
+          .. ":" .. ngx.var.server_port .. path
+        local res, err = httpc:request_uri(uri,
+            {
+                method = method,
+                body = body,
+                keepalive = false,
+                headers = headers,
+                query = query_string
+            }
+        )
+
+        ngx.status = res.status
+        ngx.print(res.body)
+    }
+}
+--- request
+GET /t
+--- error_code: 403
+--- response_body
+{"message":"Exceed body limit size"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: Exceed body limit size

--- a/t/plugin/aws-auth4.t
+++ b/t/plugin/aws-auth4.t
@@ -1,0 +1,795 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    my $user_yaml_config = <<_EOC_;
+apisix:
+  data_encryption:
+    enable_encrypt_fields: false
+_EOC_
+    $block->set_value("yaml_config", $user_yaml_config);
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: Verify by Query String: add consumer with plugin aws-auth
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack",
+                    "plugins": {
+                        "aws-auth": {
+                            "access_key": "AKIAIOSFODNN7EXAMPLE",
+                            "secret_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 2: Verify by Query String: add aws auth plugin using admin api
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "aws-auth": {
+                            "region": "us-east-1",
+                            "service": "s3"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 3: Verify by Query String: missing Authentication Query String
+--- request
+GET /hello?
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Range: bytes=0-9
+--- error_code: 403
+--- response_body
+{"message":"Missing Authentication Token"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: Missing Authentication Token
+
+
+
+=== TEST 4: Verify by Query String: Credential: algorithm mistake
+--- request
+GET /hello?X-Amz-Algorithm=FAKE-ALGO&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host;range;x-amz-content-sha256&X-Amz-Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+--- error_code: 403
+--- response_body
+{"message":"algorithm 'FAKE-ALGO' is not supported"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: algorithm 'FAKE-ALGO' is not supported
+
+
+
+=== TEST 5: Verify by Query String: Credential: access key missing
+--- request
+GET /hello?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=/20130524/us-east-1/s3/aws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host;range;x-amz-content-sha256&X-Amz-Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+--- error_code: 403
+--- response_body
+{"message":"access key missing"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: access key missing
+
+
+
+=== TEST 6: Verify by Query String: Credential: date missing
+--- request
+GET /hello?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE//us-east-1/s3/aws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host;range;x-amz-content-sha256&X-Amz-Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+--- error_code: 403
+--- response_body
+{"message":"date missing"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: date missing
+
+
+
+=== TEST 7: Verify by Query String: Credential: region missing
+--- request
+GET /hello?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20130524//s3/aws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host;range;x-amz-content-sha256&X-Amz-Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+--- error_code: 403
+--- response_body
+{"message":"region missing"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: region missing
+
+
+
+=== TEST 8: Verify by Query String: Credential: invalid region
+--- request
+GET /hello?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20130524/fake-region/s3/aws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host;range;x-amz-content-sha256&X-Amz-Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+--- error_code: 403
+--- response_body
+{"message":"Credential should be scoped to a valid Region, not 'fake-region'"}
+--- grep_error_log eval
+qr/client request can't be validated: Credential should be scoped to a valid Region, not [^,]+/
+--- grep_error_log_out
+client request can't be validated: Credential should be scoped to a valid Region, not 'fake-region'
+
+
+
+=== TEST 9: Verify by Query String: Credential: service missing
+--- request
+GET /hello?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1//aws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host;range;x-amz-content-sha256&X-Amz-Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+--- error_code: 403
+--- response_body
+{"message":"service missing"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: service missing
+
+
+
+=== TEST 10: Verify by Query String: Credential: invalid service
+--- request
+GET /hello?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/fake-service/aws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host;range;x-amz-content-sha256&X-Amz-Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+--- error_code: 403
+--- response_body
+{"message":"Credential should be scoped to correct service: 'fake-service'"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: Credential should be scoped to correct service: 'fake-service'
+
+
+
+=== TEST 11: Verify by Query String: Credential: invalid terminator
+--- request
+GET /hello?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/not_aws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host;range;x-amz-content-sha256&X-Amz-Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+--- error_code: 403
+--- response_body
+{"message":"Credential should be scoped with a valid terminator: 'aws4_request'"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: Credential should be scoped with a valid terminator: 'aws4_request'
+
+
+
+=== TEST 12: Verify by Query String: signed_header: Host missing
+--- request
+GET /hello?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=range;x-amz-content-sha256&X-Amz-Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+--- error_code: 403
+--- response_body
+{"message":"header 'Host' is not signed"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: header 'Host' is not signed
+
+
+
+=== TEST 13: Verify by Query String: clock_skew: Date in Credential scope is dismatch X-Amz-Date parameter
+--- request
+GET /hello?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request&X-Amz-Date=20000101T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host;range;x-amz-content-sha256&X-Amz-Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41
+--- more_headers
+Host: examplebucket.s3.amazonaws.com
+Range: bytes=0-9
+x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+--- error_code: 403
+--- response_body
+{"message":"Date in Credential scope does not match YYYYMMDD from ISO-8601 version of date from HTTP"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: Date in Credential scope does not match YYYYMMDD from ISO-8601 version of date from HTTP
+
+
+
+=== TEST 14: Verify by Query String: clock_skew: Signature expired
+--- config
+location /t {
+    content_by_lua_block {
+        local http  = require("resty.http")
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local now       = os.time() - 100000
+        local amzdate   = os.date("!%Y%m%dT%H%M%SZ", now) -- ISO 8601 20130524T000000Z
+        local datestamp = os.date("!%Y%m%d", now)         -- Date w/o time, used in credential scope
+
+        local method     = "GET"
+        local path       = "/hello"
+        local body       = nil
+        local access_key = "AKIAIOSFODNN7EXAMPLE"
+        local secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        local region     = "us-east-1"
+        local service    = "s3"
+        local credential = table.concat({access_key, datestamp, region, service, "aws4_request"}, "/")
+
+        local headers = {}
+        headers["Host"]                 = "examplebucket.s3.amazonaws.com"
+        headers["x-amz-content-sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+        local _, signed_headers = utils.build_canonical_headers(headers)
+
+        local query_string = {}
+
+        local signature = utils.generate_signature(
+            method,
+            path,
+            query_string,
+            headers,
+            body,
+            secret_key,
+            now,
+            region,
+            service
+        )
+
+        query_string["X-Amz-Algorithm"]     = "AWS4-HMAC-SHA256"
+        query_string["X-Amz-Credential"]    = credential
+        query_string["X-Amz-Date"]          = amzdate
+        query_string["X-Amz-Expires"]       = "86400"
+        query_string["X-Amz-SignedHeaders"] = signed_headers
+        query_string["X-Amz-Signature"]     = signature
+
+        local query_string_list = {}
+        for k,v in ipairs(query_string) do
+            table.insert(query_string_list, k .. "=" .. v)
+        end
+        local query_string_str = ""
+        if #query_string_list > 0 then
+            query_string_str = "?" .. table.concat(query_string_list, "&")
+        end
+        
+        local httpc = http.new()
+        local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
+          .. ":" .. ngx.var.server_port .. path
+        local res, err = httpc:request_uri(uri,
+            {
+                method = method,
+                body = body,
+                keepalive = false,
+                headers = headers,
+                query = query_string
+            }
+        )
+
+        ngx.status = res.status
+        ngx.print(res.body)
+    }
+}
+--- request
+GET /t
+--- error_code: 403
+--- response_body eval
+qr/{"message":"Signature expired: '.+' is now earlier than '.+'"}/
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out eval
+qr/Signature expired: '.+' is now earlier than '.+'/
+
+
+
+=== TEST 15: Verify by Query String: clock_skew: Signature in the future
+--- config
+location /t {
+    content_by_lua_block {
+        local http  = require("resty.http")
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local now       = os.time() + 100000
+        local amzdate   = os.date("!%Y%m%dT%H%M%SZ", now) -- ISO 8601 20130524T000000Z
+        local datestamp = os.date("!%Y%m%d", now)         -- Date w/o time, used in credential scope
+
+        local method     = "GET"
+        local path       = "/hello"
+        local body       = nil
+        local access_key = "AKIAIOSFODNN7EXAMPLE"
+        local secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        local region     = "us-east-1"
+        local service    = "s3"
+        local credential = table.concat({access_key, datestamp, region, service, "aws4_request"}, "/")
+
+        local headers = {}
+        headers["Host"]                 = "examplebucket.s3.amazonaws.com"
+        headers["x-amz-content-sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+        local _, signed_headers = utils.build_canonical_headers(headers)
+
+        local query_string = {}
+
+        local signature = utils.generate_signature(
+            method,
+            path,
+            query_string,
+            headers,
+            body,
+            secret_key,
+            now,
+            region,
+            service
+        )
+
+        query_string["X-Amz-Algorithm"]     = "AWS4-HMAC-SHA256"
+        query_string["X-Amz-Credential"]    = credential
+        query_string["X-Amz-Date"]          = amzdate
+        query_string["X-Amz-Expires"]       = "86400"
+        query_string["X-Amz-SignedHeaders"] = signed_headers
+        query_string["X-Amz-Signature"]     = signature
+
+        local query_string_list = {}
+        for k,v in ipairs(query_string) do
+            table.insert(query_string_list, k .. "=" .. v)
+        end
+        local query_string_str = ""
+        if #query_string_list > 0 then
+            query_string_str = "?" .. table.concat(query_string_list, "&")
+        end
+        
+        local httpc = http.new()
+        local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
+          .. ":" .. ngx.var.server_port .. path
+        local res, err = httpc:request_uri(uri,
+            {
+                method = method,
+                body = body,
+                keepalive = false,
+                headers = headers,
+                query = query_string
+            }
+        )
+
+        ngx.status = res.status
+        ngx.print(res.body)
+    }
+}
+--- request
+GET /t
+--- error_code: 403
+--- response_body eval
+qr/{"message":"Signature not yet current: '.+' is still later than '.+'"}/
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out eval
+qr/Signature not yet current: '.+' is still later than '.+'/
+
+
+
+=== TEST 16: Verify by Query String: Success
+--- config
+location /t {
+    content_by_lua_block {
+        local http  = require("resty.http")
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local now       = os.time()
+        local amzdate   = os.date("!%Y%m%dT%H%M%SZ", now) -- ISO 8601 20130524T000000Z
+        local datestamp = os.date("!%Y%m%d", now)         -- Date w/o time, used in credential scope
+
+        local method     = "GET"
+        local path       = "/hello"
+        local body       = nil
+        local access_key = "AKIAIOSFODNN7EXAMPLE"
+        local secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        local region     = "us-east-1"
+        local service    = "s3"
+        local credential = table.concat({access_key, datestamp, region, service, "aws4_request"}, "/")
+
+        local headers = {}
+        headers["Host"]                 = "examplebucket.s3.amazonaws.com"
+        headers["x-amz-content-sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+        local _, signed_headers = utils.build_canonical_headers(headers)
+
+        local query_string = {}
+
+        local signature = utils.generate_signature(
+            method,
+            path,
+            query_string,
+            headers,
+            body,
+            secret_key,
+            now,
+            region,
+            service
+        )
+
+        query_string["X-Amz-Algorithm"]     = "AWS4-HMAC-SHA256"
+        query_string["X-Amz-Credential"]    = credential
+        query_string["X-Amz-Date"]          = amzdate
+        query_string["X-Amz-Expires"]       = "86400"
+        query_string["X-Amz-SignedHeaders"] = signed_headers
+        query_string["X-Amz-Signature"]     = signature
+
+        local query_string_list = {}
+        for k,v in ipairs(query_string) do
+            table.insert(query_string_list, k .. "=" .. v)
+        end
+        local query_string_str = ""
+        if #query_string_list > 0 then
+            query_string_str = "?" .. table.concat(query_string_list, "&")
+        end
+        
+        local httpc = http.new()
+        local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
+          .. ":" .. ngx.var.server_port .. path
+        local res, err = httpc:request_uri(uri,
+            {
+                method = method,
+                body = body,
+                keepalive = false,
+                headers = headers,
+                query = query_string
+            }
+        )
+
+        ngx.status = res.status
+        ngx.print(res.body)
+    }
+}
+--- request
+GET /t
+--- response_body
+hello world
+
+
+
+=== TEST 17: Verify by Query String: Consumer not found
+--- config
+location /t {
+    content_by_lua_block {
+        local http  = require("resty.http")
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local now       = os.time()
+        local amzdate   = os.date("!%Y%m%dT%H%M%SZ", now) -- ISO 8601 20130524T000000Z
+        local datestamp = os.date("!%Y%m%d", now)         -- Date w/o time, used in credential scope
+
+        local method     = "GET"
+        local path       = "/hello"
+        local body       = nil
+        local access_key = "FAKE_ACCESS_KEY"
+        local secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        local region     = "us-east-1"
+        local service    = "s3"
+        local credential = table.concat({access_key, datestamp, region, service, "aws4_request"}, "/")
+
+        local headers = {}
+        headers["Host"]                 = "examplebucket.s3.amazonaws.com"
+        headers["x-amz-content-sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+        local _, signed_headers = utils.build_canonical_headers(headers)
+
+        local query_string = {}
+
+        local signature = utils.generate_signature(
+            method,
+            path,
+            query_string,
+            headers,
+            body,
+            secret_key,
+            now,
+            region,
+            service
+        )
+
+        query_string["X-Amz-Algorithm"]     = "AWS4-HMAC-SHA256"
+        query_string["X-Amz-Credential"]    = credential
+        query_string["X-Amz-Date"]          = amzdate
+        query_string["X-Amz-Expires"]       = "86400"
+        query_string["X-Amz-SignedHeaders"] = signed_headers
+        query_string["X-Amz-Signature"]     = signature
+
+        local query_string_list = {}
+        for k,v in ipairs(query_string) do
+            table.insert(query_string_list, k .. "=" .. v)
+        end
+        local query_string_str = ""
+        if #query_string_list > 0 then
+            query_string_str = "?" .. table.concat(query_string_list, "&")
+        end
+        
+        local httpc = http.new()
+        local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
+          .. ":" .. ngx.var.server_port .. path
+        local res, err = httpc:request_uri(uri,
+            {
+                method = method,
+                body = body,
+                keepalive = false,
+                headers = headers,
+                query = query_string
+            }
+        )
+
+        ngx.status = res.status
+        ngx.print(res.body)
+    }
+}
+--- request
+GET /t
+--- error_code: 403
+--- response_body
+{"message":"The security token included in the request is invalid."}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: The security token included in the request is invalid.
+
+
+
+=== TEST 18: Verify by Query String: Consumer not found
+--- config
+location /t {
+    content_by_lua_block {
+        local http  = require("resty.http")
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local now       = os.time()
+        local amzdate   = os.date("!%Y%m%dT%H%M%SZ", now) -- ISO 8601 20130524T000000Z
+        local datestamp = os.date("!%Y%m%d", now)         -- Date w/o time, used in credential scope
+
+        local method     = "GET"
+        local path       = "/hello"
+        local body       = nil
+        local access_key = "AKIAIOSFODNN7EXAMPLE"
+        local secret_key = "FAKE_SECRET_KEY"
+        local region     = "us-east-1"
+        local service    = "s3"
+        local credential = table.concat({access_key, datestamp, region, service, "aws4_request"}, "/")
+
+        local headers = {}
+        headers["Host"]                 = "examplebucket.s3.amazonaws.com"
+        headers["x-amz-content-sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+        local _, signed_headers = utils.build_canonical_headers(headers)
+
+        local query_string = {}
+
+        local signature = utils.generate_signature(
+            method,
+            path,
+            query_string,
+            headers,
+            body,
+            secret_key,
+            now,
+            region,
+            service
+        )
+
+        query_string["X-Amz-Algorithm"]     = "AWS4-HMAC-SHA256"
+        query_string["X-Amz-Credential"]    = credential
+        query_string["X-Amz-Date"]          = amzdate
+        query_string["X-Amz-Expires"]       = "86400"
+        query_string["X-Amz-SignedHeaders"] = signed_headers
+        query_string["X-Amz-Signature"]     = signature
+
+        local query_string_list = {}
+        for k,v in ipairs(query_string) do
+            table.insert(query_string_list, k .. "=" .. v)
+        end
+        local query_string_str = ""
+        if #query_string_list > 0 then
+            query_string_str = "?" .. table.concat(query_string_list, "&")
+        end
+        
+        local httpc = http.new()
+        local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
+          .. ":" .. ngx.var.server_port .. path
+        local res, err = httpc:request_uri(uri,
+            {
+                method = method,
+                body = body,
+                keepalive = false,
+                headers = headers,
+                query = query_string
+            }
+        )
+
+        ngx.status = res.status
+        ngx.print(res.body)
+    }
+}
+--- request
+GET /t
+--- error_code: 403
+--- response_body
+{"message":"The request signature we calculated does not match the signature you provided."}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: The request signature we calculated does not match the signature you provided.
+
+
+
+=== TEST 19: Verify by Query String: Exceed body limit size
+--- config
+location /t {
+    content_by_lua_block {
+        local http  = require("resty.http")
+        local utils = require("apisix.plugins.aws-auth.utils")
+
+        local now       = os.time()
+        local amzdate   = os.date("!%Y%m%dT%H%M%SZ", now) -- ISO 8601 20130524T000000Z
+        local datestamp = os.date("!%Y%m%d", now)         -- Date w/o time, used in credential scope
+
+        local method     = "GET"
+        local path       = "/hello"
+        local body       = string.rep("A", 1024*1024)
+        local access_key = "AKIAIOSFODNN7EXAMPLE"
+        local secret_key = "FAKE_SECRET_KEY"
+        local region     = "us-east-1"
+        local service    = "s3"
+        local credential = table.concat({access_key, datestamp, region, service, "aws4_request"}, "/")
+
+        local headers = {}
+        headers["Host"]                 = "examplebucket.s3.amazonaws.com"
+        headers["x-amz-content-sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+        local _, signed_headers = utils.build_canonical_headers(headers)
+
+        local query_string = {}
+
+        local signature = utils.generate_signature(
+            method,
+            path,
+            query_string,
+            headers,
+            body,
+            secret_key,
+            now,
+            region,
+            service
+        )
+
+        query_string["X-Amz-Algorithm"]     = "AWS4-HMAC-SHA256"
+        query_string["X-Amz-Credential"]    = credential
+        query_string["X-Amz-Date"]          = amzdate
+        query_string["X-Amz-Expires"]       = "86400"
+        query_string["X-Amz-SignedHeaders"] = signed_headers
+        query_string["X-Amz-Signature"]     = signature
+
+        local query_string_list = {}
+        for k,v in ipairs(query_string) do
+            table.insert(query_string_list, k .. "=" .. v)
+        end
+        local query_string_str = ""
+        if #query_string_list > 0 then
+            query_string_str = "?" .. table.concat(query_string_list, "&")
+        end
+        
+        local httpc = http.new()
+        local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
+          .. ":" .. ngx.var.server_port .. path
+        local res, err = httpc:request_uri(uri,
+            {
+                method = method,
+                body = body,
+                keepalive = false,
+                headers = headers,
+                query = query_string
+            }
+        )
+
+        ngx.status = res.status
+        ngx.print(res.body)
+    }
+}
+--- request
+GET /t
+--- error_code: 403
+--- response_body
+{"message":"Exceed body limit size"}
+--- grep_error_log eval
+qr/client request can't be validated: [^,]+/
+--- grep_error_log_out
+client request can't be validated: Exceed body limit size

--- a/t/plugin/aws-auth4.t
+++ b/t/plugin/aws-auth4.t
@@ -346,10 +346,10 @@ location /t {
         if #query_string_list > 0 then
             query_string_str = "?" .. table.concat(query_string_list, "&")
         end
-        
+
         local httpc = http.new()
         local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
-          .. ":" .. ngx.var.server_port .. path
+        .. ":" .. ngx.var.server_port .. path
         local res, err = httpc:request_uri(uri,
             {
                 method = method,
@@ -431,10 +431,10 @@ location /t {
         if #query_string_list > 0 then
             query_string_str = "?" .. table.concat(query_string_list, "&")
         end
-        
+
         local httpc = http.new()
         local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
-          .. ":" .. ngx.var.server_port .. path
+        .. ":" .. ngx.var.server_port .. path
         local res, err = httpc:request_uri(uri,
             {
                 method = method,
@@ -516,10 +516,10 @@ location /t {
         if #query_string_list > 0 then
             query_string_str = "?" .. table.concat(query_string_list, "&")
         end
-        
+
         local httpc = http.new()
         local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
-          .. ":" .. ngx.var.server_port .. path
+        .. ":" .. ngx.var.server_port .. path
         local res, err = httpc:request_uri(uri,
             {
                 method = method,
@@ -596,10 +596,10 @@ location /t {
         if #query_string_list > 0 then
             query_string_str = "?" .. table.concat(query_string_list, "&")
         end
-        
+
         local httpc = http.new()
         local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
-          .. ":" .. ngx.var.server_port .. path
+        .. ":" .. ngx.var.server_port .. path
         local res, err = httpc:request_uri(uri,
             {
                 method = method,
@@ -681,10 +681,10 @@ location /t {
         if #query_string_list > 0 then
             query_string_str = "?" .. table.concat(query_string_list, "&")
         end
-        
+
         local httpc = http.new()
         local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
-          .. ":" .. ngx.var.server_port .. path
+        .. ":" .. ngx.var.server_port .. path
         local res, err = httpc:request_uri(uri,
             {
                 method = method,
@@ -766,10 +766,10 @@ location /t {
         if #query_string_list > 0 then
             query_string_str = "?" .. table.concat(query_string_list, "&")
         end
-        
+
         local httpc = http.new()
         local uri = ngx.var.scheme .. "://" .. ngx.var.server_addr
-          .. ":" .. ngx.var.server_port .. path
+        .. ":" .. ngx.var.server_port .. path
         local res, err = httpc:request_uri(uri,
             {
                 method = method,


### PR DESCRIPTION
### Description

Implementing the [AWS Signature v4](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-signing.html) authentication plugin.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

### Attributes

For Consumer:

| Name       | Type   | Requirement | Description                                                                                                                                                                             |
| ---------- | ------ | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| access_key | string | required    | Unique access_key for a Consumer. This field supports saving the value in Secret Manager using the [APISIX Secret](https://apisix.apache.org/docs/apisix/terminology/secret/) resource. |
| secret_key | string | required    | Unique secret_key for a Consumer. This field supports saving the value in Secret Manager using the [APISIX Secret](https://apisix.apache.org/docs/apisix/terminology/secret/) resource. |

NOTE: `encrypt_fields = {"access_key", "secret_key"}` is also defined in the schema, which means that the field will be stored encrypted in etcd. See [encrypted storage fields](https://apisix.apache.org/docs/apisix/plugin-develop/#encrypted-storage-fields).

For Route:

| Name                       | Type            | Requirement | Default             | Description                                                                                                                                                                                                            |
| -------------------------- | --------------- | ----------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| host                       | string          | optional    |                     | Host to validate. Without validate if not provided.                                                                                                                                                                    |
| region                     | string          | optional    |                     | Region to validate. Without validate if not provided.                                                                                                                                                                  |
| service                    | string          | optional    |                     | Service to validate. Without validate if not provided.                                                                                                                                                                 |
| clock_skew                 | integer         | optional    | 60 \* 15            | Clock skew allowed by the signature in seconds. The default value is 900 seconds (15 minutes). If `X-Amz-Date` is not in request parameter, an error will occur. Setting it to 0 will skip checking the date (UNSAFE). |
| max_req_body               | integer         | optional    | 1024 \* 512         | Max Request Body size. The default value is 512 KiB.                                                                                                                                                                   |
| enable_header_method       | boolean         | optional    | true                | Enable [HTTP authorization header](https://docs.aws.amazon.com/IAM/latest/UserGuide/aws-signing-authentication-methods.html#aws-signing-authentication-methods-http) method. The default is true.                      |
| enable_query_string_method | boolean         | optional    | true                | Enable [Query string parameters](https://docs.aws.amazon.com/IAM/latest/UserGuide/aws-signing-authentication-methods.html#aws-signing-authentication-methods-query) method. The default is true.                       |
| max_expires                | integer         | optional    | 60 \* 60 \* 24 \* 7 | Sets the maximum value allowed for the `X-Amz-Expires` parameter. The default value is 604800 seconds (7 days). Setting it to 0 will skip checking exprires limit (UNSAFE).                                            |
| extra_must_sign_headers    | array of string | optional    |                     | The Request Headers that must be signed. Case insensitive.                                                                                                                                                             |
| keep_unsigned_headers      | boolean         | optional    | false               | Whether to keep the Unsigned Request Header. The default is false.                                                                                                                                                     |

