### PR TITLE
feat: support anonymous consumer

### DIFF
--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -164,6 +164,11 @@ function _M.plugin(plugin_name)
 end
 
 
+function _M.consumers_conf(plugin_name)
+    return _M.plugin(plugin_name)
+end
+
+
 -- attach chosen consumer to the ctx, used in auth plugin
 function _M.attach_consumer(ctx, consumer, conf)
     ctx.consumer = consumer

--- a/apisix/plugins/basic-auth.lua
+++ b/apisix/plugins/basic-auth.lua
@@ -124,9 +124,7 @@ local function extract_auth_header(authorization)
 
 end
 
-local function find_consumer(conf, ctx)
-    core.log.info("plugin access phase, conf: ", core.json.delay_encode(conf))
-
+local function find_consumer(ctx)
     -- 1. extract authorization from header
     local auth_header = core.request.header(ctx, "Authorization")
     if not auth_header then

--- a/apisix/plugins/basic-auth.lua
+++ b/apisix/plugins/basic-auth.lua
@@ -141,7 +141,8 @@ local function find_consumer(conf, ctx)
     end
 
     -- 2. get user info from consumer plugin
-    local cur_consumer, consumer_conf, err = consumer.find_consumer(plugin_name, "username", username)
+    local cur_consumer, consumer_conf, err = consumer.find_consumer(plugin_name, "username",
+                                             username)
     if not cur_consumer then
         core.log.warn("failed to find user: ", err or "invalid user")
         return nil, nil, "Invalid user authorization"

--- a/apisix/plugins/hmac-auth.lua
+++ b/apisix/plugins/hmac-auth.lua
@@ -28,7 +28,6 @@ local ngx_encode_base64 = ngx.encode_base64
 local plugin_name   = "hmac-auth"
 local ALLOWED_ALGORITHMS = {"hmac-sha1", "hmac-sha256", "hmac-sha512"}
 local resty_sha256 = require("resty.sha256")
-local auth_utils = require("apisix.utils.auth")
 local schema_def = require("apisix.schema_def")
 
 local schema = {

--- a/apisix/plugins/hmac-auth.lua
+++ b/apisix/plugins/hmac-auth.lua
@@ -336,7 +336,7 @@ local function find_consumer(conf, ctx)
     local validated_consumer, err = validate(ctx, conf, params)
     if not validated_consumer then
         core.log.warn("client request can't be validated: ", err or "Invalid signature")
-        return nil, nil, "client request can't be validated"
+        return nil, nil, "client request can't be validated: " .. err
     end
 
     local consumers_conf = consumer.consumers_conf(plugin_name)

--- a/apisix/plugins/hmac-auth.lua
+++ b/apisix/plugins/hmac-auth.lua
@@ -29,6 +29,7 @@ local plugin_name   = "hmac-auth"
 local ALLOWED_ALGORITHMS = {"hmac-sha1", "hmac-sha256", "hmac-sha512"}
 local resty_sha256 = require("resty.sha256")
 local auth_utils = require("apisix.utils.auth")
+local schema_def = require("apisix.schema_def")
 
 local schema = {
     type = "object",
@@ -62,6 +63,7 @@ local schema = {
             default = false,
         },
         hide_credentials = {type = "boolean", default = false},
+        anonymous_consumer = schema_def.anonymous_consumer_schema,
     },
 }
 
@@ -187,6 +189,10 @@ end
 
 
 local function validate(ctx, conf, params)
+    if not params then
+        return nil
+    end
+
     if not params.keyId or not params.signature then
         return nil, "keyId or signature missing"
     end
@@ -321,34 +327,41 @@ local function retrieve_hmac_fields(ctx)
     return hmac_params
 end
 
-
-function _M.rewrite(conf, ctx)
+local function find_consumer(conf, ctx)
     local params,err = retrieve_hmac_fields(ctx)
     if err then
-        err = "client request can't be validated: " .. err
-        if auth_utils.is_running_under_multi_auth(ctx) then
-            return 401, err
+        core.log.warn("client request can't be validated: ", err)
+        return nil, nil, "client request can't be validated: " .. err
+    end
+
+    local validated_consumer, err = validate(ctx, conf, params)
+    if not validated_consumer then
+        core.log.warn("client request can't be validated: ", err or "Invalid signature")
+        return nil, nil, "client request can't be validated"
+    end
+
+    local consumers_conf = consumer.consumers_conf(plugin_name)
+    return validated_consumer, consumers_conf, err
+end
+
+function _M.rewrite(conf, ctx)
+    local cur_consumer, consumers_conf, err = find_consumer(conf, ctx)
+    if not cur_consumer then
+        if not conf.anonymous_consumer then
+            return 401, { message = err }
         end
