### PR TITLE
fix:  deployment data plane with read-only etcd

### DIFF
--- a/apisix/cli/etcd.lua
+++ b/apisix/cli/etcd.lua
@@ -379,10 +379,14 @@ function _M.init(env, args)
         util.die("the etcd cluster needs at least 50% and above healthy nodes\n")
     end
 
+    -- The data plane does not have write permissions,
+    -- and it should not continue to prepare dirs.
     if yaml_conf.deployment.role == "data_plane" then
+        print("data plane does not have write permissions, skip preparing dirs")
         return true
     end
 
+    print("prepare dirs")
     local etcd_ok = false
     for index, host in ipairs(etcd_healthy_hosts) do
         if prepare_dirs(yaml_conf, args, index, host, host_count) then

--- a/apisix/cli/etcd.lua
+++ b/apisix/cli/etcd.lua
@@ -381,7 +381,8 @@ function _M.init(env, args)
 
     -- access from the data plane to etcd must be read-only
     if yaml_conf.deployment.role == "data_plane" then
-        print("access from the data plane to etcd must be read-only, skip initializing the data of etcd")
+        print("access from the data plane to etcd must be read-only, "
+              .."skip initializing the data of etcd")
         return true
     end
 

--- a/apisix/cli/etcd.lua
+++ b/apisix/cli/etcd.lua
@@ -379,6 +379,10 @@ function _M.init(env, args)
         util.die("the etcd cluster needs at least 50% and above healthy nodes\n")
     end
 
+    if yaml_conf.deployment.role == "data_plane" then
+        return true
+    end
+
     local etcd_ok = false
     for index, host in ipairs(etcd_healthy_hosts) do
         if prepare_dirs(yaml_conf, args, index, host, host_count) then

--- a/apisix/cli/etcd.lua
+++ b/apisix/cli/etcd.lua
@@ -380,8 +380,7 @@ function _M.init(env, args)
     end
 
     -- access from the data plane to etcd should be read-only.
-    -- data plane writes to etcd may cause security issues,
-    -- or multiple instance writes may cause performance degradation.
+    -- data plane writes to etcd may cause security issues.
     if yaml_conf.deployment.role == "data_plane" then
         print("access from the data plane to etcd should be read-only, "
               .."skip initializing the data of etcd")

--- a/apisix/cli/etcd.lua
+++ b/apisix/cli/etcd.lua
@@ -379,14 +379,16 @@ function _M.init(env, args)
         util.die("the etcd cluster needs at least 50% and above healthy nodes\n")
     end
 
-    -- access from the data plane to etcd must be read-only
+    -- access from the data plane to etcd should be read-only.
+    -- data plane writes to etcd may cause security issues,
+    -- or multiple instance writes may cause performance degradation.
     if yaml_conf.deployment.role == "data_plane" then
