### PR TITLE
fix(docker): install libyaml in arm64

### DIFF
--- a/docker/debian-dev/Dockerfile
+++ b/docker/debian-dev/Dockerfile
@@ -45,10 +45,14 @@ ARG ENTRYPOINT_PATH=./docker-entrypoint.sh
 ARG INSTALL_BROTLI=./install-brotli.sh
 ARG CHECK_STANDALONE_CONFIG=./check_standalone_config.sh
 
+# Install the runtime libyaml package
+RUN apt-get -y update --fix-missing \
+    && apt-get install -y libldap2-dev libyaml-0-2 \
+    && apt-get remove --purge --auto-remove -y
+
 COPY --from=build /usr/local/apisix /usr/local/apisix
 COPY --from=build /usr/local/openresty /usr/local/openresty
 COPY --from=build /usr/bin/apisix /usr/bin/apisix
-COPY --from=build /usr/lib/x86_64-linux-gnu/libyaml* /usr/local/lib/
 
 COPY ${INSTALL_BROTLI} /install-brotli.sh
 RUN chmod +x /install-brotli.sh \


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

What:

This PR fixes the issue where the dev image could not be built in arm64 due to the direct copy of [Dockerfile.local](https://github.com/apache/apisix-docker/blob/master/debian-dev/Dockerfile.local?rgh-link-date=2025-06-11T07%3A08%3A34Z) in the PR #12300.

How:

ref https://github.com/apache/apisix-docker/blob/d5322d57d58c569d98c225f89a8abd991429ec10/debian-dev/Dockerfile#L48

Why:

To allow [.github/workflows/push-dev-image-on-commit.yml](https://github.com/apache/apisix/pull/12322/files#diff-bb5a2d9a6ddf0e4d9e27661eb239df37de68a6559bcbd0dfdff5f7e0f95b552a) build the dev image in the arm64 runner.

It has already been tested in PR https://github.com/apache/apisix/pull/12322 and [passed CI](https://github.com/apache/apisix/actions/runs/15630131355/job/44032305598?pr=12322) on both architectures.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
