### PR TITLE
fix: add support for ignoring "load" global variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ uwsgi_temp
 proxy_temp
 fastcgi_temp
 client_body_temp
-utils/lj-releng
 utils/reindex
 *.etcd/
 t/lib/dubbo*/**/target/

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -55,5 +55,6 @@ header:
     - '.luacheckrc'
     # Exclude file contains certificate revocation information
     - 't/certs/ocsp/index.txt'
+    - 'utils/lj-releng'
 
   comment: on-failure

--- a/utils/lj-releng
+++ b/utils/lj-releng
@@ -1,20 +1,13 @@
 #!/usr/bin/env perl
-#
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+# Copyright (c) 2011-2017, Yichun "agentzh" Zhang (章亦春) agentzh@gmail.com, OpenResty Inc.
+
+# This module is licensed under the terms of the BSD license.
+
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+# Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+# Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use strict;
 use warnings;
 

--- a/utils/lj-releng
+++ b/utils/lj-releng
@@ -1,0 +1,228 @@
+#!/usr/bin/env perl
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use strict;
+use warnings;
+
+use Getopt::Std;
+
+my (@luas, @tests);
+
+my $hits = 0;
+my $RED = "\033[1;31m";
+my $NC = "\033[0m"; # No Color
+
+my %opts;
+getopts('Lse', \%opts) or die "Usage: lj-releng [-L] [-s] [-e] [files]\n";
+
+my $silent = $opts{s};
+my $stop_on_error = $opts{e};
+my $no_long_line_check = $opts{L};
+
+my $check_lua_ver = "luajit -v | awk '{print\$2}'| grep 2.1";
+my $output = `$check_lua_ver`;
+if ($output eq '') {
+    die "ERROR: lj-releng ONLY supports LuaJIT 2.1!\n";
+}
+
+if ($#ARGV != -1) {
+    @luas = @ARGV;
+
+} else {
+    @luas = split /\n/, `find . -name '*.lua'`;
+    if (-d 't') {
+        @tests = map glob, qw{ t/*.t t/*/*.t t/*/*/*.t };
+    }
+}
+
+for my $f (sort @luas) {
+    process_file($f);
+}
+
+for my $t (@tests) {
+    blank(qq{grep -H -n --color -E '\\--- ?(ONLY|LAST)' $t});
+}
+
+if ($hits) {
+    exit 1;
+}
+
+# p: prints a string to STDOUT appending \n
+# w: prints a string to STDERR appending \n
+# Both respect the $silent value
+sub p { print "$_[0]\n" if (!$silent) }
+sub w { warn  "$_[0]\n" if (!$silent) }
+
+# blank: runs a command and looks at the output. If the output is not
+# blank it is printed (and the program dies if stop_on_error is 1)
+sub blank {
+    my ($command) = @_;
+    if ($stop_on_error) {
+        my $output = `$command`;
+        if ($output ne '') {
+            die $output;
+        }
+    } else {
+        system($command);
+    }
+}
+
+my $version;
+sub process_file {
+    my $file = shift;
+    # Check the sanity of each .lua file
+    open my $in, $file or
+        die "ERROR: Can't open $file for reading: $!\n";
+    my $found_ver;
+    while (<$in>) {
+        my ($ver, $skipping);
+        if (/(?x) (?:_VERSION|version) \s* = .*? ([\d\.]*\d+) (.*? SKIP)?/) {
+            my $orig_ver = $ver = $1;
+            $found_ver = 1;
+            $skipping = $2;
+            $ver =~ s{^(\d+)\.(\d{3})(\d{3})$}{join '.', int($1), int($2), int($3)}e;
+            print("$file: $orig_ver ($ver)\n");
+            last;
+
+        } elsif (/(?x) (?:_VERSION|version) \s* = \s* ([a-zA-Z_]\S*)/) {
+            print("$file: $1\n");
+            $found_ver = 1;
+            last;
+        }
+
+        if ($ver and $version and !$skipping) {
+            if ($version ne $ver) {
+                die "$file: $ver != $version\n";
+            }
+        } elsif ($ver and !$version) {
+            $version = $ver;
+        }
+    }
+    # if (!$found_ver) {
+    #     w("WARNING: No \"_VERSION\" or \"version\" field found in `$file`.");
+    # }
+    close $in;
+
+    #p("Checking use of Lua global variables in file $file...");
+    #p("op no. line     opcode  args        ; code");
+    my $cmd = "luajit -bL $file";
+    open $in, "$cmd|"
+        or die "cannot open output pipe for \"$cmd\": $!";
+    my @sections;
+    my $sec;
+    while (<$in>) {
+
+        #warn "line: $_";
+
+        if (/^-- BYTECODE -- \S.*?:(\d+)-\d+$/) {
+            my $def_line = $1;
+            #warn "$file: $line";
+            if (defined $sec) {
+                push @sections, $sec;
+
+            }
+            $sec = {
+                def_line => $def_line,
+                gsets => [],
+                ggets => [],
+            };
+            next;
+        }
+
+        if (/^ \d+ \s+ \[ (\d+) \] \s+ (?: \W+ \s+ )? G([GS])ET \s+ .*? ; \s+ \"([^"]+)" $/x) {
+            my ($line, $op, $name) = ($1, $2, $3);
+
+            #warn "found: $line $op $name";
+            if ($op eq 'S') {
+                push @{ $sec->{gsets} }, [$line, $name];
+            } else {
+                push @{ $sec->{ggets} }, [$line, $name];
+            }
+
+            next;
+        }
+
+        if (/^ \d+ \s+ \[ \d+ \] \s+ (G[GS]ET) \s+ $/x) {
+            die "bad $1 instruction: $_";
+        }
+    }
+    close $in;
+
+    if (defined $sec) {
+        push @sections, $sec;
+    }
+
+    my $last_idx = $#sections;
+    my $i = 0;
+    for my $sec (@sections) {
+        my $def_line = $sec->{def_line};
+
+        my $gsets = $sec->{gsets};
+        my $ggets = $sec->{ggets};
+
+        for my $gset (@$gsets) {
+            $hits++;
+            my ($line, $name) = @$gset;
+            warn "${RED}ERROR${NC}: $file: line $line: setting the Lua global ",
+                 "\"$name\"\n";
+        }
+
+        if ($i == $last_idx) {
+            # being the top-level chunk
+
+            for my $gget (@$ggets) {
+                my ($line, $name) = @$gget;
+
+                if ($name =~ /^ (?: require|type|tostring|error|ngx|ndk|jit
+                                   |setmetatable|getmetatable|string|table|io
+                                   |os|print|tonumber|math|pcall|xpcall|unpack
+                                   |pairs|ipairs|assert|module|package
+                                   |coroutine|[gs]etfenv|next|rawget|rawset
+                                   |loadstring|dofile|collectgarbage|load
+                                   |rawlen|select|arg|bit|debug|ngx|ndk|newproxy)$/x)
+                {
+                    next;
+                }
+
+                $hits++;
+                warn "${RED}ERROR${NC}: $file: line $line: getting the Lua ",
+                     "global \"$name\"\n";
+            }
+
+            next;
+        }
+
+        for my $gget (@$ggets) {
+            $hits++;
+            my ($line, $name) = @$gget;
+            warn "${RED}ERROR${NC}: $file: line $line: getting the Lua ",
+                 "global \"$name\"\n";
+        }
+
+    } continue {
+        $i++;
+    }
+
+    if ($stop_on_error && $hits > 0) {
+        exit 1
+    }
+
+    unless ($no_long_line_check) {
+        p("Checking line length exceeding 100...");
+        blank("grep -H -n -E --color '.{101}' $file  | awk '{ print \"ERROR:\" \$0  }'");
+    }
+}


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)
lua global `load` is not covered by default by the lj-relang which is used for lint tests. This PR makes sure overrides the code with the one which takes that into account
needed for this: https://github.com/apache/apisix/pull/11793
### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
