### PR TITLE
fix(secret): support aws secret name contains a slash /

### DIFF
--- a/apisix/secret/aws.lua
+++ b/apisix/secret/aws.lua
@@ -18,12 +18,12 @@
 --- AWS Tools.
 local core = require("apisix.core")
 local http = require("resty.http")
-local aws = require("resty.aws")
+local aws  = require("resty.aws")
 
-local sub = core.string.sub
-local find = core.string.find
-local env = core.env
-local unpack = unpack
+local sub        = core.string.sub
+local rfind_char = core.string.rfind_char
+local env        = core.env
+local unpack     = unpack
 
 local schema = {
     type = "object",
@@ -103,7 +103,7 @@ end
 function _M.get(conf, key)
     core.log.info("fetching data from aws for key: ", key)
 
-    local idx = find(key, '/')
+    local idx = rfind_char(key, '/')
 
     local main_key = idx and sub(key, 1, idx - 1) or key
     if main_key == "" then
@@ -112,23 +112,29 @@ function _M.get(conf, key)
 
     local sub_key = idx and sub(key, idx + 1) or nil
 
-    core.log.info("main: ", main_key, sub_key and ", sub: " .. sub_key or "")
+    core.log.info("key: ", key, ", main: ", main_key, sub_key and ", sub: " .. sub_key or "")
 
-    local res, err = make_request_to_aws(conf, main_key)
+    -- key contains a slash, if secret is json
+    if main_key ~= key then
+        local res = make_request_to_aws(conf, main_key)
+
+        if res then
+            local data, err = core.json.decode(res)
+            if not data then
+                return nil, "failed to decode result, res: " .. res .. ", err: " .. err
+            end
+
+            return data[sub_key]
+        end
+    end
+
+    -- secret is string
+    local res, err = make_request_to_aws(conf, key)
     if not res then
         return nil, "failed to retrtive data from aws secret manager: " .. err
     end
 
-    if not sub_key then
-        return res
-    end
-
-    local data, err = core.json.decode(res)
-    if not data then
-        return nil, "failed to decode result, res: " .. res .. ", err: " .. err
-    end
-
-    return data[sub_key]
+    return res
 end
 
 

--- a/ci/init-common-test-service.sh
+++ b/ci/init-common-test-service.sh
@@ -25,3 +25,7 @@ sleep 3s
 docker exec -i localstack sh -c "awslocal secretsmanager create-secret --name apisix-key --description 'APISIX Secret' --secret-string '{\"jack\":\"value\"}'"
 sleep 3s
 docker exec -i localstack sh -c "awslocal secretsmanager create-secret --name apisix-mysql --description 'APISIX Secret' --secret-string 'secret'"
+sleep 3s
+docker exec -i localstack sh -c "awslocal secretsmanager create-secret --name apisix/string --description 'APISIX Secret' --secret-string 'secret'"
+sleep 3s
+docker exec -i localstack sh -c "awslocal secretsmanager create-secret --name apisix/json --description 'APISIX Secret' --secret-string '{\"jack\":\"value\"}'"

--- a/t/secret/aws.t
+++ b/t/secret/aws.t
@@ -314,3 +314,55 @@ GET /t
     }
 --- response_body
 all done
+
+
+
+=== TEST 9: get string value from aws, secret name has /
+--- config
+    location /t {
+        content_by_lua_block {
+            local aws = require("apisix.secret.aws")
+            local conf = {
+                endpoint_url = "http://127.0.0.1:4566",
+                region = "us-east-1",
+                access_key_id = "$ENV://AWS_ACCESS_KEY_ID",
+                secret_access_key = "$ENV://AWS_SECRET_ACCESS_KEY",
+                session_token = "$ENV://AWS_SESSION_TOKEN",
+            }
+            local data, err = aws.get(conf, "apisix/string")
+            if err then
+                return ngx.say(err)
+            end
+            ngx.say(data)
+        }
+    }
+--- request
+GET /t
+--- response_body
+secret
+
+
+
+=== TEST 10: get json value from aws, secret name has /
+--- config
+    location /t {
+        content_by_lua_block {
+            local aws = require("apisix.secret.aws")
+            local conf = {
+                endpoint_url = "http://127.0.0.1:4566",
+                region = "us-east-1",
+                access_key_id = "$ENV://AWS_ACCESS_KEY_ID",
+                secret_access_key = "$ENV://AWS_SECRET_ACCESS_KEY",
+                session_token = "$ENV://AWS_SESSION_TOKEN",
+            }
+            local data, err = aws.get(conf, "apisix/json/jack")
+            if err then
+                return ngx.say(err)
+            end
+            ngx.say(data)
+        }
+    }
+--- request
+GET /t
+--- response_body
+value


### PR DESCRIPTION
### Description

Currently, AWS Secrets Manager supports secret names that contain "/".
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes https://github.com/apache/apisix/issues/11647

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
