### PR TITLE
refactor: use setmetatable to set hidden variables without effecting serialisation

### DIFF
--- a/apisix/plugins/body-transformer.lua
+++ b/apisix/plugins/body-transformer.lua
@@ -29,7 +29,7 @@ local type              = type
 local pcall             = pcall
 local pairs             = pairs
 local next              = next
-
+local setmetatable      = setmetatable
 
 local transform_schema = {
     type = "object",
@@ -155,10 +155,12 @@ local function transform(conf, body, typ, ctx, request_method)
         return nil, 503, err
     end
 
-    out._ctx = ctx
-    out._body = body
-    out._escape_xml = escape_xml
-    out._escape_json = escape_json
+    setmetatable(out, {__index = {
+        _ctx = ctx,
+        _body = body,
+        _escape_xml = escape_xml,
+        _escape_json = escape_json,
+    }})
     local ok, render_out = pcall(render, out)
     if not ok then
         local err = str_format("%s template rendering: %s", typ, render_out)

--- a/t/plugin/body-transformer2.t
+++ b/t/plugin/body-transformer2.t
@@ -1,0 +1,90 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+no_long_string();
+no_shuffle();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!$block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+
+=== TEST 1: body transformer with decoded body (keyword: context)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin")
+            local core = require("apisix.core")
+
+            local req_template = ngx.encode_base64[[
+                {%
+                    local core = require 'apisix.core'
+                    local cjson = require 'cjson'
+                    context.name = "bar"
+                    context.address = nil
+                    context.age = context.age + 1
+                    local body = core.json.encode(context)
+                %}{* body *}
+            ]]
+
+            local code, body = t.test('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                string.format([[{
+                    "uri": "/echo",
+                    "plugins": {
+                        "body-transformer": {
+                            "request": {
+                                "template": "%s"
+                            }
+                        }
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        }
+                    }
+                }]], req_template)
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 2: verify the transformed body
+--- request
+POST /echo
+{"name": "foo", "address":"LA", "age": 18}
+-- response_body
+{"name": "bar", "age": 19}


### PR DESCRIPTION


### Description
Users hope to directly use the decoded body in the template of body-transformer, modify its fields, and then encode it again. Previously, we set several hidden variables in the _out variable, including function-type variables, which caused issues with direct encoding.

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
