### PR TITLE
fix: only parse and validate apisix.yaml in cli when startup

### DIFF
--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -15,6 +15,7 @@
 -- limitations under the License.
 --
 
+local ngx = ngx
 local yaml = require("lyaml")
 local profile = require("apisix.core.profile")
 local util = require("apisix.cli.util")

--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -293,7 +293,9 @@ function _M.read_yaml_conf(apisix_home)
         end
     end
 
-    if default_conf.deployment.config_provider == "yaml" then
+    --- using `not ngx` to check whether the current execution environment is apisix cli module,
+    --- because it is only necessary to parse and validate `apisix.yaml` in apisix cli.
+    if default_conf.deployment.config_provider == "yaml" and not ngx then
         local apisix_conf_path = profile:yaml_path("apisix")
         local apisix_conf_yaml, _ = util.read_file(apisix_conf_path)
         if apisix_conf_yaml then


### PR DESCRIPTION
### Description

The purpose of the `read_yaml_conf` function is to read `config.yaml`, but it also parses and validates `apisix.yaml`. This validation only needs to be performed when the CLI module starts, and there is no need to repeatedly parse and validate apisix.yaml during runtime when try to get `config.yaml`:
https://github.com/apache/apisix/blob/958312fb016f5a63eac22f0955087e1fdc390c54/apisix/core/config_local.lua#L61

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
