### PR TITLE
fix(nacos): keep old data when nacos is down

### DIFF
--- a/apisix/discovery/nacos/init.lua
+++ b/apisix/discovery/nacos/init.lua
@@ -312,11 +312,6 @@ local function fetch_full_registry(premature)
         local query_path = instance_list_path .. service_info.service_name
                            .. token_param .. namespace_param .. group_name_param
                            .. signature_param
-        data, err = get_url(base_uri, query_path)
-        if err then
-            log.error('get_url:', query_path, ' err:', err)
-            goto CONTINUE
-        end
 
         if not up_apps[namespace_id] then
             up_apps[namespace_id] = {}
@@ -324,6 +319,19 @@ local function fetch_full_registry(premature)
 
         if not up_apps[namespace_id][group_name] then
             up_apps[namespace_id][group_name] = {}
+        end
+
+        data, err = get_url(base_uri, query_path)
+        if err then
+            local exist_data = applications and applications[namespace_id] and
+                                applications[namespace_id][group_name] and
+                                applications[namespace_id][group_name][service_info.service_name]
+            if exist_data then
+                up_apps[namespace_id][group_name][service_info.service_name] = exist_data
+            end
+            log.error('request failed, will continue using existing data that may be outdated,'
+                            , 'get_url:', query_path, ' err:', err)
+            goto CONTINUE
         end
 
         for _, host in ipairs(data.hosts) do


### PR DESCRIPTION
### Description

When there is an exception in obtaining nacos data, continue to use the existing service discovery data for proxying to avoid the failure of nacos directly affecting the request forwarding of the gateway.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
