### PR TITLE
feat(standalone): support incremental synchronization

### DIFF
--- a/apisix/admin/standalone.lua
+++ b/apisix/admin/standalone.lua
@@ -40,11 +40,12 @@ local _M = {}
 
 
 local function get_config()
-    local config, err = shared_dict:get("config")
+    local config = shared_dict:get("config")
     if not config then
         return nil, "not found"
     end
 
+    local err
     config, err = core.json.decode(config)
     if not config then
         return nil, "failed to decode json: " .. err
@@ -101,7 +102,9 @@ local function update(ctx)
     if not config then
         if err ~= "not found" then
             core.log.error("failed to get config from shared dict: ", err)
-            return core.response.exit(500, {error_msg = "failed to get config from shared dict: " .. err})
+            return core.response.exit(500, {
+                error_msg = "failed to get config from shared dict: " .. err
+            })
         end
     else
         for key, version in pairs(config.conf_version) do
@@ -215,12 +218,15 @@ local function get(ctx)
     if not config then
         if err ~= "not found" then
             core.log.error("failed to get config from shared dict: ", err)
-            return core.response.exit(500, {error_msg = "failed to get config from shared dict: " .. err})
+            return core.response.exit(500, {
+                error_msg = "failed to get config from shared dict: " .. err
+            })
         end
         config = {}
         local created_objs = config_yaml.fetch_all_created_obj()
         for _, obj in pairs(created_objs) do
-            core.response.set_header("X-APISIX-Conf-Version-" .. obj.key, tostring(obj.conf_version))
+            core.response.set_header("X-APISIX-Conf-Version-" .. obj.key,
+                                        tostring(obj.conf_version))
         end
     else
         for key, version in pairs(config.conf_version) do

--- a/apisix/admin/standalone.lua
+++ b/apisix/admin/standalone.lua
@@ -30,25 +30,60 @@ local events       = require("apisix.events")
 local core         = require("apisix.core")
 local config_yaml  = require("apisix.core.config_yaml")
 local check_schema = require("apisix.core.schema").check
+local tbl_deepcopy = require("apisix.core.table").deepcopy
+
 
 local EVENT_UPDATE = "standalone-api-configuration-update"
 
 local _M = {}
 
 
-local function update_and_broadcast_config(apisix_yaml, conf_version)
-    local config = core.json.encode({
+
+local function get_config()
+    local config, err = shared_dict:get("config")
+    if not config then
+        return nil, "not found"
+    end
+
+    config, err = core.json.decode(config)
+    if not config then
+        return nil, "failed to decode json: " .. err
+    end
+    return config
+end
+
+
+local function update_and_broadcast_config(old_config, apisix_yaml, conf_version_kv)
+    local config = {
         conf = apisix_yaml,
-        conf_version = conf_version,
-    })
+        conf_version = conf_version_kv
+    }
+
+    if old_config then
+        local ori_config = tbl_deepcopy(old_config)
+        ori_config.conf_version = ori_config.conf_version or {}
+        ori_config.conf = ori_config.conf or {}
+        for key, v in pairs(conf_version_kv) do
+            if v ~= ori_config.conf_version[key] then
+                ori_config.conf[key] = apisix_yaml[key]
+                ori_config.conf_version[key] = v
+            end
+        end
+        config = ori_config
+    end
+
+    local encoded_config, encode_err = core.json.encode(config)
+    if not encoded_config then
+        core.log.error("failed to encode json: ", encode_err)
+        return nil, "failed to encode json: " .. encode_err
+    end
 
     if shared_dict then
-        -- the worker that handles Admin API calls is responsible for writing the shared dict
-        local ok, err = shared_dict:set("config", config)
+        local ok, save_err = shared_dict:set("config", encoded_config)
         if not ok then
-            return nil, "failed to save config to shared dict: " .. err
+            return nil, "failed to save config to shared dict: " .. save_err
         end
-        core.log.info("standalone config updated: ", config)
+        core.log.info("standalone config updated: ", encoded_config)
     else
         core.log.crit(config_yaml.ERR_NO_SHARED_DICT)
     end
@@ -59,24 +94,36 @@ end
 local function update(ctx)
     local content_type = core.request.header(nil, "content-type") or "application/json"
 
-    local conf_version
-    if ctx.var.arg_conf_version then
-        conf_version = tonumber(ctx.var.arg_conf_version)
-        if not conf_version then
-            return core.response.exit(400, {error_msg = "invalid conf_version: "
-                                            .. ctx.var.arg_conf_version
-                                            .. ", should be a integer" })
+
+    local update_keys
+
+    local config, err = get_config()
+    if not config then
+        if err ~= "not found" then
+            core.log.error("failed to get config from shared dict: ", err)
+            return core.response.exit(500, {error_msg = "failed to get config from shared dict: " .. err})
         end
     else
