### PR TITLE
fix: pin test-nginx to a working version to fix tests with http2

### DIFF
--- a/ci/linux_openresty_common_runner.sh
+++ b/ci/linux_openresty_common_runner.sh
@@ -38,7 +38,15 @@ do_install() {
     # sudo apt-get install tree -y
     # tree deps
 
+    # The latest version of test-nginx is not compatible with the current set of tests with ---http2 
+    # due to this commit: https://github.com/openresty/test-nginx/commit/0ccd106cbe6878318e5a591634af8f1707c411a6
+    # This change pins test-nginx to a commit before this one.
     git clone --depth 1 https://github.com/openresty/test-nginx.git test-nginx
+    cd test-nginx
+    git fetch --depth=1 origin ced30a31bafab6c68873efb17b6d80f39bcd95f5
+    git checkout ced30a31bafab6c68873efb17b6d80f39bcd95f5
+    cd ..
+
     make utils
 
     mkdir -p build-cache


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)
The latest version of test-nginx is not compatible with the current set of tests with ---http2 
due to this commit: https://github.com/openresty/test-nginx/commit/0ccd106cbe6878318e5a591634af8f1707c411a6
This change pins test-nginx to a commit before this one.
### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
