### PR TITLE
refactor(opentelemetry): replace plugin attribute with plugin metadata

### DIFF
--- a/apisix/plugins/opentelemetry.lua
+++ b/apisix/plugins/opentelemetry.lua
@@ -219,23 +219,6 @@ function _M.init()
         trace_id_ratio = trace_id_ratio_sampler_new,
     }
     hostname = core.utils.gethostname()
-
-    -- plugin_info = plugin.plugin_attr(plugin_name) or {}
-    -- local check = {"collector.address"}
-    -- core.utils.check_https(check, plugin_info, plugin_name)
-    -- local ok, err = core.schema.check(attr_schema, plugin_info)
-    -- if not ok then
-    --     core.log.error("failed to check the plugin_attr[", plugin_name, "]",
-    --             ": ", err)
-    --     return
-    -- end
-
-    -- if plugin_info.trace_id_source == "x-request-id" then
-    --     id_generator.new_ids = function()
-    --         local trace_id = core.request.headers()["x-request-id"] or ngx_var.request_id
-    --         return trace_id, id_generator.new_span_id()
-    --     end
-    -- end
 end
 
 
@@ -247,7 +230,8 @@ local function create_tracer_obj(conf)
     end
     core.log.info("metadata: ", core.json.delay_encode(metadata))
     local plugin_info = metadata.value
-
+    local check = {"collector.address"}
+    core.utils.check_https(check, plugin_info, plugin_name)
     if plugin_info.trace_id_source == "x-request-id" then
         id_generator.new_ids = function()
             local trace_id = core.request.headers()["x-request-id"] or ngx_var.request_id

--- a/apisix/plugins/opentelemetry.lua
+++ b/apisix/plugins/opentelemetry.lua
@@ -192,7 +192,7 @@ local _M = {
     priority = 12009,
     name = plugin_name,
     schema = schema,
-     metadata_schema = metadata_schema,
+    metadata_schema = metadata_schema,
 }
 
 