-        conf_version = ngx.time()
-    end
-    -- check if conf_version greater than the current version
-    local _, ver = config_yaml._get_config()
-    if conf_version <= ver then
-        return core.response.exit(400, {error_msg = "invalid conf_version: conf_version ("
-                                        .. conf_version
-                                        .. ") should be greater than the current version ("
-                                        .. ver .. ")"})
+        for key, version in pairs(config.conf_version) do
+            local header = "x-apisix-conf-version" .. "-" .. key
+            local req_conf_version = core.request.header(ctx, header)
+            if req_conf_version then
+                if not tonumber(req_conf_version) then
+                    return core.response.exit(400, {error_msg = "invalid header: [" .. header ..
+                        ": " .. req_conf_version .. "]" ..
+                        " should be a integer"})
+                end
+                req_conf_version = tonumber(req_conf_version)
+                if req_conf_version <= version then
+                    return core.response.exit(400, {error_msg = "invalid header: [" .. header ..
+                        ": " .. req_conf_version .. "]" ..
+                        " should be greater than the current version (" .. version .. ")"})
+                else
+                    update_keys = update_keys or {}
+                    update_keys[key] = req_conf_version
+                end
+            end
+        end
     end
 
     -- read the request body
@@ -107,9 +154,19 @@ local function update(ctx)
 
     -- check input by jsonschema
     local apisix_yaml = {}
+    local confi_version_kv = tbl_deepcopy(config and config.conf_version or {})
     local created_objs = config_yaml.fetch_all_created_obj()
+
     for key, obj in pairs(created_objs) do
-        if req_body[key] and #req_body[key] > 0 then
+        local updated = false
+        if not update_keys then
+            confi_version_kv[key] = confi_version_kv[key] and confi_version_kv[key] + 1 or 1
+            updated = true
+        elseif update_keys[key] then
+            confi_version_kv[key] = update_keys[key]
+            updated = true
+        end
+        if updated and req_body[key] and #req_body[key] > 0 then
             apisix_yaml[key] = table_new(1, 0)
             local item_schema = obj.item_schema
             local item_checker = obj.checker
@@ -137,12 +194,15 @@ local function update(ctx)
         end
     end
 
-    local ok, err = update_and_broadcast_config(apisix_yaml, conf_version)
+    local ok, err = update_and_broadcast_config(config, apisix_yaml, confi_version_kv)
     if not ok then
         core.response.exit(500, err)
     end
 
-    core.response.set_header("X-APISIX-Conf-Version", tostring(conf_version))
+    for key, version in pairs(confi_version_kv) do
+        core.response.set_header("X-APISIX-Conf-Version-" .. key, tostring(version))
+    end
+
     return core.response.exit(202)
 end
 
@@ -151,9 +211,23 @@ local function get(ctx)
     local accept = core.request.header(nil, "accept") or "application/json"
     local want_yaml_resp = core.string.has_prefix(accept, "application/yaml")
 
-    local _, ver, config = config_yaml._get_config()
+    local config, err = get_config()
+    if not config then
+        if err ~= "not found" then
+            core.log.error("failed to get config from shared dict: ", err)
+            return core.response.exit(500, {error_msg = "failed to get config from shared dict: " .. err})
+        end
+        config = {}
+        local created_objs = config_yaml.fetch_all_created_obj()
+        for _, obj in pairs(created_objs) do
+            core.response.set_header("X-APISIX-Conf-Version-" .. obj.key, tostring(obj.conf_version))
+        end
+    else
+        for key, version in pairs(config.conf_version) do
+            core.response.set_header("X-APISIX-Conf-Version-" .. key, tostring(version))
+        end
+    end
 
-    core.response.set_header("X-APISIX-Conf-Version", tostring(ver))
     local resp, err
     if want_yaml_resp then
         core.response.set_header("Content-Type", "application/yaml")
@@ -195,7 +269,7 @@ end
 
 
 function _M.init_worker()
-    local function update_config()
+    local function update_config(data, event, resource, pid)
         local config, err = shared_dict:get("config")
         if not config then
             core.log.error("failed to get config from shared dict: ", err)

--- a/apisix/core/config_yaml.lua
+++ b/apisix/core/config_yaml.lua
@@ -155,7 +155,7 @@ local function read_apisix_yaml(premature, pre_mtime)
     log.warn("config file ", apisix_yaml_path, " reloaded.")
 end
 
