### PR TITLE
fix: deepcopy should copy same table exactly only once

### DIFF
--- a/apisix/core/table.lua
+++ b/apisix/core/table.lua
@@ -146,14 +146,12 @@ do
     end
 
 
-    local copied_recorder = {}
-
     function deepcopy(orig)
+        local copied_recorder = {}
         local orig_type = type(orig)
         if orig_type ~= 'table' then
             return orig
         end
-
         local res = _deepcopy(orig, copied_recorder)
         _M.clear(copied_recorder)
         return res

--- a/apisix/core/table.lua
+++ b/apisix/core/table.lua
@@ -118,16 +118,20 @@ end
 local deepcopy
 do
     local function _deepcopy(orig, copied)
-        -- prevent infinite loop when a field refers its parent
-        copied[orig] = true
         -- If the array-like table contains nil in the middle,
         -- the len might be smaller than the expected.
         -- But it doesn't affect the correctness.
         local len = #orig
         local copy = new_tab(len, nkeys(orig) - len)
+        -- prevent infinite loop when a field refers its parent
+        copied[orig] = copy
         for orig_key, orig_value in pairs(orig) do
-            if type(orig_value) == "table" and not copied[orig_value] then
-                copy[orig_key] = _deepcopy(orig_value, copied)
+            if type(orig_value) == "table" then
+                if copied[orig_value] then
+                    copy[orig_key] = copied[orig_value]
+                else
+                    copy[orig_key] = _deepcopy(orig_value, copied)
+                end
             else
                 copy[orig_key] = orig_value
             end

--- a/t/core/table.t
+++ b/t/core/table.t
@@ -326,4 +326,3 @@ GET /t
 --- response_body
 table copied: {"a":{"a2":"a2"},"b":{"a2":"a2"}}
 tab_copied.a == tab_copied.b: true
-

--- a/t/core/table.t
+++ b/t/core/table.t
@@ -215,3 +215,115 @@ GET /t
 GET /t
 --- response_body
 ok
+
+
+
+=== TEST 8: deepcopy copy same table only once
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local tmp = { name = "tmp", priority = 1, enabled = true }
+            local origin = { a = { b = tmp }, c = tmp}
+            local copy = core.table.deepcopy(origin)
+            if not core.table.deep_eq(copy, origin) then
+                ngx.say("copy: ", json.encode(expect), ", origin: ", json.encode(actual))
+                return
+            end
+            if copy.a.b ~= copy.c then
+                ngx.say("copy.a.b should be the same as copy.c")
+                return
+            end
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok
+
+
+
+=== TEST 9: reference same table
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local deepcopy = core.table.deepcopy
+            local tab1 = {name = "tab1"}
+            local tab2 = {
+                a = tab1,
+                b = tab1
+            }
+            local tab_copied = deepcopy(tab2)
+
+            ngx.say("table copied: ", require("toolkit.json").encode(tab_copied))
+
+            ngx.say("tab1 == tab2.a: ", tab1 == tab2.a)
+            ngx.say("tab2.a == tab2.b: ", tab2.a == tab2.b)
+
+            ngx.say("tab_copied.a == tab1: ", tab_copied.a == tab1)
+            ngx.say("tab_copied.a == tab_copied.b: ", tab_copied.a == tab_copied.b)
+        }
+    }
+--- request
+GET /t
+--- response_body
+table copied: {"a":{"name":"tab1"},"b":{"name":"tab1"}}
+tab1 == tab2.a: true
+tab2.a == tab2.b: true
+tab_copied.a == tab1: false
+tab_copied.a == tab_copied.b: true
+
+
+
+=== TEST 10: reference table self(root node)
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local deepcopy = core.table.deepcopy
+            local tab1 = {name = "tab1"}
+            local tab2 = {
+                a = tab1,
+            }
+            tab2.c = tab2
+
+            local tab_copied = deepcopy(tab2)
+
+            ngx.say("tab_copied.a == tab1: ", tab_copied.a == tab_copied.b)
+            ngx.say("tab_copied == tab_copied.c: ", tab_copied == tab_copied.c)
+        }
+    }
+--- request
+GET /t
+--- response_body
+tab_copied.a == tab1: false
+tab_copied == tab_copied.c: true
+
+
+
+=== TEST 11: reference table self(sub node)
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local deepcopy = core.table.deepcopy
+            local tab_org = {
+                a = {
+                    a2 = "a2"
+                },
+            }
+            tab_org.b = tab_org.a
+
+            local tab_copied = deepcopy(tab_org)
+            ngx.say("table copied: ", require("toolkit.json").encode(tab_copied))
+            ngx.say("tab_copied.a == tab_copied.b: ", tab_copied.a == tab_copied.b)
+        }
+    }
+--- request
+GET /t
+--- response_body
+table copied: {"a":{"a2":"a2"},"b":{"a2":"a2"}}
+tab_copied.a == tab_copied.b: true
+


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)
The current deepcopy, when it finds that the original table has already been copied, will directly use the original table. This causes the copied table and the original table to share one table, which does not conform to the semantics of deepcopy. After fixing, the same table will be copied only once.


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
