### PR TITLE
feat: plugins in multi-auth returns error instead of logging it

### DIFF
--- a/apisix/plugins/basic-auth.lua
+++ b/apisix/plugins/basic-auth.lua
@@ -18,6 +18,8 @@ local core = require("apisix.core")
 local ngx = ngx
 local ngx_re = require("ngx.re")
 local consumer = require("apisix.consumer")
+local auth_utils = require("apisix.utils.auth")
+
 local lrucache = core.lrucache.new({
     ttl = 300, count = 512
 })
@@ -132,6 +134,9 @@ function _M.rewrite(conf, ctx)
 
     local username, password, err = extract_auth_header(auth_header)
     if err then
+        if auth_utils.is_running_under_multi_auth(ctx) then
+            return 401, err
+        end
         core.log.warn(err)
         return 401, { message = "Invalid authorization in request" }
     end

--- a/apisix/plugins/hmac-auth.lua
+++ b/apisix/plugins/hmac-auth.lua
@@ -28,6 +28,7 @@ local ngx_encode_base64 = ngx.encode_base64
 local plugin_name   = "hmac-auth"
 local ALLOWED_ALGORITHMS = {"hmac-sha1", "hmac-sha256", "hmac-sha512"}
 local resty_sha256 = require("resty.sha256")
