### PR TITLE
fix: body-transformer - failed to transform response body - XML 

### DIFF
--- a/apisix/plugins/body-transformer.lua
+++ b/apisix/plugins/body-transformer.lua
@@ -78,23 +78,32 @@ end
 
 
 local function remove_namespace(tbl)
-    for k, v in pairs(tbl) do
-        if type(v) == "table" and next(v) == nil then
+
+    local function update_namespace(ns)
+        local v = ns
+        if type(ns) == "table" and next(ns) == nil then
             v = ""
-            tbl[k] = v
+        elseif type(ns) == "table" then
+            v = remove_namespace(ns)
         end
-        if type(k) == "string" then
-            local newk = k:match(".*:(.*)")
-            if newk then
-                tbl[newk] = v
-                tbl[k] = nil
-            end
-            if type(v) == "table" then
-                remove_namespace(v)
-            end
-        end
+        return v
     end
-    return tbl
+  
+    local function remove_namespace_wrapper(old_table, new_table)
+        for k, v in pairs(old_table) do
+            if type(k) == "string" then
+                local newk = k:match(".*:(.*)")
+                if newk then
+                    new_table[newk] = update_namespace(v)
+                else
+                    new_table[k] = update_namespace(v)
+                end
+            end
+        end
+        return new_table
+    end
+    
+    return remove_namespace_wrapper(tbl, {})
 end
 
 

--- a/apisix/plugins/body-transformer.lua
+++ b/apisix/plugins/body-transformer.lua
@@ -88,7 +88,7 @@ local function remove_namespace(tbl)
         end
         return v
     end
-  
+
     local function remove_namespace_wrapper(old_table, new_table)
         for k, v in pairs(old_table) do
             if type(k) == "string" then
@@ -102,7 +102,7 @@ local function remove_namespace(tbl)
         end
         return new_table
     end
-    
+
     return remove_namespace_wrapper(tbl, {})
 end
 


### PR DESCRIPTION
### Description

Body Transformer plugin produces unpredictable errors when removing namespaces from the decoded xml table. Please see the issue #11646 for full details.

Fixes #11646

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