-local inspect = require("inspect")
+
 local function sync_data(self)
     if not self.key then
         return nil, "missing 'key' arguments"
@@ -270,7 +270,8 @@ local function sync_data(self)
                           ", it should be an object")
             end
 
-            local id = tostring(item.id or "arr_" .. idx)
+            local id = tostring(item.id) or ("arr_" .. idx)
+            item.id = id
             local modifiedIndex = item.modifiedIndex or conf_version
             local conf_item = {value = item, modifiedIndex = modifiedIndex,
                             key = "/" .. self.key .. "/" .. id}

--- a/apisix/core/config_yaml.lua
+++ b/apisix/core/config_yaml.lua
@@ -180,8 +180,6 @@ local function sync_data(self)
 
 
     local items = apisix_yaml[self.key]
-    log.warn("conf_version: ", conf_version, " self.conf_version: ", self.conf_version, " key: ", self.key,
-             " items: ", inspect(items))
     if not items then
         self.values = new_tab(8, 0)
         self.values_hash = new_tab(0, 8)
@@ -218,7 +216,6 @@ local function sync_data(self)
     end
 
     if self.single_item then
-        log.warn("single item: ", self.key, " items: ", inspect(items))
         -- treat items as a single item
         self.values = new_tab(1, 0)
         self.values_hash = new_tab(0, 1)
@@ -329,7 +326,6 @@ end
 
 
 function _M.get(self, key)
-    log.warn("get config from key: ", key, " values_hash: ", inspect(self.values_hash), " values: ", inspect(self.values))
     if not self.values_hash then
         return
     end
@@ -339,7 +335,6 @@ function _M.get(self, key)
         return nil
     end
 
-    log.warn("upstream get arr_idx: ", arr_idx, " value: ", inspect(self.values[arr_idx]))
     return self.values[arr_idx]
 end
 

--- a/apisix/core/config_yaml.lua
+++ b/apisix/core/config_yaml.lua
@@ -270,8 +270,7 @@ local function sync_data(self)
                           ", it should be an object")
             end
 
-            local id = item.id and tostring(item.id) or ("arr_" .. idx)
-            item.id = id
+            local id = item.id or ("arr_" .. idx)
             local modifiedIndex = item.modifiedIndex or conf_version
             local conf_item = {value = item, modifiedIndex = modifiedIndex,
                             key = "/" .. self.key .. "/" .. id}
@@ -293,7 +292,8 @@ local function sync_data(self)
             end
 
             if data_valid then
-                local pre_index = self.values_hash[id]
+                local item_id = tostring(id)
+                local pre_index = self.values_hash[item_id]
                 if pre_index then
                     -- remove the old item
                     local pre_val = self.values[pre_index]
@@ -306,12 +306,10 @@ local function sync_data(self)
                         self.values[pre_index] = conf_item
                     end
                 else
-                    conf_item.clean_handlers = {}
                     insert_tab(self.values, conf_item)
-                    self.values_hash[id] = #self.values
-                    if not conf_item.value.id then
-                        conf_item.value.id = id
-                    end
+                    self.values_hash[item_id] = #self.values
+                    conf_item.value.id = item_id
+                    conf_item.clean_handlers = {}
                 end
 
                 if self.filter then

--- a/apisix/core/config_yaml.lua
+++ b/apisix/core/config_yaml.lua
@@ -270,7 +270,7 @@ local function sync_data(self)
                           ", it should be an object")
             end
 
-            local id = tostring(item.id) or ("arr_" .. idx)
+            local id = item.id and tostring(item.id) or ("arr_" .. idx)
             item.id = id
             local modifiedIndex = item.modifiedIndex or conf_version
             local conf_item = {value = item, modifiedIndex = modifiedIndex,

--- a/t/admin/standalone.spec.ts
+++ b/t/admin/standalone.spec.ts
@@ -45,6 +45,20 @@ const config2 = {
     },
   ],
 };
