### PR TITLE
refactor: workflow plugin registration

### DIFF
--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -185,6 +185,10 @@ local function load_plugin(name, plugins_list, plugin_type)
         plugin.init()
     end
 
+    if plugin.workflow_handler then
+        plugin.workflow_handler()
+    end
+
     return
 end
 

--- a/apisix/plugins/limit-count.lua
+++ b/apisix/plugins/limit-count.lua
@@ -16,6 +16,7 @@
 --
 local fetch_secrets = require("apisix.secret").fetch_secrets
 local limit_count = require("apisix.plugins.limit-count.init")
+local workflow = require("apisix.plugins.workflow")
 
 local plugin_name = "limit-count"
 local _M = {
@@ -36,5 +37,14 @@ function _M.access(conf, ctx)
     return limit_count.rate_limit(conf, ctx, plugin_name, 1)
 end
 
+function _M.workflow_handler()
+    workflow.register(plugin_name,
+    function (conf, ctx)
+        return limit_count.rate_limit(conf, ctx, plugin_name, 1)
+    end,
+    function (conf)
+        return limit_count.check_schema(conf)
+    end)
+end
 
 return _M

--- a/apisix/plugins/workflow.lua
+++ b/apisix/plugins/workflow.lua
@@ -15,7 +15,6 @@
 -- limitations under the License.
 --
 local core        = require("apisix.core")
-local limit_count = require("apisix.plugins.limit-count.init")
 local expr        = require("resty.expr.v1")
 local ipairs      = ipairs
 
@@ -93,22 +92,21 @@ local function exit(conf)
 end
 
 
-local function rate_limit(conf, ctx)
-    return limit_count.rate_limit(conf, ctx, "limit-count", 1)
-end
-
 
 local support_action = {
     ["return"] = {
         handler        = exit,
         check_schema   = check_return_schema,
-    },
-    ["limit-count"] = {
-        handler        = rate_limit,
-        check_schema   = limit_count.check_schema,
     }
 }
 
+
+function _M.register(plugin_name, handler, check_schema)
+    support_action[plugin_name] = {
+        handler        = handler,
+        check_schema   = check_schema
+    }
+end
 
 function _M.check_schema(conf)
     local ok, err = core.schema.check(schema, conf)


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)
Current logic requires the table `supported_actions` defined in workflow.lua to be changed when any new plugin is added to the workflow plugin. With this change, the registration in the table is offloaded to the newly added plugin by implementing the function workflow_handler()
### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
