### PR TITLE
ci: add script to check PRs against CHANGELOG.md for completeness

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -1,0 +1,30 @@
+name: Check Changelog
+
+on:
+  push:
+    paths:
+      - 'CHANGELOG.md'
+  pull_request:
+    paths:
+      - 'CHANGELOG.md'
+
+jobs:
+  check-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run check_changelog_prs script
+        run: |
+          # Extract the latest two versions from CHANGELOG.md
+          versions=($(grep -E '^## [0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | head -n 2 | sed 's/^## //'))
+          if [ ${#versions[@]} -ge 2 ]; then
+            new_tag=${versions[0]}
+            old_tag=${versions[1]}
+            bash ci/check_changelog_prs.sh "$old_tag" "$new_tag"
+          else
+            echo "Not enough versions found in CHANGELOG.md"
+            exit 1
+          fi

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -18,13 +18,4 @@ jobs:
 
       - name: Run check_changelog_prs script
         run: |
-          # Extract the latest two versions from CHANGELOG.md
-          versions=($(grep -E '^## [0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | head -n 2 | sed 's/^## //'))
-          if [ ${#versions[@]} -ge 2 ]; then
-            new_tag=${versions[0]}
-            old_tag=${versions[1]}
-            bash ci/check_changelog_prs.sh "$old_tag" "$new_tag"
-          else
-            echo "Not enough versions found in CHANGELOG.md"
-            exit 1
-          fi
+          bash ci/check_changelog_prs.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ title: Changelog
 
 ### Change
 
+- replace plugin attribute with plugin metadata in `opentelemetry` plugin [#11940](https://github.com/apache/apisix/pull/11940)
 - refactor: ai-content-moderation to ai-aws-content-moderation [#11596](https://github.com/apache/apisix/pull/11596])
 - add expiration time for all Prometheus metrics [#11838](https://github.com/apache/apisix/pull/11838)
 - allow workflow config without case [#11787](https://github.com/apache/apisix/pull/11787)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,6 @@ title: Changelog
 
 ### Change
 
-- replace plugin attribute with plugin metadata in `opentelemetry` plugin [#11940](https://github.com/apache/apisix/pull/11940)
 - refactor: ai-content-moderation to ai-aws-content-moderation [#11596](https://github.com/apache/apisix/pull/11596])
 - add expiration time for all Prometheus metrics [#11838](https://github.com/apache/apisix/pull/11838)
 - allow workflow config without case [#11787](https://github.com/apache/apisix/pull/11787)

--- a/ci/check_changelog_prs.sh
+++ b/ci/check_changelog_prs.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -euo pipefail
+
+old_tag=$1
+new_tag=$2
+
+# Configure PR types to ignore
+IGNORE_TYPES=(
+    "docs"
+    "chore"
+    "test"
+    "ci"
+)
+
+# Configure PR numbers to ignore
+IGNORE_PRS=(
+    # 3.9.0
+    10655 10857 10858 10887 10959 11029 11041 11053 11055 11061 10976 10984 11025
+    # 3.10.0
+    11105 11128 11169 11171 11280 11333 11081 11202 11469
+    # 3.11.0
+    11463 11570
+    # 3.12.0
+    11769 11816 11881 11905 11924 11926 11973 11991 11992 11829
+)
+
+# Build ignore pattern to match the following formats:
+# - Direct keyword prefix (e.g., "docs:")
+ignore_pattern=$(IFS="|"; echo "(${IGNORE_TYPES[*]}):|(${IGNORE_TYPES[*]})\([^)]*\):")
+
+# Extract PRs between two versions from CHANGELOG.md
+echo "Extracting PRs between $old_tag and $new_tag from CHANGELOG.md..."
+changelog_prs=$(awk -v start="$new_tag" -v end="$old_tag" '
+    BEGIN { flag = 0 }
+    $0 ~ "^## " {
+        if ($0 ~ start) { flag = 1; next }
+        if (flag && $0 ~ end) { flag = 0 }
+    }
+    flag { print }
+' CHANGELOG.md | grep -oE '#[0-9]+' | sort -n)
+
+# Extract actual PRs from git log, filtering out configured types and specified PR numbers
+echo -e "\nExtracting actual PRs from git log (excluding: ${IGNORE_TYPES[*]} and PRs: ${IGNORE_PRS[*]})..."
+git_prs=$(git log "$old_tag".."$new_tag" --oneline | grep -vE "$ignore_pattern" | grep -oE '#[0-9]+' | sort -n)
+
+# Filter out specified PR numbers
+for pr in "${IGNORE_PRS[@]}"; do
+    git_prs=$(echo "$git_prs" | grep -v "#$pr")
+done
+
+# Compare the two lists
+echo -e "\nComparing PRs..."
+missing_prs=$(comm -23 <(echo "$git_prs") <(echo "$changelog_prs"))
+
+# Print comparison results
+echo -e "\n=== PR Comparison Results ==="
+echo -e "\nPRs in git log (sorted, excluding configured types):"
+echo "$git_prs" | sed 's/^/  /'
+
+echo -e "\nPRs in CHANGELOG.md (sorted):"
+echo "$changelog_prs" | sed 's/^/  /'
+
+if [ -z "$missing_prs" ]; then
+    echo -e "\n✅ All PRs are included in CHANGELOG.md"
+else
+    echo -e "\n❌ Missing PRs in CHANGELOG.md (sorted):"
+    echo "$missing_prs" | sed 's/^/  /'
+    
+    # Get detailed information for each missing PR
+    echo -e "\nDetailed information about missing PRs:"
+    for pr in $missing_prs; do
+        pr_num=${pr#\#}  # Remove # symbol
+        echo -e "\nPR $pr:"
+        # Get PR commit information
+        git log "$old_tag".."$new_tag" --oneline | grep "$pr" | while read -r line; do
+            echo "  - $line"
+        done
+        # Try to get PR title (if possible)
+        echo "  - PR URL: https://github.com/apache/apisix/pull/$pr_num"
+    done
+    exit 1
+fi

--- a/ci/check_changelog_prs.sh
+++ b/ci/check_changelog_prs.sh
@@ -54,7 +54,7 @@ IGNORE_PRS=(
 ignore_pattern=$(IFS="|"; echo "(${IGNORE_TYPES[*]}):|(${IGNORE_TYPES[*]})\([^)]*\):")
 
 # Get all versions from CHANGELOG.md
-versions=($(grep -E '^## [0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | sed 's/^## //'))
+mapfile -t versions < <(grep -E '^## [0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | sed 's/^## //')
 
 # Initialize error flag
 has_errors=0
@@ -63,7 +63,7 @@ has_errors=0
 for ((i=0; i<${#versions[@]}-1; i++)); do
     new_tag=${versions[i]}
     old_tag=${versions[i+1]}
-    
+
     # Skip if new_tag is less than or equal to 3.8.0
     if ! version_gt "$new_tag" "3.8.0"; then
         continue
@@ -102,8 +102,9 @@ for ((i=0; i<${#versions[@]}-1; i++)); do
         echo -e "\n✅ All PRs are included in CHANGELOG.md for version $new_tag"
     else
         echo -e "\n❌ [ERROR] Missing PRs in CHANGELOG.md for version $new_tag (sorted):"
-        echo "$missing_prs" | sed 's/^/  /'
-        
+
+        printf '  %s\n' "$missing_prs"
+
         # Get detailed information for each missing PR
         echo -e "\nDetailed information about missing PRs for version $new_tag:"
         for pr in $missing_prs; do

--- a/ci/check_changelog_prs.sh
+++ b/ci/check_changelog_prs.sh
@@ -1,8 +1,36 @@
 #!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 set -euo pipefail
 
 old_tag=$1
 new_tag=$2
+
+# Function to compare versions
+version_gt() {
+    test "$(printf '%s\n' "$@" | sort -V | head -n1)" != "$1"
+}
+
+# Check if versions are above 3.8.0
+if ! version_gt "${old_tag#v}" "3.8.0"; then
+    echo "Skipping check for versions below or equal to 3.8.0"
+    exit 0
+fi
 
 # Configure PR types to ignore
 IGNORE_TYPES=(


### PR DESCRIPTION
### Description
This PR provides a script to check the changelog for completeness. If a PR is not of type docs, chore, test, or ci, and is not listed in the IGNORE_PRS variable, but is missing from the changelog, the script will raise an error.

Note: This script currently only checks changelog entries for versions after 3.8.0.

#### Test record:
1. Manually removed a changelog entry for version 3.12.0, and the script correctly reported an error.
<img width="1597" alt="image" src="https://github.com/user-attachments/assets/b84ad4f6-8774-4451-a7e5-ed2eff2bb6a8" />
<img width="1234" alt="image" src="https://github.com/user-attachments/assets/886aabb1-1e35-47f9-9214-702f9669cdc9" />

2. Tested an upcoming version (e.g., 3.13.0) that hasn’t been tagged yet to verify if the script works correctly. In this case, it compares the current latest code from the main branch with the previous version (3.12.0).
<img width="877" alt="image" src="https://github.com/user-attachments/assets/7d612b57-8772-4275-9907-24e382f767d0" />


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
4. Always add/update tests for any changes unless you have a good reason.
5. Always update the documentation to reflect the changes made in the PR.
6. Make a new commit to resolve conversations instead of `push -f`.
7. To resolve merge conflicts, merge master instead of rebasing.
8. Use "request review" to notify the reviewer after making changes.
9. Only a reviewer can mark a conversation as resolved.

-->
