### PR TITLE
fix: timeout risk in usages of `lua-resty-aws`

### DIFF
--- a/apisix/plugins/ai-aws-content-moderation.lua
+++ b/apisix/plugins/ai-aws-content-moderation.lua
@@ -14,8 +14,12 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 --
+require("resty.aws.config") -- to read env vars before initing aws module
+
 local core = require("apisix.core")
-local aws_instance = require("resty.aws")()
+local aws = require("resty.aws")
+local aws_instance
+
 local http = require("resty.http")
 local fetch_secrets = require("apisix.secret").fetch_secrets
 
@@ -96,6 +100,9 @@ function _M.rewrite(conf, ctx)
 
     local comprehend = conf.comprehend
 
+    if not aws_instance then
+        aws_instance = aws()
+    end
     local credentials = aws_instance:Credentials({
         accessKeyId = comprehend.access_key_id,
         secretAccessKey = comprehend.secret_access_key,

--- a/apisix/secret/aws.lua
+++ b/apisix/secret/aws.lua
@@ -16,9 +16,12 @@
 --
 
 --- AWS Tools.
+require("resty.aws.config") -- to read env vars before initing aws module
+
 local core = require("apisix.core")
 local http = require("resty.http")
 local aws = require("resty.aws")
+local aws_instance
 
 local sub = core.string.sub
 local find = core.string.find
@@ -51,7 +54,9 @@ local _M = {
 }
 
 local function make_request_to_aws(conf, key)
-    local aws_instance = aws()
+    if not aws_instance then
+        aws_instance = aws()
+    end
 
     local region = conf.region
 

--- a/t/plugin/ai-aws-content-moderation-secrets.t
+++ b/t/plugin/ai-aws-content-moderation-secrets.t
@@ -33,6 +33,12 @@ add_block_preprocessor(sub {
         $block->set_value("request", "GET /t");
     }
 
+    my $main_config = $block->main_config // <<_EOC_;
+        env AWS_REGION=us-east-1;
+_EOC_
+
+    $block->set_value("main_config", $main_config);
+
     my $http_config = $block->http_config // <<_EOC_;
         server {
             listen 2668;

--- a/t/plugin/ai-aws-content-moderation.t
+++ b/t/plugin/ai-aws-content-moderation.t
@@ -30,6 +30,12 @@ add_block_preprocessor(sub {
         $block->set_value("request", "GET /t");
     }
 
+    my $main_config = $block->main_config // <<_EOC_;
+        env AWS_REGION=us-east-1;
+_EOC_
+
+    $block->set_value("main_config", $main_config);
+
     my $http_config = $block->http_config // <<_EOC_;
         server {
             listen 2668;

--- a/t/plugin/ai-aws-content-moderation2.t
+++ b/t/plugin/ai-aws-content-moderation2.t
@@ -26,6 +26,12 @@ no_root_location();
 add_block_preprocessor(sub {
     my ($block) = @_;
 
+    my $main_config = $block->main_config // <<_EOC_;
+        env AWS_REGION=us-east-1;
+_EOC_
+
+    $block->set_value("main_config", $main_config);
+
     if (!defined $block->request) {
         $block->set_value("request", "GET /t");
     }


### PR DESCRIPTION
### Description

When initializing the lua-resty-aws module, it may send requests to IDMS endpoint which may timeout in non-aws environment or just introduce delays in some cases. Thus it is good to remove the initialisation from the module level.

Also, it is unnecessary to initialise the module for each request. This problem has also been fixed which ensures that if any there are any delays in initialising the module, such delay would occur only once.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
