### PR TITLE
fix(consumer): missed consumer update due to wrong version in cache

### DIFF
--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -128,7 +128,8 @@ function plugin_consumer()
                     local consumer_name = get_consumer_name_from_credential_etcd_key(val.key)
                     local the_consumer = consumers:get(consumer_name)
                     if the_consumer and the_consumer.value then
-                        consumer = consumers_id_lrucache(val.key, val.modifiedIndex..the_consumer.modifiedIndex,
+                        consumer = consumers_id_lrucache(val.key, val.modifiedIndex..
+                                                         the_consumer.modifiedIndex,
                             function (val, the_consumer)
                                 consumer = core.table.clone(the_consumer.value)
                                 consumer.modifiedIndex = the_consumer.modifiedIndex

--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -171,7 +171,9 @@ function plugin_consumer()
                     goto CONTINUE
                 end
                 core.log.info("consumer:", core.json.delay_encode(consumer))
-                core.table.insert(plugins[name].nodes, consumer)
+                plugins[name].len = plugins[name].len + 1
+                core.table.insert(plugins[name].nodes, plugins[name].len,
+                                    consumer)
             end
         end
 

--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -170,6 +170,7 @@ function plugin_consumer()
                                    name, ": ", err)
                     goto CONTINUE
                 end
+
                 plugins[name].len = plugins[name].len + 1
                 core.table.insert(plugins[name].nodes, plugins[name].len,
                                     consumer)

--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -128,7 +128,7 @@ function plugin_consumer()
                     local consumer_name = get_consumer_name_from_credential_etcd_key(val.key)
                     local the_consumer = consumers:get(consumer_name)
                     if the_consumer and the_consumer.value then
-                        consumer = consumers_id_lrucache(the_consumer.value, val.modifiedIndex..the_consumer.modifiedIndex,
+                        consumer = consumers_id_lrucache(val.value.id .. name, val.modifiedIndex..the_consumer.modifiedIndex,
                             function (val, the_consumer)
                                 consumer = core.table.clone(the_consumer.value)
                                 consumer.modifiedIndex = the_consumer.modifiedIndex
@@ -144,7 +144,7 @@ function plugin_consumer()
                         goto CONTINUE
                     end
                 else
-                    consumer = consumers_id_lrucache(val.value, val.modifiedIndex,
+                    consumer = consumers_id_lrucache(val.value.id .. name, val.modifiedIndex,
                         function ()
                             consumer = core.table.clone(val.value)
                             consumer.modifiedIndex = val.modifiedIndex

--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -95,24 +95,6 @@ do
         })
 
 
-local function get_cache_version_and_consumer(val)
-    -- if the val is a Consumer, clone it to the local consumer;
-    -- if the val is a Credential, to get the Consumer by consumer_name and then clone
-    -- it to the local consumer.
-    if is_credential_etcd_key(val.key) then
-        local consumer_name = get_consumer_name_from_credential_etcd_key(val.key)
-        local the_consumer = consumers:get(consumer_name)
-        if not the_consumer or not the_consumer.value then
-            core.log.error("failed to get the consumer for the credential,",
-                " a wild credential has appeared!",
-                " credential key: ", val.key, ", consumer name: ", consumer_name)
-            return nil, nil, "failed to get the consumer for the credential"
-        end
-        return val.modifiedIndex + the_consumer.modifiedIndex, the_consumer, true
-    end
-    return val.modifiedIndex, val, false
-end
-
 local function construct_consumer_data(val, is_credential, the_consumer)
     local consumer
     if is_credential then

--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -128,7 +128,7 @@ function plugin_consumer()
                     local consumer_name = get_consumer_name_from_credential_etcd_key(val.key)
                     local the_consumer = consumers:get(consumer_name)
                     if the_consumer and the_consumer.value then
-                        consumer = consumers_id_lrucache(the_consumer.value, val.modifiedIndex+the_consumer.modifiedIndex,
+                        consumer = consumers_id_lrucache(the_consumer.value, val.modifiedIndex..the_consumer.modifiedIndex,
                             function (val, the_consumer)
                                 consumer = core.table.clone(the_consumer.value)
                                 consumer.modifiedIndex = the_consumer.modifiedIndex

--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -128,7 +128,7 @@ function plugin_consumer()
                     local consumer_name = get_consumer_name_from_credential_etcd_key(val.key)
                     local the_consumer = consumers:get(consumer_name)
                     if the_consumer and the_consumer.value then
-                        consumer = consumers_id_lrucache(val.key, val.modifiedIndex..
+                        consumer = consumers_id_lrucache(val.value.id .. name, val.modifiedIndex..
                                                          the_consumer.modifiedIndex,
                             function (val, the_consumer)
                                 consumer = core.table.clone(the_consumer.value)
@@ -145,7 +145,7 @@ function plugin_consumer()
                         goto CONTINUE
                     end
                 else
-                    consumer = consumers_id_lrucache(val.key, val.modifiedIndex,
+                    consumer = consumers_id_lrucache(val.value.id .. name, val.modifiedIndex,
                         function (val)
                             consumer = core.table.clone(val.value)
                             consumer.modifiedIndex = val.modifiedIndex

--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -94,7 +94,7 @@ do
             count = consumers_count_for_lrucache
         })
 
-local function construct_consumer_data(val, name, config)
+local function construct_consumer_data(val, name, plugin_config)
     -- if the val is a Consumer, clone it to the local consumer;
     -- if the val is a Credential, to get the Consumer by consumer_name and then clone
     -- it to the local consumer.
@@ -126,15 +126,18 @@ local function construct_consumer_data(val, name, config)
                 return consumer
             end, val)
     end
+
     -- if the consumer has labels, set the field custom_id to it.
     -- the custom_id is used to set in the request headers to the upstream.
     if consumer.labels then
         consumer.custom_id = consumer.labels["custom_id"]
     end
+
     -- Note: the id here is the key of consumer data, which
     -- is 'username' field in admin
     consumer.consumer_name = consumer.id
-    consumer.auth_conf = config
+    consumer.auth_conf = plugin_config
+
     return consumer
 end
 

--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -128,7 +128,7 @@ function plugin_consumer()
                     local consumer_name = get_consumer_name_from_credential_etcd_key(val.key)
                     local the_consumer = consumers:get(consumer_name)
                     if the_consumer and the_consumer.value then
-                        consumer = consumers_id_lrucache(val.value.id .. name, val.modifiedIndex..the_consumer.modifiedIndex,
+                        consumer = consumers_id_lrucache(val.key, val.modifiedIndex..the_consumer.modifiedIndex,
                             function (val, the_consumer)
                                 consumer = core.table.clone(the_consumer.value)
                                 consumer.modifiedIndex = the_consumer.modifiedIndex
@@ -144,7 +144,7 @@ function plugin_consumer()
                         goto CONTINUE
                     end
                 else
-                    consumer = consumers_id_lrucache(val.value.id .. name, val.modifiedIndex,
+                    consumer = consumers_id_lrucache(val.key, val.modifiedIndex,
                         function ()
                             consumer = core.table.clone(val.value)
                             consumer.modifiedIndex = val.modifiedIndex

--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -159,9 +159,18 @@ function plugin_consumer()
                         conf_version = consumers.conf_version
                     }
                 end
-
-                local consumer = consumers_id_lrucache(val.value.id .. name,
-                        val.modifiedIndex, construct_consumer_data, val, config)
+                local consumer
+                if is_credential_etcd_key(val.key) then
+                    local consumer_name = get_consumer_name_from_credential_etcd_key(val.key)
+                    local the_consumer = consumers:get(consumer_name)
+                    if the_consumer then
+                        consumer = consumers_id_lrucache(val.value.id .. name,
+                                        val.modifiedIndex+the_consumer.modifiedIndex, construct_consumer_data, val, config)
+                    end
+                else
+                    consumer = consumers_id_lrucache(val.value.id .. name,
+                                    val.modifiedIndex, construct_consumer_data, val, config)
+                end
                 if consumer == nil then
                     goto CONTINUE
                 end

--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -170,10 +170,10 @@ function plugin_consumer()
                                    name, ": ", err)
                     goto CONTINUE
                 end
-                core.log.info("consumer:", core.json.delay_encode(consumer))
                 plugins[name].len = plugins[name].len + 1
                 core.table.insert(plugins[name].nodes, plugins[name].len,
                                     consumer)
+                core.log.info("consumer:", core.json.delay_encode(consumer))
             end
         end
 

--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -141,6 +141,7 @@ local function construct_consumer_data(val, name, plugin_config)
     return consumer
 end
 
+
 function plugin_consumer()
     local plugins = {}
 

--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -146,7 +146,7 @@ function plugin_consumer()
                     end
                 else
                     consumer = consumers_id_lrucache(val.key, val.modifiedIndex,
-                        function ()
+                        function (val)
                             consumer = core.table.clone(val.value)
                             consumer.modifiedIndex = val.modifiedIndex
                             return consumer

--- a/t/admin/consumer-credentials.t
+++ b/t/admin/consumer-credentials.t
@@ -1,0 +1,165 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+log_level("info");
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: Verify consumer plugin update takes effect immediately
+--- extra_yaml_config
+nginx_config:
+  worker_processes: 1
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local json = require("toolkit.json")
+            local http = require("resty.http")
+
+            -- 1. Create route with key-auth plugin
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/anything",
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "httpbin.org:80": 1
+                        }
+                    },
+                    "plugins": {
+                        "key-auth": {
+                            "query": "apikey"
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say("Route creation failed: " .. body)
+                return
+            end
+
+            -- 2. Create consumer jack
+            code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say("Consumer creation failed: " .. body)
+                return
+            end
+
+            -- 3. Create credentials for jack
+            code, body = t('/apisix/admin/consumers/jack/credentials/auth-one',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "key-auth": {
+                            "key": "auth-one"
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say("Credential creation failed: " .. body)
+                return
+            end
+            ngx.sleep(0.5)  -- wait for etcd to sync
+            -- 4. Verify valid request succeeds
+            local httpc = http.new()
+            local res, err = httpc:request_uri(
+                "http://127.0.0.1:"..ngx.var.server_port.."/anything?apikey=auth-one",
+                { method = "GET" }
+            )
+            if not res then
+                ngx.say("Request failed: ", err)
+                return
+            end
+            
+            if res.status ~= 200 then
+                ngx.say("Unexpected status: ", res.status)
+                ngx.say(res.body)
+                return
+            end
+
+            -- 5. Update consumer with fault-injection plugin
+            code, body = t('/apisix/admin/consumers/jack',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack",
+                    "plugins": {
+                        "fault-injection": {
+                            "abort": {
+                                "http_status": 400,
+                                "body": "abort"
+                            }
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say("Consumer update failed: " .. body)
+                return
+            end
+
+            -- 6. Verify all requests return 400
+            for i = 1, 5 do
+                local res, err = httpc:request_uri(
+                    "http://127.0.0.1:"..ngx.var.server_port.."/anything?apikey=auth-one",
+                    { method = "GET" }
+                )
+                if not res then
+                    ngx.say(i, ": Request failed: ", err)
+                    return
+                end
+                
+                if res.status ~= 400 then
+                    ngx.say(i, ": Expected 400 but got ", res.status)
+                    return
+                end
+                
+                if res.body ~= "abort" then
+                    ngx.say(i, ": Unexpected response body: ", res.body)
+                    return
+                end
+            end
+
+            ngx.say("All requests aborted as expected")
+        }
+    }
+--- request
+GET /t
+--- response_body
+All requests aborted as expected
+--- error_log
+--- no_error_log
+[error]
+[alert]

--- a/t/admin/consumer-credentials.t
+++ b/t/admin/consumer-credentials.t
@@ -102,7 +102,7 @@ nginx_config:
                 ngx.say("Request failed: ", err)
                 return
             end
-            
+
             if res.status ~= 200 then
                 ngx.say("Unexpected status: ", res.status)
                 ngx.say(res.body)
@@ -140,12 +140,12 @@ nginx_config:
                     ngx.say(i, ": Request failed: ", err)
                     return
                 end
-                
+
                 if res.status ~= 400 then
                     ngx.say(i, ": Expected 400 but got ", res.status)
                     return
                 end
-                
+
                 if res.body ~= "abort" then
                     ngx.say(i, ": Unexpected response body: ", res.body)
                     return

--- a/t/admin/consumer-credentials.t
+++ b/t/admin/consumer-credentials.t
@@ -159,7 +159,3 @@ nginx_config:
 GET /t
 --- response_body
 All requests aborted as expected
---- error_log
---- no_error_log
-[error]
-[alert]


### PR DESCRIPTION
### Description
Fixes https://github.com/apache/apisix/issues/12393
This PR introduced a critical bug https://github.com/apache/apisix/pull/11840 due to which consumers are not updated  until a subsequent update in credentials due to credential version being used even for checking consumer update.

More context on this comment: https://github.com/apache/apisix/pull/11840/files#r2193898420

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
