### PR TITLE
feat: openid-connect plugin: Support extra session config options, remove unused option

### DIFF
--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -67,24 +67,16 @@ local schema = {
         },
         session = {
             type = "object",
+            description = [[configuration of the session cookie. Anything supported by
+            the lua-resty-session init constructor can be set in this object]],
             properties = {
                 secret = {
                     type = "string",
                     description = "the key used for the encrypt and HMAC calculation",
                     minLength = 16,
-                },
-                cookie = {
-                    type = "object",
-                    properties = {
-                        lifetime = {
-                            type = "integer",
-                            description = "it holds the cookie lifetime in seconds in the future",
-                        }
-                    }
                 }
             },
             required = {"secret"},
-            additionalProperties = false,
         },
         realm = {
             type = "string",


### PR DESCRIPTION




### Description

In the openid-connect plugin:
- Remove the session.cookie.lifetime option: that option doesn't exist in the lua-resty-session lib, and has no impact
- allow extra properties to support all the possible config options supported by the underlying lib

Needed because we need to change the cookie domain to set it to the base tld, and not the subdomain of the initial request, so that different product can share auth status.

Without that cookie_domain option, each subdomain needs to trigger an auth flow which are extra un-needed redirections for the user, and more importantly, if one subdomain is set to "unauth_action = pass", the user will be logged out on that domain until they explicitly log in even if they are actually already logged in on other subdomains.

Change is backward compatible because the allowed extra props allow the removed option to be still present.

Fixes
#12050 
#12028

### Checklist

- [*] I have explained the need for this PR and the problem it solves
- [*] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [*] I have updated the documentation to reflect this change
- [*] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)