### PR TITLE
fix(jwt-auth): disallow empty key configuration attributes

### DIFF
--- a/apisix/plugins/jwt-auth.lua
+++ b/apisix/plugins/jwt-auth.lua
@@ -62,8 +62,14 @@ local consumer_schema = {
     type = "object",
     -- can't use additionalProperties with dependencies
     properties = {
-        key = {type = "string"},
-        secret = {type = "string"},
+        key = {
+            type = "string",
+            minLength = 1,
+        },
+        secret = {
+            type = "string",
+            minLength = 1,
+        },
         algorithm = {
             type = "string",
             enum = {"HS256", "HS512", "RS256", "ES256"},

--- a/t/plugin/jwt-auth4.t
+++ b/t/plugin/jwt-auth4.t
@@ -160,3 +160,73 @@ GET /t
 --- more_headers
 --- response_body
 hello world
+
+
+
+=== TEST 4: ensure secret is non empty
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local t = require("lib.test_admin").test
+            -- prepare consumer with a custom key claim name
+            local csm_code, csm_body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "mike",
+                    "plugins": {
+                        "jwt-auth": {
+                            "key": "custom-user-key",
+                            "secret": ""
+                        }
+                    }
+                }]]
+            )
+            if csm_code == 200 then
+                ngx.status = 500
+                ngx.say("error")
+                return
+            end
+            ngx.status = csm_code
+            ngx.say(csm_body)
+        }
+    }
+--- error_code: 400
+--- response_body eval
+qr/\\"secret\\" validation failed: string too short, expected at least 1, got 0/
+
+
+
+=== TEST 5: ensure key is non empty
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local t = require("lib.test_admin").test
+            -- prepare consumer with a custom key claim name
+            local csm_code, csm_body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "mike",
+                    "plugins": {
+                        "jwt-auth": {
+                            "key": "",
+                            "algorithm": "RS256",
+                            "public_key": "somekey",
+                            "private_key": "someprivkey"
+                        }
+                    }
+                }]]
+            )
+            if csm_code == 200 then
+                ngx.status = 500
+                ngx.say("error")
+                return
+            end
+            ngx.status = csm_code
+            ngx.say(csm_body)
+        }
+    }
+--- error_code: 400
+--- response_body eval
+qr/\\"key\\" validation failed: string too short, expected at least 1, got 0/


### PR DESCRIPTION
### Description

`key` and `secret` attributes should not be allowed to be configured empty.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
