### PR TITLE
fix(traffic-split): `upstream_obj.upstream` should not be a string

### DIFF
--- a/apisix/plugins/traffic-split.lua
+++ b/apisix/plugins/traffic-split.lua
@@ -217,8 +217,7 @@ local function new_rr_obj(weighted_upstreams)
             -- If the upstream object has only the weight value, it means
             -- that the upstream weight value on the default route has been reached.
             -- Mark empty upstream services in the plugin.
-            upstream_obj.upstream = "plugin#upstream#is#empty"
-            server_list[upstream_obj.upstream] = upstream_obj.weight
+            server_list["plugin#upstream#is#empty"] = upstream_obj.weight
 
         end
     end

--- a/t/plugin/traffic-split5.t
+++ b/t/plugin/traffic-split5.t
@@ -549,7 +549,7 @@ nginx_config:
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/upstreams/1',
                  ngx.HTTP_PUT,
-                 [[{                 
+                 [[{
                     "type": "roundrobin",
                     "nodes": {
                         "127.0.0.1:1970":10
@@ -564,7 +564,7 @@ nginx_config:
 
             local code, body = t('/apisix/admin/upstreams/2',
                  ngx.HTTP_PUT,
-                 [[{                 
+                 [[{
                     "type": "roundrobin",
                     "nodes": {
                         "127.0.0.1:1971":10

--- a/t/plugin/traffic-split5.t
+++ b/t/plugin/traffic-split5.t
@@ -538,7 +538,7 @@ Content-Type: application/x-www-form-urlencoded;charset=UTF-8
 
 
 
-=== TEST 6: failure after plugin reload
+=== TEST 12: failure after plugin reload
 --- extra_yaml_config
 nginx_config:
   worker_processes: 1

--- a/t/plugin/traffic-split5.t
+++ b/t/plugin/traffic-split5.t
@@ -535,3 +535,102 @@ id=1
 Content-Type: application/x-www-form-urlencoded;charset=UTF-8
 --- response_body
 1970
+
+
+
+=== TEST 6: failure after plugin reload
+--- extra_yaml_config
+nginx_config:
+  worker_processes: 1
+
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/upstreams/1',
+                 ngx.HTTP_PUT,
+                 [[{                 
+                    "type": "roundrobin",
+                    "nodes": {
+                        "127.0.0.1:1970":10
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            local code, body = t('/apisix/admin/upstreams/2',
+                 ngx.HTTP_PUT,
+                 [[{                 
+                    "type": "roundrobin",
+                    "nodes": {
+                        "127.0.0.1:1971":10
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "uri": "/hello",
+                    "plugins": {
+                        "traffic-split": {
+                            "rules": [
+                                {
+                                    "weighted_upstreams": [
+                                        {
+                                            "upstream_id": "2",
+                                            "weight": 1
+                                        },
+                                        {
+                                            "weight": 1
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "upstream_id": "1"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                return
+            end
+
+            local code, body = t('/hello')
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            local code, body = t('/apisix/admin/plugins/reload', ngx.HTTP_PUT)
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            local code, body = t('/hello')
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            ngx.say("passed.")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed.


### PR DESCRIPTION
### Description

During creation of roundrobin object for upstream in traffic-split. `upstream_obj.upstream`: [1] is assigned a string if the upstream configuration only has the weight value.

In this case, if we reload the plugin via the plugin reload API. The roundrobin object gets recreated but since `upstream_obj.upstream` has a string value. `upstream_obj.upstream.vid = i`: [2] causes panic because it expects `upstream_obj` to be a table.

[1]: https://github.com/apache/apisix/blob/6a845761c3fbb18bd4bdc5efb278a6c351ae7434/apisix/plugins/traffic-split.lua#L220
[2]: https://github.com/apache/apisix/blob/6a845761c3fbb18bd4bdc5efb278a6c351ae7434/apisix/plugins/traffic-split.lua#L208

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
