### PR TITLE
fix: zipkin trace_id and span_id format in ngx_var

### DIFF
--- a/apisix/plugins/zipkin.lua
+++ b/apisix/plugins/zipkin.lua
@@ -223,8 +223,8 @@ function _M.rewrite(plugin_conf, ctx)
                                              to_hex(span_context.trace_id),
                                              to_hex(span_context.span_id),
                                              span_context:get_baggage_item("x-b3-sampled"))
-        ngx_var.zipkin_trace_id = span_context.trace_id
-        ngx_var.zipkin_span_id = span_context.span_id
+        ngx_var.zipkin_trace_id = to_hex(span_context.trace_id)
+        ngx_var.zipkin_span_id = to_hex(span_context.span_id)
     end
 
     if not ctx.opentracing_sample then

--- a/t/plugin/mcp-bridge.t
+++ b/t/plugin/mcp-bridge.t
@@ -91,7 +91,7 @@ passed
 
 
 === TEST 3: test mcp client
---- timeout: 15
+--- timeout: 20
 --- exec
 cd t/plugin/mcp && pnpm test 2>&1
 --- no_error_log

--- a/t/plugin/zipkin3.t
+++ b/t/plugin/zipkin3.t
@@ -55,6 +55,20 @@ _EOC_
             ngx.log(ngx.ERR,"ngx_var.zipkin_context_traceparent:",ngx.var.zipkin_context_traceparent)
         end
 
+        local trace_id = ngx.var.zipkin_trace_id
+        if trace_id == nil or trace_id == '' then
+           ngx.log(ngx.ERR,"ngx_var.zipkin_trace_id is empty")
+        else
+            ngx.log(ngx.ERR,"ngx_var.zipkin_trace_id:",ngx.var.zipkin_trace_id)
+        end
+
+        local span_id = ngx.var.zipkin_span_id
+        if span_id == nil or span_id == '' then
+           ngx.log(ngx.ERR,"ngx_var.zipkin_span_id is empty")
+        else
+            ngx.log(ngx.ERR,"ngx_var.zipkin_span_id:",ngx.var.zipkin_span_id)
+        end
+
         local orig = orig_func(...)
         return orig
     end
@@ -118,7 +132,23 @@ qr/ngx_var.zipkin_context_traceparent:00-\w{32}-\w{16}-01*/
 
 
 
-=== TEST 3: trigger zipkin with disable set variables
+=== TEST 3: trigger zipkin with open set variables
+--- request
+GET /echo
+--- error_log eval
+qr/ngx_var.zipkin_trace_id:\w{32}/
+
+
+
+=== TEST 4: trigger zipkin with open set variables
+--- request
+GET /echo
+--- error_log eval
+qr/ngx_var.zipkin_span_id:\w{16}/
+
+
+
+=== TEST 5: trigger zipkin with disable set variables
 --- extra_yaml_config
 plugins:
     - zipkin


### PR DESCRIPTION
### Description

According to Zipkin's documentation, the TraceID passed via HTTP headers uses lowercase hexadecimal encoding, not binary data. For example, the B3 specification states that the value of the X-B3-TraceId header is 16 or 32 lowercase hexadecimal characters (corresponding to 64 or 128 bits, respectively)
- https://zipkin.io/pages/instrumenting.html#:~:text=Ids%20are%20encoded%20as%20hex,strings
- https://github.com/openzipkin/b3-propagation?tab=readme-ov-file#traceid-1

We need to convert the trace_id and span_id formats stored in the variables.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #12271

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
