### PR TITLE
Enable GitHub Discussions

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -159,3 +159,6 @@ github:
       commits:      notifications@apisix.apache.org
       issues:       notifications@apisix.apache.org
       pullrequests: notifications@apisix.apache.org
+    github:
+      features:
+        discussions: true


### PR DESCRIPTION


ASF is using this file to manage features, so we need to enable it manually though this file. 