### PR TITLE
Fixed broken link to tutorial in Manage API Consumers tutorial

### DIFF
--- a/docs/en/latest/tutorials/manage-api-consumers.md
+++ b/docs/en/latest/tutorials/manage-api-consumers.md
@@ -261,4 +261,4 @@ Note that you can also add or remove a consumer from any consumer group and enab
 
 ## More Tutorials
 
-Read our other [tutorials](./expose-api.md) to learn more about API Management.
+Read our other [tutorials](https://apisix.apache.org/docs/apisix/tutorials/expose-api) to learn more about API Management.


### PR DESCRIPTION
### Description

This PR is a potential fix for the broken link to the tutorial in #11217. The issue is that the link to the tutorial only exists in the English documentation and not in the Chinese version. It was discussed that we could link the Chinese page to the English version of the tutorial as well. I've updated the link so that both versions of the page points to the correct tutorial page instead of `./expose-api.md`, which only exists in the English version and not in Chinese.
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes #11217

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
