### PR TITLE
fix(ai-proxy): missing parsed_url nil check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,6 +175,10 @@ jobs:
           sudo --preserve-env=OPENRESTY_VERSION \
           ./ci/${{ matrix.os_name }}_runner.sh do_install
 
+      - name: Setup tmate session
+        if: always()
+        uses: mxschmitt/action-tmate@v3
+
       - name: Linux Script
         env:
           TEST_FILE_SUB_DIR: ${{ matrix.test_dir }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,10 +175,6 @@ jobs:
           sudo --preserve-env=OPENRESTY_VERSION \
           ./ci/${{ matrix.os_name }}_runner.sh do_install
 
-      - name: Setup tmate session
-        if: always()
-        uses: mxschmitt/action-tmate@v3
-
       - name: Linux Script
         env:
           TEST_FILE_SUB_DIR: ${{ matrix.test_dir }}

--- a/apisix/plugins/ai-proxy/drivers/openai.lua
+++ b/apisix/plugins/ai-proxy/drivers/openai.lua
@@ -42,11 +42,11 @@ function _M.request(conf, request_table, ctx)
     end
 
     local ok, err = httpc:connect({
-        scheme = parsed_url.scheme or "https",
-        host = parsed_url.host or DEFAULT_HOST,
-        port = parsed_url.port or DEFAULT_PORT,
+        scheme = endpoint and parsed_url.scheme or "https",
+        host = endpoint and parsed_url.host or DEFAULT_HOST,
+        port = endpoint and parsed_url.port or DEFAULT_PORT,
         ssl_verify = conf.ssl_verify,
-        ssl_server_name = parsed_url.host or DEFAULT_HOST,
+        ssl_server_name = endpoint and parsed_url.host or DEFAULT_HOST,
         pool_size = conf.keepalive and conf.keepalive_pool,
     })
 
@@ -54,7 +54,7 @@ function _M.request(conf, request_table, ctx)
         return nil, "failed to connect to LLM server: " .. err
     end
 
-    local path = (parsed_url.path or DEFAULT_PATH)
+    local path = (endpoint and parsed_url.path or DEFAULT_PATH)
 
     local headers = (conf.auth.header or {})
     headers["Content-Type"] = "application/json"

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -465,6 +465,8 @@ _EOC_
         $block->set_value("stream_config", $stream_config);
     }
 
+    my $custom_trusted_cert = $block->custom_trusted_cert // 'cert/apisix.crt';
+
     my $stream_server_config = $block->stream_server_config // <<_EOC_;
     listen 2005 ssl;
     ssl_certificate             cert/apisix.crt;
@@ -737,7 +739,7 @@ _EOC_
         http3 off;
         ssl_certificate             cert/apisix.crt;
         ssl_certificate_key         cert/apisix.key;
-        lua_ssl_trusted_certificate cert/apisix.crt;
+        lua_ssl_trusted_certificate $custom_trusted_cert;
 
         ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
 

--- a/t/plugin/ai-proxy2.t
+++ b/t/plugin/ai-proxy2.t
@@ -201,7 +201,7 @@ passed
 
 
 
-=== TEST 5: set route with right query param
+=== TEST 5: set route without overriding the endpoint_url
 --- config
     location /t {
         content_by_lua_block {
@@ -248,18 +248,7 @@ passed
 
 
 === TEST 6: send request
---- yaml_config
-apisix:
-  node_listen: 1984
-  ssl:
-    lua_ssl_trusted_certificate: /etc/ssl/certs/ca-certificates.crt
-deployment:
-  role: traditional
-  role_traditional:
-    config_provider: etcd
-  etcd:
-    host:
-      - "http://127.0.0.1:2379"
+--- custom_trusted_cert: /etc/ssl/certs/ca-certificates.crt
 --- request
 POST /anything
 { "messages": [ { "role": "system", "content": "You are a mathematician" }, { "role": "user", "content": "What is 1+1?"} ] }


### PR DESCRIPTION
### Description

The ai-proxy plugin code had missing nil check for `parsed_url`. This bug remained undetected by the test cases as all test cases use valid override.endpoint. While developing the plugin, this bug remained undeteced by me too because I was using self hosted openai server.

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
