### PR TITLE
fix: flaky test due to slow network on npm

### DIFF
--- a/t/plugin/mcp-bridge.t
+++ b/t/plugin/mcp-bridge.t
@@ -98,3 +98,4 @@ cd t/plugin/mcp && pnpm test 2>&1
 failed to execute the script with status
 --- response_body eval
 qr/PASS .\/bridge.spec.ts/
+--- timeout: 10


### PR DESCRIPTION
### Description

This test is consistently failing on master. https://github.com/apache/apisix/actions/runs/16110621443/job/45453229725
The npx command always loads dependencies from [npmjs.org](http://npmjs.org/), and if the network is blocked, the time taken for this test will exceed expectations.
The PR adds a timeout. 

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
