### PR TITLE
fix: add sleep to fix flaky healthcheck cli test

### DIFF
--- a/t/cli/test_status_api.sh
+++ b/t/cli/test_status_api.sh
@@ -52,6 +52,8 @@ make run
 curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:7085/status | grep 200 \
 || (echo "failed: status api didn't return 200"; exit 1)
 
+sleep 2
+
 curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:7085/status/ready | grep 200 \
 || (echo "failed: status/ready api didn't return 200"; exit 1)
 


### PR DESCRIPTION
### Description
Due to the CLI test introduced in recent standalone healthcheck PR, the CI is failing on master as well making the test flaky.
https://github.com/apache/apisix/actions/runs/15330643322/job/43165226189?pr=12263#step:7:7542
The reason is that /status/ready is being hit in test before all workers can be ready. This PR adds a 2 second sleep to make sure workers are ready.

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
