### PR TITLE
fix: failing CI due to wrong status from upstream in traffic split

### DIFF
--- a/t/plugin/traffic-split.t
+++ b/t/plugin/traffic-split.t
@@ -673,9 +673,9 @@ GET /t
                         name = "upstream_A",
                         type = "roundrobin",
                         pass_host = "rewrite",
-                        upstream_host = "www.apiseven.com",
+                        upstream_host = "httpbin.org",
                         nodes = {
-                          ["www.apiseven.com:80"] = 0
+                          ["httpbin.org:80"] = 0
                         }
                       },
                       weight = 100000
@@ -715,7 +715,7 @@ passed
 --- error_code eval
 [200, 200]
 --- error_log_like eval
-qr/(dns resolver domain: www.apiseven.com to \d+.\d+.\d+.\d+){2}/
+qr/(dns resolver domain: httpbin.org to \d+.\d+.\d+.\d+){2}/
 
 
 


### PR DESCRIPTION
### Description

Example of failing test in master: https://github.com/apache/apisix/actions/runs/12578912814.
This is because this upstream returns 302 redirect now instead of 200. Replacing this with httpbin.org.

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
