### PR TITLE
fix: resync etcd when a lower revision is found

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -262,9 +262,13 @@ local function do_run_watch(premature)
             cancel_watch(http_cli)
             break
         end
-        if rev > watch_ctx.rev then
-            watch_ctx.rev = rev + 1
+        if rev < watch_ctx.rev then
+            log.warn("received smaller revision, rev=", rev, ", watch_ctx.rev=", watch_ctx.rev,". etcd may be restarted. resyncing....")
+            produce_res(nil, "restarted")
+            cancel_watch(http_cli)
+            break
         end
+        watch_ctx.rev = rev + 1
         produce_res(res)
     end
 end
@@ -569,6 +573,7 @@ local function load_full_data(self, dir_res, headers)
     end
 
     if headers then
+        self.prev_index = tonumber(headers["X-Etcd-Index"]) or 0
         self:upgrade_version(headers["X-Etcd-Index"])
     end
 
@@ -633,7 +638,7 @@ local function sync_data(self)
     log.info("res: ", json.delay_encode(dir_res, true), ", err: ", err)
 
     if not dir_res then
-        if err == "compacted" then
+        if err == "compacted" or err == "restarted" then
             self.need_reload = true
             log.error("waitdir [", self.key, "] err: ", err,
                      ", will read the configuration again via readdir")


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)
When using ingress controller in etcd mode, if the ingress restarts the revision in etcd will start over since its stateless.
APISIX on receiving updates ignores the lower revision. This PR makes sure that a full resync is triggered when lower revision is found.
### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
