### PR TITLE
docs: fix wrong data structure in `file-logger` plugin example

### DIFF
--- a/docs/en/latest/plugins/file-logger.md
+++ b/docs/en/latest/plugins/file-logger.md
@@ -51,7 +51,7 @@ The `file-logger` Plugin is used to push log streams to a specific location.
 | include_req_body_expr  | array   | False    | Filter for when the `include_req_body` attribute is set to `true`. Request body is only logged when the expression set here evaluates to `true`. See [lua-resty-expr](https://github.com/api7/lua-resty-expr) for more. |
 | include_resp_body      | boolean | False     | When set to `true` includes the response body in the log file.                                                                                                                                                                |
 | include_resp_body_expr | array   | False     | When the `include_resp_body` attribute is set to `true`, use this to filter based on [lua-resty-expr](https://github.com/api7/lua-resty-expr). If present, only logs the response into file if the expression evaluates to `true`. |
-| match        | array[] | False   | Logs will be recorded when the rule matching is successful if the option is set. See [lua-resty-expr](https://github.com/api7/lua-resty-expr#operator-list) for a list of available expressions.   |
+| match        | array[array] | False   | Logs will be recorded when the rule matching is successful if the option is set. See [lua-resty-expr](https://github.com/api7/lua-resty-expr#operator-list) for a list of available expressions.   |
 
 ### Example of default log format
 
@@ -175,11 +175,11 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1 \
   "plugins": {
     "file-logger": {
       "path": "logs/file.log",
-      "match": {
-        {
-          { "arg_name","==","jack" }
-        }
-      }
+      "match": [
+        [
+          [ "arg_name","==","jack" ]
+        ]
+      ]
     }
   },
   "upstream": {

--- a/docs/zh/latest/plugins/file-logger.md
+++ b/docs/zh/latest/plugins/file-logger.md
@@ -53,7 +53,7 @@ description: API 网关 Apache APISIX file-logger 插件可用于将日志数据
 | include_req_body_expr | array   | 否   | 当 `include_req_body` 属性设置为 `true` 时的过滤器。只有当此处设置的表达式求值为 `true` 时，才会记录请求体。有关更多信息，请参阅 [lua-resty-expr](https://github.com/api7/lua-resty-expr) 。 |
 | include_resp_body      | boolean | 否   | 当设置为 `true` 时，生成的文件包含响应体。                                                                                               |
 | include_resp_body_expr | array   | 否   | 当 `include_resp_body` 属性设置为 `true` 时，使用该属性并基于 [lua-resty-expr](https://github.com/api7/lua-resty-expr) 进行过滤。如果存在，则仅在表达式计算结果为 `true` 时记录响应。       |
-| match        | array[] | 否   |  当设置了这个选项后，只有匹配规则的日志才会被记录。`match` 是一个表达式列表，具体请参考 [lua-resty-expr](https://github.com/api7/lua-resty-expr#operator-list)。   |
+| match        | array[array] | 否   |  当设置了这个选项后，只有匹配规则的日志才会被记录。`match` 是一个表达式列表，具体请参考 [lua-resty-expr](https://github.com/api7/lua-resty-expr#operator-list)。   |
 
 ### 默认日志格式示例
 
@@ -190,11 +190,11 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1 \
   "plugins": {
     "file-logger": {
       "path": "logs/file.log",
-      "match": {
-        {
-          { "arg_name","==","jack" }
-        }
-      }
+      "match": [
+        [
+          [ "arg_name","==","jack" ]
+        ]
+      ]
     }
   },
   "upstream": {


### PR DESCRIPTION
### Description

Fix wrong data structure in `file-logger` plugin example.

Close #12115 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