+const routeWithModifiedIndex = {
+  routes: [
+    {
+      id: "r1",
+      uri: "/r1",
+      modifiedIndex: 1,
+      upstream: {
+        nodes: { "127.0.0.1:1980": 1 },
+        type: "roundrobin",
+      },
+      plugins: { "proxy-rewrite": { uri: "/hello" } },
+    },
+  ],
+};
 const clientConfig = {
   baseURL: "http://localhost:1984",
   headers: {
@@ -70,7 +84,10 @@ describe("Admin - Standalone", () => {
       const resp = await client.get(ENDPOINT);
       expect(resp.status).toEqual(200);
       expect(resp.headers["content-type"]).toEqual("application/json");
-      expect(resp.headers["x-apisix-conf-version"]).toEqual("0");
+      expect(resp.headers["x-apisix-conf-version-routes"]).toEqual("0");
+      expect(resp.headers["x-apisix-conf-version-ssls"]).toEqual("0");
+      expect(resp.headers["x-apisix-conf-version-services"]).toEqual("0");
+      expect(resp.headers["x-apisix-conf-version-upstreams"]).toEqual("0");
       expect(resp.data).toEqual({});
     });
 
@@ -80,23 +97,24 @@ describe("Admin - Standalone", () => {
       });
       expect(resp.status).toEqual(200);
       expect(resp.headers["content-type"]).toEqual("application/yaml");
-      expect(resp.headers["x-apisix-conf-version"]).toEqual("0");
+      expect(resp.headers["x-apisix-conf-version-routes"]).toEqual("0");
+      expect(resp.headers["x-apisix-conf-version-ssls"]).toEqual("0");
+      expect(resp.headers["x-apisix-conf-version-services"]).toEqual("0");
+      expect(resp.headers["x-apisix-conf-version-upstreams"]).toEqual("0");
 
       // The lyaml-encoded empty Lua table becomes an array, which is expected, but shouldn't be
       expect(resp.data).toEqual([]);
     });
 
     it("update config (add routes, by json)", async () => {
-      const resp = await client.put(ENDPOINT, config1, {
-        params: { conf_version: 1 },
-      });
+      const resp = await client.put(ENDPOINT, config1);
       expect(resp.status).toEqual(202);
     });
 
     it("dump config (json format)", async () => {
       const resp = await client.get(ENDPOINT);
       expect(resp.status).toEqual(200);
-      expect(resp.headers["x-apisix-conf-version"]).toEqual("1");
+      expect(resp.headers["x-apisix-conf-version-routes"]).toEqual("1");
     });
 
     it("dump config (yaml format)", async () => {
@@ -105,7 +123,7 @@ describe("Admin - Standalone", () => {
         responseType: 'text',
       });
       expect(resp.status).toEqual(200);
-      expect(resp.headers["x-apisix-conf-version"]).toEqual("1");
+      expect(resp.headers["x-apisix-conf-version-routes"]).toEqual("1");
       expect(resp.data).toContain("routes:")
       expect(resp.data).toContain("id: r1")
       expect(resp.data.startsWith('---')).toBe(false);
@@ -123,7 +141,6 @@ describe("Admin - Standalone", () => {
         ENDPOINT,
         YAML.stringify(config2),
         {
-          params: { conf_version: 2 },
           headers: { "Content-Type": "application/yaml" },
         }
       );
@@ -133,7 +150,7 @@ describe("Admin - Standalone", () => {
     it("dump config (json format)", async () => {
       const resp = await client.get(ENDPOINT);
       expect(resp.status).toEqual(200);
-      expect(resp.headers["x-apisix-conf-version"]).toEqual("2");
+      expect(resp.headers["x-apisix-conf-version-routes"]).toEqual("2");
     });
 
     it('check route "r1"', () =>
@@ -173,14 +190,16 @@ describe("Admin - Standalone", () => {
         ENDPOINT,
         YAML.stringify(config2),
         {
-          params: { conf_version: 0 },
-          headers: { "Content-Type": "application/yaml" },
+          headers: { 
+            "Content-Type": "application/yaml",
+            "x-apisix-conf-version-routes": 1,
+          },
         }
       );
       expect(resp.status).toEqual(400);
       expect(resp.data).toEqual({
         error_msg:
-          "invalid conf_version: conf_version (0) should be greater than the current version (3)",
+          "invalid header: [x-apisix-conf-version-routes: 1] should be greater than the current version (3)",
       });
     });
 
@@ -190,12 +209,15 @@ describe("Admin - Standalone", () => {
         YAML.stringify(config2),
         {
           params: { conf_version: "abc" },
-          headers: { "Content-Type": "application/yaml" },
+          headers: { 
+            "Content-Type": "application/yaml",
+            "x-apisix-conf-version-routes": "adc",
+          },
         }
       );
       expect(resp.status).toEqual(400);
       expect(resp.data).toEqual({
-        error_msg: "invalid conf_version: abc, should be a integer",
+        error_msg: "invalid header: [x-apisix-conf-version-routes: adc] should be a integer",
       });
     });
 
@@ -227,6 +249,49 @@ describe("Admin - Standalone", () => {
       expect(resp.data).toEqual({
         error_msg: "invalid request body: empty request body",
       });
+    });
+
+    it("control resource changes using modifiedIndex", async () => {
+      const c1 = structuredClone(routeWithModifiedIndex);
+      c1.routes[0].modifiedIndex = 1;
+
+      const c2 = structuredClone(c1);
+      c2.routes[0].uri = "/r2";
+
+      const c3 = structuredClone(c2);
+      c3.routes[0].modifiedIndex = 2;
+
+      // Update with c1
+      const resp = await clientException.put(ENDPOINT, c1);
+      expect(resp.status).toEqual(202);
+
+      // Check route /r1 exists
+      const resp_1 = await client.get("/r1");
+      expect(resp_1.status).toEqual(200);
+
+      // Update with c2
+      const resp2 = await clientException.put(ENDPOINT, c2);
+      expect(resp2.status).toEqual(202);
+
+      // Check route /r1 exists
+      const resp2_2 = await client.get("/r1");
+      expect(resp2_2.status).toEqual(200);
+
+      // Check route /r2 not exists
+      const resp2_1 = await client.get("/r2").catch((err) => err.response);
+      expect(resp2_1.status).toEqual(404);
+
+      // Update with c3
+      const resp3 = await clientException.put(ENDPOINT, c3);
+      expect(resp3.status).toEqual(202);
+
+      // Check route /r1 not exists
+      const resp3_1 = await client.get("/r1").catch((err) => err.response);
+      expect(resp3_1.status).toEqual(404);
+
+      // Check route /r2 exists
+      const resp3_2 = await client.get("/r2");
+      expect(resp3_2.status).toEqual(200);
     });
   });
 });

