### PR TITLE
fix(standalone): lack of configuration validation in api

### DIFF
--- a/apisix/admin/stream_routes.lua
+++ b/apisix/admin/stream_routes.lua
@@ -19,14 +19,14 @@ local resource = require("apisix.admin.resource")
 local stream_route_checker = require("apisix.stream.router.ip_port").stream_route_checker
 
 
-local function check_conf(id, conf, need_id, schema)
+local function check_conf(id, conf, need_id, schema, skip_etcd_check)
     local ok, err = core.schema.check(schema, conf)
     if not ok then
         return nil, {error_msg = "invalid configuration: " .. err}
     end
 
     local upstream_id = conf.upstream_id
-    if upstream_id then
+    if upstream_id and not skip_etcd_check then
         local key = "/upstreams/" .. upstream_id
         local res, err = core.etcd.get(key)
         if not res then
@@ -43,7 +43,7 @@ local function check_conf(id, conf, need_id, schema)
     end
 
     local service_id = conf.service_id
-    if service_id then
+    if service_id and not skip_etcd_check then
         local key = "/services/" .. service_id
         local res, err = core.etcd.get(key)
         if not res then
@@ -72,7 +72,12 @@ return resource.new({
     name = "stream_routes",
     kind = "stream route",
     schema = core.schema.stream_route,
-    checker = check_conf,
+    checker = function (id, conf, need_id, schema)
+        return check_conf(id, conf, need_id, schema)
+    end,
+    standalone_checker = function (id, conf, need_id, schema)
+        return check_conf(id, conf, need_id, schema, true)
+    end,
     unsupported_methods = { "patch" },
     list_filter_fields = {
         service_id = true,


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

#### Which issue(s) this PR fixes:

In standalone mode, the lack of code validation related to admin API results in incorrect configurations being able to pass validation, as shown in the following example:
* Invalid plugin
* route/service with invalid upstream

##### When configuring an invalid upstream:


**Expect:**
```bash
curl "http://127.0.0.1:9180/apisix/admin/configs" -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -v -d '{
    "routes": [
        {
            "id": "r1",
            "uri": "/r2",
            "upstream": {
                "type": "chash",
                "nodes": {
                    "127.0.0.1:1980": 1
                },
                "hash_on": "vars",
                "key": "args_abc"
            }
        }
    ]
}'

< HTTP/1.1 400 Bad Request
< Server: APISIX/3.13.0
< 
{"error_msg":"invalid configuration: failed to match pattern \"^((uri|server_name|server_addr|request_uri|remote_port|remote_addr|query_string|host|hostname|mqtt_client_id)|arg_[0-9a-zA-z_-]+)$\" with \"args_abc\""}
```

**Actual:**
```
curl "http://127.0.0.1:9180/apisix/admin/configs" -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -v -d '{
    "routes": [
        {
            "id": "r1",
            "uri": "/r2",
            "upstream": {
                "type": "chash",
                "nodes": {
                    "127.0.0.1:1980": 1
                },
                "hash_on": "vars",
                "key": "args_abc"
            }
        }
    ]
}'
> 
< HTTP/1.1 202 Accepted
< Server: APISIX/3.13.0
< 
```


##### When configuring an invalid plugin

**Actual:**

```bash
 curl "http://127.0.0.1:9180/apisix/admin/configs" -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -v -X PUT -d '{
    "routes": [
        {
            "id": "r1",
            "uri": "/r2",
            "upstream": {
                "type": "chash",
                "nodes": {
                    "127.0.0.1:1980": 1
                },
                "hash_on": "vars",
                "key": "arg_abc"
            },
            "plugins": {
                "proxy-rewrite234": {
                    "uri": "/hello"
                }
            }
        }
    ]
}'
>
< HTTP/1.1 202 Accepted
< Server: APISIX/3.13.0
<
```

**Expect:**

```bash
curl "http://127.0.0.1:9180/apisix/admin/configs" -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '{
    "routes": [
        {
            "id": "r1",
            "uri": "/r2",
            "upstream": {
                "type": "chash",
                "nodes": {
                    "127.0.0.1:1980": 1
                },
                "hash_on": "vars",
                "key": "args_abc"
            },
            "plugins": {
                "proxy-rewrite234": {
                    "uri": "/hello"
                }
            }
        }
    ]
}'
>
< HTTP/1.1 400 Bad Request
< Server: APISIX/3.13.0
< 
{"error_msg":"unknown plugin [proxy-rewrite234]"}
```

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
