### PR TITLE
fix(ai-proxy-multi): dead loop when retrying

### DIFF
--- a/apisix/plugins/ai-proxy-multi.lua
+++ b/apisix/plugins/ai-proxy-multi.lua
@@ -145,7 +145,6 @@ end
 
 
 local function pick_target(ctx, conf, ups_tab)
-    ctx.ai_balancer_try_count = (ctx.ai_balancer_try_count or 0) + 1
     if ctx.ai_balancer_try_count > 1 then
         if ctx.server_picker and ctx.server_picker.after_balance then
             ctx.server_picker.after_balance(ctx, true)
@@ -172,6 +171,7 @@ end
 
 
 local function get_load_balanced_provider(ctx, conf, ups_tab, request_table)
+    ctx.ai_balancer_try_count = (ctx.ai_balancer_try_count or 0) + 1
     local provider_name, provider_conf
     if #conf.providers == 1 then
         provider_name = conf.providers[1].name
@@ -215,7 +215,7 @@ local function proxy_request_to_llm(conf, request_table, ctx)
     local ai_driver = require("apisix.plugins.ai-drivers." .. provider)
     local res, err, httpc = ai_driver:request(conf, request_table, extra_opts)
     if not res then
-        if (ctx.balancer_try_count or 0) < 1 then
+        if (ctx.ai_balancer_try_count or 0) < 1 then
             core.log.warn("failed to send request to LLM: ", err, ". Retrying...")
             goto retry
         end

--- a/apisix/plugins/ai-proxy-multi.lua
+++ b/apisix/plugins/ai-proxy-multi.lua
@@ -215,7 +215,7 @@ local function proxy_request_to_llm(conf, request_table, ctx)
     local ai_driver = require("apisix.plugins.ai-drivers." .. provider)
     local res, err, httpc = ai_driver:request(conf, request_table, extra_opts)
     if not res then
-        if (ctx.ai_balancer_try_count or 0) < 1 then
+        if (ctx.ai_balancer_try_count or 0) < 2 then
             core.log.warn("failed to send request to LLM: ", err, ". Retrying...")
             goto retry
         end

--- a/t/plugin/ai-proxy-multi2.t
+++ b/t/plugin/ai-proxy-multi2.t
@@ -362,7 +362,7 @@ passed
 
 
 
-=== TEST 5: set route with unavailable endpoint
+=== TEST 9: set route with unavailable endpoint
 --- config
     location /t {
         content_by_lua_block {
@@ -415,7 +415,7 @@ passed
 
 
 
-=== TEST 8: ai-proxy-multi should retry once and fail
+=== TEST 10: ai-proxy-multi should retry once and fail
 # i.e it should not attempt to proxy request endlessly
 --- request
 POST /anything

--- a/t/plugin/ai-proxy-multi2.t
+++ b/t/plugin/ai-proxy-multi2.t
@@ -359,3 +359,68 @@ POST /anything
 found query params: {"api_key":"apikey","some_query":"yes"}
 --- response_body
 passed
+
+
+
+=== TEST 5: set route with unavailable endpoint
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "uri": "/anything",
+                    "plugins": {
+                        "ai-proxy-multi": {
+                            "providers": [
+                                {
+                                    "name": "openai",
+                                    "model": "gpt-4",
+                                    "weight": 1,
+                                    "auth": {
+                                        "header": {
+                                            "Authorization": "Bearer token"
+                                        }
+                                    },
+                                    "options": {
+                                        "max_tokens": 512,
+                                        "temperature": 1.0
+                                    },
+                                    "override": {
+                                        "endpoint": "http://unavailable.endpoint.ehfwuehr:404"
+                                    }
+                                }
+                            ],
+                            "ssl_verify": false
+                        }
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "canbeanything.com": 1
+                        }
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 8: ai-proxy-multi should retry once and fail
+# i.e it should not attempt to proxy request endlessly
+--- request
+POST /anything
+{ "messages": [ { "role": "system", "content": "You are a mathematician" }, { "role": "user", "content": "What is 1+1?"} ] }
+--- error_code: 500
+--- error_log
+parse_domain(): failed to parse domain: unavailable.endpoint.ehfwuehr, error: failed to query the DNS server: dns
+phase_func(): failed to send request to LLM service: failed to connect to LLM server: failed to parse domain


### PR DESCRIPTION
### Description

The number of retries is counted on `ctx.ai_balancer_try_count`, the variable name mismatch will lead to infinite retry loop. This has been fixed.

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
