### PR TITLE
ci: remove redundant package steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,14 +62,6 @@ jobs:
           path: deps
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ matrix.os_name }}-${{ hashFiles('apisix-master-0.rockspec') }}
 
-      - name: Extract branch name
-        if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
-        id: branch_env
-        shell: bash
-        run: |
-          echo "version=${GITHUB_REF##*/}" >>$GITHUB_OUTPUT
-          echo "fullname=apache-apisix-${GITHUB_REF##*/}-src.tgz" >>$GITHUB_OUTPUT
-
       - name: Extract test type
         shell: bash
         id: test_env
@@ -101,17 +93,6 @@ jobs:
         run: |
           make ci-env-up project_compose_ci=ci/pod/docker-compose.common.yml
           sudo ./ci/init-common-test-service.sh
-
-      - name: Create tarball
-        if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
-        run: |
-          make compress-tar VERSION=${{ steps.branch_env.outputs.version }}
-
-      - name: Remove source code
-        if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
-        run: |
-          rm -rf $(ls -1 --ignore=*.tgz --ignore=ci --ignore=t --ignore=utils --ignore=.github)
-          tar zxvf ${{ steps.branch_env.outputs.fullname }}
 
       - name: Cache images
         id: cache-images


### PR DESCRIPTION
Fixes #
- https://github.com/apache/apisix/pull/3521 This PR had added a release check to package and upload release artifact.

- https://github.com/apache/apisix/pull/5567 This PR removed the release artifact step but the rest of the steps were left which are of no use now.

Those steps also are failing CI on release PR: https://github.com/apache/apisix/pull/12378 and can be removed

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
