### PR TITLE
feat(splunk-logger): allow configuring keepalive_timeout

### DIFF
--- a/apisix/plugins/splunk-hec-logging.lua
+++ b/apisix/plugins/splunk-hec-logging.lua
@@ -148,6 +148,7 @@ local function send_to_splunk(conf, entries)
         method = "POST",
         body = table_concat(t),
         headers = request_headers,
+        keepalive_timeout = conf.endpoint.keepalive_timeout
     })
 
     if not res then

--- a/apisix/plugins/splunk-hec-logging.lua
+++ b/apisix/plugins/splunk-hec-logging.lua
@@ -51,6 +51,12 @@ local schema = {
                     type = "integer",
                     minimum = 1,
                     default = 10
+                },
+                keepalive_timeout = {
+                    type = "integer",
+                    minimum = 1000,
+                    default = 60000,
+                    description = "keepalive timeout in milliseconds",
                 }
             },
             required = { "uri", "token" }

--- a/docs/en/latest/plugins/splunk-hec-logging.md
+++ b/docs/en/latest/plugins/splunk-hec-logging.md
@@ -43,6 +43,7 @@ When the Plugin is enabled, APISIX will serialize the request context informatio
 | endpoint.token   | True     |         | Splunk HEC authentication token.                                                                                                                                                 |
 | endpoint.channel | False    |         | Splunk HEC send data channel identifier. Read more: [About HTTP Event Collector Indexer Acknowledgment](https://docs.splunk.com/Documentation/Splunk/8.2.3/Data/AboutHECIDXAck). |
 | endpoint.timeout | False    | 10      | Splunk HEC send data timeout in seconds.                                                                                                                                         |
+| endpoint.keepalive_timeout | False    | 60000      | Keepalive timeout in milliseconds.                                                                                                                                  |
 | ssl_verify       | False    | true    | When set to `true` enables SSL verification as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake).                                          |
 | log_format       | False    |  | Log format declared as key value pairs in JSON format. Values only support strings. [APISIX](../apisix-variable.md) or [Nginx](http://nginx.org/en/docs/varindex.html) variables can be used by prefixing the string with `$`. |
 


### PR DESCRIPTION
### Description

The default keepalive timeout is too long and will lead to lot of sockets left open in high scale.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
