### PR TITLE
fix: jwt-auth, token exp cannot be set normally  #11650

### DIFF
--- a/apisix/plugins/jwt-auth.lua
+++ b/apisix/plugins/jwt-auth.lua
@@ -254,7 +254,7 @@ local function get_real_payload(key, auth_conf, payload)
     }
     if payload then
         local extra_payload = core.json.decode(payload)
-        core.table.merge(extra_payload, real_payload)
+        core.table.merge(real_payload, extra_payload)
         return extra_payload
     end
     return real_payload


### PR DESCRIPTION
### Description

Swapped the two parameters of core.table.merge in the get_real_payload method, which caused us to be unable to set the expiration time of the token

Fixes  #11650 


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
