### PR TITLE
fix: deepcopy should copy same table exactly only once

### DIFF
--- a/apisix/core/table.lua
+++ b/apisix/core/table.lua
@@ -127,7 +127,7 @@ do
         -- prevent infinite loop when a field refers its parent
         copied[orig] = copy
         for orig_key, orig_value in pairs(orig) do
-            local path = parent .. "." .. orig_key
+            local path = parent .. "." .. tostring(orig_key)
             if opts and array_find(opts.shallows, path) then
                 copy[orig_key] = orig_value
             else

--- a/apisix/core/table.lua
+++ b/apisix/core/table.lua
@@ -91,7 +91,7 @@ end
 -- @usage
 -- local arr = {"a", "b", "c"}
 -- local idx = core.table.array_find(arr, "b") -- idx = 2
-function _M.array_find(array, val)
+local function array_find(array, val)
     if type(array) ~= "table" then
         return nil
     end
@@ -104,6 +104,7 @@ function _M.array_find(array, val)
 
     return nil
 end
+_M.array_find = array_find
 
 
 -- only work under lua51 or luajit
@@ -117,19 +118,28 @@ end
 
 local deepcopy
 do
-    local function _deepcopy(orig, copied)
-        -- prevent infinite loop when a field refers its parent
-        copied[orig] = true
+    local function _deepcopy(orig, copied, parent, opts)
         -- If the array-like table contains nil in the middle,
         -- the len might be smaller than the expected.
         -- But it doesn't affect the correctness.
         local len = #orig
         local copy = new_tab(len, nkeys(orig) - len)
+        -- prevent infinite loop when a field refers its parent
+        copied[orig] = copy
         for orig_key, orig_value in pairs(orig) do
-            if type(orig_value) == "table" and not copied[orig_value] then
-                copy[orig_key] = _deepcopy(orig_value, copied)
-            else
+            local path = parent .. "." .. orig_key
+            if opts and array_find(opts.shallows, path) then
                 copy[orig_key] = orig_value
+            else
+                if type(orig_value) == "table" then
+                    if copied[orig_value] then
+                        copy[orig_key] = copied[orig_value]
+                    else
+                        copy[orig_key] = _deepcopy(orig_value, copied, path, opts)
+                    end
+                else
+                    copy[orig_key] = orig_value
+                end
             end
         end
 
@@ -144,13 +154,13 @@ do
 
     local copied_recorder = {}
 
-    function deepcopy(orig)
+    function deepcopy(orig, opts)
         local orig_type = type(orig)
         if orig_type ~= 'table' then
             return orig
         end
 
-        local res = _deepcopy(orig, copied_recorder)
+        local res = _deepcopy(orig, copied_recorder, "self", opts)
         _M.clear(copied_recorder)
         return res
     end

--- a/apisix/core/table.lua
+++ b/apisix/core/table.lua
@@ -23,6 +23,7 @@ local newproxy     = newproxy
 local getmetatable = getmetatable
 local setmetatable = setmetatable
 local select       = select
+local tostring     = tostring
 local new_tab      = require("table.new")
 local nkeys        = require("table.nkeys")
 local ipairs       = ipairs

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -246,15 +246,7 @@ local function parse_domain_in_route(route)
     -- don't modify the modifiedIndex to avoid plugin cache miss because of DNS resolve result
     -- has changed
 
-    local parent = route.value.upstream.parent
-    if parent then
-        route.value.upstream.parent = nil
-    end
-    route.dns_value = core.table.deepcopy(route.value)
-    if parent then
-        route.value.upstream.parent = parent
-        route.dns_value.upstream.parent = parent
-    end
+    route.dns_value = core.table.deepcopy(route.value, { shallows = { "self.upstream.parent"}})
     route.dns_value.upstream.nodes = new_nodes
     core.log.info("parse route which contain domain: ",
                   core.json.delay_encode(route, true))

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -584,7 +584,7 @@ end
 
 
 local function merge_service_route(service_conf, route_conf)
-    local new_conf = core.table.deepcopy(service_conf)
+    local new_conf = core.table.deepcopy(service_conf, { shallows = {"self.value.upstream.parent"}})
     new_conf.value.service_id = new_conf.value.id
     new_conf.value.id = route_conf.value.id
     new_conf.modifiedIndex = route_conf.modifiedIndex
@@ -658,7 +658,7 @@ end
 local function merge_service_stream_route(service_conf, route_conf)
     -- because many fields in Service are not supported by stream route,
     -- so we copy the stream route as base object
-    local new_conf = core.table.deepcopy(route_conf)
+    local new_conf = core.table.deepcopy(route_conf, { shallows = {"self.value.upstream.parent"}})
     if service_conf.value.plugins then
         for name, conf in pairs(service_conf.value.plugins) do
             if not new_conf.value.plugins then
@@ -706,7 +706,8 @@ local function merge_consumer_route(route_conf, consumer_conf, consumer_group_co
         return route_conf
     end
 
-    local new_route_conf = core.table.deepcopy(route_conf)
+    local new_route_conf = core.table.deepcopy(route_conf,
+                            { shallows = {"self.value.upstream.parent"}})
 
     if consumer_group_conf then
         for name, conf in pairs(consumer_group_conf.value.plugins) do

--- a/apisix/plugins/ai.lua
+++ b/apisix/plugins/ai.lua
@@ -69,7 +69,9 @@ local default_keepalive_pool = {}
 
 local function create_router_matching_cache(api_ctx)
     orig_router_http_matching(api_ctx)
-    return core.table.deepcopy(api_ctx)
+    return core.table.deepcopy(api_ctx, {
+        shallows = { "self.matched_route.value.upstream.parent" }
+    })
 end
 
 


### PR DESCRIPTION
### Description

The current deepcopy, when it finds that the original table has already been copied, will directly use the original table. This causes the copied table and the original table to share one table, which does not conform to the semantics of deepcopy. After fixing, the same table will be copied only once by default, we also allow specifying special fields to use shallow copy because, for the health checker module, we need to mount the checker corresponding to the upstream into the original route table so that old checker objects can be released when routes are updated or deleted.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
