### PR TITLE
chore(ai-content-moderation): add debug log to record moderation results

### DIFF
--- a/apisix/plugins/ai-content-moderation.lua
+++ b/apisix/plugins/ai-content-moderation.lua
@@ -157,6 +157,8 @@ function _M.rewrite(conf, ctx)
         return HTTP_INTERNAL_SERVER_ERROR, "failed to get moderation results from response"
     end
 
+    core.log.debug("moderation results: ", core.json.delay_encode(results, true))
+
     for _, result in ipairs(results) do
         if conf.moderation_categories then
             for _, item in pairs(result.Labels) do

--- a/t/plugin/ai-content-moderation.t
+++ b/t/plugin/ai-content-moderation.t
@@ -298,7 +298,10 @@ request body exceeds PROFANITY threshold
 
 
 === TEST 12: good_request should pass
+--- log_level: debug
 --- request
 POST /echo
 {"model":"gpt-4o-mini","messages":[{"role":"user","content":"good_request"}]}
 --- error_code: 200
+--- error_log eval
+qr/moderation results:.*"Toxicity":0.02150000333786.*/


### PR DESCRIPTION
### Description

Recording the results returned by the content moderation service in debug logs can help us identify the reasons for request rejections.

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
