### PR TITLE
fix: enable issue of endpointslices for k8s discovery

### DIFF
--- a/.github/workflows/kubernetes-ci.yml
+++ b/.github/workflows/kubernetes-ci.yml
@@ -53,6 +53,8 @@ jobs:
 
           kubectl apply -f ./t/kubernetes/configs/endpoint.yaml
 
+          kubectl apply -f ./t/kubernetes/configs/endpointslices.yaml
+
           KUBERNETES_CLIENT_TOKEN_CONTENT=$(kubectl get secrets | grep apisix-test | awk '{system("kubectl get secret -o jsonpath={.data.token} "$1" | base64 --decode")}')
 
           KUBERNETES_CLIENT_TOKEN_DIR="/tmp/var/run/secrets/kubernetes.io/serviceaccount"

--- a/apisix/discovery/kubernetes/init.lua
+++ b/apisix/discovery/kubernetes/init.lua
@@ -31,7 +31,6 @@ local core = require("apisix.core")
 local util = require("apisix.cli.util")
 local local_conf = require("apisix.core.config_local").local_conf()
 local informer_factory = require("apisix.discovery.kubernetes.informer_factory")
-local cjson = require("cjson")
 
 
 local ctx
@@ -61,9 +60,6 @@ local function on_endpoint_slices_modified(handle, endpoint)
     core.table.clear(endpoint_buffer)
 
     local endpointslices = endpoint.endpoints
