### PR TITLE
fix(ai-proxy): remove model options' `stream` default value

### DIFF
--- a/apisix/plugins/ai-proxy/schema.lua
+++ b/apisix/plugins/ai-proxy/schema.lua
@@ -70,11 +70,6 @@ local model_options_schema = {
             maximum = 1,
 
         },
-        stream = {
-            description = "Stream response by SSE",
-            type = "boolean",
-            default = false,
-        }
     }
 }
 

--- a/apisix/plugins/ai-proxy/schema.lua
+++ b/apisix/plugins/ai-proxy/schema.lua
@@ -70,6 +70,10 @@ local model_options_schema = {
             maximum = 1,
 
         },
+        stream = {
+            description = "Stream response by SSE",
+            type = "boolean",
+        }
     }
 }
 

--- a/docs/en/latest/plugins/ai-proxy-multi.md
+++ b/docs/en/latest/plugins/ai-proxy-multi.md
@@ -68,7 +68,7 @@ Proxying requests to OpenAI is supported now. Other LLM services will be support
 | provider.options.output_cost | No           | number   | Cost per 1M tokens in the AI-generated output. Minimum is 0.                                                  |             |
 | provider.options.temperature | No           | number   | Defines the model's temperature (0.0 - 5.0) for randomness in responses.                                      |             |
 | provider.options.top_p       | No           | number   | Defines the top-p probability mass (0 - 1) for nucleus sampling.                                              |             |
-| provider.options.stream      | No           | boolean  | Enables streaming responses via SSE.                                                                          | false       |
+| provider.options.stream      | No           | boolean  | Enables streaming responses via SSE.                                                                          |             |
 | provider.override.endpoint   | No           | string   | Custom host override for the AI provider.                                                                     |             |
 | passthrough                  | No           | boolean  | If true, requests are forwarded without processing.                                                           | false       |
 | timeout                      | No           | integer  | Request timeout in milliseconds (1-60000).                                                                    | 3000        |

--- a/docs/en/latest/plugins/ai-proxy.md
+++ b/docs/en/latest/plugins/ai-proxy.md
@@ -61,7 +61,7 @@ Proxying requests to OpenAI is supported now. Other LLM services will be support
 | model.options.output_cost | No           | Number   | Cost per 1M tokens in the output of the AI. Minimum: 0                               |
 | model.options.temperature | No           | Number   | Matching temperature for models. Range: 0.0 - 5.0                                    |
 | model.options.top_p       | No           | Number   | Top-p probability mass. Range: 0 - 1                                                 |
-| model.options.stream      | No           | Boolean  | Stream response by SSE. Default: false                                               |
+| model.options.stream      | No           | Boolean  | Stream response by SSE.                                                              |
 | override.endpoint         | No           | String   | Override the endpoint of the AI provider                                             |
 | passthrough               | No           | Boolean  | If enabled, the response from LLM will be sent to the upstream. Default: false       |
 | timeout                   | No           | Integer  | Timeout in milliseconds for requests to LLM. Range: 1 - 60000. Default: 3000         |


### PR DESCRIPTION
### Description

Passing stream option in request body has no effect as it is overridden by default value in the schema. If I want to support stream mode, I need specify stream option in plugin configuration explicitly, which is a bad UX.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
