### PR TITLE
fix: check if `config` contains duplicate resources in API-driven standalone mode

### DIFF
--- a/apisix/admin/standalone.lua
+++ b/apisix/admin/standalone.lua
@@ -45,9 +45,10 @@ local function check_duplicate(item, key, id_set)
     end
 
     if id_set[identifier] then
-        return "duplicate " .. identifier_type .. " found " .. identifier
+        return true,"duplicate " .. identifier_type .. " found " .. identifier
     end
     id_set[identifier] = true
+    return false
 end
 
 local function get_config()
@@ -183,9 +184,10 @@ local function update(ctx)
                         core.response.exit(400, {error_msg = err_prefix .. err})
                     end
                 end
-                -- check duplicate resource
-                local err = check_duplicate(item, key, id_set)
-                if err then
+                -- prevent updating resource with the same ID
+                -- (e.g., service ID or other resource IDs) in a single request
+                local duplicated, err = check_duplicate(item, key, id_set)
+                if duplicated then
                     core.log.error(err)
                     core.response.exit(400, { error_msg = err })
                 end

--- a/apisix/admin/standalone.lua
+++ b/apisix/admin/standalone.lua
@@ -44,10 +44,6 @@ local function check_duplicate(item, key, id_set)
         identifier_type = "id"
     end
 
-    if not identifier then
-        return
-    end
-
     if id_set[identifier] then
         return "duplicate " .. identifier_type .. " found " .. identifier
     end

--- a/apisix/admin/standalone.lua
+++ b/apisix/admin/standalone.lua
@@ -36,7 +36,7 @@ local _M = {}
 
 local function check_duplicate(item, key, id_set)
     local identifier, identifier_type
-    if key == "consumer" then
+    if key == "consumers" then
         identifier = item.username
         identifier_type = "username"
     else
@@ -190,8 +190,8 @@ local function update(ctx)
                 -- check duplicate resource
                 local err = check_duplicate(item, key, id_set)
                 if err then
-                    core.log.error(err_prefix, err)
-                    core.response.exit(400, { error_msg = err_prefix .. err })
+                    core.log.error(err)
+                    core.response.exit(400, { error_msg = err })
                 end
 
                 table_insert(apisix_yaml[key], item)

--- a/apisix/admin/standalone.lua
+++ b/apisix/admin/standalone.lua
@@ -37,8 +37,8 @@ local _M = {}
 local function check_duplicate(item, key, id_set)
     local identifier, identifier_type
     if key == "consumers" then
-        identifier = item.username
-        identifier_type = "username"
+        identifier = item.id or item.username
+        identifier_type = item.id and "credential id" or "username"
     else
         identifier = item.id
         identifier_type = "id"

--- a/apisix/admin/standalone.lua
+++ b/apisix/admin/standalone.lua
@@ -45,7 +45,7 @@ local function check_duplicate(item, key, id_set)
     end
 
     if id_set[identifier] then
-        return true,"duplicate " .. identifier_type .. " found " .. identifier
+        return true, "found duplicate " .. identifier_type .. " " .. identifier .. " in " .. key
     end
     id_set[identifier] = true
     return false

--- a/t/admin/standalone.t
+++ b/t/admin/standalone.t
@@ -208,3 +208,31 @@ x-apisix-conf-version-routes: 100
 --- error_code: 400
 --- response_body
 {"error_msg":"routes_conf_version must be greater than or equal to (1062)"}
+
+
+=== TEST 11: duplicate route id found
+--- config
+    location /t {}
+--- request
+PUT /apisix/admin/configs
+{"routes_conf_version":1,"routes":[{"id":"r1","uri":"/r2","upstream_id":"u1","plugins":{"proxy-rewrite":{"uri":"/hello"}}},
+{"id":"r1","uri":"/r2","upstream_id":"u1","plugins":{"proxy-rewrite":{"uri":"/hello"}}}]}
+--- more_headers
+X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
+--- error_code: 400
+--- response_body
+{"error_msg":"duplicate id found r1"}
+
+
+=== TEST 12: duplicate consumer username found
+--- config
+    location /t {}
+--- request
+PUT /apisix/admin/configs
+{"consumers_conf_version":1,"consumers":[{"username":"consumer1","plugins":{"key-auth":{"key":"consumer1"}}},
+{"username":"consumer1","plugins":{"key-auth":{"key":"consumer1"}}}]}
+--- more_headers
+X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
+--- error_code: 400
+--- response_body
+{"error_msg":"duplicate username found consumer1"}

