### PR TITLE
fix: etcd watch restart when receive invalid revision

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -289,7 +289,8 @@ local function run_watch(premature)
 
     local ok, err = ngx_thread_wait(run_watch_th, check_worker_th)
     if not ok then
-        log.error("run_watch or check_worker thread terminates failed, retart those threads, error: " .. inspect(err))
+        log.error("run_watch or check_worker thread terminates failed"
+        .. " restart those threads, error: ".. inspect(err))
     end
 
     ngx_thread_kill(run_watch_th)

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -289,8 +289,8 @@ local function run_watch(premature)
 
     local ok, err = ngx_thread_wait(run_watch_th, check_worker_th)
     if not ok then
-        log.error("run_watch or check_worker thread terminates failed"
-        .. " restart those threads, error: ".. inspect(err))
+        log.error("run_watch or check_worker thread terminates failed",
+                        " restart those threads, error: ", inspect(err))
     end
 
     ngx_thread_kill(run_watch_th)

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -257,6 +257,11 @@ local function do_run_watch(premature)
         end
 
         local rev = tonumber(res.result.header.revision)
+        if rev == nil then
+            log.warn("receive a invalid revision header, header: ", inspect(res.result.header))
+            cancel_watch(http_cli)
+            break
+        end
         if rev > watch_ctx.rev then
             watch_ctx.rev = rev + 1
         end
@@ -284,7 +289,7 @@ local function run_watch(premature)
 
     local ok, err = ngx_thread_wait(run_watch_th, check_worker_th)
     if not ok then
-        log.error("check_worker thread terminates failed, retart checker, error: " .. err)
+        log.error("run_watch or check_worker thread terminates failed, retart those threads, error: " .. inspect(err))
     end
 
     ngx_thread_kill(run_watch_th)


### PR DESCRIPTION
### Description
```
 [error] 56#56: *223892756 lua user thread aborted: runtime error: /usr/local/apisix/apisix/core/config_etcd.lua:260: attempt to compare number with nil
stack traceback:
coroutine 0:
    /usr/local/apisix/apisix/core/config_etcd.lua: in function </usr/local/apisix/apisix/core/config_etcd.lua:130>
coroutine 1:
    [C]: in function 'ngx_thread_wait'
    /usr/local/apisix/apisix/core/config_etcd.lua:285: in function </usr/local/apisix/apisix/core/config_etcd.lua:268>, context: ngx.timer
 [error] 56#56: *223892756 lua entry thread aborted: runtime error: /usr/local/apisix/apisix/core/config_etcd.lua:287: attempt to concatenate local 'err' (a boolean value)
stack traceback:
coroutine 0:
    /usr/local/apisix/apisix/core/config_etcd.lua: in function </usr/local/apisix/apisix/core/config_etcd.lua:268>, context: ngx.timer
```
When the revision contained in the response returned by etcd watch API is empty, it will cause the watch thread to abort. Since the thread exits abnormally, the error object return from `ngx.thread.wait` is either nil or a boolean value (nil can be reproduced, but boolean cannot, I don't know why yet), causing subsequent log printing to abort too and making it impossible to restart the watch thread.
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
