### PR TITLE
fix(workflow/push-dev-image-on-commit): remove already defined `uses`

### DIFF
--- a/.github/workflows/push-dev-image-on-commit.yml
+++ b/.github/workflows/push-dev-image-on-commit.yml
@@ -58,7 +58,6 @@ jobs:
           fi
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
         if: github.ref == 'refs/heads/master'
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

When resolving the conflict at the end of 12322, merging the upstream has an error: https://github.com/apache/apisix/actions/runs/15817495699

![CleanShot 2025-06-23 at 15 08 36@2x](https://github.com/user-attachments/assets/ddad97fb-c17b-447e-8e27-016d7dfb9400)

This error is not reflected in the CI and is ignored. Therefore, this PR needs to be submitted to fix it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
