### PR TITLE
fix: prometheus metrics expiration must be set for each metric

### DIFF
--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -137,7 +137,7 @@ function _M.http_init(prometheus_enabled_in_stream)
     end
 
     local status_exptime = core.table.try_read_attr(attr, "metrics", "http_status", "expire")
-    local latency_metrics_exptime = core.table.try_read_attr(attr, "metrics", "http_latency", "expire")
+    local latency_exptime = core.table.try_read_attr(attr, "metrics", "http_latency", "expire")
     local bandwidth_exptime = core.table.try_read_attr(attr, "metrics", "bandwidth", "expire")
 
     prometheus = base_prometheus.init("prometheus-metrics", metric_prefix)
@@ -192,7 +192,7 @@ function _M.http_init(prometheus_enabled_in_stream)
     metrics.latency = prometheus:histogram("http_latency",
         "HTTP request latency in milliseconds per service in APISIX",
         {"type", "route", "service", "consumer", "node", unpack(extra_labels("http_latency"))},
-        buckets, latency_metrics_exptime)
+        buckets, latency_exptime)
 
     metrics.bandwidth = prometheus:counter("bandwidth",
             "Total bandwidth in bytes consumed per service in APISIX",

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -136,10 +136,9 @@ function _M.http_init(prometheus_enabled_in_stream)
         metric_prefix = attr.metric_prefix
     end
 
-    local exptime
-    if attr and attr.expire then
-        exptime = attr.expire
-    end
+    local status_metrics_exptime = core.table.try_read_attr(attr, "metrics", "http_status", "expire")
+    local latency_metrics_exptime = core.table.try_read_attr(attr, "metrics", "http_latency", "expire")
+    local bandwidth_metrics_exptime = core.table.try_read_attr(attr, "metrics", "bandwidth", "expire")
 
     prometheus = base_prometheus.init("prometheus-metrics", metric_prefix)
 
@@ -172,7 +171,7 @@ function _M.http_init(prometheus_enabled_in_stream)
     metrics.upstream_status = prometheus:gauge("upstream_status",
             "Upstream status from health check",
             {"name", "ip", "port"},
-            exptime)
+            status_metrics_exptime)
 
     -- per service
 
@@ -183,7 +182,7 @@ function _M.http_init(prometheus_enabled_in_stream)
             "HTTP status codes per service in APISIX",
             {"code", "route", "matched_uri", "matched_host", "service", "consumer", "node",
             unpack(extra_labels("http_status"))},
-            exptime)
+            status_metrics_exptime)
 
     local buckets = DEFAULT_BUCKETS
     if attr and attr.default_buckets then
@@ -193,12 +192,12 @@ function _M.http_init(prometheus_enabled_in_stream)
     metrics.latency = prometheus:histogram("http_latency",
         "HTTP request latency in milliseconds per service in APISIX",
         {"type", "route", "service", "consumer", "node", unpack(extra_labels("http_latency"))},
-        buckets, exptime)
+        buckets, latency_metrics_exptime)
 
     metrics.bandwidth = prometheus:counter("bandwidth",
             "Total bandwidth in bytes consumed per service in APISIX",
             {"type", "route", "service", "consumer", "node", unpack(extra_labels("bandwidth"))},
-            exptime)
+            bandwidth_metrics_exptime)
 
     if prometheus_enabled_in_stream then
         init_stream_metrics()

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -136,9 +136,9 @@ function _M.http_init(prometheus_enabled_in_stream)
         metric_prefix = attr.metric_prefix
     end
 
-    local status_metrics_exptime = core.table.try_read_attr(attr, "metrics", "http_status", "expire")
+    local status_exptime = core.table.try_read_attr(attr, "metrics", "http_status", "expire")
     local latency_metrics_exptime = core.table.try_read_attr(attr, "metrics", "http_latency", "expire")
-    local bandwidth_metrics_exptime = core.table.try_read_attr(attr, "metrics", "bandwidth", "expire")
+    local bandwidth_exptime = core.table.try_read_attr(attr, "metrics", "bandwidth", "expire")
 
     prometheus = base_prometheus.init("prometheus-metrics", metric_prefix)
 
@@ -171,7 +171,7 @@ function _M.http_init(prometheus_enabled_in_stream)
     metrics.upstream_status = prometheus:gauge("upstream_status",
             "Upstream status from health check",
             {"name", "ip", "port"},
-            status_metrics_exptime)
+            status_exptime)
 
     -- per service
 
@@ -182,7 +182,7 @@ function _M.http_init(prometheus_enabled_in_stream)
             "HTTP status codes per service in APISIX",
             {"code", "route", "matched_uri", "matched_host", "service", "consumer", "node",
             unpack(extra_labels("http_status"))},
-            status_metrics_exptime)
+            status_exptime)
 
     local buckets = DEFAULT_BUCKETS
     if attr and attr.default_buckets then
