### PR TITLE
feat(control): add hosts/reload to control api

### DIFF
--- a/apisix/control/router.lua
+++ b/apisix/control/router.lua
@@ -203,10 +203,15 @@ local function reload_plugins()
     plugin_mod.load()
 end
 
+local function reload_hosts()
+    core.log.info("start to hot reload hosts")
+    core.resolver.reload_hosts()
+end
+
 
 function _M.init_worker()
-    -- register reload plugin handler
-    events:register(reload_plugins, builtin_v1_routes.reload_event, "PUT")
+    events:register(reload_plugins, builtin_v1_routes.reload_plugins_event, "PUT")
+    events:register(reload_hosts, builtin_v1_routes.reload_hosts_event, "PUT")
 end
 
 return _M

--- a/apisix/core/resolver.lua
+++ b/apisix/core/resolver.lua
@@ -41,6 +41,16 @@ local function init_hosts_ip()
 end
 
 
+function _M.reload_hosts()
+    init_hosts_ip()
+end
+
+
+function _M.get_hosts()
+    return HOSTS_IP_MATCH_CACHE
+end
+
+
 function _M.init_resolver(args)
     --  initialize /etc/hosts
     init_hosts_ip()

--- a/docs/en/latest/control-api.md
+++ b/docs/en/latest/control-api.md
@@ -485,3 +485,19 @@ Triggers a hot reload of the plugins.
 ```shell
 curl "http://127.0.0.1:9090/v1/plugins/reload" -X PUT
 ```
+
+### PUT /v1/hosts/reload
+
+Triggers a hot reload of the hosts.
+
+```shell
+curl "http://127.0.0.1:9090/v1/hosts/reload" -X PUT
+```
+
+### GET /v1/hosts
+
+Get the hosts in the cache.
+
+```shell
+curl "http://127.0.0.1:9090/v1/hosts"
+```


### PR DESCRIPTION
### Description

As a user, I want to resync `/etc/hosts` when there is an update. This pr introduces an API endpoint that allows users to manually trigger a reload。

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
