### PR TITLE
feat(standalone): support revision in API-driven standalone mode like etcd

### DIFF
--- a/docs/en/latest/deployment-modes.md
+++ b/docs/en/latest/deployment-modes.md
@@ -138,6 +138,9 @@ This makes it possible to disable the Admin API and discover configuration chang
 
 #### API-driven (Experimental)
 
+> This mode is experimental, please do not rely on it in your production environment.
+> We use it to validate certain specific workloads and if it is appropriate we will turn it into an officially supported feature, otherwise it will be removed.
+
 ##### Overview
 
 The API-driven mode is an emerging paradigm for standalone deployment. The routing rules are entirely in memory and not in a file, requiring updates through the dedicated Standalone Admin API. Changes overwrite the entire configuration and take effect immediately without requiring a reboot, as it is hot updated.

--- a/docs/en/latest/deployment-modes.md
+++ b/docs/en/latest/deployment-modes.md
@@ -163,12 +163,11 @@ This disables the local file source of configuration in favor of the API. When A
 
     If no `X-APISIX-Conf-Version-<resource>` headers are provided, APISIX treats the request as a full sync, replacing all existing resources.
 
-    If the supplied version for any resource type is ≤ the server’s current version, the request for that resource will be rejected. 
+    If the supplied version for any resource type is ≤ the server’s current version, the request for that resource will be rejected.
 
 * modifiedIndex per resource
 
     Allow setting an index for each resource, APISIX compares it to its modifiedIndex to determine whether to accept the update.
-
 
 **Example:**
 

--- a/docs/en/latest/deployment-modes.md
+++ b/docs/en/latest/deployment-modes.md
@@ -153,7 +153,7 @@ To enable this mode, set the APISIX role to `traditional` (to start both the API
 deployment:
   role: traditional
   role_traditional:
-    config_provider: yamls
+    config_provider: yaml
 ```
 
 This disables the local file source of configuration in favor of the API. When APISIX starts, it uses an empty configuration until updated via the API.
@@ -175,14 +175,11 @@ This disables the local file source of configuration in favor of the API. When A
 
     APISIX compares each provided `<resource>_conf_version` against its in-memory `<resource>_conf_version` for that resource type. If the provided `<resource>_conf_version` is:
 
-  - **Greater than** the current `conf_version`
-    If your `<resource>_conf_version` is **higher**, APISIX will **rebuild/reset** that resource type’s data to match your payload.
+  - **Greater than** the current `conf_version`, APISIX will **rebuild/reset** that resource type’s data to match your payload.
 
-  - **Equal to** the current `conf_version`
-    If it is **equal**, APISIX treats the resource as **unchanged** and **ignores** it (no data is rebuilt).
+  - **Equal to** the current `conf_version`, APISIX treats the resource as **unchanged** and **ignores** it (no data is rebuilt).
 
-  - **Less than** the current `conf_version`
-    If it is **lower**, APISIX considers your update **stale** and **rejects** the request for that resource type with a **400 Bad Request**.
+  - **Less than** the current `conf_version`, APISIX considers your update **stale** and **rejects** the request for that resource type with a **400 Bad Request**.
 
 * `modifiedIndex` by individual resource
 
@@ -234,7 +231,7 @@ In APISIX memory, the current configuration is:
     "routes_conf_version": 1000,
     "upstreams_conf_version": 1000,
 }
-
+```
 Update the previous upstreams configuration by setting a higher version number, such as 1001, to replace the current version 1000:
 
 ```shell

--- a/docs/en/latest/deployment-modes.md
+++ b/docs/en/latest/deployment-modes.md
@@ -143,7 +143,7 @@ This makes it possible to disable the Admin API and discover configuration chang
 
 ##### Overview
 
-The API-driven mode is an emerging paradigm for standalone deployment. The routing rules are entirely in memory and not in a file, requiring updates through the dedicated Standalone Admin API. Changes overwrite the entire configuration and take effect immediately without requiring a reboot, as it is hot updated.
+API-driven mode is an emerging paradigm for standalone deployment, where routing rules are stored entirely in memory rather than in a configuration file. Updates must be made through the dedicated Standalone Admin API. Each update replaces the full configuration and takes effect immediately through hot updates, without requiring a restart.
 
 ##### Configuration
 
@@ -160,7 +160,7 @@ This disables the local file source of configuration in favor of the API. When A
 
 ##### API Endpoints
 
-* Per-resource-type conf_version
+* `conf_version` by resource type
 
     Use `<resource>_conf_version` to indicate the client’s current version for each resource type (e.g. routes, upstreams, services, etc.).
 
@@ -173,7 +173,7 @@ This disables the local file source of configuration in favor of the API. When A
     }
     ```
 
-    APISIX compares each provided `<resource>_conf_version` against its in-memory `<resource>_conf_version` for that resource type:
+    APISIX compares each provided `<resource>_conf_version` against its in-memory `<resource>_conf_version` for that resource type. If the provided `<resource>_conf_version` is:
 
   - **Greater than** the current `conf_version`
     If your `<resource>_conf_version` is **higher**, APISIX will **rebuild/reset** that resource type’s data to match your payload.
@@ -184,11 +184,11 @@ This disables the local file source of configuration in favor of the API. When A
   - **Less than** the current `conf_version`
     If it is **lower**, APISIX considers your update **stale** and **rejects** the request for that resource type with a **400 Bad Request**.
 
-* modifiedIndex per resource
+* `modifiedIndex` by individual resource
 
-    Allow setting an index for each resource, APISIX compares it to its modifiedIndex to determine whether to accept the update.
+    Allow setting an index for each resource. APISIX compares this index to its modifiedIndex to determine whether to accept the update.
 
-**Example:**
+##### Example
 
 1. get configuration
 
@@ -235,7 +235,7 @@ In APISIX memory, the current configuration is:
     "upstreams_conf_version": 1000,
 }
 