--- a/t/admin/standalone.t
+++ b/t/admin/standalone.t
@@ -212,10 +212,10 @@ x-apisix-conf-version-routes: 100
 
 === TEST 11: duplicate route id found
 --- config
-    location /t {}
+    location /t11 {}
 --- request
 PUT /apisix/admin/configs
-{"routes_conf_version":1,"routes":[{"id":"r1","uri":"/r2","upstream_id":"u1","plugins":{"proxy-rewrite":{"uri":"/hello"}}},
+{"routes_conf_version":1063,"routes":[{"id":"r1","uri":"/r2","upstream_id":"u1","plugins":{"proxy-rewrite":{"uri":"/hello"}}},
 {"id":"r1","uri":"/r2","upstream_id":"u1","plugins":{"proxy-rewrite":{"uri":"/hello"}}}]}
 --- more_headers
 X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
@@ -226,10 +226,10 @@ X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
 
 === TEST 12: duplicate consumer username found
 --- config
-    location /t {}
+    location /t12 {}
 --- request
 PUT /apisix/admin/configs
-{"consumers_conf_version":1,"consumers":[{"username":"consumer1","plugins":{"key-auth":{"key":"consumer1"}}},
+{"consumers_conf_version":1064,"consumers":[{"username":"consumer1","plugins":{"key-auth":{"key":"consumer1"}}},
 {"username":"consumer1","plugins":{"key-auth":{"key":"consumer1"}}}]}
 --- more_headers
 X-API-KEY: edd1c9f034335f136f87ad84b625c8f1

--- a/t/admin/standalone.t
+++ b/t/admin/standalone.t
@@ -222,7 +222,7 @@ PUT /apisix/admin/configs
 X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
 --- error_code: 400
 --- response_body
-{"error_msg":"duplicate id found r1"}
+{"error_msg":"found duplicate id r1 in routes"}
 
 
 
@@ -237,4 +237,4 @@ PUT /apisix/admin/configs
 X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
 --- error_code: 400
 --- response_body
-{"error_msg":"duplicate username found consumer1"}
+{"error_msg":"found duplicate username consumer1 in consumers"}

--- a/t/admin/standalone.t
+++ b/t/admin/standalone.t
@@ -238,3 +238,21 @@ X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
 --- error_code: 400
 --- response_body
 {"error_msg":"found duplicate username consumer1 in consumers"}
+
+
+
+=== TEST 13: duplicate consumer credential id found
+--- config
+    location /t13 {}
+--- request
+PUT /apisix/admin/configs
+{"consumers_conf_version":1065,"consumers":[
+    {"username": "john_1"},
+    {"id":"john_1/credentials/john-a","plugins":{"key-auth":{"key":"auth-a"}}},
+    {"id":"john_1/credentials/john-a","plugins":{"key-auth":{"key":"auth-a"}}}
+]}
+--- more_headers
+X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
+--- error_code: 400
+--- response_body
+{"error_msg":"found duplicate credential id john_1/credentials/john-a in consumers"}

--- a/t/admin/standalone.t
+++ b/t/admin/standalone.t
@@ -210,6 +210,7 @@ x-apisix-conf-version-routes: 100
 {"error_msg":"routes_conf_version must be greater than or equal to (1062)"}
 
 
+
 === TEST 11: duplicate route id found
 --- config
     location /t11 {}
@@ -222,6 +223,7 @@ X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
 --- error_code: 400
 --- response_body
 {"error_msg":"duplicate id found r1"}
+
 
 
 === TEST 12: duplicate consumer username found


### PR DESCRIPTION
### Description
add duplicate resource check in API-driven standalone mode

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #12259 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
