### PR TITLE
docs: update CHANGELOG with recent changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ title: Changelog
 - Fix: timeout risk in usages of lua-resty-aws [#12070](https://github.com/apache/apisix/pull/12070)
 - Fix: ai-rate-limiting not allowed to limit to a single instance [#12061](https://github.com/apache/apisix/pull/12061)
 - Fix: update watch_ctx.revision to avoid multiple resyncs [#12021](https://github.com/apache/apisix/pull/12021)
+- Fix: ai-proxy remove passthrough [#12014](https://github.com/apache/apisix/pull/12014)
 - Fix: ai-proxy dead loop when retrying [#12012](https://github.com/apache/apisix/pull/12012)
 - Fix: error while trying to log table in ai-content-moderation plugin [#11994](https://github.com/apache/apisix/pull/11994)
 - Fix: resync etcd when a lower revision is found [#12015](https://github.com/apache/apisix/pull/12015)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ title: Changelog
 ### Change
 
 - replace plugin attribute with plugin metadata in `opentelemetry` plugin [#11940](https://github.com/apache/apisix/pull/11940)
+- refactor: ai-content-moderation to ai-aws-content-moderation [#11596](https://github.com/apache/apisix/pull/11596])
 - add expiration time for all Prometheus metrics [#11838](https://github.com/apache/apisix/pull/11838)
 - allow workflow config without case [#11787](https://github.com/apache/apisix/pull/11787)
 - refactor: ai-content-moderation to ai-aws-content-moderation (#12010)
@@ -91,6 +92,11 @@ title: Changelog
 
 ### Bugfixes
 
+- Fix: timeout risk in usages of lua-resty-aws [#12070](https://github.com/apache/apisix/pull/12070)
+- Fix: ai-rate-limiting not allowed to limit to a single instance [#12061](https://github.com/apache/apisix/pull/12061)
+- Fix: update watch_ctx.revision to avoid multiple resyncs [#12021](https://github.com/apache/apisix/pull/12021)
+- Fix: ai-proxy dead loop when retrying [#12012](https://github.com/apache/apisix/pull/12012)
+- Fix: error while trying to log table in ai-content-moderation plugin [#11994](https://github.com/apache/apisix/pull/11994)
 - Fix: resync etcd when a lower revision is found [#12015](https://github.com/apache/apisix/pull/12015)
 - Fix: remove model options' `stream` default value [#12013](https://github.com/apache/apisix/pull/12013)
 - Fix: grpc-web response contains two trailer chunks [#11988](https://github.com/apache/apisix/pull/11988)
@@ -98,6 +104,7 @@ title: Changelog
 - Fix: race condition problem while update upstream.nodes [#11916](https://github.com/apache/apisix/pull/11916)
 - Fix: `upstream_obj.upstream` should not be a string [#11932](https://github.com/apache/apisix/pull/11932)
 - Fix: query params in override.endpoint not being sent to LLMs [#11863](https://github.com/apache/apisix/pull/11863)
+- Fix: add support for ignoring "load" global variable [#11862](https://github.com/apache/apisix/pull/11862)
 - Fix: corrupt data in routes() response due to healthchecker data [#11844](https://github.com/apache/apisix/pull/11844)
 - Fix: deepcopy should copy same table exactly only once [#11861](https://github.com/apache/apisix/pull/11861)
 - Fix: disallow empty key configuration attributes [#11852](https://github.com/apache/apisix/pull/11852)
@@ -112,6 +119,7 @@ title: Changelog
 
 ### Core
 
+- set default value of ssl_trusted_certificate to system [#11993](https://github.com/apache/apisix/pull/11993)
 - upgrade openresty version to v1.27.11 [#11936](https://github.com/apache/apisix/pull/11936)
 - Support the use of system-provided CA certs in `ssl_trusted_certificate` [#11809](https://github.com/apache/apisix/pull/11809)
 - support _meta.pre_function to execute custom logic before execution of each phase [#11793](https://github.com/apache/apisix/pull/11793)
@@ -184,6 +192,7 @@ title: Changelog
 
 ### Bugfixes
 
+- Fix: add libyaml-dev dependency for apt [#11291](https://github.com/apache/apisix/pull/11291)
 - Fix: etcd sync data checker should work [#11457](https://github.com/apache/apisix/pull/11457)
 - Fix: plugin metadata add id value for etcd checker [#11452](https://github.com/apache/apisix/pull/11452)
 - Fix: allow trailing period in SNI and CN for SSL [#11414](https://github.com/apache/apisix/pull/11414)
@@ -234,6 +243,9 @@ title: Changelog
   - [#11010](https://github.com/apache/apisix/pull/11010)
   - [#11027](https://github.com/apache/apisix/pull/11027)
 - :sunrise: add plugins/reload to control api [#10905](https://github.com/apache/apisix/pull/10905)
+- :sunrise: consul deduplicate and sort [#10941](https://github.com/apache/apisix/pull/10941)
+- :sunrise: update lua-resty-t1k to 1.1.1 [#11029](https://github.com/apache/apisix/pull/11029)
+- :sunrise: support uri_arg_ when use radixtree_uri_with_parameter [#10645](https://github.com/apache/apisix/pull/10645)
 
 ### Plugins
 
@@ -253,6 +265,8 @@ title: Changelog
 
 ### Bug Fixes
 
+- Fix: keep different strategy response header consistency [#11048](https://github.com/apache/apisix/pull/11048)
+- Fix: add apisix/plugin/limit-req to makefile [#10955](https://github.com/apache/apisix/pull/10959)
 - Fix: wrong namespace related endpoint in k8s [#10917](https://github.com/apache/apisix/pull/10917)
 - Fix: when delete the secret cause 500 error [#10902](https://github.com/apache/apisix/pull/10902)
 - Fix: jwe-decrypt secret length restriction [#10928](https://github.com/apache/apisix/pull/10928)
@@ -262,6 +276,7 @@ title: Changelog
 - Fix: add compatibility headers [#10828](https://github.com/apache/apisix/pull/10828)
 - Fix: missing trailers issue [#10851](https://github.com/apache/apisix/pull/10851)
 - Fix: decryption failure [#10843](https://github.com/apache/apisix/pull/10843)
+- Fix: linux-install-luarocks are not compatible with the openresty environment [#10813](https://github.com/apache/apisix/pull/10813)
 - Fix: server-side sessions locked by not calling explicit session:close() [#10788](https://github.com/apache/apisix/pull/10788)
 - Fix: skip brotli compression for upstream compressed response [#10740](https://github.com/apache/apisix/pull/10740)
 - Fix: use_jwks breaking authentication header [#10670](https://github.com/apache/apisix/pull/10670)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,7 +244,6 @@ title: Changelog
   - [#11027](https://github.com/apache/apisix/pull/11027)
 - :sunrise: add plugins/reload to control api [#10905](https://github.com/apache/apisix/pull/10905)
 - :sunrise: consul deduplicate and sort [#10941](https://github.com/apache/apisix/pull/10941)
-- :sunrise: update lua-resty-t1k to 1.1.1 [#11029](https://github.com/apache/apisix/pull/11029)
 - :sunrise: support uri_arg_ when use radixtree_uri_with_parameter [#10645](https://github.com/apache/apisix/pull/10645)
 
 ### Plugins


### PR DESCRIPTION
This PR reviews the changelog entries for versions after APISIX 3.8.0 to identify any missing entries.

**Note**: PRs related to documentation, chores, tests, and CI changes should not be included in the changelog.

The following table lists PRs that need to be added to the changelog (marked as "Yes" in the "Missing" column).

## 3.9.0
| PR Title | PR Link | Missing | Notes |
| --- | --- | --- | --- |
| feat: support uri_arg_ when use radixtree_uri_with_parameter | https://github.com/apache/apisix/pull/10645 | Yes | - |
| Revert "fix: the leak of prometheus metrics (#10655)" (#11025) | https://github.com/apache/apisix/pull/10655 | No | Revert PR |
| fix: linux-install-luarocks are not compatible with the openresty environment (#10813) | https://github.com/apache/apisix/pull/10813 | Yes | - |
| fix(ci): stability of consul test cases (#10857) | https://github.com/apache/apisix/pull/10857 | No | CI fix PR should not appear in changelog |
| fix(ci): npm install error (#10858) | https://github.com/apache/apisix/pull/10858 | No | CI fix PR should not appear in changelog |
| feat: support openresty-1.25.3.1 (#10887) | https://github.com/apache/apisix/pull/10887 | No | Dependency version upgrade |
| feat: consul deduplicate and sort (#10941) | https://github.com/apache/apisix/pull/10941 | Yes | - |
| fix: add apisix/plugin/limit-req to makefile (#10959) | https://github.com/apache/apisix/pull/10959 | No | Dependency upgrade |
| feat(chaitin-waf): update lua-resty-t1k to 1.1.3 (#11029) | https://github.com/apache/apisix/pull/11029 | No | Dependency upgrade |
| fix(ci): consul test cases run before cluster ready (#11041) | https://github.com/apache/apisix/pull/11041 | No | Test fix |
| fix(proxy-cache): keep different strategy response header consistency (#11048) | https://github.com/apache/apisix/pull/11048 | Yes | - |
| perf(ssl): reuse array length variable (#11053) | https://github.com/apache/apisix/pull/11053 | No | Code optimization |
| remove QQ group (#11055) | https://github.com/apache/apisix/pull/11055 | No | Remove QQ group |
| feat: release 3.9.0 (#11061) | https://github.com/apache/apisix/pull/11061 | No | Version release |

## 3.10.0
| PR Title | PR Link | Missing | Notes |
| --- | --- | --- | --- |
| fix: rectify the warning printed when admin_key_required == false | https://github.com/apache/apisix/pull/11105 | No | - |
| chore(deps): bump apache/skywalking-eyes from 0.5.0 to 0.6.0 | https://github.com/apache/apisix/pull/11128 | No | Dependency upgrade |
| chore(deps): bump golang.org/x/net | https://github.com/apache/apisix/pull/11169 | No | Dependency upgrade |
| chore(deps): bump golang.org/x/net | https://github.com/apache/apisix/pull/11171 | No | Dependency upgrade |
| infra: Increase PR reviewers to 3 when merge to master | https://github.com/apache/apisix/pull/11280 | No | Infrastructure change |
| fix: add libyaml-dev dependency for apt. (#11291) | https://github.com/apache/apisix/pull/11291 | Yes | - |
| build(undeps): remove all rocks before remove openresty (#11333) | https://github.com/apache/apisix/pull/11333 | No | - |

## 3.11.0
| PR Title | PR Link | Missing | Notes |
| --- | --- | --- | --- |
| Update lua-resty-kafka to 0.23-0 (#11463) | https://github.com/apache/apisix/pull/11463 | No | Dependency upgrade |

## 3.12.0
| PR Title | PR Link | Missing | Notes |
| --- | --- | --- | --- |
| refactor(google-cloud-logging): unify google-cloud-oauth.lua file (#11596) | https://github.com/apache/apisix/pull/11596 | Yes | Plugin configuration changes: https://github.com/apache/apisix/pull/11596/files#diff-019f351242af8db316a3f53536b72bb9908e2e00f483493de7e2304ce12c379eR46 |
| fix: otel ci test error (#11769) | https://github.com/apache/apisix/pull/11769 | No | Test fix |
| fix: pin test-nginx to a working version to fix tests with --- http2 (#11816) | https://github.com/apache/apisix/pull/11816 | No | Test fix |
| fix: add support for ignoring "load" global variable (#11862) | https://github.com/apache/apisix/pull/11862 | Yes | - |
| revert: adding lj-releng file (#11881) | https://github.com/apache/apisix/pull/11881 | No | Revert operation |
| fix: failing CI due to wrong status from upstream in traffic split (#11905) | https://github.com/apache/apisix/pull/11905 | No | Test fix |
| fix: the docs website build error (#11924) | https://github.com/apache/apisix/pull/11924 | No | Documentation fix |
| fix: the zh docs website build failed due to incorrect unclosed tag <br> (#11926) | https://github.com/apache/apisix/pull/11926 | No | Documentation fix |
| fix: the docs website build failed due to incorrect unclosed tag <br> (#11973) | https://github.com/apache/apisix/pull/11973 | No | Documentation fix |
| fix(ai-proxy): abstract a base for ai-proxy (#11991) | https://github.com/apache/apisix/pull/11991 | No | - |
| fix(grpc-web): useless code and code format (#11992) | https://github.com/apache/apisix/pull/11992 | No | Code optimization |
| feat: set default value of ssl_trusted_certificate to system (#11993) | https://github.com/apache/apisix/pull/11993 | Yes | - |
| fix: error while trying to log table in ai-content-moderation plugin (#11994) | https://github.com/apache/apisix/pull/11994 | Yes | - |
| fix(ai-proxy-multi): dead loop when retrying (#12012) | https://github.com/apache/apisix/pull/12012 | Yes | - |
| fix(ai-proxy): remove passthrough (#12014) | https://github.com/apache/apisix/pull/12014 | Yes | - |
| fix: update watch_ctx.revision to avoid multiple resyncs (#12021) | https://github.com/apache/apisix/pull/12021 | Yes | - |
| fix(ai-rate-limiting): not allowed to limit to a single instance (#12061) | https://github.com/apache/apisix/pull/12061 | Yes | - |
| fix: timeout risk in usages of lua-resty-aws (#12070) | https://github.com/apache/apisix/pull/12070 | Yes | - |

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
