### PR TITLE
fix: original key being modified causing cache inconsistency

### DIFF
--- a/apisix/core/ctx.lua
+++ b/apisix/core/ctx.lua
@@ -224,6 +224,7 @@ do
         __index = function(t, key)
             local cached = t._cache[key]
             if cached ~= nil then
+                log.info("serving ctx value from cache for key: ", key)
                 return cached
             end
 
@@ -283,14 +284,14 @@ do
                 end
 
             elseif core_str.has_prefix(key, "http_") then
-                key = key:lower()
-                key = re_gsub(key, "-", "_", "jo")
-                val = get_var(key, t._request)
+                local arg_key = key:lower()
+                arg_key = re_gsub(arg_key, "-", "_", "jo")
+                val = get_var(arg_key, t._request)
 
             elseif core_str.has_prefix(key, "graphql_") then
                 -- trim the "graphql_" prefix
-                key = sub_str(key, 9)
-                val = get_parsed_graphql()[key]
+                local arg_key = sub_str(key, 9)
+                val = get_parsed_graphql()[arg_key]
 
             else
                 local getter = apisix_var_names[key]

--- a/t/core/ctx3.t
+++ b/t/core/ctx3.t
@@ -1,0 +1,100 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!$block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+    if (!$block->response_body) {
+        $block->set_value("response_body", "passed\n");
+    }
+
+    if (!$block->no_error_log && !$block->error_log) {
+        $block->set_value("no_error_log", "[error]\n[alert]");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: parse graphql only once and use subsequent from cache
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [=[{
+                        "methods": ["POST"],
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "plugins": {
+                            "serverless-pre-function": {
+                                "phase": "header_filter",
+                                "functions" : ["return function(conf, ctx) 
+                                                ngx.log(ngx.WARN, 'find ctx._graphql: ', ctx.var.graphql_name == \"repo\");
+                                                ngx.log(ngx.WARN, 'find ctx._graphql: ', ctx.var.graphql_name == \"repo\");
+                                                ngx.log(ngx.WARN, 'find ctx._graphql: ', ctx.var.graphql_name == \"repo\");
+                                                end"]
+                            }
+                        },
+                        "uri": "/hello",
+                        "vars": [["graphql_name", "==", "repo"]]
+                }]=]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 2: hit
+--- request
+POST /hello
+query repo {
+    owner {
+        name
+    }
+}
+--- response_body
+hello world
+--- error_log
+--- grep_error_log eval
+qr/serving ctx value from cache for key: graphql_name/
+--- grep_error_log_out
+serving ctx value from cache for key: graphql_name
+serving ctx value from cache for key: graphql_name
+serving ctx value from cache for key: graphql_name

--- a/t/core/ctx3.t
+++ b/t/core/ctx3.t
@@ -58,7 +58,7 @@ __DATA__
                         "plugins": {
                             "serverless-pre-function": {
                                 "phase": "header_filter",
-                                "functions" : ["return function(conf, ctx) 
+                                "functions" : ["return function(conf, ctx)
                                                 ngx.log(ngx.WARN, 'find ctx._graphql: ', ctx.var.graphql_name == \"repo\");
                                                 ngx.log(ngx.WARN, 'find ctx._graphql: ', ctx.var.graphql_name == \"repo\");
                                                 ngx.log(ngx.WARN, 'find ctx._graphql: ', ctx.var.graphql_name == \"repo\");


### PR DESCRIPTION
Fixes #
While  calculating the value of the key, the current logic overrides the original key and stores the wrong key in the cache causing cache miss. This PR makes sure that original key is not modified.
### Checklist 

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
