### PR TITLE
fix: flaky t/admin/filter.t due to url encoding for query params

### DIFF
--- a/t/admin/filter.t
+++ b/t/admin/filter.t
@@ -1053,4 +1053,3 @@ passed
         }
     }
 --- error_code: 200
---- ONLY

--- a/t/admin/filter.t
+++ b/t/admin/filter.t
@@ -1035,8 +1035,8 @@ passed
             end
 
             -- check both service_id and upstream_id
-            local code, body, res = t('/apisix/admin/routes?filter='
-                                        .. ngx.encode_args({ service_id = "1", upstream_id = "1" }),
+            local code, body, res = t('/apisix/admin/routes?'
+                                        .. ngx.encode_args({filter = ngx.encode_args({ service_id = "1", upstream_id = "1" })}),
                 ngx.HTTP_GET
             )
             res = json.decode(res)
@@ -1053,3 +1053,4 @@ passed
         }
     }
 --- error_code: 200
+--- ONLY


### PR DESCRIPTION
### Description

failed jobs:
https://github.com/apache/apisix/actions/runs/15817495697/job/44579024603
https://github.com/apache/apisix/actions/runs/15821515715/job/44591668640
<img width="2717" alt="image" src="https://github.com/user-attachments/assets/8b52bbe7-ace6-4999-9ddb-871b3e951e96" />

the result of 
```
ngx.encode_args({ service_id = "1", upstream_id = "1" })
```
is `service_id=1&upstream_id=1` or `upstream_id=1&service_id=1`, the order of `service_id` and `upstream_id` is random.
so the final uri is `/apisix/admin/routes?filter=service_id=1&upstream_id=1` or  `/apisix/admin/routes?filter=upstream_id=1&service_id=1`, because second one meaning only filter by `upstream_id=1`, and the result is same as `service_id=1 && upstream_id=1`, so this test case working sometimes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
