### PR TITLE
fix: support multiple versions of Elasticsearch logger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Remove source code
         if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
         run: |
-          sudo rm -rf $(ls -1 --ignore=*.tgz --ignore=ci --ignore=t --ignore=utils --ignore=.github)
+          rm -rf $(ls -1 --ignore=*.tgz --ignore=ci --ignore=t --ignore=utils --ignore=.github)
           tar zxvf ${{ steps.branch_env.outputs.fullname }}
 
       - name: Cache images

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Remove source code
         if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
         run: |
-          rm -rf $(ls -1 --ignore=*.tgz --ignore=ci --ignore=t --ignore=utils --ignore=.github)
+          sudo rm -rf $(ls -1 --ignore=*.tgz --ignore=ci --ignore=t --ignore=utils --ignore=.github)
           tar zxvf ${{ steps.branch_env.outputs.fullname }}
 
       - name: Cache images

--- a/apisix/plugins/elasticsearch-logger.lua
+++ b/apisix/plugins/elasticsearch-logger.lua
@@ -54,11 +54,6 @@ local schema = {
                     lua time format: https://www.lua.org/pil/22.1.html",
                     -- example: service-$host-{"%Y-%m-%d"}
                 },
-                type = {
-                    type = "string",
-                    description = "Type is partially supported with compat headers in version 8 \
-                    and unsupported on version 9"
-                }
             },
             required = {"index"}
         },
@@ -147,8 +142,7 @@ local function get_logger_entry(conf, ctx)
     local entry = log_util.get_log_entry(plugin_name, conf, ctx)
     return core.json.encode({
             create = {
-                _index = conf.field.index,
-                _type = conf.field.type
+                _index = conf.field.index
             }
         }) .. "\n" ..
         core.json.encode(entry) .. "\n"
@@ -228,10 +222,6 @@ local function send_to_elasticsearch(conf, entries)
     elseif conf._version == "9" then
         headers["Content-Type"] = headers["Content-Type"] .. compat_header_8
         headers["Accept"] = headers["Accept"] .. compat_header_8
