### PR TITLE
fix(ci): remove lualdap deps

### DIFF
--- a/apisix-master-0.rockspec
+++ b/apisix-master-0.rockspec
@@ -71,7 +71,6 @@ dependencies = {
     "ext-plugin-proto = 0.6.1",
     "casbin = 1.41.9-1",
     "inspect == 3.1.1",
-    "lualdap = 1.2.6-1",
     "lua-resty-rocketmq = 0.3.0-0",
     "opentelemetry-lua = 0.2-3",
     "net-url = 0.9-1",

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -182,7 +182,7 @@ GRPC_SERVER_EXAMPLE_VER=20210819
 
 linux_get_dependencies () {
     apt update
-    apt install -y cpanminus build-essential libncurses5-dev libreadline-dev libssl-dev perl libpcre3 libpcre3-dev libldap2-dev
+    apt install -y cpanminus build-essential libncurses5-dev libreadline-dev libssl-dev perl libpcre3 libpcre3-dev
     apt-get install -y libyaml-dev
     wget https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
 }

--- a/ci/linux-install-openresty.sh
+++ b/ci/linux-install-openresty.sh
@@ -35,7 +35,7 @@ sudo add-apt-repository -y "deb https://openresty.org/package/${arch_path}ubuntu
 sudo add-apt-repository -y "deb http://repos.apiseven.com/packages/${arch_path}debian bullseye main"
 
 sudo apt-get update
-sudo apt-get install -y libldap2-dev openresty-pcre-dev openresty-zlib-dev build-essential gcc g++ cpanminus
+sudo apt-get install -y openresty-pcre-dev openresty-zlib-dev build-essential gcc g++ cpanminus
 
 SSL_LIB_VERSION=${SSL_LIB_VERSION-openssl}
 ENABLE_FIPS=${ENABLE_FIPS:-"false"}

--- a/utils/install-dependencies.sh
+++ b/utils/install-dependencies.sh
@@ -78,7 +78,7 @@ function install_dependencies_with_apt() {
     sudo apt-get update
 
     # install some compilation tools
-    sudo apt-get install -y curl make gcc g++ cpanminus libpcre3 libpcre3-dev libldap2-dev libyaml-dev unzip openresty-zlib-dev openresty-pcre-dev
+    sudo apt-get install -y curl make gcc g++ cpanminus libpcre3 libpcre3-dev libyaml-dev unzip openresty-zlib-dev openresty-pcre-dev
 }
 
 # Identify the different distributions and call the corresponding function


### PR DESCRIPTION
### Description

fix: https://github.com/apache/apisix/actions/runs/12293837387/job/34451936593?pr=11824#step:5:22314

**The current version of `lualdap` has been archived: https://luarocks.org/modules/fperrad/lualdap**

![img_v3_02hj_f505a433-b18d-45ba-811c-ea12bd9f2c5g](https://github.com/user-attachments/assets/0656ac80-47cc-4955-821d-f28dbbbfe79e)

### fix

I noticed that the implementation of ldap-auth has been replaced, and the lualdap dependency has not been used. So I think it needs to be removed.

* This PR is introduced: https://github.com/apache/apisix/pull/3894
* Replaced by resty-ldap: https://github.com/apache/apisix/pull/7590


### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
