### PR TITLE
fix(opentelemetry): remove plugin attr set_ngx_var

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -740,11 +740,9 @@ http {
         {% end %}
 
         # opentelemetry_set_ngx_var starts
-        {% if opentelemetry_set_ngx_var then %}
         set $opentelemetry_context_traceparent          '';
         set $opentelemetry_trace_id                     '';
         set $opentelemetry_span_id                      '';
-        {% end %}
         # opentelemetry_set_ngx_var ends
 
         # zipkin_set_ngx_var starts

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -550,11 +550,6 @@ Please modify "admin_key" in conf/config.yaml .
         end
     end
 
-    local opentelemetry_set_ngx_var
-    if enabled_plugins["opentelemetry"] and yaml_conf.plugin_attr["opentelemetry"] then
-        opentelemetry_set_ngx_var = yaml_conf.plugin_attr["opentelemetry"].set_ngx_var
-    end
-
     local zipkin_set_ngx_var
     if enabled_plugins["zipkin"] and yaml_conf.plugin_attr["zipkin"] then
         zipkin_set_ngx_var = yaml_conf.plugin_attr["zipkin"].set_ngx_var
@@ -581,7 +576,6 @@ Please modify "admin_key" in conf/config.yaml .
         control_server_addr = control_server_addr,
         prometheus_server_addr = prometheus_server_addr,
         proxy_mirror_timeouts = proxy_mirror_timeouts,
-        opentelemetry_set_ngx_var = opentelemetry_set_ngx_var,
         zipkin_set_ngx_var = zipkin_set_ngx_var
     }
 

--- a/docs/en/latest/plugins/opentelemetry.md
+++ b/docs/en/latest/plugins/opentelemetry.md
@@ -198,7 +198,16 @@ The following example demonstrates how to configure the `opentelemetry` Plugin t
 - `opentelemetry_trace_id`: trace ID of the current span
 - `opentelemetry_span_id`: span ID of the current span
 
-Update the configuration file as below. You should customize the access log format to use the `opentelemetry` Plugin variables, and set `opentelemetry` variables in the `set_ngx_var` field.
+Configure the plugin metadata to set `set_ngx_var` as true:
+
+```shell
+curl http://127.0.0.1:9180/apisix/admin/plugin_metadata/opentelemetry -H "X-API-KEY: $admin_key" -X PUT -d '
+{
+    "set_ngx_var": true
+}'
+```
+
+Update the configuration file as below. You should customize the access log format to use the `opentelemetry` Plugin variables.
 
 ```yaml title="conf/config.yaml"
 nginx_config:
@@ -206,9 +215,6 @@ nginx_config:
     enable_access_log: true
     access_log_format: '{"time": "$time_iso8601","opentelemetry_context_traceparent": "$opentelemetry_context_traceparent","opentelemetry_trace_id": "$opentelemetry_trace_id","opentelemetry_span_id": "$opentelemetry_span_id","remote_addr": "$remote_addr"}'
     access_log_format_escape: json
-plugin_attr:
-  opentelemetry:
-    set_ngx_var: true
 ```
 
 Reload APISIX for configuration changes to take effect.

--- a/docs/zh/latest/plugins/opentelemetry.md
+++ b/docs/zh/latest/plugins/opentelemetry.md
@@ -197,6 +197,15 @@ Attributes:
 - `opentelemetry_trace_id`: 当前 span 的 trace_id
 - `opentelemetry_span_id`: 当前 span 的 span_id
 
+配置插件元数据以将 `set_ngx_var` 设置为 true：
+
+```shell
+curl http://127.0.0.1:9180/apisix/admin/plugin_metadata/opentelemetry -H "X-API-KEY: $admin_key" -X PUT -d '
+{
+    "set_ngx_var": true
+}'
+```
+
 如下更新配置文件。你应该自定义访问日志格式以使用 `opentelemetry` 插件变量，并在 `set_ngx_var` 字段中设置 `opentelemetry` 变量。
 
 ```yaml title="conf/config.yaml"
@@ -205,9 +214,6 @@ nginx_config:
     enable_access_log: true
     access_log_format: '{"time": "$time_iso8601","opentelemetry_context_traceparent": "$opentelemetry_context_traceparent","opentelemetry_trace_id": "$opentelemetry_trace_id","opentelemetry_span_id": "$opentelemetry_span_id","remote_addr": "$remote_addr"}'
     access_log_format_escape: json
-plugin_attr:
-  opentelemetry:
-    set_ngx_var: true
 ```
 
 重新加载 APISIX 以使配置更改生效。


### PR DESCRIPTION
### Description

We changed the attribute of the Opentelemetry plugin to metadata in PR https://github.com/apache/apisix/pull/11940. After that, users can set the `set_ngx_var` property in metadata. However, the generated template file still relies on the `set_ngx_var` property from the plugin attribute to predefine variables https://github.com/apache/apisix/blob/master/apisix/cli/ops.lua#L553-L556, which will confuse users. This PR removes this judgment and allows this property to be controlled in metadata only.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #12402

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
