### PR TITLE
change: mark `server-info` plugin as deprecated

### DIFF
--- a/apisix/cli/config.lua
+++ b/apisix/cli/config.lua
@@ -237,7 +237,8 @@ local _M = {
     "limit-count",
     "limit-req",
     "gzip",
-    "server-info",
+    -- deprecated and will be removed in a future release
+    -- "server-info",
     "traffic-split",
     "redirect",
     "response-rewrite",

--- a/apisix/plugins/server-info.lua
+++ b/apisix/plugins/server-info.lua
@@ -260,6 +260,7 @@ end
 
 
 function _M.init()
+    core.log.warn("The server-info plugin is deprecated and will be removed in a future release.")
     if core.config ~= require("apisix.core.config_etcd") then
         -- we don't need to report server info if etcd is not in use.
         return

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -500,7 +500,7 @@ plugins:                           # plugin list (sorted by priority)
   - ai-proxy-multi                 # priority: 998
   #- brotli                        # priority: 996
   - gzip                           # priority: 995
-  - server-info                    # priority: 990
+  #- server-info                    # priority: 990
   - traffic-split                  # priority: 966
   - redirect                       # priority: 900
   - response-rewrite               # priority: 899

--- a/docs/en/latest/plugins/server-info.md
+++ b/docs/en/latest/plugins/server-info.md
@@ -32,6 +32,12 @@ description: This document contains information about the Apache APISIX server-i
 
 The `server-info` Plugin periodically reports basic server information to etcd.
 
+:::warning
+
+The `server-info` Plugin is deprecated and will be removed in a future release.
+
+:::
+
 The information reported by the Plugin is explained below:
 
 | Name         | Type    | Description                                                                                                            |

--- a/docs/en/latest/plugins/server-info.md
+++ b/docs/en/latest/plugins/server-info.md
@@ -34,7 +34,7 @@ The `server-info` Plugin periodically reports basic server information to etcd.
 
 :::warning
 
-The `server-info` Plugin is deprecated and will be removed in a future release.
+The `server-info` Plugin is deprecated and will be removed in a future release. For more details about the deprecation and removal plan, please refer to [this discussion](https://github.com/apache/apisix/discussions/12298).
 
 :::
 

--- a/docs/zh/latest/plugins/server-info.md
+++ b/docs/zh/latest/plugins/server-info.md
@@ -32,6 +32,12 @@ description: 本文介绍了关于 Apache APISIX `server-info` 插件的基本�
 
 `server-info` 插件可以定期将服务基本信息上报至 etcd。
 
+:::warning
+
+`server-info` 插件已弃用，将在未来的版本中被移除。
+
+:::
+
 服务信息中每一项的含义如下：
 
 | 名称             | 类型    | 描述                                                                                                                   |

--- a/docs/zh/latest/plugins/server-info.md
+++ b/docs/zh/latest/plugins/server-info.md
@@ -34,7 +34,7 @@ description: 本文介绍了关于 Apache APISIX `server-info` 插件的基本�
 
 :::warning
 
-`server-info` 插件已弃用，将在未来的版本中被移除。
+`server-info` 插件已弃用，将在未来的版本中被移除。更多关于弃用和移除计划的信息，请参考[这个讨论](https://github.com/apache/apisix/discussions/12298)。
 
 :::
 

--- a/t/admin/plugins.t
+++ b/t/admin/plugins.t
@@ -111,7 +111,6 @@ limit-conn
 limit-count
 limit-req
 gzip
-server-info
 traffic-split
 redirect
 response-rewrite

--- a/t/debug/debug-mode.t
+++ b/t/debug/debug-mode.t
@@ -70,7 +70,6 @@ loaded plugin and sort by priority: 1003 name: limit-conn
 loaded plugin and sort by priority: 1002 name: limit-count
 loaded plugin and sort by priority: 1001 name: limit-req
 loaded plugin and sort by priority: 995 name: gzip
-loaded plugin and sort by priority: 990 name: server-info
 loaded plugin and sort by priority: 966 name: traffic-split
 loaded plugin and sort by priority: 900 name: redirect
 loaded plugin and sort by priority: 899 name: response-rewrite


### PR DESCRIPTION
### Description
mark `server-info` plugin as deprecated and update docs

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
mailing list: https://lists.apache.org/thread/nrwqo1gbc0z4z48fkb8dd4rn0trnfnz9

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
