### PR TITLE
fix: the docs website build failed due to incorrect unclosed tag `<br>`

### DIFF
--- a/docs/en/latest/plugins/opentelemetry.md
+++ b/docs/en/latest/plugins/opentelemetry.md
@@ -6,7 +6,6 @@ keywords:
   - Plugin
   - OpenTelemetry
 description: The opentelemetry Plugin instruments APISIX and sends traces to OpenTelemetry collector based on the OpenTelemetry specification, in binary-encoded OLTP over HTTP.
-
 ---
 <!--
 #
@@ -73,7 +72,7 @@ Reload APISIX for changes to take effect.
 | Name                                  | Type          | Required | Default      | Valid Values | Description |
 |---------------------------------------|---------------|----------|--------------|--------------|-------------|
 | sampler                               | object        | False    | -            | -            | Sampling configuration. |
-| sampler.name                          | string        | False    | `always_off` | ["always_on", "always_off", "trace_id_ratio", "parent_base"]  | Sampling strategy.<br>To always sample, use `always_on`.<br>To never sample, use `always_off`.<br>To randomly sample based on a given ratio, use `trace_id_ratio`.<br>To use the sampling decision of the span's parent, use `parent_base`. If there is no parent, use the root sampler. |
+| sampler.name                          | string        | False    | `always_off` | ["always_on", "always_off", "trace_id_ratio", "parent_base"]  | Sampling strategy.<br />To always sample, use `always_on`.<br />To never sample, use `always_off`.<br />To randomly sample based on a given ratio, use `trace_id_ratio`.<br />To use the sampling decision of the span's parent, use `parent_base`. If there is no parent, use the root sampler. |
 | sampler.options                       | object        | False    | -            | -            | Parameters for sampling strategy. |
 | sampler.options.fraction              | number        | False    | 0            | [0, 1]       | Sampling ratio when the sampling strategy is `trace_id_ratio`. |
 | sampler.options.root                  | object        | False    | -            | -            | Root sampler when the sampling strategy is `parent_base` strategy. |


### PR DESCRIPTION
### Description

This PR fixes build failures caused by unclosed HTML `<br>` tags in the `opentelemetry.md` documentation file.

The changes:
- update unclosed `<br>` tags to `<br />`

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
