### PR TITLE
docs: Correcting grammatical errors in the installation guide document.

### DIFF
--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -314,9 +314,8 @@ You can update your configuration file as shown below:
 ```yaml title="conf/config.yaml"
 deployment:
   admin:
-    admin_key
-      -
-        name: "admin"
+    admin_key:
+      - name: "admin"
         key: newsupersecurekey
         role: admin
 ```

--- a/docs/zh/latest/installation-guide.md
+++ b/docs/zh/latest/installation-guide.md
@@ -304,9 +304,8 @@ deployment:
 ```yaml title="./conf/config.yaml"
 deployment:
   admin:
-    admin_key
-      -
-        name: "admin"
+    admin_key:
+      - name: "admin"
         key: newsupersecurekey  # 请修改 key 的值
         role: admin
 ```


### PR DESCRIPTION
### Description

There is a grammatical error in the provided config.yaml configuration in the "Updating Admin API key" section of the APISIX installation guide, missing a colon.

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