+local auth_utils = require("apisix.utils.auth")
 
 local schema = {
     type = "object",
@@ -324,7 +325,11 @@ end
 function _M.rewrite(conf, ctx)
     local params,err = retrieve_hmac_fields(ctx)
     if err then
-        core.log.warn("client request can't be validated: ", err)
+        err = "client request can't be validated: " .. err
+        if auth_utils.is_running_under_multi_auth(ctx) then
+            return 401, err
+        end
+        core.log.warn(err)
         return 401, {message = "client request can't be validated: " .. err}
     end
 
@@ -333,7 +338,11 @@ function _M.rewrite(conf, ctx)
     end
     local validated_consumer, err = validate(ctx, conf, params)
     if not validated_consumer then
-        core.log.warn("client request can't be validated: ", err or "Invalid signature")
+        err = "client request can't be validated: " .. (err or "Invalid signature")
+        if auth_utils.is_running_under_multi_auth(ctx) then
+            return 401, err
+        end
+        core.log.warn(err)
         return 401, {message = "client request can't be validated"}
     end
 

--- a/apisix/plugins/hmac-auth.lua
+++ b/apisix/plugins/hmac-auth.lua
@@ -330,7 +330,7 @@ function _M.rewrite(conf, ctx)
             return 401, err
         end
         core.log.warn(err)
-        return 401, {message = "client request can't be validated: " .. err}
+        return 401, {message = err}
     end
 
     if conf.hide_credentials then

--- a/apisix/plugins/jwt-auth.lua
+++ b/apisix/plugins/jwt-auth.lua
@@ -237,8 +237,8 @@ function _M.rewrite(conf, ctx)
     local jwt_obj = jwt:load_jwt(jwt_token)
     core.log.info("jwt object: ", core.json.delay_encode(jwt_obj))
     if not jwt_obj.valid then
+        err = "JWT token invalid: " .. jwt_obj.reason
         if auth_utils.is_running_under_multi_auth(ctx) then
-            err = "JWT token invalid: " .. jwt_obj.reason
             return 401, err
         end
         core.log.warn(err)

--- a/apisix/plugins/jwt-auth.lua
+++ b/apisix/plugins/jwt-auth.lua
@@ -19,6 +19,7 @@ local jwt      = require("resty.jwt")
 local consumer_mod = require("apisix.consumer")
 local resty_random = require("resty.random")
 local new_tab = require ("table.new")
+local auth_utils = require("apisix.utils.auth")
 
 local ngx_encode_base64 = ngx.encode_base64
 local ngx_decode_base64 = ngx.decode_base64
@@ -236,7 +237,11 @@ function _M.rewrite(conf, ctx)
     local jwt_obj = jwt:load_jwt(jwt_token)
     core.log.info("jwt object: ", core.json.delay_encode(jwt_obj))
     if not jwt_obj.valid then
-        core.log.warn("JWT token invalid: ", jwt_obj.reason)
+        if auth_utils.is_running_under_multi_auth(ctx) then
+            err = "JWT token invalid: " .. jwt_obj.reason
+            return 401, err
+        end
+        core.log.warn(err)
         return 401, {message = "JWT token invalid"}
     end
 
@@ -260,7 +265,11 @@ function _M.rewrite(conf, ctx)
 
     local auth_secret, err = get_auth_secret(consumer.auth_conf)
     if not auth_secret then
-        core.log.error("failed to retrieve secrets, err: ", err)
+        err = "failed to retrieve secrets, err: " .. err
+        if auth_utils.is_running_under_multi_auth(ctx) then
+            return 401, err
+        end
+        core.log.error(err)
         return 503, {message = "failed to verify jwt"}
     end
     local claim_specs = jwt:get_default_validation_options(jwt_obj)
@@ -270,7 +279,11 @@ function _M.rewrite(conf, ctx)
     core.log.info("jwt object: ", core.json.delay_encode(jwt_obj))
 
     if not jwt_obj.verified then
-        core.log.warn("failed to verify jwt: ", jwt_obj.reason)
+        err = "failed to verify jwt: " .. jwt_obj.reason
+        if auth_utils.is_running_under_multi_auth(ctx) then
+            return 401, err
+        end
+        core.log.warn(err)
         return 401, {message = "failed to verify jwt"}
     end
 

--- a/apisix/plugins/multi-auth.lua
+++ b/apisix/plugins/multi-auth.lua
@@ -84,7 +84,7 @@ function _M.rewrite(conf, ctx)
                 core.log.debug(auth_plugin_name .. " succeed to authenticate the request")
                 goto authenticated
             else
-                core.table.insert(errors, auth_plugin_name .. 
+                core.table.insert(errors, auth_plugin_name ..
                         " failed to authenticate the request, code: "
                         .. auth_code .. ". error: " .. err)
             end

--- a/apisix/plugins/multi-auth.lua
+++ b/apisix/plugins/multi-auth.lua
@@ -84,7 +84,8 @@ function _M.rewrite(conf, ctx)
                 core.log.debug(auth_plugin_name .. " succeed to authenticate the request")
                 goto authenticated
             else
-                core.table.insert(errors, auth_plugin_name .. " failed to authenticate the request, code: "
+                core.table.insert(errors, auth_plugin_name .. 
+                        " failed to authenticate the request, code: "
                         .. auth_code .. ". error: " .. err)
             end
         end

--- a/apisix/plugins/multi-auth.lua
+++ b/apisix/plugins/multi-auth.lua
@@ -17,6 +17,7 @@
 local core = require("apisix.core")
 local require = require
 local pairs = pairs
+local type = type
 
 local schema = {
     type = "object",
@@ -93,7 +94,7 @@ function _M.rewrite(conf, ctx)
 
     :: authenticated ::
     if status_code ~= nil then
-        for _, error in ipairs(errors) do
+        for _, error in pairs(errors) do
             core.log.warn(error)
         end
         return 401, { message = "Authorization Failed" }

--- a/apisix/utils/auth.lua
+++ b/apisix/utils/auth.lua
@@ -1,3 +1,20 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
 local _M = {}
 
 function _M.is_running_under_multi_auth(ctx)

--- a/apisix/utils/auth.lua
+++ b/apisix/utils/auth.lua
@@ -1,0 +1,7 @@
+local _M = {}
+
+function _M.is_running_under_multi_auth(ctx)
+    return ctx._plugin_name == "multi-auth"
+end
+
+return _M

--- a/t/plugin/multi-auth2.t
+++ b/t/plugin/multi-auth2.t
@@ -103,7 +103,7 @@ passed
 
 
 
-=== TEST 5: invalid basic-auth credentials
+=== TEST 3: invalid basic-auth credentials
 --- request
 GET /hello
 --- more_headers
@@ -118,7 +118,7 @@ hmac-auth failed to authenticate the request, code: 401. error: client request c
 
 
 
-=== TEST 6: valid basic-auth creds
+=== TEST 4: valid basic-auth creds
 --- request
 GET /hello
 --- more_headers
@@ -130,7 +130,7 @@ failed to authenticate the request
 
 
 
-=== TEST 7: missing hmac auth authorization header
+=== TEST 5: missing hmac auth authorization header
 --- request
 GET /hello
 --- error_code: 401
@@ -141,7 +141,7 @@ hmac-auth failed to authenticate the request, code: 401. error: client request c
 
 
 
-=== TEST 8: hmac auth missing algorithm
+=== TEST 6: hmac auth missing algorithm
 --- request
 GET /hello
 --- more_headers
@@ -155,7 +155,7 @@ hmac-auth failed to authenticate the request, code: 401. error: client request c
 
 
 
-=== TEST 11: add consumer with username and jwt-auth plugins
+=== TEST 7: add consumer with username and jwt-auth plugins
 --- config
     location /t {
         content_by_lua_block {
@@ -186,7 +186,7 @@ passed
 
 
 
-=== TEST 12: test with expired jwt token
+=== TEST 8: test with expired jwt token
 --- request
 GET /hello
 --- error_code: 401
@@ -199,7 +199,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtle
 
 
 
-=== TEST 13: test with jwt token containing wrong signature
+=== TEST 9: test with jwt token containing wrong signature
 --- request
 GET /hello
 --- error_code: 401
@@ -212,7 +212,7 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtle
 
 
 
-=== TEST 14: verify jwt-auth
+=== TEST 10: verify jwt-auth
 --- request
 GET /hello
 --- more_headers

--- a/t/plugin/multi-auth2.t
+++ b/t/plugin/multi-auth2.t
@@ -1,0 +1,223 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+no_long_string();
+no_root_location();
+no_shuffle();
+run_tests;
+
+__DATA__
+
+=== TEST 1: add consumer with basic-auth and key-auth plugins
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "foo",
+                    "plugins": {
+                        "basic-auth": {
+                            "username": "foo",
+                            "password": "bar"
+                        },
+                        "jwt-auth": {
+                            "key": "user-key",
+                            "secret": "my-secret-key"
+                        }
+                    }
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 2: enable multi auth plugin using admin api
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "multi-auth": {
+                            "auth_plugins": [
+                                {
+                                    "basic-auth": {}
+                                },
+                                {
+                                    "jwt-auth": {}
+                                },
+                                {
+                                    "hmac-auth": {}
+                                }
+                            ]
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 5: invalid basic-auth credentials
+--- request
+GET /hello
+--- more_headers
+Authorization: Basic YmFyOmJhcgo=
+--- error_code: 401
+--- response_body
+{"message":"Authorization Failed"}
+--- error_log
+basic-auth failed to authenticate the request, code: 401. error: Invalid user authorization
+jwt-auth failed to authenticate the request, code: 401. error: JWT token invalid: invalid jwt string
+hmac-auth failed to authenticate the request, code: 401. error: client request can't be validated: Authorization header does not start with 'Signature'
+
+
+
+=== TEST 6: valid basic-auth creds
+--- request
+GET /hello
+--- more_headers
+Authorization: Basic Zm9vOmJhcg==
+--- response_body
+hello world
+--- no_error_log
+failed to authenticate the request
+
+
+
+=== TEST 7: missing hmac auth authorization header
+--- request
+GET /hello
+--- error_code: 401
+--- response_body
+{"message":"Authorization Failed"}
+--- error_log
+hmac-auth failed to authenticate the request, code: 401. error: client request can't be validated: missing Authorization header
+
+
+
+=== TEST 8: hmac auth missing algorithm
+--- request
+GET /hello
+--- more_headers
+Authorization: Signature keyId="my-access-key",headers="@request-target date" ,signature="asdf"
+Date: Thu, 24 Sep 2020 06:39:52 GMT
+--- error_code: 401
+--- response_body
+{"message":"Authorization Failed"}
+--- error_log
+hmac-auth failed to authenticate the request, code: 401. error: client request can't be validated: algorithm missing
+
+
+
+=== TEST 11: add consumer with username and jwt-auth plugins
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack",
+                    "plugins": {
+                        "jwt-auth": {
+                            "key": "user-key",
+                            "secret": "my-secret-key"
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 12: test with expired jwt token
+--- request
+GET /hello
+--- error_code: 401
+--- response_body
+{"message":"Authorization Failed"}
+--- error_log
+jwt-auth failed to authenticate the request, code: 401. error: failed to verify jwt: 'exp' claim expired at Tue, 23 Jul 2019 08:28:21 GMT
+--- more_headers
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTU2Mzg3MDUwMX0.pPNVvh-TQsdDzorRwa-uuiLYiEBODscp9wv0cwD6c68
+
+
+
+=== TEST 13: test with jwt token containing wrong signature
+--- request
+GET /hello
+--- error_code: 401
+--- response_body
+{"message":"Authorization Failed"}
+--- error_log
+jwt-auth failed to authenticate the request, code: 401. error: failed to verify jwt: signature mismatch: fNtFJnNnJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
+--- more_headers
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTg3OTMxODU0MX0.fNtFJnNnJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
+
+
+
+=== TEST 14: verify jwt-auth
+--- request
+GET /hello
+--- more_headers
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTg3OTMxODU0MX0.fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
+--- response_body
+hello world
+--- no_error_log
+failed to authenticate the request


### PR DESCRIPTION
### Description

When using auth plugins with the multi auth plugin, if one of the authentication fails but other auth plugins succeed, the basic auth plugin will record a warning log, causing inconvenience to the user.

[apisix/apisix/plugins/multi-auth.lua at master · apache/apisix](https://github.com/apache/apisix/blob/master/apisix/plugins/multi-auth.lua#L75) The muti auth plugin does not record the error message returned by the plugin.

### Solution:
When there are multiple plugins in muti auth, if the final verification is passed (that is, any plugin is verified), even if other plugins return errors, no error log needs to be recorded
If all plugins fail to verify, summarize the error messages of multiple plugins into a log for recording.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
