### PR TITLE
fix: release healthchecker on 0 nodes

### DIFF
--- a/apisix/upstream.lua
+++ b/apisix/upstream.lua
@@ -327,6 +327,7 @@ function _M.set_by_route(route, api_ctx)
 
     local nodes_count = up_conf.nodes and #up_conf.nodes or 0
     if nodes_count == 0 then
+        release_checker(up_conf.parent)
         return HTTP_CODE_UPSTREAM_UNAVAILABLE, "no valid upstream node"
     end
 

--- a/apisix/upstream.lua
+++ b/apisix/upstream.lua
@@ -327,7 +327,9 @@ function _M.set_by_route(route, api_ctx)
 
     local nodes_count = up_conf.nodes and #up_conf.nodes or 0
     if nodes_count == 0 then
-        release_checker(up_conf.parent)
+        if up_conf.parent and up_conf.parent.checker then
+            release_checker(up_conf.parent)
+        end
         return HTTP_CODE_UPSTREAM_UNAVAILABLE, "no valid upstream node"
     end
 

--- a/apisix/upstream.lua
+++ b/apisix/upstream.lua
@@ -82,6 +82,9 @@ _M.set = set_directly
 
 
 local function release_checker(healthcheck_parent)
+    if not healthcheck_parent or not healthcheck_parent.checker then
+        return
+    end
     local checker = healthcheck_parent.checker
     core.log.info("try to release checker: ", tostring(checker))
     checker:delayed_clear(3)
@@ -327,9 +330,7 @@ function _M.set_by_route(route, api_ctx)
 
     local nodes_count = up_conf.nodes and #up_conf.nodes or 0
     if nodes_count == 0 then
-        if up_conf.parent and up_conf.parent.checker then
-            release_checker(up_conf.parent)
-        end
+        release_checker(up_conf.parent)
         return HTTP_CODE_UPSTREAM_UNAVAILABLE, "no valid upstream node"
     end
 


### PR DESCRIPTION
### Description
Follow up to this fix: https://github.com/apache/apisix/pull/12118
The healthchecker should also be released when new node count is 0.

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