-        core.log.warn(err)
-        return 401, {message = err}
+        cur_consumer, consumers_conf, err = consumer.get_anonymous_consumer(conf.anonymous_consumer)
+        if not cur_consumer then
+            core.log.error(err)
+            return 401, { message = "Invalid user authorization" }
+        end
     end
 
     if conf.hide_credentials then
         core.request.set_header("Authorization", nil)
     end
-    local validated_consumer, err = validate(ctx, conf, params)
-    if not validated_consumer then
-        err = "client request can't be validated: " .. (err or "Invalid signature")
-        if auth_utils.is_running_under_multi_auth(ctx) then
-            return 401, err
-        end
-        core.log.warn(err)
-        return 401, {message = "client request can't be validated"}
-    end
 
-    local consumer_conf = consumer.plugin(plugin_name)
-    consumer.attach_consumer(ctx, validated_consumer, consumer_conf)
-    core.log.info("hit hmac-auth rewrite")
+    consumer.attach_consumer(ctx, cur_consumer, consumers_conf)
 end
 
 

--- a/apisix/plugins/jwt-auth.lua
+++ b/apisix/plugins/jwt-auth.lua
@@ -289,10 +289,10 @@ local function find_consumer(conf, ctx)
     if not jwt_obj.verified then
         err = "failed to verify jwt: " .. jwt_obj.reason
         if auth_utils.is_running_under_multi_auth(ctx) then
-            return nil, nil, err
+            return nil, nil, "failed to verify jwt"
         end
         core.log.warn(err)
-        return nil, nil, err
+        return nil, nil, "failed to verify jwt"
     end
 
     return consumer, consumer_conf

--- a/apisix/plugins/key-auth.lua
+++ b/apisix/plugins/key-auth.lua
@@ -81,10 +81,15 @@ local function find_consumer(ctx, conf)
         return 401, {message = "Missing API key in request"}
     end
 
-    local consumer, consumer_conf, err = consumer_mod.find_consumer(plugin_name, "username", username)
+    local consumer_conf = consumer_mod.plugin(plugin_name)
+    if not consumer_conf then
+        return 401, {message = "Missing related consumer"}
+    end
+
+    local consumers = consumer_mod.consumers_kv(plugin_name, consumer_conf, "key")
+    local consumer = consumers[key]
     if not consumer then
-        core.log.warn("failed to find user: ", err or "invalid user")
-        return nil, nil, "Invalid user authorization"
+        return 401, {message = "Invalid API key in request"}
     end
     core.log.info("consumer: ", core.json.delay_encode(consumer))
 
@@ -97,6 +102,7 @@ local function find_consumer(ctx, conf)
             core.request.set_uri_args(ctx, args)
         end
     end
+
     return consumer, consumer_conf
 end
 

--- a/apisix/plugins/key-auth.lua
+++ b/apisix/plugins/key-auth.lua
@@ -78,18 +78,18 @@ local function find_consumer(ctx, conf)
     end
 
     if not key then
-        return 401, {message = "Missing API key in request"}
+        return nil, nil, "Missing API key in request"
     end
 
     local consumer_conf = consumer_mod.plugin(plugin_name)
     if not consumer_conf then
-        return 401, {message = "Missing related consumer"}
+        return nil, nil, "Missing related consumer"
     end
 
     local consumers = consumer_mod.consumers_kv(plugin_name, consumer_conf, "key")
     local consumer = consumers[key]
     if not consumer then
-        return 401, {message = "Invalid API key in request"}
+        return nil, nil, "Invalid API key in request"
     end
     core.log.info("consumer: ", core.json.delay_encode(consumer))
 