-Due `upstreams_conf_version: 1001` > `upstreams_conf_version: 1000`, APISIX will update the upstreams configuration:
+Update the previous upstreams configuration by setting a higher version number, such as 1001, to replace the current version 1000:
 
 ```shell
 curl -X PUT http://127.0.0.1:9180/apisix/admin/configs \

--- a/docs/en/latest/deployment-modes.md
+++ b/docs/en/latest/deployment-modes.md
@@ -232,6 +232,7 @@ In APISIX memory, the current configuration is:
     "upstreams_conf_version": 1000,
 }
 ```
+
 Update the previous upstreams configuration by setting a higher version number, such as 1001, to replace the current version 1000:
 
 ```shell

--- a/docs/en/latest/deployment-modes.md
+++ b/docs/en/latest/deployment-modes.md
@@ -199,17 +199,17 @@ This returns the current configuration in JSON or YAML format.
 
 ```json
 {
-    "consumer_groups_conf_version": 1000,
-    "consumers_conf_version": 1000,
-    "global_rules_conf_version": 1000,
-    "plugin_configs_conf_version": 1000,
-    "plugin_metadata_conf_version": 1000,
-    "protos_conf_version": 1000,
-    "routes_conf_version": 1000,
-    "secrets_conf_version": 1000,
-    "services_conf_version": 1000,
-    "ssls_conf_version": 1000,
-    "upstreams_conf_version": 1000
+    "consumer_groups_conf_version": 0,
+    "consumers_conf_version": 0,
+    "global_rules_conf_version": 0,
+    "plugin_configs_conf_version": 0,
+    "plugin_metadata_conf_version": 0,
+    "protos_conf_version": 0,
+    "routes_conf_version": 0,
+    "secrets_conf_version": 0,
+    "services_conf_version": 0,
+    "ssls_conf_version": 0,
+    "upstreams_conf_version": 0
 }
 ```
 
@@ -244,6 +244,7 @@ curl -X PUT http://127.0.0.1:9180/apisix/admin/configs \
     "upstreams_conf_version": 1001,
     "routes": [
         {
+            "modifiedIndex": 1000,
             "id": "r1",
             "uri": "/hello",
             "upstream_id": "u1"
@@ -251,6 +252,7 @@ curl -X PUT http://127.0.0.1:9180/apisix/admin/configs \
     ],
     "upstreams": [
         {
+            "modifiedIndex": 1001,
             "id": "u1",
             "nodes": {
                 "127.0.0.1:1980": 1,

--- a/docs/en/latest/deployment-modes.md
+++ b/docs/en/latest/deployment-modes.md
@@ -172,13 +172,13 @@ This disables the local file source of configuration in favor of the API. When A
 
     APISIX compares each provided `<resource>_conf_version` against its in-memory `<resource>_conf_version` for that resource type:
 
-  - **Greater than** the current `conf_version`  
+  - **Greater than** the current `conf_version`
     If your `<resource>_conf_version` is **higher**, APISIX will **rebuild/reset** that resource type’s data to match your payload.
 
-  - **Equal to** the current `conf_version`  
+  - **Equal to** the current `conf_version`
     If it is **equal**, APISIX treats the resource as **unchanged** and **ignores** it (no data is rebuilt).
 
-  - **Less than** the current `conf_version`  
+  - **Less than** the current `conf_version`
     If it is **lower**, APISIX considers your update **stale** and **rejects** the request for that resource type with a **400 Bad Request**.
 
 * modifiedIndex per resource

--- a/t/admin/standalone.spec.ts
+++ b/t/admin/standalone.spec.ts
@@ -249,6 +249,7 @@ describe("Admin - Standalone", () => {
       expect(resp2.status).toEqual(202);
 
       // Check route /r1 exists
+      // But it is not applied because the modifiedIndex is the same as the old value
       const resp2_2 = await client.get("/r1");
       expect(resp2_2.status).toEqual(200);
 

--- a/t/admin/standalone.spec.ts
+++ b/t/admin/standalone.spec.ts
@@ -124,6 +124,12 @@ describe("Admin - Standalone", () => {
       expect(resp.data.consumers_conf_version).toEqual(1);
     });
 
+    it("check default value", async () => {
+      const resp = await client.get(ENDPOINT);
+      expect(resp.status).toEqual(200);
+      expect(resp.data.routes).toEqual(config1.routes);
+    });
+
     it("dump config (yaml format)", async () => {
       const resp = await client.get(ENDPOINT, {
         headers: { Accept: "application/yaml" },

--- a/t/admin/standalone.t
+++ b/t/admin/standalone.t
@@ -68,7 +68,7 @@ qr/PASS admin\/standalone.spec.ts/
 --- config
     location /t {} # force the worker to restart by changing the configuration
 --- request
-PUT /apisix/admin/configs?conf_version=101
+PUT /apisix/admin/configs
 {"routes":[{"id":"r1","uri":"/r1","upstream":{"nodes":{"127.0.0.1:1980":1},"type":"roundrobin"},"plugins":{"proxy-rewrite":{"uri":"/hello"}}}]}
 --- more_headers
 X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
@@ -91,7 +91,7 @@ hello world
 --- config
     location /t2 {}
 --- request
-PUT /apisix/admin/configs?conf_version=102
+PUT /apisix/admin/configs
 {}
 --- more_headers
 X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
@@ -105,3 +105,46 @@ X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
 --- request
 GET /r1
 --- error_code: 404
+
+
+
+=== TEST 6: route references upstream, but only updates the route
+--- config
+    location /t6 {}
+--- pipelined_requests eval
+[
+    "PUT /apisix/admin/configs\n" . "{\"routes\":[{\"id\":\"r1\",\"uri\":\"/r1\",\"upstream_id\":\"u1\",\"plugins\":{\"proxy-rewrite\":{\"uri\":\"/hello\"}}}],\"upstreams\":[{\"id\":\"u1\",\"nodes\":{\"127.0.0.1:1980\":1},\"type\":\"roundrobin\"}]}",
+    "PUT /apisix/admin/configs\n" . "{\"routes\":[{\"id\":\"r1\",\"uri\":\"/r2\",\"upstream_id\":\"u1\",\"plugins\":{\"proxy-rewrite\":{\"uri\":\"/hello\"}}}]}"
+]
+--- more_headers eval
+[
+    "X-API-KEY: edd1c9f034335f136f87ad84b625c8f1",
+    "X-API-KEY: edd1c9f034335f136f87ad84b625c8f1\n" . "x-apisix-conf-version-routes: 100",
+]
+--- error_code eval
+[202, 202]
+
+
+
+=== TEST 7: hit r2
+--- config
+    location /t3 {}
+--- pipelined_requests eval
+["GET /r1", "GET /r2"]
+--- error_code eval
+[404, 200]
+
+
+
+=== TEST 8: put invalid conf_version
+--- config
+    location /t {}
+--- request
+PUT /apisix/admin/configs
+{"routes":[{"id":"r1","uri":"/r2","upstream_id":"u1","plugins":{"proxy-rewrite":{"uri":"/hello"}}}]}
+--- more_headers
+X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
+x-apisix-conf-version-routes: 100
+--- error_code: 400
+--- response_body
+{"error_msg":"invalid header: [x-apisix-conf-version-routes: 100] should be greater than the current version (100)"}


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

In standalone mode, APISIX’s Admin API currently requires clients to retrieve the entire configuration on every sync. As configurations grow in size or change more often, this full-sync approach can lead to unnecessary network traffic and increased latency in applying updates. Moreover, frequent resource changes force a full rebuild of the internal radixtree, which significantly degrades lookup performance under heavy churn.

In the scenario of service discovery, the upstream will always update frequently, and we hope to only update the upstream without affecting the usage of other resources.

**Control the changes of each resource by adding `<resource-type>_conf_version`**:

```json
{
    "consumer_groups_conf_version": 1000,
    "consumers_conf_version": 1000,
    "global_rules_conf_version": 1000,
    "plugin_configs_conf_version": 1000,
    "plugin_metadata_conf_version": 1000,
    "protos_conf_version": 1000,
    "routes_conf_version": 1000,
    "secrets_conf_version": 1000,
    "services_conf_version": 1000,
    "ssls_conf_version": 1000,
    "upstreams_conf_version": 1000
    "routes": [
        {
            "id": "r1",
            "uri": "/hello",
            "upstream_id": "u1"
        }
    ],
    "upstreams": [
        {
            "id": "u1",
            "nodes": {
                "127.0.0.1:1980": 1,
                "127.0.0.1:1980": 1
            },
            "type": "roundrobin"
        }
    ]
    "services":[]
}
```

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
