### PR TITLE
Add proxy-chain plugin to chain multiple upstream service calls

### DIFF
--- a/apisix/plugins/proxy-chain.lua
+++ b/apisix/plugins/proxy-chain.lua
@@ -1,0 +1,147 @@
+local core = require("apisix.core")
+local http = require("resty.http")
+local cjson = require("cjson")
+
+local plugin_name = "proxy-chain"
+
+
+local schema = {
+    type = "object",
+    properties = {
+        services = {
+            type = "array",
+            items = {
+                type = "object",
+                properties = {
+                    uri = { type = "string", minLength = 1 },
+                    method = { type = "string", enum = {"GET", "POST", "PUT", "DELETE"}, default = "POST" }
+                },
+                required = {"uri"}
+            },
+            minItems = 1
+        },
+        token_header = { type = "string" } 
+    },
+    required = {"services"}
+}
+
+local _M = {
+    version = 0.1,
+    priority = 1000,
+    name = plugin_name,
+    schema = schema,
+    description = "A plugin to chain multiple service requests and merge their responses."
+}
+
+function _M.check_schema(conf)
+    return core.schema.check(schema, conf)
+end
+
+function _M.access(conf, ctx)
+    
+    ngx.req.read_body()
+    local original_body = ngx.req.get_body_data()
+    local original_data = {}
+
+    core.log.info("Original body: ", original_body or "nil")
+    if original_body and original_body ~= "" then
+        local success, decoded = pcall(cjson.decode, original_body)
+        if success then
+            original_data = decoded
+        else
+            core.log.warn("Invalid JSON in original body: ", original_body)
+        end
+    end
+
+    local uri_args = ngx.req.get_uri_args()
+    for k, v in pairs(uri_args) do
+        original_data[k] = v
+    end
+
+    
+    local headers = ngx.req.get_headers()
+    local auth_header
+    if conf.token_header then
+        local token = headers[conf.token_header] or headers[conf.token_header:lower()] or ""
+        if token == "" then
+            core.log.info("No token found in header: ", conf.token_header, ", falling back to Authorization")
+            token = headers["Authorization"] or headers["authorization"] or ""
+            if token ~= "" then
+                token = token:gsub("^Bearer%s+", "")
+            end
+        end
+        if token ~= "" then
+            core.log.info("Token extracted from ", conf.token_header, ": ", token)
+            auth_header = "Bearer " .. token
+        else
+            core.log.info("No token provided in ", conf.token_header, " or Authorization, proceeding without auth")
+        end
+    else
+        local token = headers["Authorization"] or headers["authorization"] or ""
+        if token ~= "" then
+            token = token:gsub("^Bearer%s+", "")
+            core.log.info("Token extracted from Authorization: ", token)
+            auth_header = "Bearer " .. token
+        else
+            core.log.info("No token_header specified and no Authorization provided, proceeding without auth")
+        end
+    end
+
+    local merged_data = core.table.deepcopy(original_data)
+
+    
+    for i, service in ipairs(conf.services) do
+        local httpc = http.new()
+        local service_headers = {
+            ["Content-Type"] = "application/json",
+            ["Accept"] = "*/*"
+        }
+        if auth_header then
+            service_headers["Authorization"] = auth_header
+        end
+
+        local res, err = httpc:request_uri(service.uri, {
+            method = service.method,
+            body = cjson.encode(merged_data),
+            headers = service_headers
+        })
+
+        if not res then
+            core.log.error("Failed to call service ", service.uri, ": ", err)
+            return 500, { error = "Failed to call service: " .. service.uri }
+        end
+
+        if res.status ~= 200 then
+            core.log.error("Service ", service.uri, " returned non-200 status: ", res.status, " body: ", res.body or "nil")
+            return res.status, { error = "Service error", body = res.body }
+        end
+
+        core.log.info("Response from ", service.uri, ": ", res.body or "nil")
+
+        local service_data = {}
+        if res.body and res.body ~= "" then
+            local success, decoded = pcall(cjson.decode, res.body)
+            if success then
+                service_data = decoded
+            else
+                core.log.error("Invalid JSON in response from ", service.uri, ": ", res.body)
+                return 500, { error = "Invalid JSON in response from " .. service.uri }
+            end
+        end
+
+        for k, v in pairs(service_data) do
+            merged_data[k] = v
+        end
+    end
+
+    local new_body = cjson.encode(merged_data)
+    core.log.info("Merged data sent to upstream: ", new_body)
+
+    ctx.proxy_chain_response = merged_data
+    ngx.req.set_body_data(new_body)
+    if auth_header then
+        ngx.req.set_header("Authorization", auth_header)
+    end
+end
+
+return _M


