### PR TITLE
revert: fix: forward-auth request body too large

### DIFF
--- a/apisix/plugins/forward-auth.lua
+++ b/apisix/plugins/forward-auth.lua
@@ -118,23 +118,17 @@ function _M.access(conf, ctx)
         method = conf.request_method
     }
 
-    local httpc = http.new()
-    httpc:set_timeout(conf.timeout)
     if params.method == "POST" then
-        local client_body_reader, err = httpc:get_client_body_reader()
-        if client_body_reader then
-            params.body = client_body_reader
-        else
-            core.log.warn("failed to get client_body_reader. err: ", err,
-            " using core.request.get_body() instead")
-            params.body = core.request.get_body()
-        end
+        params.body = core.request.get_body()
     end
 
     if conf.keepalive then
         params.keepalive_timeout = conf.keepalive_timeout
         params.keepalive_pool = conf.keepalive_pool
     end
+
+    local httpc = http.new()
+    httpc:set_timeout(conf.timeout)
 
     local res, err = httpc:request_uri(conf.uri, params)
     if not res and conf.allow_degradation then


### PR DESCRIPTION
### Description
This PR https://github.com/apache/apisix/pull/10589/files, introduced a bug due to which the request body is emptied after being read by the auth service and the upstream doesn't receive the request body. Therefore, this PR needs to be reverted.

The new solution after this revert is accepted will be:
Do not pass the whole request body to the auth service and extract data from body into headers and then forward to the auth service. The headers to be extracted will be specified with a new field: `extra_headers`

Fixes https://github.com/apache/apisix/issues/11200

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