-        if conf.field.type then
-            core.log.warn("type is not supported in Elasticsearch 9, removing `type`")
-            conf.field.type = nil
-        end
     end
     if conf.auth then
         local authorization = "Basic " .. ngx.encode_base64(

--- a/apisix/plugins/elasticsearch-logger.lua
+++ b/apisix/plugins/elasticsearch-logger.lua
@@ -26,8 +26,6 @@ local math_random     = math.random
 
 local plugin_name = "elasticsearch-logger"
 local batch_processor_manager = bp_manager_mod.new(plugin_name)
-local compat_header_7 = ";compatible-with=7"
-local compat_header_8 = ";compatible-with=8"
 
 local schema = {
     type = "object",
@@ -224,13 +222,6 @@ local function send_to_elasticsearch(conf, entries)
         ["Content-Type"] = "application/x-ndjson",
         ["Accept"] = "application/vnd.elasticsearch+json"
     }
-    if conf._version == "8" then
-        headers["Content-Type"] = headers["Content-Type"] .. compat_header_7
-        headers["Accept"] = headers["Accept"] .. compat_header_7
-    elseif conf._version == "9" then
-        headers["Content-Type"] = headers["Content-Type"] .. compat_header_8
-        headers["Accept"] = headers["Accept"] .. compat_header_8
-    end
     if conf.auth then
         local authorization = "Basic " .. ngx.encode_base64(
             conf.auth.username .. ":" .. conf.auth.password

--- a/ci/pod/docker-compose.plugin.yml
+++ b/ci/pod/docker-compose.plugin.yml
@@ -249,6 +249,43 @@ services:
       http.port: 9201
       xpack.security.enabled: 'true'
 
+  elasticsearch-noauth-3:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.0.0
+    restart: unless-stopped
+    ports:
+      - "9600:9200"
+      - "9700:9300"
+    environment:
+      ES_JAVA_OPTS: -Xms512m -Xmx512m
+      discovery.type: single-node
+      xpack.security.enabled: 'false'
+
+  elasticsearch-auth-3:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.0.0
+    restart: unless-stopped
+    ports:
+      - "9401:9201"
+    environment:
+      ES_JAVA_OPTS: -Xms512m -Xmx512m
+      discovery.type: single-node
+      ELASTIC_USERNAME: elastic
+      ELASTIC_PASSWORD: 123456
+      http.port: 9201
+      xpack.security.enabled: 'true'
+
+  elasticsearch-auth-4:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.7.0
+    restart: unless-stopped
+    ports:
+      - "9501:9201"
+    environment:
+      ES_JAVA_OPTS: -Xms512m -Xmx512m
+      discovery.type: single-node
+      ELASTIC_USERNAME: elastic
+      ELASTIC_PASSWORD: 123456
+      http.port: 9201
+      xpack.security.enabled: 'true'
+
   # The function services of OpenFunction
   test-header:
     image: test-header-image:latest

--- a/ci/pod/docker-compose.plugin.yml
+++ b/ci/pod/docker-compose.plugin.yml
@@ -225,17 +225,6 @@ services:
       http.port: 9201
       xpack.security.enabled: 'true'
 
-  elasticsearch-noauth-2:
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.0.2
-    restart: unless-stopped
-    ports:
-      - "9400:9200"
-      - "9500:9300"
-    environment:
-      ES_JAVA_OPTS: -Xms512m -Xmx512m
-      discovery.type: single-node
-      xpack.security.enabled: 'false'
-
   elasticsearch-auth-2:
     image: docker.elastic.co/elasticsearch/elasticsearch:9.0.2
     restart: unless-stopped
@@ -248,17 +237,6 @@ services:
       ELASTIC_PASSWORD: 123456
       http.port: 9201
       xpack.security.enabled: 'true'
-
-  elasticsearch-noauth-3:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.0.0
-    restart: unless-stopped
-    ports:
-      - "9600:9200"
-      - "9700:9300"
-    environment:
-      ES_JAVA_OPTS: -Xms512m -Xmx512m
-      discovery.type: single-node
-      xpack.security.enabled: 'false'
 
   elasticsearch-auth-3:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.0.0

--- a/ci/pod/docker-compose.plugin.yml
+++ b/ci/pod/docker-compose.plugin.yml
@@ -225,6 +225,29 @@ services:
       http.port: 9201
       xpack.security.enabled: 'true'
 
+  elasticsearch-noauth-2:
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.0.2
+    restart: unless-stopped
+    ports:
+      - "9400:9200"
+      - "9500:9300"
+    environment:
+      ES_JAVA_OPTS: -Xms512m -Xmx512m
+      discovery.type: single-node
+      xpack.security.enabled: 'false'
+
+  elasticsearch-auth-2:
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.0.2
+    restart: unless-stopped
+    ports:
+      - "9301:9201"
+    environment:
+      ES_JAVA_OPTS: -Xms512m -Xmx512m
+      discovery.type: single-node
+      ELASTIC_USERNAME: elastic
+      ELASTIC_PASSWORD: 123456
+      http.port: 9201
+      xpack.security.enabled: 'true'
 
   # The function services of OpenFunction
   test-header:

--- a/docs/en/latest/plugins/elasticsearch-logger.md
+++ b/docs/en/latest/plugins/elasticsearch-logger.md
@@ -42,7 +42,6 @@ The `elasticsearch-logger` Plugin pushes request and response logs in batches to
 | endpoint_addrs  | array[string] | True     |                             | Elasticsearch API endpoint addresses. If multiple endpoints are configured, they will be written randomly.            |
 | field         | object   | True     |                             | Elasticsearch `field` configuration.                          |
 | field.index   | string  | True     |                             | Elasticsearch [_index field](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-index-field.html#mapping-index-field). |
-| field.type    | string  | False    | Elasticsearch default value | Elasticsearch [_type field](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/mapping-type-field.html#mapping-type-field). |
 | log_format | object | False    |                             | Custom log format in key-value pairs in JSON format. Support [APISIX](../apisix-variable.md) or [NGINX variables](http://nginx.org/en/docs/varindex.html) in values. |
 | auth          | array   | False    |                             | Elasticsearch [authentication](https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-up-authentication.html) configuration. |
 | auth.username | string  | True     |                             | Elasticsearch [authentication](https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-up-authentication.html) username. |
@@ -110,7 +109,7 @@ admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"/
 
 The following example demonstrates how you can enable the `elasticsearch-logger` Plugin on a route, which logs client requests and responses to the Route and pushes logs to Elasticsearch.
 
-Create a Route with `elasticsearch-logger` to configure the `index` field as `gateway` and the `type` field as `logs`:
+Create a Route with `elasticsearch-logger` to configure the `index` field as `gateway`:
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
@@ -122,8 +121,7 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
       "elasticsearch-logger": {
         "endpoint_addrs": ["http://elasticsearch:9200"],
         "field": {
-          "index": "gateway",
-          "type": "logs"
+          "index": "gateway"
         }
       }
     },
@@ -149,7 +147,6 @@ Navigate to the Kibana dashboard on [localhost:5601](http://localhost:5601) and 
 ```json
 {
   "_index": "gateway",
-  "_type": "logs",
   "_id": "CE-JL5QBOkdYRG7kEjTJ",
   "_version": 1,
   "_score": 1,
@@ -215,8 +212,7 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
       "elasticsearch-logger": {
         "endpoint_addrs": ["http://elasticsearch:9200"],
         "field": {
-          "index": "gateway",
-          "type": "logs"
+          "index": "gateway"
       }
     },
     "upstream": {
@@ -257,7 +253,6 @@ Navigate to the Kibana dashboard on [localhost:5601](http://localhost:5601) and 
 ```json
 {
   "_index": "gateway",
-  "_type": "logs",
   "_id": "Ck-WL5QBOkdYRG7kODS0",
   "_version": 1,
   "_score": 1,
@@ -288,8 +283,7 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
       "elasticsearch-logger": {
         "endpoint_addrs": ["http://elasticsearch:9200"],
         "field": {
-          "index": "gateway",
-          "type": "logs"
+          "index": "gateway"
         },
         "include_req_body": true,
         "include_req_body_expr": [["arg_log_body", "==", "yes"]]
@@ -319,7 +313,6 @@ Navigate to the Kibana dashboard on [localhost:5601](http://localhost:5601) and 
 ```json
 {
   "_index": "gateway",
-  "_type": "logs",
   "_id": "Dk-cL5QBOkdYRG7k7DSW",
   "_version": 1,
   "_score": 1,
@@ -384,7 +377,6 @@ Navigate to the Kibana dashboard __Discover__ tab and you should see a log gener
 ```json
 {
   "_index": "gateway",
-  "_type": "logs",
   "_id": "EU-eL5QBOkdYRG7kUDST",
   "_version": 1,
   "_score": 1,

--- a/docs/zh/latest/plugins/elasticsearch-logger.md
+++ b/docs/zh/latest/plugins/elasticsearch-logger.md
@@ -43,7 +43,6 @@ description: elasticsearch-logger Plugin 将请求和响应日志批量推送到
 | endup_addrs | array[string] | 是 | | Elasticsearch API 端点地址。如果配置了多个端点，则会随机写入。 |
 | field | object | 是 | | Elasticsearch `field` 配置。 |
 | field.index | string | 是 | | Elasticsearch [_index 字段](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-index-field.html#mapping-index-field)。 |
-| field.type | string | 否 | Elasticsearch 默认值 | Elasticsearch [_type 字段](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/mapping-type-field.html#mapping-type-field)。 |
 | log_format | object | 否 | | JSON 格式的键值对中的自定义日志格式。值中支持 [APISIX](../apisix-variable.md) 或 [NGINX 变量](http://nginx.org/en/docs/varindex.html)。 |
 | auth | array | 否 | | Elasticsearch [身份验证](https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-up-authentication.html) 配置。 |
 | auth.username | string | 是 | | Elasticsearch [身份验证](https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-up-authentication.html) 用户名​​。 |
@@ -111,7 +110,7 @@ admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"/
 
 以下示例演示如何在路由上启用 `elasticsearch-logger` 插件，该插件记录客户端对路由的请求和响应，并将日志推送到 Elasticsearch。
 
-使用 `elasticsearch-logger` 创建路由，将 `index` 字段配置为 `gateway`，将 `type` 字段配置为 `logs`：
+使用 `elasticsearch-logger` 创建路由，将 `index` 字段配置为 `gateway`：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
@@ -123,8 +122,7 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
       "elasticsearch-logger": {
         "endpoint_addrs": ["http://elasticsearch:9200"],
         "field": {
-          "index": "gateway",
-          "type": "logs"
+          "index": "gateway"
         }
       }
     },
@@ -150,7 +148,6 @@ curl -i "http://127.0.0.1:9080/anything"
 ```json
 {
   "_index": "gateway",
-  "_type": "logs",
   "_id": "CE-JL5QBOkdYRG7kEjTJ",
   "_version": 1,
   "_score": 1,
@@ -216,8 +213,7 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
       "elasticsearch-logger": {
         "endpoint_addrs": ["http://elasticsearch:9200"],
         "field": {
-          "index": "gateway",
-          "type": "logs"
+          "index": "gateway"
       }
     },
     "upstream": {
@@ -258,7 +254,6 @@ curl -i "http://127.0.0.1:9080/anything" -H "env: dev"
 ```json
 {
   "_index": "gateway",
-  "_type": "logs",
   "_id": "Ck-WL5QBOkdYRG7kODS0",
   "_version": 1,
   "_score": 1,
@@ -289,8 +284,7 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
       "elasticsearch-logger": {
         "endpoint_addrs": ["http://elasticsearch:9200"],
         "field": {
-          "index": "gateway",
-          "type": "logs"
+          "index": "gateway"
         },
         "include_req_body": true,
         "include_req_body_expr": [["arg_log_body", "==", "yes"]]
@@ -320,7 +314,6 @@ curl -i "http://127.0.0.1:9080/anything?log_body=yes" -X POST -d '{"env": "dev"}
 ```json
 {
   "_index": "gateway",
-  "_type": "logs",
   "_id": "Dk-cL5QBOkdYRG7k7DSW",
   "_version": 1,
   "_score": 1,
@@ -385,7 +378,6 @@ curl -i "http://127.0.0.1:9080/anything" -X POST -d '{"env": "dev"}'
 ```json
 {
   "_index": "gateway",
-  "_type": "logs",
   "_id": "EU-eL5QBOkdYRG7kUDST",
   "_version": 1,
   "_score": 1,

--- a/t/plugin/elasticsearch-logger.t
+++ b/t/plugin/elasticsearch-logger.t
@@ -882,7 +882,10 @@ Action/metadata line [1] contains an unknown parameter [_type]
     }
 --- response_body
 passed
-=== TEST 26: test route (auth success)
+
+
+
+=== TEST 22: test route (auth success)
 --- request
 GET /hello
 --- wait: 2
@@ -893,7 +896,7 @@ Batch Processor[elasticsearch-logger] successfully processed the entries
 
 
 
-=== TEST 22: set route (auth) - warning should be given with version 9 when deprecated field is passed
+=== TEST 23: set route (auth) - warning should be given with version 9 when deprecated field is passed
 --- config
     location /t {
         content_by_lua_block {
@@ -933,7 +936,7 @@ passed
 
 
 
-=== TEST 23: test route (auth success)
+=== TEST 24: test route (auth success)
 --- request
 GET /hello
 --- wait: 2

--- a/t/plugin/elasticsearch-logger.t
+++ b/t/plugin/elasticsearch-logger.t
@@ -892,4 +892,3 @@ GET /hello
 hello world
 --- error_log
 Batch Processor[elasticsearch-logger] successfully processed the entries
-

--- a/t/plugin/elasticsearch-logger.t
+++ b/t/plugin/elasticsearch-logger.t
@@ -304,7 +304,7 @@ GET /hello
 --- response_body
 hello world
 --- error_log
-failed to get Elasticsearch version: server returned status: 401
+failed to process entries: elasticsearch server returned status: 401
 
 
 
@@ -885,6 +885,106 @@ passed
 
 
 === TEST 22: test route (auth success)
+--- request
+GET /hello
+--- wait: 2
+--- response_body
+hello world
+--- error_log
+Batch Processor[elasticsearch-logger] successfully processed the entries
+
+
+
+=== TEST 23: set route (auth) - check compat with version 7
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, {
+                uri = "/hello",
+                upstream = {
+                    type = "roundrobin",
+                    nodes = {
+                        ["127.0.0.1:1980"] = 1
+                    }
+                },
+                plugins = {
+                    ["elasticsearch-logger"] = {
+                        endpoint_addr = "http://127.0.0.1:9401",
+                        field = {
+                            index = "services"
+                        },
+                        auth = {
+                            username = "elastic",
+                            password = "123456"
+                        },
+                        batch_max_size = 1,
+                        inactive_timeout = 1
+                    }
+                }
+            })
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 24: test route (auth success)
+--- request
+GET /hello
+--- wait: 2
+--- response_body
+hello world
+--- error_log
+Batch Processor[elasticsearch-logger] successfully processed the entries
+
+
+
+=== TEST 25: set route (auth) - check compat with version 6
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, {
+                uri = "/hello",
+                upstream = {
+                    type = "roundrobin",
+                    nodes = {
+                        ["127.0.0.1:1980"] = 1
+                    }
+                },
+                plugins = {
+                    ["elasticsearch-logger"] = {
+                        endpoint_addr = "http://127.0.0.1:9501",
+                        field = {
+                            index = "services"
+                        },
+                        auth = {
+                            username = "elastic",
+                            password = "123456"
+                        },
+                        batch_max_size = 1,
+                        inactive_timeout = 1
+                    }
+                }
+            })
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 26: test route (auth success)
 --- request
 GET /hello
 --- wait: 2

--- a/t/plugin/elasticsearch-logger.t
+++ b/t/plugin/elasticsearch-logger.t
@@ -46,8 +46,7 @@ __DATA__
                 {
                     endpoint_addr = "http://127.0.0.1:9200",
                     field = {
-                        index = "services",
-                        type = "collector"
+                        index = "services"
                     },
                     auth = {
                         username = "elastic",
@@ -894,53 +893,3 @@ hello world
 --- error_log
 Batch Processor[elasticsearch-logger] successfully processed the entries
 
-
-
-=== TEST 23: set route (auth) - warning should be given with version 9 when deprecated field is passed
---- config
-    location /t {
-        content_by_lua_block {
-            local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, {
-                uri = "/hello",
-                upstream = {
-                    type = "roundrobin",
-                    nodes = {
-                        ["127.0.0.1:1980"] = 1
-                    }
-                },
-                plugins = {
-                    ["elasticsearch-logger"] = {
-                        endpoint_addr = "http://127.0.0.1:9301",
-                        field = {
-                            index = "services",
-                            type = "xyz"
-                        },
-                        auth = {
-                            username = "elastic",
-                            password = "123456"
-                        },
-                        batch_max_size = 1,
-                        inactive_timeout = 1
-                    }
-                }
-            })
-            if code >= 300 then
-                ngx.status = code
-            end
-            ngx.say(body)
-        }
-    }
---- response_body
-passed
-
-
-
-=== TEST 24: test route (auth success)
---- request
-GET /hello
---- wait: 2
---- response_body
-hello world
---- error_log
-type is not supported in Elasticsearch 9, removing `type`


### PR DESCRIPTION
Fixes 
Error comes when using elasticsearch version 9+
![Screenshot From 2025-06-23 12-29-02](https://github.com/user-attachments/assets/00fc81be-2134-496c-9dce-c8196dcf87be)

We want to remove the compat header and have a general support for all major versions.

For elasticsearch logger plugin comptability check. Following are the observations and conclusion based on reading docs and self testing.

The `type` field issue:
Before version 7, the `type` field was required in json schema https://github.com/elastic/elasticsearch/blob/8453f7701de25c467ce08088ddddac185cb8028c/rest-api-spec/src/main/resources/rest-api-spec/api/create.json#L21.
The current tests without `type` fail on version 6(here it's 6.7) with the following error

Batch Processor[elasticsearch-logger] failed to process entries: elasticsearch server returned status: 400, body: {"error":{"root_cause":[{"type":"action_request_validation_exception","reason":"Validation Failed: 1: type is missing;"}]

Adding a _type in the code fixes the above test.
Conclusion
As suggested in the migration guide, we can hardcode the `type` to "_doc" in versions prior to 7 and on 7+ we can omit `type` completely
Indices created in 6.x only allow a single-type per index. Any name can be used for the type, but there can be only one. The preferred type name is _doc, so that index APIs have the same path as they will have in 7.0: PUT {index}/_doc/{id} and POST {index}/_doc


The `id` field issue:
Another problem was detected while running tests on older version(6), when _id was not passed along with _index,. the following error was reported:

Batch Processor[elasticsearch-logger] failed to process entries: elasticsearch server returned status: 400, body: {"error":{"root_cause":[{"type":"action_request_validation_exception","reason":"Validation Failed: 1: an id must be provided if version type or value are set;"}],"

In older version, _id is also required https://github.com/elastic/elasticsearch/blob/8453f7701de25c467ce08088ddddac185cb8028c/rest-api-spec/src/main/resources/rest-api-spec/api/create.json#L9
But I when I used index API instead of create API, request passed even without _id for all versions 6,7,8

-            create = {
+            index = {
                 _index = conf.field.index,
-                _type = conf.field.type
+                _type = "_doc",
             }
         }) .. "\n" ..


The doc says
A create action fails if a document with the same ID already exists in the target An index action adds or replaces a document as necessary.
An answer in the discuss forum says
Neither is used to create an index (although they may do so as a side-effect of inserting the first document into a new index). "index" indexes a document. "create" only indexes a document if it doesn't already exist. It used to be that "create" was faster if you knew that your docs didn't already exist. But now, since versioning was added, "index" performs as well as "create"
Another answer suggests
you use create if a doc with that id already exists, if you use index it will create a document or update it if xisting.
Conclusion: To me it looks okay to replace create with index



Conclusion:
We can remove `type` from plugin configuration and for detected version below 7, hardcode it as `_doc`
We can replace Create with Index in the request body.
We run all tests on version 8 and my PR adds a comptability test with version 9. We can add two more compatibilty tests with 6 and 7 to confirm our changes.

Result: We will be able to support ES versions 6,7,8,9

References and other relevant information:
https://www.elastic.co/guide/en/elasticsearch/reference/6.7/release-notes-6.7.0.html. Search "Deprecate types" in this doc.
From reading this issue: https://github.com/elastic/elasticsearch/issues/35190
Though a temporary parameter was added `include_type_name` which defaults to true between 6.7 upto 7 meaning by default `type` was being sent but it could be turned off.
Then between 7 and 8 this field was default to false meaning by default the `type` will no longer be sent and a deprecated warning will come.
Then after 8+ this include_type_name was removed and `type` was no longer supported.
References:
https://www.elastic.co/docs/reference/elasticsearch/rest-apis/compatibility
https://www.elastic.co/guide/en/elasticsearch/reference/8.18/rest-api-compatibility.html
https://github.com/elastic/elasticsearch-ruby/issues/2665
### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
