### PR TITLE
fix: timeout risk in ai-content-moderation

### DIFF
--- a/apisix/plugins/ai-content-moderation.lua
+++ b/apisix/plugins/ai-content-moderation.lua
@@ -15,7 +15,7 @@
 -- limitations under the License.
 --
 local core = require("apisix.core")
-local aws_instance = require("resty.aws")()
+local aws = require("resty.aws")
 local http = require("resty.http")
 local fetch_secrets = require("apisix.secret").fetch_secrets
 
@@ -117,6 +117,7 @@ function _M.rewrite(conf, ctx)
         return HTTP_BAD_REQUEST, "messages not found in request body"
     end
 
+    local aws_instance = aws()
     local provider = conf.provider[next(conf.provider)]
 
     local credentials = aws_instance:Credentials({

--- a/t/plugin/ai-content-moderation-secrets.t
+++ b/t/plugin/ai-content-moderation-secrets.t
@@ -33,6 +33,12 @@ add_block_preprocessor(sub {
         $block->set_value("request", "GET /t");
     }
 
+    my $main_config = $block->main_config // <<_EOC_;
+        env AWS_REGION=us-east-1;
+_EOC_
+
+    $block->set_value("main_config", $main_config);
+
     my $http_config = $block->http_config // <<_EOC_;
         server {
             listen 2668;

--- a/t/plugin/ai-content-moderation.t
+++ b/t/plugin/ai-content-moderation.t
@@ -30,6 +30,12 @@ add_block_preprocessor(sub {
         $block->set_value("request", "GET /t");
     }
 
+    my $main_config = $block->main_config // <<_EOC_;
+        env AWS_REGION=us-east-1;
+_EOC_
+
+    $block->set_value("main_config", $main_config);
+
     my $http_config = $block->http_config // <<_EOC_;
         server {
             listen 2668;


### PR DESCRIPTION
### Description

When the region is not configured (globally) the aws client falls back to using IDMS endpoint to load aws config. In some CI environments, the IDMS endpoint configured in lua-resty-aws might not be available which could lead to timeout errors in CI.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
