### PR TITLE
docs: fix the ai-proxy override.endpoint

### DIFF
--- a/docs/en/latest/plugins/ai-proxy.md
+++ b/docs/en/latest/plugins/ai-proxy.md
@@ -62,7 +62,7 @@ Proxying requests to OpenAI is supported now. Other LLM services will be support
 | model.options.temperature | No           | Number   | Matching temperature for models. Range: 0.0 - 5.0                                    |
 | model.options.top_p       | No           | Number   | Top-p probability mass. Range: 0 - 1                                                 |
 | model.options.stream      | No           | Boolean  | Stream response by SSE. Default: false                                               |
-| model.override.endpoint   | No           | String   | Override the endpoint of the AI provider                                             |
+| override.endpoint         | No           | String   | Override the endpoint of the AI provider                                             |
 | passthrough               | No           | Boolean  | If enabled, the response from LLM will be sent to the upstream. Default: false       |
 | timeout                   | No           | Integer  | Timeout in milliseconds for requests to LLM. Range: 1 - 60000. Default: 3000         |
 | keepalive                 | No           | Boolean  | Enable keepalive for requests to LLM. Default: true                                  |


### PR DESCRIPTION
### Description

The `override.endpoint` configuration in the `ai-proxy` plugin is not under the `model` configuration.
Documentation update only - to be in sync with the following code from
`plugins/ai-proxy/drivers/openai.lua`:
```
local endpoint = core.table.try_read_attr(conf, "override", "endpoint")
```

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
