### PR TITLE
docs: change the API address in the terminology credential documentation example

### DIFF
--- a/docs/en/latest/terminology/credential.md
+++ b/docs/en/latest/terminology/credential.md
@@ -79,7 +79,7 @@ admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"/
 2. Create 2 `key-auth` Credentials for the Consumer.
 
     ```shell
-    curl http://127.0.0.1:9180/apisix/admin/consumers/jack/key-auth-one \
+    curl http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials/key-auth-one \
     -H "X-API-KEY: $admin_key" -X PUT -d '
     {
         "plugins": {
@@ -91,7 +91,7 @@ admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"/
     ```
 
     ```shell
-    curl http://127.0.0.1:9180/apisix/admin/consumers/jack/key-auth-two \
+    curl http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials/key-auth-two \
     -H "X-API-KEY: $admin_key" -X PUT -d '
     {
         "plugins": {

--- a/docs/zh/latest/terminology/credential.md
+++ b/docs/zh/latest/terminology/credential.md
@@ -80,7 +80,7 @@ admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"/
 2. 为 Consumer 配置 2 个 启用 `key-auth` 的 Credential。
 
     ```shell
-    curl http://127.0.0.1:9180/apisix/admin/consumers/jack/key-auth-one \
+    curl http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials/key-auth-one \
     -H "X-API-KEY: $admin_key" -X PUT -d '
     {
         "plugins": {
@@ -92,7 +92,7 @@ admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"/
     ```
 
     ```shell
-    curl http://127.0.0.1:9180/apisix/admin/consumers/jack/key-auth-two \
+    curl http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials/key-auth-two \
     -H "X-API-KEY: $admin_key" -X PUT -d '
     {
         "plugins": {


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

When I consulted the terminology/credential document, I found that the API address in the example was different from the API address for creating credentials in the admin-api. I verified that the API address in the terminology/credential example was wrong, and I tried to change it according to the admin-api document.


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
