### PR TITLE
fix(ai-rate-limiting): not allowed to limit to a single instance

### DIFF
--- a/apisix/plugins/ai-rate-limiting.lua
+++ b/apisix/plugins/ai-rate-limiting.lua
@@ -47,7 +47,8 @@ local schema = {
         },
         instances = {
             type = "array",
-            items = instance_limit_schema
+            items = instance_limit_schema,
+            minItems = 1,
         },
         rejected_code = {
             type = "integer", minimum = 200, maximum = 599, default = 503
@@ -56,7 +57,18 @@ local schema = {
             type = "string", minLength = 1
         },
     },
-    required = {"limit", "time_window"},
+    dependencies = {
+        limit = {"time_window"},
+        time_window = {"limit"}
+    },
+    anyOf = {
+        {
+            required = {"limit", "time_window"}
+        },
+        {
+            required = {"instances"}
+        }
+    }
 }
 
 local _M = {
@@ -112,6 +124,10 @@ end
 local function fetch_limit_conf_kvs(conf)
     local mt = {
         __index = function(t, k)
+            if not conf.limit then
+                return nil
+            end
+
             local limit_conf = transform_limit_conf(conf, nil, k)
             t[k] = limit_conf
             return limit_conf
@@ -134,6 +150,9 @@ function _M.access(conf, ctx)
 
     local limit_conf_kvs = limit_conf_cache(conf, nil, fetch_limit_conf_kvs, conf)
     local limit_conf = limit_conf_kvs[ai_instance_name]
+    if not limit_conf then
+        return
+    end
     local code, msg = limit_count.rate_limit(limit_conf, ctx, plugin_name, 1, true)
     ctx.ai_rate_limiting = code and true or false
     return code, msg
@@ -164,6 +183,10 @@ function _M.check_instance_status(conf, ctx, instance_name)
 
     local limit_conf_kvs = limit_conf_cache(conf, nil, fetch_limit_conf_kvs, conf)
     local limit_conf = limit_conf_kvs[instance_name]
+    if not limit_conf then
+        return true
+    end
+
     local code, _ = limit_count.rate_limit(limit_conf, ctx, plugin_name, 1, true)
     if code then
         core.log.info("rate limit for instance: ", instance_name, " code: ", code)
@@ -202,7 +225,9 @@ function _M.log(conf, ctx)
 
     local limit_conf_kvs = limit_conf_cache(conf, nil, fetch_limit_conf_kvs, conf)
     local limit_conf = limit_conf_kvs[instance_name]
-    limit_count.rate_limit(limit_conf, ctx, plugin_name, used_tokens)
+    if limit_conf then
+        limit_count.rate_limit(limit_conf, ctx, plugin_name, used_tokens)
+    end
 end
 
 


### PR DESCRIPTION
### Description

Disallow rate limiting single instance in ai-proxy-multi.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
