### PR TITLE
fix(ai-proxy): query params in override.endpoint not being sent to LLMs

### DIFF
--- a/apisix/plugins/ai-proxy/drivers/openai.lua
+++ b/apisix/plugins/ai-proxy/drivers/openai.lua
@@ -21,6 +21,7 @@ local http = require("resty.http")
 local url  = require("socket.url")
 
 local pairs = pairs
+local type  = type
 
 -- globals
 local DEFAULT_HOST = "api.openai.com"

--- a/apisix/plugins/ai-proxy/drivers/openai.lua
+++ b/apisix/plugins/ai-proxy/drivers/openai.lua
@@ -54,6 +54,15 @@ function _M.request(conf, request_table, ctx)
         return nil, "failed to connect to LLM server: " .. err
     end
 
+    local query_params = conf.auth.query or {}
+
+    if type(parsed_url) == "table" and parsed_url.query and #parsed_url.query > 0 then
+        local args_tab = core.string.decode_args(parsed_url.query)
+        if type(args_tab) == "table" then
+            core.table.merge(query_params, args_tab)
+        end
+    end
+
     local path = (endpoint and parsed_url.path or DEFAULT_PATH)
 
     local headers = (conf.auth.header or {})
@@ -64,7 +73,7 @@ function _M.request(conf, request_table, ctx)
         keepalive = conf.keepalive,
         ssl_verify = conf.ssl_verify,
         path = path,
-        query = conf.auth.query
+        query = query_params
     }
 
     if conf.model.options then

--- a/t/plugin/ai-proxy2.t
+++ b/t/plugin/ai-proxy2.t
@@ -73,7 +73,7 @@ add_block_preprocessor(sub {
             }
 
 
-            location /test/params/in/overriden/endpoint {
+            location /test/params/in/overridden/endpoint {
                 content_by_lua_block {
                     local json = require("cjson.safe")
                     local core = require("apisix.core")
@@ -306,7 +306,7 @@ POST /anything
                                 }
                             },
                             "override": {
-                                "endpoint": "http://localhost:6724/test/params/in/overriden/endpoint?some_query=yes"
+                                "endpoint": "http://localhost:6724/test/params/in/overridden/endpoint?some_query=yes"
                             },
                             "ssl_verify": false
                         }

--- a/t/plugin/ai-proxy2.t
+++ b/t/plugin/ai-proxy2.t
@@ -71,6 +71,31 @@ add_block_preprocessor(sub {
                     ngx.say("passed")
                 }
             }
+
+
+            location /test/params/in/overriden/endpoint {
+                content_by_lua_block {
+                    local json = require("cjson.safe")
+                    local core = require("apisix.core")
+
+                    if ngx.req.get_method() ~= "POST" then
+                        ngx.status = 400
+                        ngx.say("Unsupported request method: ", ngx.req.get_method())
+                    end
+
+                    local query_auth = ngx.req.get_uri_args()["api_key"]
+                    ngx.log(ngx.INFO, "found query params: ", core.json.stably_encode(ngx.req.get_uri_args()))
+
+                    if query_auth ~= "apikey" then
+                        ngx.status = 401
+                        ngx.say("Unauthorized")
+                        return
+                    end
+
+                    ngx.status = 200
+                    ngx.say("passed")
+                }
+            }
         }
 _EOC_
 
@@ -253,3 +278,65 @@ passed
 POST /anything
 { "messages": [ { "role": "system", "content": "You are a mathematician" }, { "role": "user", "content": "What is 1+1?"} ] }
 --- error_code: 401
+
+
+
+=== TEST 7: query params in override.endpoint should be sent to LLM
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "uri": "/anything",
+                    "plugins": {
+                        "ai-proxy": {
+                            "auth": {
+                                "query": {
+                                    "api_key": "apikey"
+                                }
+                            },
+                            "model": {
+                                "provider": "openai",
+                                "name": "gpt-35-turbo-instruct",
+                                "options": {
+                                    "max_tokens": 512,
+                                    "temperature": 1.0
+                                }
+                            },
+                            "override": {
+                                "endpoint": "http://localhost:6724/test/params/in/overriden/endpoint?some_query=yes"
+                            },
+                            "ssl_verify": false
+                        }
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "canbeanything.com": 1
+                        }
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 8: send request
+--- request
+POST /anything
+{ "messages": [ { "role": "system", "content": "You are a mathematician" }, { "role": "user", "content": "What is 1+1?"} ] }
+--- error_code: 200
+--- error_log
+found query params: {"api_key":"apikey","some_query":"yes"}
+--- response_body
+passed


### PR DESCRIPTION
### Description

Although the `ai-proxy` plugin officially supports only `openai` as an LLM provider, the plugin can be used to proxy requests to azure-openai service as mentioned in this blog: https://docs.api7.ai/apisix/how-to-guide/ai-gateway/proxy-azure-openai-requests, by entering the correct URL in `override.endpoint` attribute of `ai-proxy`.

However, the `azure-openai` deployment URL contains some query params that wasn't being carried into the request (HTTP request made by `ai-proxy` plugin) to the LLM endpoint. This PR ensures that query params in `override.endpoint` are appropriately used.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
