### PR TITLE
docs: move AI plugins into the AI category and correct `ai-rate-limiting` plugin doc display name

### DIFF
--- a/docs/en/latest/config.json
+++ b/docs/en/latest/config.json
@@ -68,6 +68,21 @@
       "items": [
         {
           "type": "category",
+          "label": "AI",
+          "items": [
+            "plugins/ai-proxy",
+            "plugins/ai-proxy-multi",
+            "plugins/ai-rate-limiting",
+            "plugins/ai-prompt-guard",
+            "plugins/ai-aws-content-moderation",
+            "plugins/ai-prompt-decorator",
+            "plugins/ai-prompt-template",
+            "plugins/ai-rag",
+            "plugins/ai-request-rewrite"
+          ]
+        },
+        {
+          "type": "category",
           "label": "General",
           "items": [
             "plugins/batch-requests",
@@ -81,30 +96,22 @@
             "plugins/ext-plugin-post-req",
             "plugins/ext-plugin-post-resp",
             "plugins/inspect",
-            "plugins/ocsp-stapling",
-            "plugins/ai-prompt-guard",
-            "plugins/ai-aws-content-moderation"
+            "plugins/ocsp-stapling"
           ]
         },
         {
           "type": "category",
           "label": "Transformation",
           "items": [
-            "plugins/ai-prompt-decorator",
             "plugins/response-rewrite",
             "plugins/proxy-rewrite",
             "plugins/grpc-transcode",
             "plugins/grpc-web",
-            "plugins/ai-prompt-template",
             "plugins/fault-injection",
             "plugins/mocking",
             "plugins/degraphql",
             "plugins/body-transformer",
-            "plugins/ai-proxy",
-            "plugins/ai-proxy-multi",
-            "plugins/attach-consumer-label",
-            "plugins/ai-rag",
-            "plugins/ai-request-rewrite"
+            "plugins/attach-consumer-label"
           ]
         },
         {
@@ -159,8 +166,7 @@
             "plugins/request-id",
             "plugins/proxy-control",
             "plugins/client-control",
-            "plugins/workflow",
-            "plugins/ai-rate-limiting"
+            "plugins/workflow"
           ]
         },
         {

--- a/docs/en/latest/plugins/ai-rate-limiting.md
+++ b/docs/en/latest/plugins/ai-rate-limiting.md
@@ -1,5 +1,5 @@
 ---
-title: AI Rate Limiting
+title: ai-rate-limiting
 keywords:
   - Apache APISIX
   - API Gateway


### PR DESCRIPTION
### Description

Move AI plugins into the AI category and correct `ai-rate-limiting` plugin doc display name

Close #12088.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
