### PR TITLE
fix: allow for large shared_size in kubernetes discovery

### DIFF
--- a/apisix/discovery/kubernetes/schema.lua
+++ b/apisix/discovery/kubernetes/schema.lua
@@ -101,7 +101,7 @@ local default_weight_schema = {
 
 local shared_size_schema = {
     type = "string",
-    pattern = [[^[1-9][0-9]?m$]],
+    pattern = [[^[1-9][0-9]*m$]],
     default = "1m",
 }
 

--- a/t/kubernetes/discovery/kubernetes.t
+++ b/t/kubernetes/discovery/kubernetes.t
@@ -385,3 +385,39 @@ qr/re-read the token value/
 --- grep_error_log_out
 re-read the token value
 re-read the token value
+
+
+
+=== TEST 8: default value with minimal configuration and large shared_size
+--- yaml_config
+apisix:
+  node_listen: 1984
+  config_center: yaml
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+discovery:
+  kubernetes:
+    client:
+        token: ${KUBERNETES_CLIENT_TOKEN}
+    shared_size: "1000m"
+--- request
+GET /compare
+{
+  "service": {
+    "schema": "https",
+    "host": "${KUBERNETES_SERVICE_HOST}",
+    "port": "${KUBERNETES_SERVICE_PORT}"
+  },
+  "client": {
+    "token": "${KUBERNETES_CLIENT_TOKEN}"
+  },
+  "watch_endpoint_slices": false,
+  "shared_size": "1000m",
+  "default_weight": 50
+}
+--- more_headers
+Content-type: application/json
+--- response_body
+true


### PR DESCRIPTION
Fixes https://github.com/apache/apisix/issues/11857
Currently due to schema validation limitation, setting higher shared_size results in following error
``` bash
nginx: [error] init_by_lua error: /home/ashish/dev/apisix/apisix/core.lua:21: failed to parse yaml config: invalid discovery kubernetes configuration: object matches none of the required
stack traceback:

```
### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