--- a/t/admin/standalone.spec.ts
+++ b/t/admin/standalone.spec.ts
@@ -190,7 +190,7 @@ describe("Admin - Standalone", () => {
         ENDPOINT,
         YAML.stringify(config2),
         {
-          headers: { 
+          headers: {
             "Content-Type": "application/yaml",
             "x-apisix-conf-version-routes": 1,
           },
@@ -209,7 +209,7 @@ describe("Admin - Standalone", () => {
         YAML.stringify(config2),
         {
           params: { conf_version: "abc" },
-          headers: { 
+          headers: {
             "Content-Type": "application/yaml",
             "x-apisix-conf-version-routes": "adc",
           },

--- a/t/admin/standalone.t
+++ b/t/admin/standalone.t
@@ -126,7 +126,7 @@ GET /r1
 
 
 
-=== TEST 8: hit r2
+=== TEST 7: hit r2
 --- config
     location /t3 {}
 --- pipelined_requests eval
@@ -136,7 +136,7 @@ GET /r1
 
 
 
-=== TEST 7: put invalid conf_version
+=== TEST 8: put invalid conf_version
 --- config
     location /t {} 
 --- request
@@ -148,4 +148,3 @@ x-apisix-conf-version-routes: 100
 --- error_code: 400
 --- response_body
 {"error_msg":"invalid header: [x-apisix-conf-version-routes: 100] should be greater than the current version (100)"}
-

--- a/t/admin/standalone.t
+++ b/t/admin/standalone.t
@@ -110,7 +110,7 @@ GET /r1
 
 === TEST 6: route references upstream, but only updates the route
 --- config
-    location /t6 {} 
+    location /t6 {}
 --- pipelined_requests eval
 [
     "PUT /apisix/admin/configs\n" . "{\"routes\":[{\"id\":\"r1\",\"uri\":\"/r1\",\"upstream_id\":\"u1\",\"plugins\":{\"proxy-rewrite\":{\"uri\":\"/hello\"}}}],\"upstreams\":[{\"id\":\"u1\",\"nodes\":{\"127.0.0.1:1980\":1},\"type\":\"roundrobin\"}]}",
@@ -138,7 +138,7 @@ GET /r1
 
 === TEST 8: put invalid conf_version
 --- config
-    location /t {} 
+    location /t {}
 --- request
 PUT /apisix/admin/configs
 {"routes":[{"id":"r1","uri":"/r2","upstream_id":"u1","plugins":{"proxy-rewrite":{"uri":"/hello"}}}]}


### PR DESCRIPTION
### Description

In standalone mode, APISIX’s Admin API currently requires clients to retrieve the entire configuration on every sync. As configurations grow in size or change more often, this full-sync approach can lead to unnecessary network traffic and increased latency in applying updates. Moreover, frequent resource changes force a full rebuild of the internal radixtree, which significantly degrades lookup performance under heavy churn.

* Versioned headers per resource type: Clients may include X-APISIX-Conf-Version-<resource> headers to indicate the last-known version for each resource kind.

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
