### PR TITLE
feat: Changed the logic to detect token generation uri with parameterized content type.

### DIFF
--- a/apisix/plugins/authz-keycloak.lua
+++ b/apisix/plugins/authz-keycloak.lua
@@ -768,7 +768,7 @@ function _M.access(conf, ctx)
     local headers = core.request.headers(ctx)
     local need_grant_token = conf.password_grant_token_generation_incoming_uri and
         ctx.var.request_uri == conf.password_grant_token_generation_incoming_uri and
-        headers["content-type"] == "application/x-www-form-urlencoded" and
+        sub_str(headers["content-type"], 1, 11) == "application/x-www-form-urlencoded" and
         core.request.get_method() == "POST"
     if need_grant_token then
         return generate_token_using_password_grant(conf,ctx)

--- a/apisix/plugins/authz-keycloak.lua
+++ b/apisix/plugins/authz-keycloak.lua
@@ -768,7 +768,7 @@ function _M.access(conf, ctx)
     local headers = core.request.headers(ctx)
     local need_grant_token = conf.password_grant_token_generation_incoming_uri and
         ctx.var.request_uri == conf.password_grant_token_generation_incoming_uri and
-        sub_str(headers["content-type"], 1, 11) == "application/x-www-form-urlencoded" and
+        sub_str(headers["content-type"], 1, 33) == "application/x-www-form-urlencoded" and
         core.request.get_method() == "POST"
     if need_grant_token then
         return generate_token_using_password_grant(conf,ctx)

--- a/docs/en/latest/plugins/authz-keycloak.md
+++ b/docs/en/latest/plugins/authz-keycloak.md
@@ -143,6 +143,8 @@ curl --location --request POST 'http://127.0.0.1:9080/api/token' \
 --data-urlencode 'password=<Password>'
 ```
 
+Note: For the value of the `Content-Type` header, it also support the parameterized form which defind in the section [3.1.1.5](https://www.rfc-editor.org/rfc/rfc7231#section-3.1.1.5) of [RFC7231](https://www.rfc-editor.org/rfc/rfc7231). For example `Content-Type: application/json; charset=utf-8`.
+
 ## Enable Plugin
 
 The example below shows how you can enable the `authz-keycloak` Plugin on a specific Route. `${realm}` represents the realm name in Keycloak.

--- a/docs/zh/latest/plugins/authz-keycloak.md
+++ b/docs/zh/latest/plugins/authz-keycloak.md
@@ -127,6 +127,8 @@ description: 本文介绍了关于 Apache APISIX `authz-keycloak` 插件的基�
     --data-urlencode 'password=<Password>'
     ```
 
+    注意：对于`Content-Type`头的值，此插件也支持参数化的形式（具体定义在[RFC7231](https://www.rfc-editor.org/rfc/rfc7231)的第[3.1.1.5](https://www.rfc-editor.org/rfc/rfc7231#section-3.1.1.5)小节）。具体示例`Content-Type: application/json; charset=utf-8`。
+
 ## 如何启用
 
 以下示例为你展示了如何在指定 Route 中启用 `authz-keycloak` 插件，其中 `${realm}` 是 Keycloak 中的 `realm` 名称：


### PR DESCRIPTION
### Description

In HTTP specification, the form of Content-Type as following:
Content-Type: <media-type>[; key=value]

For examples:

Content-Type: text/html; charset=utf-8
Content-Type: multipart/form-data; boundary=boundary-string

But in the authz-keycloak plugin, the condition to decide if current request is for granting token from Keycloak must be full match the "application/x-www-form-urlencoded". It will cause some client libraries to be unable to obtain the token.

For example, the RestTemplate in SpringFramework, it will add parameter after the content-type directive automatically.

This pull request resolved this issue.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
