### PR TITLE
fix: the health checker can't be released due to the health parent being released early

### DIFF
--- a/apisix/core/config_util.lua
+++ b/apisix/core/config_util.lua
@@ -58,6 +58,10 @@ end
 -- or cancelled. Note that Nginx worker exit doesn't trigger the clean handler.
 -- Return an index so that we can cancel it later.
 function _M.add_clean_handler(item, func)
+    if not item.clean_handlers then
+        return nil, "clean handlers for the item are nil"
+    end
+
     if not item.clean_handlers._id then
         item.clean_handlers._id = 1
     end

--- a/apisix/upstream.lua
+++ b/apisix/upstream.lua
@@ -155,10 +155,20 @@ local function create_checker(upstream)
         end
     end
 
+    local check_idx, err = core.config_util.add_clean_handler(healthcheck_parent, release_checker)
+    if not check_idx then
+        upstream.is_creating_checker = nil
+        checker:clear()
+        checker:stop()
+        core.log.error("failed to add clean handler, err:",
+            err, " healthcheck parent:", core.json.delay_encode(healthcheck_parent, true))
+
+        return nil
+    end
+
     healthcheck_parent.checker = checker
     healthcheck_parent.checker_upstream = upstream
-    healthcheck_parent.checker_idx =
-        core.config_util.add_clean_handler(healthcheck_parent, release_checker)
+    healthcheck_parent.checker_idx = check_idx
 
     upstream.is_creating_checker = nil
 


### PR DESCRIPTION
When a client requests, if the currently hit route or the corresponding upstream changes again, APISIX will try to re-create the health check checker for the upstream of the currently hit route and release the original health check checker.

During the process of re-creating the health check checker, when each upstream node is added as the target of the health check, the locking operation may take a long time to execute.

If the process of creating a health check checker is relatively long, and the route or the corresponding upstream changes at the same time, the parent of the upstream has been released, and in the previous step, the re-created healthcheck checker will be added to an empty object (the original intention is to Added to the new upstream parent), the checker can't be released, resulting in an "orphan" checker, which always performs health checks on the old nodes.