### PR TITLE
fix: use right modifiedIndex for consumer when use credential

### DIFF
--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -114,6 +114,7 @@ local function plugin_consumer()
                     local the_consumer = consumers:get(consumer_name)
                     if the_consumer and the_consumer.value then
                         consumer = core.table.clone(the_consumer.value)
+                        consumer.modifiedIndex = the_consumer.modifiedIndex
                         consumer.credential_id = get_credential_id_from_etcd_key(val.key)
                     else
                         -- Normally wouldn't get here:
@@ -125,6 +126,7 @@ local function plugin_consumer()
                     end
                 else
                     consumer = core.table.clone(val.value)
+                    consumer.modifiedIndex = val.modifiedIndex
                 end
 
                 -- if the consumer has labels, set the field custom_id to it.
@@ -137,7 +139,6 @@ local function plugin_consumer()
                 -- is 'username' field in admin
                 consumer.consumer_name = consumer.id
                 consumer.auth_conf = config
-                consumer.modifiedIndex = val.modifiedIndex
                 core.log.info("consumer:", core.json.delay_encode(consumer))
                 core.table.insert(plugins[name].nodes, consumer)
             end

--- a/t/plugin/consumer-bug-fix.t
+++ b/t/plugin/consumer-bug-fix.t
@@ -1,0 +1,124 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_shuffle();
+no_root_location();
+
+run_tests;
+
+__DATA__
+=== TEST 1: add consumer jack1
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack1",
+                    "plugins": {
+                        "key-auth": {
+                            "key": "auth-one"
+                        },
+                        "echo":{"body": "before change"}
+                    }
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+=== TEST 2: add route
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "uri": "/hello",
+                        "upstream": {
+                            "type": "roundrobin",
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            }
+                        },
+                        "plugins": {
+                            "key-auth": {}
+                        }
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+=== TEST 3: verify 20 times
+--- pipelined_requests eval
+["GET /hello", "GET /hello", "GET /hello", "GET /hello","GET /hello", "GET /hello", "GET /hello", "GET /hello","GET /hello", "GET /hello", "GET /hello", "GET /hello","GET /hello", "GET /hello", "GET /hello", "GET /hello","GET /hello", "GET /hello", "GET /hello", "GET /hello"]
+--- more_headers
+apikey: auth-one
+--- response_body eval
+["before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change"]
+=== TEST 4: modify consumer
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack1",
+                    "plugins": {
+                        "key-auth": {
+                            "key": "auth-one"
+                        },
+                        "echo":{"body": "after change"}
+                    }
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+=== TEST 5: verify 20 times
+--- pipelined_requests eval
+["GET /hello", "GET /hello", "GET /hello", "GET /hello","GET /hello", "GET /hello", "GET /hello", "GET /hello","GET /hello", "GET /hello", "GET /hello", "GET /hello","GET /hello", "GET /hello", "GET /hello", "GET /hello","GET /hello", "GET /hello", "GET /hello", "GET /hello"]
+--- more_headers
+apikey: auth-one
+--- response_body eval
+["after change","after change","after change","after change","after change","after change","after change","after change","after change","after change","after change","after change","after change","after change","after change","after change","after change","after change","after change","after change"]

--- a/t/plugin/consumer-bug-fix.t
+++ b/t/plugin/consumer-bug-fix.t
@@ -24,6 +24,7 @@ no_root_location();
 run_tests;
 
 __DATA__
+
 === TEST 1: add consumer jack1
 --- config
     location /t {
@@ -51,6 +52,9 @@ __DATA__
 GET /t
 --- response_body
 passed
+
+
+
 === TEST 2: add route
 --- config
     location /t {
@@ -81,6 +85,9 @@ passed
 GET /t
 --- response_body
 passed
+
+
+
 === TEST 3: verify 20 times
 --- pipelined_requests eval
 ["GET /hello", "GET /hello", "GET /hello", "GET /hello","GET /hello", "GET /hello", "GET /hello", "GET /hello","GET /hello", "GET /hello", "GET /hello", "GET /hello","GET /hello", "GET /hello", "GET /hello", "GET /hello","GET /hello", "GET /hello", "GET /hello", "GET /hello"]
@@ -88,6 +95,9 @@ passed
 apikey: auth-one
 --- response_body eval
 ["before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change","before change"]
+
+
+
 === TEST 4: modify consumer
 --- config
     location /t {
@@ -115,6 +125,9 @@ apikey: auth-one
 GET /t
 --- response_body
 passed
+
+
+
 === TEST 5: verify 20 times
 --- pipelined_requests eval
 ["GET /hello", "GET /hello", "GET /hello", "GET /hello","GET /hello", "GET /hello", "GET /hello", "GET /hello","GET /hello", "GET /hello", "GET /hello", "GET /hello","GET /hello", "GET /hello", "GET /hello", "GET /hello","GET /hello", "GET /hello", "GET /hello", "GET /hello"]


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Due to wrong modified index being assigned to consumer, it doesn't get the updated data. This PR fixes that.
### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