--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -29,7 +29,7 @@ local plugins_schema = {
 
 _M.anonymous_consumer_schema = {
     type = "string",
-    minLength = "1" 
+    minLength = "1"
 }
 
 local id_schema = {

--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -27,6 +27,11 @@ local plugins_schema = {
     type = "object"
 }
 
+_M.anonymous_consumer_schema = {
+    type = "string",
+    minLength = "1" 
+}
+
 local id_schema = {
     anyOf = {
         {

--- a/t/plugin/basic-auth-anonymous-consumer.t
+++ b/t/plugin/basic-auth-anonymous-consumer.t
@@ -170,7 +170,7 @@ hello world
 
 
 
-=== TEST 4: request without basic-auth header will be from anonymous consumer and different rate limit will apply
+=== TEST 5: request without basic-auth header will be from anonymous consumer and different rate limit will apply
 --- pipelined_requests eval
 ["GET /hello", "GET /hello", "GET /hello", "GET /hello"]
 --- error_code eval
@@ -178,7 +178,7 @@ hello world
 
 
 
-=== TEST 5: add basic auth plugin with non-existent anonymous_consumer
+=== TEST 6: add basic auth plugin with non-existent anonymous_consumer
 --- config
     location /t {
         content_by_lua_block {
@@ -214,7 +214,7 @@ passed
 
 
 
-=== TEST 6: anonymous-consumer configured in the route should not be found
+=== TEST 7: anonymous-consumer configured in the route should not be found
 --- request
 GET /hello
 --- error_code: 401

--- a/t/plugin/basic-auth-anonymous-consumer.t
+++ b/t/plugin/basic-auth-anonymous-consumer.t
@@ -132,7 +132,7 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            
+
             for i = 1, 5, 1 do
                 local code, body = t('/hello',
                     ngx.HTTP_GET,

--- a/t/plugin/basic-auth-anonymous-consumer.t
+++ b/t/plugin/basic-auth-anonymous-consumer.t
@@ -1,0 +1,224 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+
+no_long_string();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    my $user_yaml_config = <<_EOC_;
+apisix:
+  data_encryption:
+    enable_encrypt_fields: false
+_EOC_
+    $block->set_value("yaml_config", $user_yaml_config);
+});
+
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: add consumer jack and anonymous
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack",
+                    "plugins": {
+                        "basic-auth": {
+                            "username": "foo",
+                            "password": "bar"
+                        },
+                        "limit-count": {
+                            "count": 4,
+                            "time_window": 60
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "anonymous",
+                    "plugins": {
+                        "limit-count": {
+                            "count": 1,
+                            "time_window": 60
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+passed
+
+
+
+=== TEST 2: add basic auth plugin using admin api
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "basic-auth": {
+                            "anonymous_consumer": "anonymous"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 3: normal consumer
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            
+            for i = 1, 5, 1 do
+                local code, body = t('/hello',
+                    ngx.HTTP_GET,
+                    nil,
+                    nil,
+                    {
+                        Authorization = "Basic Zm9vOmJhcg=="
+                    }
+                )
+
+                if code >= 300 then
+                    ngx.say("failed" .. code)
+                    return
+                end
+                ngx.say(body .. i)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed1
+passed2
+passed3
+passed4
+failed503
+
+
+
+=== TEST 4: request without basic-auth header will be from anonymous consumer and it will pass
+--- request
+GET /hello
+--- response_body
+hello world
+
+
+
+=== TEST 4: request without basic-auth header will be from anonymous consumer and different rate limit will apply
+--- pipelined_requests eval
+["GET /hello", "GET /hello", "GET /hello", "GET /hello"]
+--- error_code eval
+[200, 503, 503, 503]
+
+
+
+=== TEST 5: add basic auth plugin with non-existent anonymous_consumer
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "basic-auth": {
+                            "anonymous_consumer": "not-found-anonymous"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 6: anonymous-consumer configured in the route should not be found
+--- request
+GET /hello
+--- error_code: 401
+--- error_log
+failed to get anonymous consumer not-found-anonymous
+--- response_body
+{"message":"Invalid user authorization"}

--- a/t/plugin/hmac-auth-anonymous-consumer.t
+++ b/t/plugin/hmac-auth-anonymous-consumer.t
@@ -1,0 +1,189 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+
+no_long_string();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    my $user_yaml_config = <<_EOC_;
+apisix:
+  data_encryption:
+    enable_encrypt_fields: false
+_EOC_
+    $block->set_value("yaml_config", $user_yaml_config);
+});
+
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: add consumer jack and anonymous
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack",
+                    "plugins": {
+                        "hmac-auth": {
+                            "key_id": "user-key",
+                            "secret_key": "my-secret-key"
+                        },
+                        "limit-count": {
+                            "count": 4,
+                            "time_window": 60
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "anonymous",
+                    "plugins": {
+                        "limit-count": {
+                            "count": 1,
+                            "time_window": 60
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+passed
+
+
+
+=== TEST 2: add hmac auth plugin using admin api
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "hmac-auth": {
+                            "anonymous_consumer": "anonymous"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 3: request without hmac-auth header will be from anonymous consumer and it will pass
+--- request
+GET /hello
+--- response_body
+hello world
+
+
+
+=== TEST 4: request without hmac-auth header will be from anonymous consumer and different rate limit will apply
+--- pipelined_requests eval
+["GET /hello", "GET /hello", "GET /hello", "GET /hello"]
+--- error_code eval
+[200, 503, 503, 503]
+
+
+
+=== TEST 5: add hmac auth plugin with non-existent anonymous_consumer
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "hmac-auth": {
+                            "anonymous_consumer": "not-found-anonymous"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 6: anonymous-consumer configured in the route should not be found
+--- request
+GET /hello
+--- error_code: 401
+--- error_log
+failed to get anonymous consumer not-found-anonymous
+--- response_body
+{"message":"Invalid user authorization"}

--- a/t/plugin/jwt-auth-anonymous-consumer.t
+++ b/t/plugin/jwt-auth-anonymous-consumer.t
@@ -1,0 +1,224 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+
+no_long_string();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    my $user_yaml_config = <<_EOC_;
+apisix:
+  data_encryption:
+    enable_encrypt_fields: false
+_EOC_
+    $block->set_value("yaml_config", $user_yaml_config);
+});
+
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: add consumer jack and anonymous
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack",
+                    "plugins": {
+                        "jwt-auth": {
+                            "key": "user-key",
+                            "secret": "my-secret-key"
+                        },
+                        "limit-count": {
+                            "count": 4,
+                            "time_window": 60
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "anonymous",
+                    "plugins": {
+                        "limit-count": {
+                            "count": 1,
+                            "time_window": 60
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+passed
+
+
+
+=== TEST 2: add jwt auth plugin using admin api
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "jwt-auth": {
+                            "anonymous_consumer": "anonymous"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 3: normal consumer
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            
+            for i = 1, 5, 1 do
+                local code, body = t('/hello',
+                    ngx.HTTP_GET,
+                    nil,
+                    nil,
+                    {
+                        Authorization = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTg3OTMxODU0MX0.fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs"
+                    }
+                )
+
+                if code >= 300 then
+                    ngx.say("failed" .. code)
+                    return
+                end
+                ngx.say(body .. i)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed1
+passed2
+passed3
+passed4
+failed503
+
+
+
+=== TEST 4: request without jwt-auth header will be from anonymous consumer and it will pass
+--- request
+GET /hello
+--- response_body
+hello world
+
+
+
+=== TEST 4: request without jwt-auth header will be from anonymous consumer and different rate limit will apply
+--- pipelined_requests eval
+["GET /hello", "GET /hello", "GET /hello", "GET /hello"]
+--- error_code eval
+[200, 503, 503, 503]
+
+
+
+=== TEST 5: add jwt auth plugin with non-existent anonymous_consumer
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "jwt-auth": {
+                            "anonymous_consumer": "not-found-anonymous"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 6: anonymous-consumer configured in the route should not be found
+--- request
+GET /hello
+--- error_code: 401
+--- error_log
+failed to get anonymous consumer not-found-anonymous
+--- response_body
+{"message":"Invalid user authorization"}

--- a/t/plugin/jwt-auth-anonymous-consumer.t
+++ b/t/plugin/jwt-auth-anonymous-consumer.t
@@ -132,7 +132,7 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            
+
             for i = 1, 5, 1 do
                 local code, body = t('/hello',
                     ngx.HTTP_GET,

--- a/t/plugin/jwt-auth-anonymous-consumer.t
+++ b/t/plugin/jwt-auth-anonymous-consumer.t
@@ -170,7 +170,7 @@ hello world
 
 
 
-=== TEST 4: request without jwt-auth header will be from anonymous consumer and different rate limit will apply
+=== TEST 5: request without jwt-auth header will be from anonymous consumer and different rate limit will apply
 --- pipelined_requests eval
 ["GET /hello", "GET /hello", "GET /hello", "GET /hello"]
 --- error_code eval
@@ -178,7 +178,7 @@ hello world
 
 
 
-=== TEST 5: add jwt auth plugin with non-existent anonymous_consumer
+=== TEST 6: add jwt auth plugin with non-existent anonymous_consumer
 --- config
     location /t {
         content_by_lua_block {
@@ -214,7 +214,7 @@ passed
 
 
 
-=== TEST 6: anonymous-consumer configured in the route should not be found
+=== TEST 7: anonymous-consumer configured in the route should not be found
 --- request
 GET /hello
 --- error_code: 401

--- a/t/plugin/key-auth-anonymous-consumer.t
+++ b/t/plugin/key-auth-anonymous-consumer.t
@@ -131,7 +131,7 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            
+
             for i = 1, 5, 1 do
                 local code, body = t('/hello',
                     ngx.HTTP_GET,

--- a/t/plugin/key-auth-anonymous-consumer.t
+++ b/t/plugin/key-auth-anonymous-consumer.t
@@ -169,7 +169,7 @@ hello world
 
 
 
-=== TEST 4: request without key-auth header will be from anonymous consumer and different rate limit will apply
+=== TEST 5: request without key-auth header will be from anonymous consumer and different rate limit will apply
 --- pipelined_requests eval
 ["GET /hello", "GET /hello", "GET /hello", "GET /hello"]
 --- error_code eval
@@ -177,7 +177,7 @@ hello world
 
 
 
-=== TEST 5: add key auth plugin with non-existent anonymous_consumer
+=== TEST 6: add key auth plugin with non-existent anonymous_consumer
 --- config
     location /t {
         content_by_lua_block {
@@ -213,7 +213,7 @@ passed
 
 
 
-=== TEST 6: anonymous-consumer configured in the route should not be found
+=== TEST 7: anonymous-consumer configured in the route should not be found
 --- request
 GET /hello
 --- error_code: 401

--- a/t/plugin/key-auth-anonymous-consumer.t
+++ b/t/plugin/key-auth-anonymous-consumer.t
@@ -1,0 +1,223 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+
+no_long_string();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    my $user_yaml_config = <<_EOC_;
+apisix:
+  data_encryption:
+    enable_encrypt_fields: false
+_EOC_
+    $block->set_value("yaml_config", $user_yaml_config);
+});
+
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: add consumer jack and anonymous
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack",
+                    "plugins": {
+                        "key-auth": {
+                            "key": "auth-one"
+                        },
+                        "limit-count": {
+                            "count": 4,
+                            "time_window": 60
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "anonymous",
+                    "plugins": {
+                        "limit-count": {
+                            "count": 1,
+                            "time_window": 60
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+passed
+
+
+
+=== TEST 2: add key auth plugin using admin api
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "key-auth": {
+                            "anonymous_consumer": "anonymous"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 3: normal consumer
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            
+            for i = 1, 5, 1 do
+                local code, body = t('/hello',
+                    ngx.HTTP_GET,
+                    nil,
+                    nil,
+                    {
+                        apikey = "auth-one"
+                    }
+                )
+
+                if code >= 300 then
+                    ngx.say("failed" .. code)
+                    return
+                end
+                ngx.say(body .. i)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed1
+passed2
+passed3
+passed4
+failed503
+
+
+
+=== TEST 4: request without key-auth header will be from anonymous consumer and it will pass
+--- request
+GET /hello
+--- response_body
+hello world
+
+
+
+=== TEST 4: request without key-auth header will be from anonymous consumer and different rate limit will apply
+--- pipelined_requests eval
+["GET /hello", "GET /hello", "GET /hello", "GET /hello"]
+--- error_code eval
+[200, 503, 503, 503]
+
+
+
+=== TEST 5: add key auth plugin with non-existent anonymous_consumer
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "key-auth": {
+                            "anonymous_consumer": "not-found-anonymous"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 6: anonymous-consumer configured in the route should not be found
+--- request
+GET /hello
+--- error_code: 401
+--- error_log
+failed to get anonymous consumer not-found-anonymous
+--- response_body
+{"message":"Invalid user authorization"}


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)
Currently, the built-in user authentication logic in APISIX is either successful authentication reflected to the corresponding Consumer object, or authentication failure directly returned to the caller authentication failure return.

Some users want a dummy consumer framed as "anonymous" consumer to be attached to the request when authentication fails so that certain rules (as plugins) defined in the "anonymous" consumer will be applied.
### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
