### PR TITLE
refactor: change log level to debug to avoid unnecessary logs

### DIFF
--- a/apisix/core/ctx.lua
+++ b/apisix/core/ctx.lua
@@ -224,7 +224,7 @@ do
         __index = function(t, key)
             local cached = t._cache[key]
             if cached ~= nil then
-                log.info("serving ctx value from cache for key: ", key)
+                log.debug("serving ctx value from cache for key: ", key)
                 return cached
             end
 

--- a/t/core/ctx3.t
+++ b/t/core/ctx3.t
@@ -17,6 +17,7 @@
 use t::APISIX 'no_plan';
 
 repeat_each(1);
+log_level('debug');
 no_long_string();
 no_root_location();
 


### PR DESCRIPTION
Fixes #
For each request, the following log is printed multiple times and the logs get flooded with it. The primary purpose for this log was for testing so it should be set to debug.
### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