-    ngx.log(ngx.WARN,"-----------size of endpintslica",#endpointslices)
-    ngx.log(ngx.WARN, "Type of endpointslices: ", type(endpointslices))
-    ngx.log(ngx.WARN,"-----Data-----",cjson.encode(endpointslices))
     for _, endpointslice in ipairs(endpointslices or {}) do
         if endpointslice.addresses then
             local addresses = endpointslice.addresses

--- a/apisix/discovery/kubernetes/init.lua
+++ b/apisix/discovery/kubernetes/init.lua
@@ -31,6 +31,7 @@ local core = require("apisix.core")
 local util = require("apisix.cli.util")
 local local_conf = require("apisix.core.config_local").local_conf()
 local informer_factory = require("apisix.discovery.kubernetes.informer_factory")
+local cjson = require("cjson")
 
 
 local ctx
@@ -60,9 +61,12 @@ local function on_endpoint_slices_modified(handle, endpoint)
     core.table.clear(endpoint_buffer)
 
     local endpointslices = endpoint.endpoints
+    ngx.log(ngx.WARN,"-----------size of endpintslica",#endpointslices)
+    ngx.log(ngx.WARN, "Type of endpointslices: ", type(endpointslices))
+    ngx.log(ngx.WARN,"-----Data-----",cjson.encode(endpointslices))
     for _, endpointslice in ipairs(endpointslices or {}) do
         if endpointslice.addresses then
-            local addresses = endpointslices.addresses
+            local addresses = endpointslice.addresses
             for _, port in ipairs(endpoint.ports or {}) do
                 local port_name
                 if port.name then
@@ -73,14 +77,14 @@ local function on_endpoint_slices_modified(handle, endpoint)
                     port_name = tostring(port.port)
                 end
 
-                if endpointslice.conditions and endpointslice.condition.ready then
+                if endpointslice.conditions and endpointslice.conditions.ready then
                     local nodes = endpoint_buffer[port_name]
                     if nodes == nil then
                         nodes = core.table.new(0, #endpointslices * #addresses)
                         endpoint_buffer[port_name] = nodes
                     end
 
-                    for _, address in ipairs(endpointslices.addresses) do
+                    for _, address in ipairs(addresses) do
                         core.table.insert(nodes, {
                             host = address.ip,
                             port = port.port,
@@ -431,7 +435,7 @@ local function single_mode_init(conf)
 
     local default_weight = conf.default_weight
     local endpoints_informer, err
-    if conf.watch_endpoint_slices_schema then
+    if conf.watch_endpoint_slices then
         endpoints_informer, err = informer_factory.new("discovery.k8s.io", "v1",
                                                        "EndpointSlice", "endpointslices", "")
     else
@@ -445,7 +449,7 @@ local function single_mode_init(conf)
     setup_namespace_selector(conf, endpoints_informer)
     setup_label_selector(conf, endpoints_informer)
 
-    if conf.watch_endpoint_slices_schema then
+    if conf.watch_endpoint_slices then
         endpoints_informer.on_added = on_endpoint_slices_modified
         endpoints_informer.on_modified = on_endpoint_slices_modified
     else
@@ -537,7 +541,7 @@ local function multiple_mode_init(confs)
         local default_weight = conf.default_weight
 
         local endpoints_informer, err
-        if conf.watch_endpoint_slices_schema then
+        if conf.watch_endpoint_slices then
             endpoints_informer, err = informer_factory.new("discovery.k8s.io", "v1",
                                                            "EndpointSlice", "endpointslices", "")
         else
@@ -551,7 +555,7 @@ local function multiple_mode_init(confs)
         setup_namespace_selector(conf, endpoints_informer)
         setup_label_selector(conf, endpoints_informer)
 
-        if conf.watch_endpoint_slices_schema then
+        if conf.watch_endpoint_slices then
             endpoints_informer.on_added = on_endpoint_slices_modified
             endpoints_informer.on_modified = on_endpoint_slices_modified
         else

--- a/docs/en/latest/discovery/kubernetes.md
+++ b/docs/en/latest/discovery/kubernetes.md
@@ -302,7 +302,7 @@ A: The Kubernetes service discovery only uses privileged processes to [_List-Wat
 
 **Q: What permissions do [_ServiceAccount_](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) require?**
 
-A: ServiceAccount requires the permissions of cluster-level [ get, list, watch ] endpoints resources, the declarative definition is as follows:
+A: ServiceAccount requires the permissions of cluster-level [ get, list, watch ] endpoints and endpointslices resources, the declarative definition is as follows:
 
 ```yaml
 kind: ServiceAccount
@@ -315,11 +315,14 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
- name: apisix-test
+  name: apisix-test
 rules:
-- apiGroups: [ "" ]
-  resources: [ endpoints,endpointslices ]
-  verbs: [ get,list,watch ]
+  - apiGroups: [ "" ]
+    resources: [ endpoints]
+    verbs: [ get,list,watch ]
+  - apiGroups: [ "discovery.k8s.io" ]
+    resources: [ endpointslices ]
+    verbs: [ get,list,watch ]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1

--- a/docs/zh/latest/discovery/kubernetes.md
+++ b/docs/zh/latest/discovery/kubernetes.md
@@ -300,7 +300,7 @@ A: Kubernetes 服务发现只使用特权进程监听 Kubernetes Endpoints，然
 
 **Q: [_ServiceAccount_](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) 需要的权限有哪些？**
 
-A: [_ServiceAccount_](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) 需要集群级 [ get,list,watch ] endpoints 资源的的权限，其声明式定义如下：
+A: [_ServiceAccount_](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) 需要集群级 [ get,list,watch ] endpoints and endpointslices 资源的的权限，其声明式定义如下：
 
 ```yaml
 kind: ServiceAccount
@@ -313,11 +313,14 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
- name: apisix-test
+  name: apisix-test
 rules:
-- apiGroups: [ "" ]
-  resources: [ endpoints,endpointslices ]
-  verbs: [ get,list,watch ]
+  - apiGroups: [ "" ]
+    resources: [ endpoints]
+    verbs: [ get,list,watch ]
+  - apiGroups: [ "discovery.k8s.io" ]
+    resources: [ endpointslices ]
+    verbs: [ get,list,watch ]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1

--- a/t/kubernetes/configs/endpointslices.yaml
+++ b/t/kubernetes/configs/endpointslices.yaml
@@ -3,7 +3,7 @@
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
+# (the "License"); you may not use this file excepslicet in compliance with
 # the License.  You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
@@ -15,33 +15,47 @@
 # limitations under the License.
 #
 
-kind: ServiceAccount
+kind: Namespace
 apiVersion: v1
 metadata:
-  name: apisix-test
-  namespace: default
+  name: ns-a
 ---
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
 metadata:
-  name: apisix-test
-rules:
-  - apiGroups: [ "" ]
-    resources: [ endpoints]
-    verbs: [ get,list,watch ]
-  - apiGroups: [ "discovery.k8s.io" ]
-    resources: [ endpointslices ]
-    verbs: [ get,list,watch ]
+  name: epslice
+  namespace: ns-a
+addressType: IPv4
+endpoints: [ ]
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+
+kind: Namespace
+apiVersion: v1
 metadata:
-  name: apisix-test
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: apisix-test
-subjects:
-  - kind: ServiceAccount
-    name: apisix-test
-    namespace: default
+  name: ns-b
+---
+
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: epslice
+  namespace: ns-b
+addressType: IPv4
+endpoints: [ ]
+---
+
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: ns-c
+---
+
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  name: epslice
+  namespace: ns-c
+addressType: IPv4
+endpoints: [ ]
+---

--- a/t/kubernetes/discovery/kubernetes3.t
+++ b/t/kubernetes/discovery/kubernetes3.t
@@ -148,11 +148,11 @@ _EOC_
 
                     if op.op == "replace_endpointslices" then
                         method = "PATCH"
-                        path = "/apis/discovery.k8s.io/namespaces/" .. op.namespace .. "/endpointslices/" .. op.name
+                        path = "/apis/discovery.k8s.io/v1/namespaces/" .. op.namespace .. "/endpointslices/" .. op.name
                         if #op.endpoints == 0 then
                             body = '[{"path":"/endpoints","op":"replace","value":[]}]'
                         else
-                            local t = { { op = "replace", path = "/endpoints", value = op.endpoints } }
+                            local t = { { op = "replace", path = "/endpoints", value = op.endpoints }, { op = "replace", path = "/ports", value = op.ports } }
                             body = core.json.encode(t, true)
                         end
                         headers["Content-Type"] = "application/json-patch+json"
@@ -160,7 +160,7 @@ _EOC_
 
                     if op.op == "replace_labels" then
                         method = "PATCH"
-                        path = "/apis/discovery.k8s.io/namespaces/" .. op.namespace .. "/endpointslices/" .. op.name
+                        path = "/apis/discovery.k8s.io/v1/namespaces/" .. op.namespace .. "/endpointslices/" .. op.name
                         local t = { { op = "replace", path = "/metadata/labels", value = op.labels } }
                         body = core.json.encode(t, true)
                         headers["Content-Type"] = "application/json-patch+json"
@@ -243,7 +243,7 @@ POST /operators
     {
         "op": "replace_endpointslices",
         "namespace": "ns-a",
-        "name": "ep",
+        "name": "epslice",
         "endpoints": [
             {
                 "addresses": [
@@ -272,7 +272,7 @@ POST /operators
         ],
         "ports": [
             {
-                "name": "p",
+                "name": "p1",
                 "port": 5001
             }
         ]
@@ -284,7 +284,7 @@ POST /operators
     {
         "op": "replace_endpointslices",
         "namespace": "ns-b",
-        "name": "ep",
+        "name": "epslice",
         "endpoints": [
             {
                 "addresses": [
@@ -313,7 +313,7 @@ POST /operators
         ],
         "ports": [
             {
-                "name": "p",
+                "name": "p2",
                 "port": 5002
             }
         ]
@@ -325,7 +325,7 @@ POST /operators
     {
         "op": "replace_endpointslices",
         "namespace": "ns-c",
-        "name": "ep",
+        "name": "epslice",
         "endpoints": [
             {
                 "addresses": [
@@ -345,7 +345,7 @@ POST /operators
                     "20.0.0.2"
                 ],
                 "conditions": {
-                    "ready": true,
+                    "ready": false,
                     "serving": true,
                     "terminating": false
                 },
@@ -354,7 +354,7 @@ POST /operators
         ],
         "ports": [
             {
-                "name": "p",
+                "name": "p3",
                 "port": 5003
             }
         ]
@@ -364,7 +364,8 @@ POST /operators
 Content-type: application/json
 --- response_body_like
 .*"name":"default/kubernetes".*
-
+--- error-log
+attempt to get length of local 'endpointslices' (a userdata value)
 
 
 === TEST 2: use default parameters
@@ -372,13 +373,13 @@ Content-type: application/json
 --- request
 GET /queries
 [
-  "first/ns-a/ep:p1","first/ns-a/ep:p2","first/ns-b/ep:p1","first/ns-b/ep:p2","first/ns-c/ep:5001","first/ns-c/ep:5002",
-  "second/ns-a/ep:p1","second/ns-a/ep:p2","second/ns-b/ep:p1","second/ns-b/ep:p2","second/ns-c/ep:5001","second/ns-c/ep:5002"
+  "first/ns-a/epslice:p1","first/ns-a/epslice:p1","first/ns-b/epslice:p2","first/ns-b/epslice:p2","first/ns-c/epslice:p3","first/ns-c/epslice:p3",
+  "second/ns-a/epslice:p1","second/ns-a/epslice:p1","second/ns-b/epslice:p2","second/ns-b/epslice:p2","second/ns-c/epslice:p3","second/ns-c/epslice:p3"
 ]
 --- more_headers
 Content-type: application/json
 --- response_body eval
-qr{ 0 0 2 2 0 0 0 0 2 2 0 0 }
+qr{ 2 2 2 2 2 2 2 2 2 2 2 2 }
 
 
 
@@ -411,17 +412,54 @@ discovery:
 --- request
 GET /queries
 [
-  "first/ns-a/ep:p1","first/ns-a/ep:p2","first/ns-b/ep:p1","first/ns-b/ep:p2","first/ns-c/ep:5001","first/ns-c/ep:5002",
-  "second/ns-a/ep:p1","second/ns-a/ep:p2","second/ns-b/ep:p1","second/ns-b/ep:p2","second/ns-c/ep:5001","second/ns-c/ep:5002"
+  "first/ns-a/epslice:p1","first/ns-a/epslice:p1","first/ns-b/epslice:p2","first/ns-b/epslice:p2","first/ns-c/epslice:p3","first/ns-c/epslice:p3",
+  "second/ns-a/epslice:p1","second/ns-a/epslice:p1","second/ns-b/epslice:p2","second/ns-b/epslice:p2","second/ns-c/epslice:p3","second/ns-c/epslice:p3"
 ]
 --- more_headers
 Content-type: application/json
 --- response_body eval
-qr{ 0 0 2 2 0 0 0 0 2 2 0 0 }
+qr{ 2 2 2 2 2 2 2 2 2 2 2 2 }
 
 
+=== TEST 4: use namespace selector equal
+--- yaml_config
+apisix:
+  node_listen: 1984
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+discovery:
+  kubernetes:
+    - id: first
+      service:
+        host: ${KUBERNETES_SERVICE_HOST}
+        port: ${KUBERNETES_SERVICE_PORT}
+      client:
+        token_file: ${KUBERNETES_CLIENT_TOKEN_FILE}
+      watch_endpoint_slices: true
+      namespace_selector:
+        equal: ns-a
+    - id: second
+      service:
+        schema: "http"
+        host: "127.0.0.1"
+        port: "6445"
+      watch_endpoint_slices: true
+      client:
+        token: ${KUBERNETES_CLIENT_TOKEN}
+--- request
+GET /queries
+[
+  "first/ns-a/epslice:p1","first/ns-a/epslice:p1","first/ns-b/epslice:p2","first/ns-b/epslice:p2","first/ns-c/epslice:p3","first/ns-c/epslice:p3",
+  "second/ns-a/epslice:p1","second/ns-a/epslice:p1","second/ns-b/epslice:p2","second/ns-b/epslice:p2","second/ns-c/epslice:p3","second/ns-c/epslice:p3"
+]
+--- more_headers
+Content-type: application/json
+--- response_body eval
+qr{ 2 2 0 0 0 0 2 2 2 2 2 2 }
 
-=== TEST 4: test dump
+=== TEST 5: test dump
 --- yaml_config eval: $::yaml_config
 --- request
 GET /dump


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

use `conf.watch_endpoint_slices` to enable endpointslices whenever it is set to true. Fixed the test.

Fixes #11631

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
