### PR TITLE
chore: remove extra slash when locating LuaJIT binary

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -38,7 +38,7 @@ if [[ -e $OR_EXEC && "$OR_VER" -ge 119 ]]; then
     # OpenResty version is >= 1.19, use luajit by default
     ROOT=$(${OR_EXEC} -V 2>&1 | grep prefix | grep -Eo 'prefix=(.*)/nginx\s+--' | grep -Eo '/.*/')
     # find the luajit binary of openresty
-    LUAJIT_BIN="$ROOT"/luajit/bin/luajit
+    LUAJIT_BIN="$ROOT"luajit/bin/luajit
 
     # use the luajit of openresty
     echo "$LUAJIT_BIN $APISIX_LUA $*"


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

When locating the LuaJIT binary within OpenResty [here](https://github.com/apache/apisix/blob/d38d5b698be0913ee1c28980f57f7545ad99e603/bin/apisix#L41), an extra `/` is being appended to the path, resulting in an incorrect path like `/usr/local/openresty//luajit/bin/luajit`.

I removed the extra / when constructing the LuaJIT binary path. This ensures the correct path format without the double slash.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
