### PR TITLE
fix: `get_keys` only return first 1024 items in shared dict by default

### DIFF
--- a/apisix/discovery/kubernetes/init.lua
+++ b/apisix/discovery/kubernetes/init.lua
@@ -634,7 +634,7 @@ end
 
 
 local function dump_endpoints_from_dict(endpoint_dict)
-    local keys, err = endpoint_dict:get_keys()
+    local keys, err = endpoint_dict:get_keys(0)
     if err then
         core.log.error("get keys from discovery dict failed: ", err)
         return


### PR DESCRIPTION
### Description

From OpenResty Doc:
> By default, only the first 1024 keys (if any) are returned. When the <max_count> argument is given the value 0, then all the keys will be returned even there is more than 1024 keys in the dictionary.

We should return complete data in the `/v1/discovery/{service}/dump` control API, otherwise, it will confuse users.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