--- a/apisix/plugins/opentelemetry.lua
+++ b/apisix/plugins/opentelemetry.lua
@@ -198,7 +198,13 @@ local _M = {
 
 function _M.check_schema(conf, schema_type)
     if schema_type == core.schema.TYPE_METADATA then
-        return core.schema.check(metadata_schema, conf)
+        local ok, err = core.schema.check(metadata_schema, conf)
+        if not ok then
+            return ok, err
+        end
+        local check = {"collector.address"}
+        core.utils.check_https(check, conf, plugin_name)
+        return true
     end
     return core.schema.check(schema, conf)
 end
@@ -308,8 +314,6 @@ function _M.rewrite(conf, api_ctx)
     end
     core.log.info("metadata: ", core.json.delay_encode(metadata))
     local plugin_info = metadata.value
-    local check = {"collector.address"}
-    core.utils.check_https(check, plugin_info, plugin_name)
     local vars = api_ctx.var
 
     local tracer, err = core.lrucache.plugin_ctx(lrucache, api_ctx, nil,

--- a/apisix/plugins/opentelemetry.lua
+++ b/apisix/plugins/opentelemetry.lua
@@ -222,16 +222,7 @@ function _M.init()
 end
 
 
-local function create_tracer_obj(conf)
-    local metadata = plugin.plugin_metadata(plugin_name)
-    if metadata == nil then
-        core.log.warn("plugin_metadata is required for opentelemetry plugin to working properly")
-        return
-    end
-    core.log.info("metadata: ", core.json.delay_encode(metadata))
-    local plugin_info = metadata.value
-    local check = {"collector.address"}
-    core.utils.check_https(check, plugin_info, plugin_name)
+local function create_tracer_obj(conf, plugin_info)
     if plugin_info.trace_id_source == "x-request-id" then
         id_generator.new_ids = function()
             local trace_id = core.request.headers()["x-request-id"] or ngx_var.request_id
@@ -310,6 +301,15 @@ end
 
 
 function _M.rewrite(conf, api_ctx)
+    local metadata = plugin.plugin_metadata(plugin_name)
+    if metadata == nil then
+        core.log.warn("plugin_metadata is required for opentelemetry plugin to working properly")
+        return
+    end
+    core.log.info("metadata: ", core.json.delay_encode(metadata))
+    local plugin_info = metadata.value
+    local check = {"collector.address"}
+    core.utils.check_https(check, plugin_info, plugin_name)
     local vars = api_ctx.var
 
     local tracer, err = core.lrucache.plugin_ctx(lrucache, api_ctx, nil, create_tracer_obj, conf)

--- a/apisix/plugins/opentelemetry.lua
+++ b/apisix/plugins/opentelemetry.lua
@@ -312,7 +312,7 @@ function _M.rewrite(conf, api_ctx)
     core.utils.check_https(check, plugin_info, plugin_name)
     local vars = api_ctx.var
 
-    local tracer, err = core.lrucache.plugin_ctx(lrucache, api_ctx, nil, create_tracer_obj, conf)
+    local tracer, err = core.lrucache.plugin_ctx(lrucache, api_ctx, nil, create_tracer_obj, conf, plugin_info)
     if not tracer then
         core.log.error("failed to fetch tracer object: ", err)
         return

--- a/apisix/plugins/opentelemetry.lua
+++ b/apisix/plugins/opentelemetry.lua
@@ -312,7 +312,8 @@ function _M.rewrite(conf, api_ctx)
     core.utils.check_https(check, plugin_info, plugin_name)
     local vars = api_ctx.var
 
-    local tracer, err = core.lrucache.plugin_ctx(lrucache, api_ctx, nil, create_tracer_obj, conf, plugin_info)
+    local tracer, err = core.lrucache.plugin_ctx(lrucache, api_ctx, nil,
+                                                create_tracer_obj, conf, plugin_info)
     if not tracer then
         core.log.error("failed to fetch tracer object: ", err)
         return

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -444,7 +444,7 @@ plugins:                           # plugin list (sorted by priority)
   - request-id                     # priority: 12015
   - zipkin                         # priority: 12011
   #- skywalking                    # priority: 12010
-  - opentelemetry                 # priority: 12009
+  #- opentelemetry                 # priority: 12009
   - ext-plugin-pre-req             # priority: 12000
   - fault-injection                # priority: 11000
   - mocking                        # priority: 10900

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -444,7 +444,7 @@ plugins:                           # plugin list (sorted by priority)
   - request-id                     # priority: 12015
   - zipkin                         # priority: 12011
   #- skywalking                    # priority: 12010
-  #- opentelemetry                 # priority: 12009
+  - opentelemetry                 # priority: 12009
   - ext-plugin-pre-req             # priority: 12000
   - fault-injection                # priority: 11000
   - mocking                        # priority: 10900

--- a/docs/en/latest/plugins/opentelemetry.md
+++ b/docs/en/latest/plugins/opentelemetry.md
@@ -36,33 +36,41 @@ The `opentelemetry` Plugin can be used to report tracing data according to the [
 
 The Plugin only supports binary-encoded [OLTP over HTTP](https://opentelemetry.io/docs/reference/specification/protocol/otlp/#otlphttp).
 
-## Static Configurations
+## Configurations
 
 By default, configurations of the Service name, tenant ID, collector, and batch span processor are pre-configured in [default configuration](https://github.com/apache/apisix/blob/master/apisix/cli/config.lua).
 
-To customize these values, add the corresponding configurations to `config.yaml`. For example:
+You can change this configuration of the Plugin through the endpoint `apisix/admin/plugin_metadata/opentelemetry` For example:
 
-```yaml
-plugin_attr:
-  opentelemetry:
-    trace_id_source: x-request-id     # Specify the source of the trace ID, `x-request-id` or `random`. When set to `x-request-id`,
-                                      # the value of the `x-request-id` header will be used as the trace ID.
-    resource:                         # Additional resource to append to the trace.
-      service.name: APISIX            # Set the Service name for OpenTelemetry traces.
-    collector:
-      address: 127.0.0.1:4318       # Set the address of the OpenTelemetry collector to send traces to.
-      request_timeout: 3            # Set the timeout for requests to the OpenTelemetry collector in seconds.
-      request_headers:              # Set the headers to include in requests to the OpenTelemetry collector.
-        Authorization: token        # Set the authorization header to include an access token.
-    batch_span_processor:           # Trace span processor.
-      drop_on_queue_full: false     # Drop spans when the export queue is full.
-      max_queue_size: 1024          # Set the maximum size of the span export queue.
-      batch_timeout: 2              # Set the timeout for span batches to wait in the export queue before
-                                    # being sent.
-      inactive_timeout: 1           # Set the timeout for spans to wait in the export queue before being sent,
-                                    # if the queue is not full.
-      max_export_batch_size: 16     # Set the maximum number of spans to include in each batch sent to the OpenTelemetry collector.
-    set_ngx_var: false              # Export opentelemetry variables to nginx variables.
+```bash
+admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
+```
+
+:::
+
+```shell
+curl http://127.0.0.1:9180/apisix/admin/plugin_metadata/opentelemetry -H "X-API-KEY: $admin_key" -X PUT -d '
+{
+    "trace_id_source": "x-request-id",
+    "resource": {
+      "service.name": "APISIX"
+    },
+    "collector": {
+      "address": "127.0.0.1:4318",
+      "request_timeout": 3,
+      "request_headers": {
+        "Authorization": "token"
+      },
+      "batch_span_processor": {
+        "drop_on_queue_full": false,
+        "max_queue_size": 1024,
+        "batch_timeout": 2,
+        "inactive_timeout": 1,
+        "max_export_batch_size": 16
+      },
+      "set_ngx_var": false
+    }
+}'
 ```
 
 Reload APISIX for changes to take effect.

--- a/docs/en/latest/plugins/opentelemetry.md
+++ b/docs/en/latest/plugins/opentelemetry.md
@@ -76,8 +76,6 @@ curl http://127.0.0.1:9180/apisix/admin/plugin_metadata/opentelemetry -H "X-API-
 }'
 ```
 
-Reload APISIX for changes to take effect.
-
 ## Attributes
 
 | Name                                  | Type          | Required | Default      | Valid Values | Description |

--- a/docs/en/latest/plugins/opentelemetry.md
+++ b/docs/en/latest/plugins/opentelemetry.md
@@ -42,6 +42,9 @@ By default, configurations of the Service name, tenant ID, collector, and batch 
 
 You can change this configuration of the Plugin through the endpoint `apisix/admin/plugin_metadata/opentelemetry` For example:
 
+:::note
+You can fetch the `admin_key` from `config.yaml` and save to an environment variable with the following command:
+
 ```bash
 admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
 ```

--- a/docs/zh/latest/plugins/opentelemetry.md
+++ b/docs/zh/latest/plugins/opentelemetry.md
@@ -39,7 +39,7 @@ description: opentelemetry 插件可用于根据 OpenTelemetry 协议规范上�
 
 默认情况下，服务名称、租户 ID、collector 和 batch span processor 的配置已预配置在[默认配置](https://github.com/apache/apisix/blob/master/apisix/cli/config.lua)中。
 
-您可以通过端点 `apisix/admin/plugin_metadata/opentelemetry` 更改插件的配置,例如:
+您可以通过端点 `apisix/admin/plugin_metadata/opentelemetry` 更改插件的配置，例如：
 
 :::note
 您可以从“ config.yaml”获取“ admin_key”,并使用以下命令保存到环境变量中:

--- a/docs/zh/latest/plugins/opentelemetry.md
+++ b/docs/zh/latest/plugins/opentelemetry.md
@@ -42,7 +42,7 @@ description: opentelemetry 插件可用于根据 OpenTelemetry 协议规范上�
 您可以通过端点 `apisix/admin/plugin_metadata/opentelemetry` 更改插件的配置，例如：
 
 :::note
-您可以从“ config.yaml”获取“ admin_key”,并使用以下命令保存到环境变量中:
+您可以从“config.yaml”获取“admin_key”,并使用以下命令保存到环境变量中：
 
 ```bash
 admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')

--- a/docs/zh/latest/plugins/opentelemetry.md
+++ b/docs/zh/latest/plugins/opentelemetry.md
@@ -75,8 +75,6 @@ curl http://127.0.0.1:9180/apisix/admin/plugin_metadata/opentelemetry -H "X-API-
 }'
 ```
 
-重新加载 APISIX 以使更改生效。
-
 ## 属性
 
 | 名称                                  | 类型           | 必选项    | 默认值        | 有效值        | 描述 |

--- a/docs/zh/latest/plugins/opentelemetry.md
+++ b/docs/zh/latest/plugins/opentelemetry.md
@@ -35,32 +35,41 @@ description: opentelemetry 插件可用于根据 OpenTelemetry 协议规范上�
 
 `opentelemetry` 插件可用于根据 [OpenTelemetry Specification](https://opentelemetry.io/docs/reference/specification/) 协议规范上报 Traces 数据。该插件仅支持二进制编码的 OLTP over HTTP，即请求类型为 `application/x-protobuf` 的数据上报。
 
-## 静态配置
+## 配置
 
 默认情况下，服务名称、租户 ID、collector 和 batch span processor 的配置已预配置在[默认配置](https://github.com/apache/apisix/blob/master/apisix/cli/config.lua)中。
 
-要自定义这些值，请将相应的配置添加到 `config.yaml` 中。例如：
+您可以通过端点 `apisix/admin/plugin_metadata/opentelemetry` 更改插件的配置,例如:
 
-```yaml
-plugin_attr:
-  opentelemetry:
-    trace_id_source: x-request-id     # 指定追踪 ID 的来源，`x-request-id` 或 `random`。当设置为 `x-request-id` 时，
-                                      # `x-request-id` 头的值将用作追踪 ID。
-    resource:                         # 追加到追踪的额外资源。
-      service.name: APISIX            # 为 OpenTelemetry 追踪设置服务名称。
-    collector:
-      address: 127.0.0.1:4318       # 设置要发送追踪的 OpenTelemetry 收集器的地址。
-      request_timeout: 3            # 设置请求 OpenTelemetry 收集器的超时时间（秒）。
-      request_headers:              # 设置请求 OpenTelemetry 收集器时要包含的头信息。
-        Authorization: token        # 设置授权头以包含访问令牌。
-    batch_span_processor:           # 追踪跨度处理器。
-      drop_on_queue_full: false     # 当导出队列满时丢弃跨度。
-      max_queue_size: 1024          # 设置跨度导出队列的最大大小。
-      batch_timeout: 2              # 设置跨度批次在导出队列中等待的超时时间，
-                                    # 然后发送。
-      inactive_timeout: 1           # 设置跨度在导出队列中等待的超时时间，如果队列不满，则发送。
-      max_export_batch_size: 16     # 设置每个批次发送到 OpenTelemetry 收集器的跨度的最大数量。
-    set_ngx_var: false              # 将 opentelemetry 变量导出到 nginx 变量。
+```bash
+admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
+```
+
+:::
+
+```shell
+curl http://127.0.0.1:9180/apisix/admin/plugin_metadata/opentelemetry -H "X-API-KEY: $admin_key" -X PUT -d '
+{
+    "trace_id_source": "x-request-id",
+    "resource": {
+      "service.name": "APISIX"
+    },
+    "collector": {
+      "address": "127.0.0.1:4318",
+      "request_timeout": 3,
+      "request_headers": {
+        "Authorization": "token"
+      },
+      "batch_span_processor": {
+        "drop_on_queue_full": false,
+        "max_queue_size": 1024,
+        "batch_timeout": 2,
+        "inactive_timeout": 1,
+        "max_export_batch_size": 16
+      },
+      "set_ngx_var": false
+    }
+}'
 ```
 
 重新加载 APISIX 以使更改生效。

--- a/docs/zh/latest/plugins/opentelemetry.md
+++ b/docs/zh/latest/plugins/opentelemetry.md
@@ -41,6 +41,9 @@ description: opentelemetry 插件可用于根据 OpenTelemetry 协议规范上�
 
 您可以通过端点 `apisix/admin/plugin_metadata/opentelemetry` 更改插件的配置,例如:
 
+:::note
+您可以从“ config.yaml”获取“ admin_key”,并使用以下命令保存到环境变量中:
+
 ```bash
 admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
 ```

--- a/t/plugin/opentelemetry3.t
+++ b/t/plugin/opentelemetry3.t
@@ -100,6 +100,21 @@ __DATA__
                 return body
             end
 
+            local code, body = t('/apisix/admin/plugin_metadata/opentelemetry',
+                ngx.HTTP_PUT,
+                [[{
+                    "batch_span_processor": {
+                        "max_export_batch_size": 1,
+                        "inactive_timeout": 0.5
+                    },
+                    set_ngx_var: true
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+                return body
+            end
+
             local code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
                 [[{

--- a/t/plugin/opentelemetry3.t
+++ b/t/plugin/opentelemetry3.t
@@ -30,12 +30,6 @@ add_block_preprocessor(sub {
 plugins:
     - http-logger
     - opentelemetry
-plugin_attr:
-    opentelemetry:
-        set_ngx_var: true
-        batch_span_processor:
-            max_export_batch_size: 1
-            inactive_timeout: 0.5
 _EOC_
         $block->set_value("extra_yaml_config", $extra_yaml_config);
     }
@@ -107,7 +101,7 @@ __DATA__
                         "max_export_batch_size": 1,
                         "inactive_timeout": 0.5
                     },
-                    set_ngx_var: true
+                    "set_ngx_var": true
                 }]]
                 )
             if code >= 300 then
@@ -177,12 +171,33 @@ qr/request log: \{.*"opentelemetry_context_traceparent":"00-\w{32}-\w{16}-01".*\
 plugins:
     - http-logger
     - opentelemetry
-plugin_attr:
-    opentelemetry:
-        set_ngx_var: false
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+
+            local code, body = t('/apisix/admin/plugin_metadata/opentelemetry',
+                ngx.HTTP_PUT,
+                [[{
+                    "set_ngx_var": false
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+                return body
+            end
+        }
+    }
+--- request
+GET /t
+
+
+
+=== TEST 4: trigger opentelemetry with open set variables
 --- request
 GET /hello
 --- response_body
 hello world
+--- wait: 1
 --- error_log eval
 qr/request log: \{.*"opentelemetry_context_traceparent":"".*\}/

--- a/t/plugin/opentelemetry4-bugfix-pb-state.t
+++ b/t/plugin/opentelemetry4-bugfix-pb-state.t
@@ -23,17 +23,6 @@ add_block_preprocessor(sub {
         my $extra_yaml_config = <<_EOC_;
 plugins:
     - opentelemetry
-plugin_attr:
-    opentelemetry:
-        trace_id_source: x-request-id
-        batch_span_processor:
-            max_export_batch_size: 1
-            inactive_timeout: 0.5
-        collector:
-            address: 127.0.0.1:4318
-            request_timeout: 3
-            request_headers:
-                foo: bar
 _EOC_
         $block->set_value("extra_yaml_config", $extra_yaml_config);
     }
@@ -49,7 +38,38 @@ run_tests;
 
 __DATA__
 
-=== TEST 1: set additional_attributes with match
+=== TEST 1: add plugin metadata
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/plugin_metadata/opentelemetry',
+                ngx.HTTP_PUT,
+                [[{
+                    "batch_span_processor": {
+                        "max_export_batch_size": 1,
+                        "inactive_timeout": 0.5
+                    },
+                    "trace_id_source": "x-request-id",
+                    "collector": {
+                        "address": "127.0.0.1:4318",
+                        "request_timeout": 3,
+                        "request_headers": {
+                            "foo": "bar"
+                        }
+                    }
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+
+
+
+=== TEST 2: set additional_attributes with match
 --- config
     location /t {
         content_by_lua_block {
@@ -91,7 +111,7 @@ passed
 
 
 
-=== TEST 2: opentelemetry expands headers
+=== TEST 3: opentelemetry expands headers
 --- extra_init_by_lua
     local otlp = require("opentelemetry.trace.exporter.otlp")
     local orig_export_spans = otlp.export_spans

--- a/t/plugin/opentelemetry4-bugfix-pb-state.t
+++ b/t/plugin/opentelemetry4-bugfix-pb-state.t
@@ -66,6 +66,10 @@ __DATA__
             ngx.say(body)
         }
     }
+--- request
+GET /t
+--- response_body
+passed
 
 
 

--- a/t/plugin/opentelemetry5.t
+++ b/t/plugin/opentelemetry5.t
@@ -54,6 +54,9 @@ __DATA__
                         "inactive_timeout": 0.5
                     },
                     "trace_id_source": "x-request-id",
+                    "resource": {
+                        "service.name": "APISIX"
+                    },
                     "collector": {
                         "address": "127.0.0.1:4318",
                         "request_timeout": 3,

--- a/t/plugin/security-warning2.t
+++ b/t/plugin/security-warning2.t
@@ -185,7 +185,7 @@ plugins:
             if code >= 300 then
                 ngx.status = code
             end
-            --- deleting this data so this doesn't effect when metadata schema is validated 
+            --- deleting this data so this doesn't effect when metadata schema is validated
             --- at init in next test.
             local code, body = t('/apisix/admin/plugin_metadata/opentelemetry',
                 ngx.HTTP_DELETE)

--- a/t/plugin/security-warning2.t
+++ b/t/plugin/security-warning2.t
@@ -138,21 +138,30 @@ Using openid-connect proxy_opts.http_proxy with no TLS is a security risk
 --- extra_yaml_config
 plugins:
     - opentelemetry
-plugin_attr:
-    opentelemetry:
-        trace_id_source: x-request-id
-        batch_span_processor:
-            max_export_batch_size: 1
-            inactive_timeout: 0.5
-        collector:
-            address: http://127.0.0.1:4318
-            request_timeout: 3
-            request_headers:
-                foo: bar
 --- config
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/plugin_metadata/opentelemetry',
+                ngx.HTTP_PUT,
+                [[{
+                    "batch_span_processor": {
+                        "max_export_batch_size": 1,
+                        "inactive_timeout": 0.5
+                    },
+                    "trace_id_source": "x-request-id",
+                    "collector": {
+                        "address": "http://127.0.0.1:4318",
+                        "request_timeout": 3,
+                        "request_headers": {
+                            "foo": "bar"
+                        }
+                    }
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
             local code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
                 [[{
@@ -176,6 +185,13 @@ plugin_attr:
             if code >= 300 then
                 ngx.status = code
             end
+            --- deleting this data so this doesn't effect when metadata schema is validated 
+            --- at init in next test.
+            local code, body = t('/apisix/admin/plugin_metadata/opentelemetry',
+                ngx.HTTP_DELETE)
+            if code >= 300 then
+                ngx.status = code
+            end
             ngx.say(body)
         }
     }
@@ -190,21 +206,30 @@ Using opentelemetry collector.address with no TLS is a security risk
 --- extra_yaml_config
 plugins:
     - opentelemetry
-plugin_attr:
-    opentelemetry:
-        trace_id_source: x-request-id
-        batch_span_processor:
-            max_export_batch_size: 1
-            inactive_timeout: 0.5
-        collector:
-            address: https://127.0.0.1:4318
-            request_timeout: 3
-            request_headers:
-                foo: bar
 --- config
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/plugin_metadata/opentelemetry',
+                ngx.HTTP_PUT,
+                [[{
+                    "batch_span_processor": {
+                        "max_export_batch_size": 1,
+                        "inactive_timeout": 0.5
+                    },
+                    "trace_id_source": "x-request-id",
+                    "collector": {
+                        "address": "https://127.0.0.1:4318",
+                        "request_timeout": 3,
+                        "request_headers": {
+                            "foo": "bar"
+                        }
+                    }
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
             local code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
                 [[{


### PR DESCRIPTION
### Description
This PR replaces plugin attribute with plugin metadata in Opentelemetry plugin. Now the same configuration will have to be passed with plugin metadata and not attribute.
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
