### PR TITLE
fix: error while trying to log table in ai-content-moderation plugin

### DIFF
--- a/apisix/plugins/ai-content-moderation.lua
+++ b/apisix/plugins/ai-content-moderation.lua
@@ -148,7 +148,7 @@ function _M.rewrite(conf, ctx)
     })
 
     if not res then
-        core.log.error("failed to send request to ", provider, ": ", err)
+        core.log.error("failed to send request to ", endpoint, ": ", err)
         return HTTP_INTERNAL_SERVER_ERROR, err
     end
 

--- a/t/plugin/ai-content-moderation2.t
+++ b/t/plugin/ai-content-moderation2.t
@@ -1,0 +1,88 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+log_level("info");
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: sanity
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/echo",
+                    "plugins": {
+                        "ai-content-moderation": {
+                            "provider": {
+                                "aws_comprehend": {
+                                    "access_key_id": "access",
+                                    "secret_access_key": "ea+secret",
+                                    "region": "us-east-1",
+                                    "endpoint": "http://localhost:2668"
+                                }
+                            },
+                            "llm_provider": "openai"
+                        }
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        }
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 2: request should fail
+--- request
+POST /echo
+{"model":"gpt-4o-mini","messages":[{"role":"user","content":"toxic"}]}
+--- error_code: 500
+--- response_body chomp
+Comprehend:detectToxicContent() failed to connect to 'http://localhost:2668': connection refused
+--- error_log
+failed to send request to http://localhost: Comprehend:detectToxicContent() failed to connect to 'http://localhost:2668': connection refused


### PR DESCRIPTION
### Description
```bash
2025/02/25 04:00:33 [error] 115#115: *8048 lua entry thread aborted: runtime error: /usr/local/apisix/apisix/plugins/ai-content-moderation.lua:151: bad argument #2 to 'error' (expected table to have __tostring metamethod)
stack traceback:
coroutine 0:
        [C]: in function 'error'
        /usr/local/apisix/apisix/plugins/ai-content-moderation.lua:151: in function 'phase_func'
        /usr/local/apisix/apisix/plugin.lua:1205: in function 'run_plugin'
        /usr/local/apisix/apisix/init.lua:681: in function 'http_access_phase'
        access_by_lua(nginx.conf:319):2: in main chunk, client: 172.20.0.1, server: _, request: "POST /post HTTP/1.1", host: "127.0.0.1:9080"
```
This bug is encountered because a table is passed directly to log function. This PR fixes it.
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
