### PR TITLE
Upstreams variable support

### DIFF
--- a/apisix/core/utils.lua
+++ b/apisix/core/utils.lua
@@ -461,5 +461,35 @@ function _M.check_tls_bool(fields, conf, plugin_name)
     end
 end
 
+---
+-- Checks if a string is an nginx variable.
+-- An nginx variable starts with the '$' character.
+--
+-- @function core.utils.is_nginx_variable
+-- @tparam string str The string to check
+-- @treturn boolean true if the string starts with '$', false otherwise
+-- @usage
+-- local utils = require("apisix.core.utils")
+--
+-- -- Usage examples:
+-- local is_var = utils.is_nginx_variable("$host")     -- true
+-- local is_var = utils.is_nginx_variable("host")      -- false
+-- local is_var = utils.is_nginx_variable("${host}")   -- true
+-- local is_var = utils.is_nginx_variable("\\$host")   -- false
+--
+-- -- Usage in APISIX context:
+-- if utils.is_nginx_variable(up_conf.service_name) then
+--     -- Handle as nginx variable
+-- else
+--     -- Handle as regular service name
+-- end
+function _M.is_nginx_variable(str)
+    if not str or type(str) ~= "string" then
+        return false
+    end
+
+    -- Check if the string starts with '$' and it's not escaped
+    return str:sub(1, 1) == "$" and not (str:sub(1, 2) == "\\$")
+end
 
 return _M

--- a/apisix/upstream.lua
+++ b/apisix/upstream.lua
@@ -291,10 +291,9 @@ function _M.set_by_route(route, api_ctx)
             return 503, err
         end
 
+        local service_name = up_conf.service_name
         if core.utils.is_nginx_variable(up_conf.service_name) then
-            local service_name = core.utils.resolve_nginx_variable(up_conf.service_name)
-        else
-            local service_name = up_conf.service_name
+            service_name = core.utils.resolve_var(up_conf.service_name, api_ctx.var)
         end
 
         local new_nodes, err = dis.nodes(service_name, up_conf.discovery_args)

--- a/apisix/upstream.lua
+++ b/apisix/upstream.lua
@@ -291,7 +291,13 @@ function _M.set_by_route(route, api_ctx)
             return 503, err
         end
 
-        local new_nodes, err = dis.nodes(up_conf.service_name, up_conf.discovery_args)
+        if core.utils.is_nginx_variable(up_conf.service_name) then
+            local service_name = core.utils.resolve_nginx_variable(up_conf.service_name)
+        else
+            local service_name = up_conf.service_name
+        end
+
+        local new_nodes, err = dis.nodes(service_name, up_conf.discovery_args)
         if not new_nodes then
             return HTTP_CODE_UPSTREAM_UNAVAILABLE, "no valid upstream node: " .. (err or "nil")
         end

--- a/t/core/utils.t
+++ b/t/core/utils.t
@@ -393,3 +393,33 @@ res:nil
 res:5
 res:12
 res:7
+
+
+
+=== TEST X: is_nginx_variable
+--- config
+    location /t {
+        content_by_lua_block {
+            local is_nginx_variable = require("apisix.core.utils").is_nginx_variable
+
+            local cases = {
+                {str = "$host", expected = true},
+                {str = "host", expected = false},
+                {str = "${host}", expected = true},
+                {str = "\\$host", expected = false},
+                {str = nil, expected = false},
+                {str = 123, expected = false},
+                {str = "", expected = false},
+            }
+
+            for _, case in ipairs(cases) do
+                local res = is_nginx_variable(case.str)
+                assert(res == case.expected,
+                       string.format("case %s failed: got %s, expected %s",
+                                   case.str, res, case.expected))
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body


### PR DESCRIPTION
### Description

Added support for Nginx variables in the `service_name` parameter for service discovery. This allows dynamic service name resolution based on Nginx variables such as `$host`, `$http_host`, and others, working with all service discovery implementations (Consul, Eureka, Nacos, etc.).

### Detailed Description

#### Problem

The current implementation of service discovery in APISIX does not support using Nginx variables in the `service_name` parameter. This limits configuration flexibility as the service name must be hardcoded in the configuration, regardless of which service discovery implementation is used.

#### Solution

Added support for Nginx variables in the `service_name` parameter at the upstream level. This change enables dynamic service name resolution across all service discovery implementations. For example:

#### Usage Example

1. Define a variable in Nginx configuration:
```nginx
map $http_host $backend {
  default echo;
  "~([^.]+).domain.local" $1;
}
```

2. Define routes
```yaml
routes:
  -
    uri: "/*"
    host: "*.domain.local"
    upstream:
      service_name: $backend  # Nginx variable
      type: "roundrobin"
      discovery_type: "consul"  # or any other discovery type
```

2. Use the variable in route configuration with any service discovery:
```yaml
routes:
  -
    uri: "/*"
    host: "*.domain.local"
    upstream:
      service_name: $backend
      type: "roundrobin"
      discovery_type: "consul"  # or "eureka", "nacos", etc.
```

In this example, if a request comes to `service1.domain.local`, the `$backend` variable will be set to `service1`, and APISIX will look for a service with this name in the configured service discovery system.

#### Backward Compatibility

The change is fully backward compatible because:
1. Existing configurations will continue to work without changes
2. The new functionality is only activated when using Nginx variables in `service_name`
3. The change is implemented at the upstream level, making it available to all service discovery implementations

---

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->