-        print("access from the data plane to etcd must be read-only, "
+        print("access from the data plane to etcd should be read-only, "
               .."skip initializing the data of etcd")
         return true
     end
 
-    print("APISIX is initializing the data of etcd")
+    print("trying to initialize the data of etcd")
     local etcd_ok = false
     for index, host in ipairs(etcd_healthy_hosts) do
         if prepare_dirs(yaml_conf, args, index, host, host_count) then

--- a/apisix/cli/etcd.lua
+++ b/apisix/cli/etcd.lua
@@ -379,14 +379,13 @@ function _M.init(env, args)
         util.die("the etcd cluster needs at least 50% and above healthy nodes\n")
     end
 
-    -- The data plane does not have write permissions,
-    -- and it should not continue to prepare dirs.
+    -- access from the data plane to etcd must be read-only
     if yaml_conf.deployment.role == "data_plane" then
-        print("data plane does not have write permissions, skip preparing dirs")
+        print("access from the data plane to etcd must be read-only, skip initializing the data of etcd")
         return true
     end
 
-    print("prepare dirs")
+    print("APISIX is initializing the data of etcd")
     local etcd_ok = false
     for index, host in ipairs(etcd_healthy_hosts) do
         if prepare_dirs(yaml_conf, args, index, host, host_count) then

--- a/t/cli/test_deployment_data_plane_with_readonly-etcd.sh
+++ b/t/cli/test_deployment_data_plane_with_readonly-etcd.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+. ./t/cli/common.sh
+
+# clean etcd data
+etcdctl del / --prefix
+
+etcdctl user add root <<EOF
+test
+test
+EOF
+etcdctl role add root
+etcdctl user grant-role root root
+# add readonly user
+etcdctl user add apisix-data-plane <<EOF
+test
+test
+EOF
+etcdctl role add data-plane-role
+etcdctl role grant-permission --prefix=true data-plane-role read /apisix
+etcdctl user grant-role apisix-data-plane data-plane-role
+
+etcdctl auth enable
+
+# data_plane can start with readonly etcd user
+echo '
+deployment:
+    role: data_plane
+    role_data_plane:
+        config_provider: etcd
+    etcd:
+        host:
+            - https://127.0.0.1:12379
+        user: apisix-data-plane
+        password: test
+        prefix: "/apisix"
+        timeout: 30
+        tls:
+            verify: false
+' > conf/config.yaml
+
+make run
+
+sleep 1
+
+res=$(etcdctl -u root:test get / --prefix | wc -l)
+
+if [ ! $res -eq 0 ]; then
+    echo "failed: data_plane should not write data to etcd"
+    exit 1
+fi
+
+echo "passed: data_plane does not write data to etcd"
+
+etcdctl -u root:test user remove apisix-data-plane
+etcdctl -u root:test role remove data-plane-role
+etcdctl -u root:test user remove root
+etcdctl -u root:test role remove root
+etcdctl -u root:test auth disable

--- a/t/cli/test_deployment_data_plane_with_readonly_etcd.sh
+++ b/t/cli/test_deployment_data_plane_with_readonly_etcd.sh
@@ -56,6 +56,9 @@ deployment:
 
 out=$(make run 2>&1 || true)
 make stop
+
+echo "$out"
+
 if echo "$out" | grep 'etcdserver: permission denied'; then
     echo "failed: data_plane should not write data to etcd"
     exit 1

--- a/t/cli/test_deployment_data_plane_with_readonly_etcd.sh
+++ b/t/cli/test_deployment_data_plane_with_readonly_etcd.sh
@@ -22,6 +22,106 @@
 # clean etcd data
 etcdctl del / --prefix
 
+# non data_plane can prepare dirs when init etcd
+echo '
+deployment:
+    role: traditional
+    role_traditional:
+        config_provider: etcd
+    etcd:
+        host:
+            - http://127.0.0.1:2379
+        prefix: /apisix
+        timeout: 30
+' >conf/config.yaml
+
+out=$(make init 2>&1 || true)
+if ! echo "$out" | grep 'prepare dirs'; then
+    echo "failed: non data_plane should prepare dirs"
+    exit 1
+fi
+echo "passed: non data_plane can prepare dirs when init etcd"
+
+# start apisix to test non data_plane can work with etcd
+make run
+sleep 3
+
+admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
+curl -o /dev/null -s -w %{http_code} -i http://127.0.0.1:9180/apisix/admin/routes/1 -H "X-API-KEY: $admin_key" -X PUT -d '
+{
+    "upstream": {
+        "nodes": {
+            "127.0.0.1:1980": 1
+        },
+        "type": "roundrobin"
+    },
+    "uri": "/hello",
+    "plugins": {
+        "serverless-pre-function": {
+            "phase": "rewrite",
+            "functions": ["
+                return function(conf, ctx)
+                    local core = require(\"apisix.core\")
+                    return core.response.exit(200)
+                end
+            "]
+        }
+    }
+}'
+
+# check can access the route
+code=$(curl -o /dev/null -s -w %{http_code} http://127.0.0.1:9080/hello)
+if [ ! "$code" -eq 200 ]; then
+    echo "failed: non data_plane should be able to access the route"
+    exit 1
+fi
+
+echo "passed: non data_plane can work with etcd"
+
+# prepare for data_plane with etcd
+# stop apisix
+make stop
+sleep 3
+
+# data_plane can skip prepare dirs when init with etcd
+echo '
+deployment:
+    role: data_plane
+    role_data_plane:
+        config_provider: etcd
+    etcd:
+        host:
+            - http://127.0.0.1:2379
+        prefix: /apisix
+        timeout: 30
+' >conf/config.yaml
+
+out=$(make init 2>&1 || true)
+if echo "$out" | grep 'prepare dirs'; then
+    echo "failed: data_plane should not prepare dirs"
+    exit 1
+fi
+if ! echo "$out" | grep 'data plane does not have write permissions, skip preparing dirs'; then
+    echo "failed: data_plane should skip preparing dirs"
+    exit 1
+fi
+echo "passed: data_plane can skip prepare dirs when init with etcd"
+
+# start apisix to test data_plane can work with etcd
+make run
+sleep 3
+
+code=$(curl -o /dev/null -s -w %{http_code} http://127.0.0.1:9080/hello)
+if [ ! "$code" -eq 200 ]; then
+    echo "failed: data_plane should be able to access the route"
+    exit 1
+fi
+echo "passed: data_plane can work with etcd"
+
+# prepare for data_plane with read-only etcd
+# stop apisix
+make stop
+sleep 3
 # add root user to help disable auth
 etcdctl user add "root:test"
 etcdctl role add root
@@ -34,7 +134,7 @@ etcdctl user grant-role apisix-data-plane data-plane-role
 # enable auth
 etcdctl auth enable
 
-# data_plane can start with read-only etcd
+# data_plane can skip prepare dirs when init with read-only etcd
 echo '
 deployment:
     role: data_plane
@@ -47,17 +147,29 @@ deployment:
         password: test
         prefix: /apisix
         timeout: 30
-' > conf/config.yaml
+' >conf/config.yaml
 
 out=$(make init 2>&1 || true)
-sleep 3
-
-if echo "$out" | grep 'etcdserver: permission denied'; then
-    echo "failed: data_plane should not write data to etcd"
+if echo "$out" | grep 'prepare dirs'; then
+    echo "failed: data_plane should not prepare dirs"
     exit 1
 fi
-
+if ! echo "$out" | grep 'data plane does not have write permissions, skip preparing dirs'; then
+    echo "failed: data_plane should skip preparing dirs"
+    exit 1
+fi
 echo "passed: data_plane can init with read-only etcd"
+
+# start apisix to test data_plane can work with read-only etcd
+make run
+sleep 3
+
+code=$(curl -o /dev/null -s -w %{http_code} http://127.0.0.1:9080/hello)
+if [ ! "$code" -eq 200 ]; then
+    echo "failed: data_plane should be able to access the route with read-only etcd"
+    exit 1
+fi
+echo "passed: data_plane can work with read-only etcd"
 
 # clean up
 etcdctl --user=root:test auth disable

--- a/t/cli/test_deployment_data_plane_with_readonly_etcd.sh
+++ b/t/cli/test_deployment_data_plane_with_readonly_etcd.sh
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-# . ./t/cli/common.sh
+. ./t/cli/common.sh
 
 # clean etcd data
 etcdctl del / --prefix

--- a/t/cli/test_deployment_data_plane_with_readonly_etcd.sh
+++ b/t/cli/test_deployment_data_plane_with_readonly_etcd.sh
@@ -36,7 +36,7 @@ deployment:
 ' >conf/config.yaml
 
 out=$(make init 2>&1 || true)
-if ! echo "$out" | grep 'APISIX is initializing the data of etcd'; then
+if ! echo "$out" | grep 'trying to initialize the data of etcd'; then
     echo "failed: non data_plane should init the data of etcd"
     exit 1
 fi
@@ -96,11 +96,11 @@ deployment:
 ' >conf/config.yaml
 
 out=$(make init 2>&1 || true)
-if echo "$out" | grep 'APISIX is initializing the data of etcd'; then
+if echo "$out" | grep 'trying to initialize the data of etcd'; then
     echo "failed: data_plane should not init the data of etcd"
     exit 1
 fi
-if ! echo "$out" | grep 'access from the data plane to etcd must be read-only, skip initializing the data of etcd'; then
+if ! echo "$out" | grep 'access from the data plane to etcd should be read-only, skip initializing the data of etcd'; then
     echo "failed: data_plane should skip initializing the data of etcd"
     exit 1
 fi
@@ -149,11 +149,11 @@ deployment:
 ' >conf/config.yaml
 
 out=$(make init 2>&1 || true)
-if echo "$out" | grep 'APISIX is initializing the data of etcd'; then
+if echo "$out" | grep 'trying to initialize the data of etcd'; then
     echo "failed: data_plane should not init the data of etcd (read-only)"
     exit 1
 fi
-if ! echo "$out" | grep 'access from the data plane to etcd must be read-only, skip initializing the data of etcd'; then
+if ! echo "$out" | grep 'access from the data plane to etcd should be read-only, skip initializing the data of etcd'; then
     echo "failed: data_plane should skip initializing the data of etcd (read-only)"
     exit 1
 fi

--- a/t/cli/test_deployment_data_plane_with_readonly_etcd.sh
+++ b/t/cli/test_deployment_data_plane_with_readonly_etcd.sh
@@ -56,7 +56,7 @@ deployment:
 
 out=$(make run 2>&1 || true)
 make stop
-if ! echo "$out" | grep 'etcdserver: permission denied'; then
+if echo "$out" | grep 'etcdserver: permission denied'; then
     echo "failed: data_plane should not write data to etcd"
     exit 1
 fi


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

**What**

This PR implements skipping write operations to etcd when the `deployment.role` is `data_plane`.

**How**

Make a judgment in `etcd.init()`.

**Why**

Since `init_etcd` is called directly in https://github.com/apache/apisix-docker/blob/release/apisix-3.2.2/debian-dev/docker-entrypoint.sh#L39-L40, it does not make judgments like in https://github.com/apache/apisix/blob/3.2.2/apisix/cli/ops.lua#L821-L823. Causes apisix running as a container, there will be a problem when `deployment.role` is `data_plane`.

From a maintenance perspective, I also want to avoid adding things in places like `docker-entrypoint.sh`, as this would obviously duplicate more code. As for testing, there's currently no direct testing of the APISIX container, and it's difficult for me to do this in a short amount of time.

After this modification, it can currently avoid similar issues when calling `init_etcd` or `etcd.init()` anywhere.

In the future, we can actually remove the redundant checks in https://github.com/apache/apisix/blob/3.2.2/apisix/cli/ops.lua#L821-L823.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
