### PR TITLE
fix: handle consul nil port cases by defaulting to port 80

### DIFF
--- a/apisix/discovery/consul/init.lua
+++ b/apisix/discovery/consul/init.lua
@@ -516,8 +516,8 @@ function _M.connect(premature, consul_server, retry_delay)
                     end
 
                     local svc_address, svc_port = node.Service.Address, node.Service.Port
-                    -- Handle nil port case - default to 80 for HTTP services
-                    if not svc_port then
+                    -- Handle nil or 0 port case - default to 80 for HTTP services
+                    if not svc_port or svc_port == 0 then
                         svc_port = 80
                     end
                     -- if nodes is nil, new nodes table and set to up_services

--- a/apisix/discovery/consul/init.lua
+++ b/apisix/discovery/consul/init.lua
@@ -225,8 +225,8 @@ local function watch_catalog(consul_server)
     ::RETRY::
     local watch_result, watch_err = client:get(consul_server.consul_watch_catalog_url)
     local watch_error_info = (watch_err ~= nil and watch_err)
-                             or ((watch_result ~= nil and watch_result.status ~= 200)
-                             and watch_result.status)
+                            or ((watch_result ~= nil and watch_result.status ~= 200)
+                            and watch_result.status)
     if watch_error_info then
         log.error("connect consul: ", consul_server.consul_server_url,
             " by sub url: ", consul_server.consul_watch_catalog_url,
@@ -516,7 +516,7 @@ function _M.connect(premature, consul_server, retry_delay)
                     end
 
                     local svc_address, svc_port = node.Service.Address, node.Service.Port
-                    -- Handle nil port case - default to 80 for HTTP services  
+                    -- Handle nil port case - default to 80 for HTTP services
                     if not svc_port then
                         svc_port = 80
                     end

--- a/apisix/discovery/consul/init.lua
+++ b/apisix/discovery/consul/init.lua
@@ -225,8 +225,8 @@ local function watch_catalog(consul_server)
     ::RETRY::
     local watch_result, watch_err = client:get(consul_server.consul_watch_catalog_url)
     local watch_error_info = (watch_err ~= nil and watch_err)
-                            or ((watch_result ~= nil and watch_result.status ~= 200)
-                            and watch_result.status)
+                             or ((watch_result ~= nil and watch_result.status ~= 200)
+                             and watch_result.status)
     if watch_error_info then
         log.error("connect consul: ", consul_server.consul_server_url,
             " by sub url: ", consul_server.consul_watch_catalog_url,
@@ -516,8 +516,8 @@ function _M.connect(premature, consul_server, retry_delay)
                     end
 
                     local svc_address, svc_port = node.Service.Address, node.Service.Port
-                    -- Handle nil port case - default to 80 for HTTP services
-                    if not svc_port then
+                    -- Handle nil or 0 port case - default to 80 for HTTP services
+                    if not svc_port or svc_port == 0 then
                         svc_port = 80
                     end
                     -- if nodes is nil, new nodes table and set to up_services

--- a/apisix/discovery/consul/init.lua
+++ b/apisix/discovery/consul/init.lua
@@ -516,8 +516,8 @@ function _M.connect(premature, consul_server, retry_delay)
                     end
 
                     local svc_address, svc_port = node.Service.Address, node.Service.Port
-                    -- Handle nil or 0 port case - default to 80 for HTTP services
-                    if not svc_port or svc_port == 0 then
+                    -- Handle nil port case - default to 80 for HTTP services
+                    if not svc_port then
                         svc_port = 80
                     end
                     -- if nodes is nil, new nodes table and set to up_services

--- a/apisix/discovery/consul/init.lua
+++ b/apisix/discovery/consul/init.lua
@@ -516,6 +516,10 @@ function _M.connect(premature, consul_server, retry_delay)
                     end
 
                     local svc_address, svc_port = node.Service.Address, node.Service.Port
+                    -- Handle nil port case - default to 80 for HTTP services  
+                    if not svc_port then
+                        svc_port = 80
+                    end
                     -- if nodes is nil, new nodes table and set to up_services
                     if not nodes then
                         nodes = core.table.new(1, 0)

--- a/docs/en/latest/discovery/consul.md
+++ b/docs/en/latest/discovery/consul.md
@@ -162,7 +162,6 @@ When APISIX retrieves service information from Consul, it handles port values as
 - If the service registration includes a valid port number, that port will be used.
 - If the port is `nil` (not specified) or `0`, APISIX will default to port `80` for HTTP services.
 
-
 ### Upstream setting
 
 #### L7

--- a/docs/en/latest/discovery/consul.md
+++ b/docs/en/latest/discovery/consul.md
@@ -155,6 +155,14 @@ curl -X PUT 'http://127.0.0.1:8500/v1/agent/service/register' \
 In some cases, same service name might exist in different consul servers.
 To avoid confusion, use the full consul key url path as service name in practice.
 
+### Port Handling
+
+When APISIX retrieves service information from Consul, it handles port values as follows:
+
+- If the service registration includes a valid port number, that port will be used.
+- If the port is `nil` (not specified) or `0`, APISIX will default to port `80` for HTTP services.
+
+
 ### Upstream setting
 
 #### L7

--- a/t/discovery/consul2.t
+++ b/t/discovery/consul2.t
@@ -317,7 +317,7 @@ discovery:
             local code, body, res = t.test('/v1/discovery/consul/show_dump_file',
                 ngx.HTTP_GET)
             local entity = json.decode(res)
-            
+
             -- Check that service_no_port exists and has default port 80
             local service_no_port = entity.services.service_no_port
             if service_no_port and #service_no_port > 0 then

--- a/t/discovery/consul2.t
+++ b/t/discovery/consul2.t
@@ -140,6 +140,7 @@ location /consul3 {
     "PUT /consul1/deregister/service_b2",
     "PUT /consul1/deregister/service_a3",
     "PUT /consul1/deregister/service_a4",
+    "PUT /consul1/deregister/service_no_port",
     "PUT /consul2/deregister/service_a1",
     "PUT /consul2/deregister/service_a2",
     "PUT /consul3/deregister/service_a1",
@@ -148,13 +149,14 @@ location /consul3 {
     "PUT /consul1/register\n" . "{\"ID\":\"service_a2\",\"Name\":\"service_a\",\"Tags\":[\"primary\",\"v1\"],\"Address\":\"127.0.0.1\",\"Port\":30512,\"Meta\":{\"service_a_version\":\"4.0\"},\"EnableTagOverride\":false,\"Weights\":{\"Passing\":10,\"Warning\":1}}",
     "PUT /consul1/register\n" . "{\"ID\":\"service_a3\",\"Name\":\"service_a\",\"Tags\":[\"primary\",\"v1\"],\"Address\":\"localhost\",\"Port\":30511,\"Meta\":{\"service_a_version\":\"4.0\"},\"EnableTagOverride\":false,\"Weights\":{\"Passing\":10,\"Warning\":1}}",
     "PUT /consul1/register\n" . "{\"ID\":\"service_a4\",\"Name\":\"service_a\",\"Tags\":[\"primary\",\"v1\"],\"Address\":\"localhost\",\"Port\":30512,\"Meta\":{\"service_a_version\":\"4.0\"},\"EnableTagOverride\":false,\"Weights\":{\"Passing\":10,\"Warning\":1}}",
+    "PUT /consul1/register\n" . "{\"ID\":\"service_no_port\",\"Name\":\"service_no_port\",\"Tags\":[\"primary\",\"v1\"],\"Address\":\"127.0.0.1\",\"Meta\":{\"service_version\":\"1.0\"},\"EnableTagOverride\":false,\"Weights\":{\"Passing\":10,\"Warning\":1}}",
     "PUT /consul2/register\n" . "{\"ID\":\"service_a1\",\"Name\":\"service_a\",\"Tags\":[\"primary\",\"v1\"],\"Address\":\"127.0.0.1\",\"Port\":30511,\"Meta\":{\"service_a_version\":\"4.0\"},\"EnableTagOverride\":false,\"Weights\":{\"Passing\":10,\"Warning\":1}}",
     "PUT /consul2/register\n" . "{\"ID\":\"service_a2\",\"Name\":\"service_a\",\"Tags\":[\"primary\",\"v1\"],\"Address\":\"127.0.0.1\",\"Port\":30512,\"Meta\":{\"service_a_version\":\"4.0\"},\"EnableTagOverride\":false,\"Weights\":{\"Passing\":10,\"Warning\":1}}",
     "PUT /consul3/register\n" . "{\"ID\":\"service_a1\",\"Name\":\"service_a\",\"Tags\":[\"primary\",\"v1\"],\"Address\":\"127.0.0.1\",\"Port\":30511,\"Meta\":{\"service_a_version\":\"4.0\"},\"EnableTagOverride\":false,\"Weights\":{\"Passing\":10,\"Warning\":1}}",
     "PUT /consul3/register\n" . "{\"ID\":\"service_a2\",\"Name\":\"service_a\",\"Tags\":[\"primary\",\"v1\"],\"Address\":\"127.0.0.1\",\"Port\":30512,\"Meta\":{\"service_a_version\":\"4.0\"},\"EnableTagOverride\":false,\"Weights\":{\"Passing\":10,\"Warning\":1}}",
 ]
 --- error_code eval
-[200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200]
+[200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200]
 
 
 
@@ -187,7 +189,7 @@ discovery:
 --- request
 GET /t
 --- response_body
-{"service_a":[{"host":"127.0.0.1","port":30511,"weight":1},{"host":"127.0.0.1","port":30512,"weight":1},{"host":"localhost","port":30511,"weight":1},{"host":"localhost","port":30512,"weight":1}]}
+{"service_a":[{"host":"127.0.0.1","port":30511,"weight":1},{"host":"127.0.0.1","port":30512,"weight":1},{"host":"localhost","port":30511,"weight":1},{"host":"localhost","port":30512,"weight":1}],"service_no_port":[{"host":"127.0.0.1","port":80,"weight":1}]}
 
 
 
@@ -221,7 +223,7 @@ discovery:
 --- request
 GET /t
 --- response_body
-{"service_a":[{"host":"127.0.0.1","port":30511,"weight":1},{"host":"127.0.0.1","port":30512,"weight":1},{"host":"localhost","port":30511,"weight":1},{"host":"localhost","port":30512,"weight":1}]}
+{"service_a":[{"host":"127.0.0.1","port":30511,"weight":1},{"host":"127.0.0.1","port":30512,"weight":1},{"host":"localhost","port":30511,"weight":1},{"host":"localhost","port":30512,"weight":1}],"service_no_port":[{"host":"127.0.0.1","port":80,"weight":1}]}
 
 
 
@@ -255,7 +257,7 @@ discovery:
 --- request
 GET /t
 --- response_body
-{"service_a":[{"host":"127.0.0.1","port":30511,"weight":1},{"host":"localhost","port":30511,"weight":1},{"host":"127.0.0.1","port":30512,"weight":1},{"host":"localhost","port":30512,"weight":1}]}
+{"service_a":[{"host":"127.0.0.1","port":30511,"weight":1},{"host":"localhost","port":30511,"weight":1},{"host":"127.0.0.1","port":30512,"weight":1},{"host":"localhost","port":30512,"weight":1}],"service_no_port":[{"host":"127.0.0.1","port":80,"weight":1}]}
 
 
 
@@ -289,38 +291,11 @@ discovery:
 --- request
 GET /t
 --- response_body
-{"service_a":[{"host":"127.0.0.1","port":30511,"weight":1},{"host":"127.0.0.1","port":30512,"weight":1},{"host":"localhost","port":30511,"weight":1},{"host":"localhost","port":30512,"weight":1}]}
+{"service_a":[{"host":"127.0.0.1","port":30511,"weight":1},{"host":"127.0.0.1","port":30512,"weight":1},{"host":"localhost","port":30511,"weight":1},{"host":"localhost","port":30512,"weight":1}],"service_no_port":[{"host":"127.0.0.1","port":80,"weight":1}]}
 
 
 
-=== TEST 6: service without port should default to port 80
---- config
-location /consul1 {
-    rewrite  ^/consul1/(.*) /v1/agent/service/$1 break;
-    proxy_pass http://127.0.0.1:9500;
-}
---- pipelined_requests eval
-[
-    "PUT /consul1/deregister/service_no_port",
-    "PUT /consul1/register\n" . "{\"ID\":\"service_no_port\",\"Name\":\"service_no_port\",\"Tags\":[\"primary\",\"v1\"],\"Address\":\"127.0.0.1\",\"Meta\":{\"service_version\":\"1.0\"},\"EnableTagOverride\":false,\"Weights\":{\"Passing\":10,\"Warning\":1}}",
-]
---- error_code eval
-[200, 200]
---- yaml_config
-apisix:
-  node_listen: 1984
-  enable_control: true
-discovery:
-  consul:
-    servers:
-      - "http://127.0.0.1:9500"
-    dump:
-      path: "consul.dump"
-      load_on_init: false
-
-
-
-=== TEST 7: show dump services for service without port
+=== TEST 6: verify service without port defaults to port 80
 --- yaml_config
 apisix:
   node_listen: 1984


### PR DESCRIPTION
### Description

When using consul as a service registry, if a user registers a service without filling in the port number, the default value is not set in apisix, resulting in `svc_port` possibly being `nil`, which in turn results in `local service_id = svc_address ... “:” ... svc_port` cannot be spliced.

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/apache/apisix/issues/11134

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