@@ -197,7 +197,7 @@ function _M.http_init(prometheus_enabled_in_stream)
     metrics.bandwidth = prometheus:counter("bandwidth",
             "Total bandwidth in bytes consumed per service in APISIX",
             {"type", "route", "service", "consumer", "node", unpack(extra_labels("bandwidth"))},
-            bandwidth_metrics_exptime)
+            bandwidth_exptime)
 
     if prometheus_enabled_in_stream then
         init_stream_metrics()

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -599,22 +599,34 @@ plugin_attr:          # Plugin attributes
     #    extra_labels:
     #      - upstream_addr: $upstream_addr
     #      - status: $upstream_status  # The label name does not need to be the same as the variable name.
+    #    expire: 0                        # The expiration time of metrics in seconds.
+                                          # 0 means the metrics will not expire.
+                                          # Only affect apisix_http_status, apisix_bandwidth, and apisix_http_latency.
+                                          # If you need to set the expiration time, it is recommended to use 600, which is 10 minutes.
     #  http_latency:
     #    extra_labels:
     #      - upstream_addr: $upstream_addr
+    #    expire: 0                        # The expiration time of metrics in seconds.
+                                          # 0 means the metrics will not expire.
+                                          # Only affect apisix_http_status, apisix_bandwidth, and apisix_http_latency.
+                                          # If you need to set the expiration time, it is recommended to use 600, which is 10 minutes.
     #  bandwidth:
     #    extra_labels:
     #      - upstream_addr: $upstream_addr
+    #    expire: 0                        # The expiration time of metrics in seconds.
+                                          # 0 means the metrics will not expire.
+                                          # Only affect apisix_http_status, apisix_bandwidth, and apisix_http_latency.
+                                          # If you need to set the expiration time, it is recommended to use 600, which is 10 minutes.
     # default_buckets:
     #   - 10
     #   - 50
     #   - 100
     #   - 200
     #   - 500
-    # expire: 0                       # The expiration time of metrics in seconds.
-                                      # 0 means the metrics will not expire.
-                                      # Only affect apisix_http_status, apisix_bandwidth, and apisix_http_latency.
-                                      # If you need to set the expiration time, it is recommended to use 600, which is 10 minutes.
+        # expire: 0                       # The expiration time of metrics in seconds.
+                                          # 0 means the metrics will not expire.
+                                          # Only affect apisix_http_status, apisix_bandwidth, and apisix_http_latency.
+                                          # If you need to set the expiration time, it is recommended to use 600, which is 10 minutes.
   server-info:                        # Plugin: server-info
     report_ttl: 60                    # Set the TTL in seconds for server info in etcd.
                                       # Maximum: 86400. Minimum: 3.

--- a/t/plugin/prometheus-metrics-expiry.t
+++ b/t/plugin/prometheus-metrics-expiry.t
@@ -1,0 +1,133 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+BEGIN {
+    if ($ENV{TEST_NGINX_CHECK_LEAK}) {
+        $SkipReason = "unavailable for the hup tests";
+
+    } else {
+        $ENV{TEST_NGINX_USE_HUP} = 1;
+        undef $ENV{TEST_NGINX_USE_STAP};
+    }
+}
+
+use t::APISIX 'no_plan';
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: set route with prometheus ttl
+--- yaml_config
+plugin_attr:
+    prometheus:
+        default_buckets:
+            - 15
+            - 55
+            - 105
+            - 205
+            - 505
+        metrics:
+            http_status:
+                expire: 1
+            http_latency:
+                expire: 1
+            bandwidth:
+                expire: 1
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code = t('/apisix/admin/routes/metrics',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "public-api": {}
+                    },
+                    "uri": "/apisix/prometheus/metrics"
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+                return
+            end
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "prometheus": {}
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello1"
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            local code, body = t('/hello1',
+                ngx.HTTP_GET,
+                "",
+                nil,
+                nil
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.sleep(2)
+            local code, pass, body = t('/apisix/prometheus/metrics',
+                ngx.HTTP_GET,
+                "",
+                nil,
+                nil
+            )
+
+            local metrics_to_check = {"apisix_bandwidth", "http_latency", "http_status",}
+
+            -- verify that above mentioned metrics are not in the metrics response
+            for _, v in pairs(metrics_to_check) do
+                local match, err = ngx.re.match(body, "\\b" .. v .. "\\b", "m")
+                if match then
+                    ngx.status = 500
+                    ngx.say("error found " .. v .. " in metrics")
+                    return
+                end
+            end
+
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed


### PR DESCRIPTION
### Description

Previously a feature was added that enabled making prometheus metrics expirable. Such configuration didn't have the flexibility to be set for only certain metrics. This PR ensures each metric (among status, latency and bandwidth) has configurable expiry.

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