### PR DESCRIPTION
### Description

This Pull Request introduces the `proxy-chain` plugin to APISIX, designed to enhance the gateway's ability to orchestrate complex workflows by chaining multiple upstream service calls in a sequential manner. The plugin merges the responses from these services into a single payload, which is then passed to the final upstream, making it ideal for scenarios requiring data aggregation or step-by-step processing across microservices.

### Purpose

The primary goal of the `proxy-chain` plugin is to simplify workflows where a single client request needs to interact with multiple backend services before producing a final response. For example, in an e-commerce checkout process, the plugin can:
1. Fetch user data from a customer service.
2. Validate payment details from a payment service.
3. Combine the results and forward them to an order processing service.

This eliminates the need for clients to manage these interactions manually and reduces latency by handling them server-side within APISIX.

### How It Works

The plugin operates in the `access` phase of APISIX's request lifecycle and performs the following steps:
1. **Request Parsing**: Extracts the incoming request body (JSON) and URI arguments, merging them into an initial data set.
2. **Token Handling**: Optionally extracts an authentication token from a configurable header (e.g., `Token` or `Authorization`) and passes it to downstream services.
3. **Service Chaining**: Iterates through a list of configured services, making HTTP requests to each in sequence:
    - Sends the current merged data as the request body.
    - Merges the response (JSON) into the cumulative data set.
4. **Final Output**: Updates the request body with the merged data and forwards it to the upstream, optionally including the authentication token.

The plugin includes error handling for failed service calls or invalid JSON responses, returning appropriate HTTP status codes and error messages.

### Configuration Schema

| Name           | Type   | Required | Default | Description                                      |
|----------------|--------|----------|---------|--------------------------------------------------|
| `services`     | array  | Yes      | -       | List of upstream services to chain.              |
| `services.uri` | string | Yes      | -       | URI of the upstream service.                     |
| `services.method` | string | Yes   | "POST"  | HTTP method (GET, POST, PUT, DELETE).            |
| `token_header` | string | No       | -       | Custom header name for passing a token between services. |

### Example Usage

Below is an example of how to configure and use the `proxy-chain` plugin in APISIX:

#### Route Configuration
```json
{
  "uri": "/offl/v1/checkout",
  "methods": ["POST"],
  "plugins": {
    "proxy-chain": {
      "services": [
        {
          "uri": "http://customer_service/api/v1/user",
          "method": "POST"
        },
        {
          "uri": "http://payment_service/api/v1/validate",
          "method": "POST"
        }
      ],
      "token_header": "Token"
    },
    "proxy-rewrite": {
      "uri": "/api/v1/checkout"
    }
  },
  "upstream_id": "550932803756229477"
}
```
## Expected Behavior:
The plugin sends {"order_id": "12345"} to customer_service/api/v1/user, receiving something like {"user_id": "67890"}.

It then sends the merged data {"order_id": "12345", "user_id": "67890"} to payment_service/api/v1/validate, receiving {"status": "valid"}.

The final merged data {"order_id": "12345", "user_id": "67890", "status": "valid"} is rewritten to /api/v1/checkout and sent to the upstream.

## Changes Introduced
Added apisix/apisix/plugins/proxy-chain.lua with the plugin implementation.

Updated documentation in docs/en/latest/plugins/proxy-chain.md (to be added in a follow-up commit if needed).

## Why Include This Plugin?
Flexibility: Enables complex service orchestration without additional middleware.

Performance: Reduces client-side latency by handling chaining server-side.

Reusability: Useful across various use cases like authentication flows, data aggregation, and microservices coordination.

## Testing
The plugin has been tested in a Dockerized APISIX environment (version 3.11.0-debian) with the example configuration above.

Error handling for failed service calls and invalid JSON responses is verified.

Suggestions for unit tests in t/plugin/ are welcome!

## Next Steps
Requesting feedback on the implementation and configuration schema.

Willing to add unit tests if required for acceptance