### PR TITLE
fix(forward-auth): extra_headers not resolving variable on $post_arg.

### DIFF
--- a/apisix/core/utils.lua
+++ b/apisix/core/utils.lua
@@ -295,7 +295,7 @@ local resolve_var
 do
     local _ctx
     local n_resolved
-    local pat = [[(?<!\\)\$(\{(\w+)\}|(\w+))]]
+    local pat = [[(?<!\\)\$(\{([\w\.]+)\}|([\w\.]+))]]
     local _escaper
 
     local function resolve(m)

--- a/apisix/plugins/forward-auth.lua
+++ b/apisix/plugins/forward-auth.lua
@@ -21,7 +21,6 @@ local http     = require("resty.http")
 local pairs    = pairs
 local type     = type
 local tostring = tostring
-local sub_str  = string.sub
 
 local schema = {
     type = "object",
@@ -125,19 +124,13 @@ function _M.access(conf, ctx)
             if type(value) == "number" then
                 value = tostring(value)
             end
-            if core.string.has_prefix(value, "$") then
-                -- If the value starts with a dollar sign, treat it as a variable
-                -- and resolve it from the context.
-                local sub_str_len = #value - 1  -- Exclude the dollar sign
-                if sub_str_len > 0 then
-                    local trimmed_value = sub_str(value, 2)  -- Remove the dollar sign
-                    local resolve_value = ctx.var[trimmed_value]
-                    if resolve_value then
-                        auth_headers[header] = resolve_value
-                    end
-                end
-            else
-                auth_headers[header] = value
+            local resolve_value, err = core.utils.resolve_var(value, ctx.var)
+            if not err then
+                auth_headers[header] = resolve_value
+            end
+            if err then
+                core.log.error("failed to resolve variable in extra header '",
+                                header, "': ",value,": ",err)
             end
         end
     end

--- a/docs/en/latest/plugins/forward-auth.md
+++ b/docs/en/latest/plugins/forward-auth.md
@@ -173,7 +173,7 @@ Location: http://example.com/auth
 When the decision is to be made on the basis of POST body, then it is recommended to use `$post_arg.*` with `extra_headers` field and make the decision on Authorization service on basis of headers rather than using POST `request_method` to pass the entire request body to Authorization service.
 :::
 
-Create a serverless function on the `/auth` route that checks for the presence of the `tenant_id` header and confirms its value. If present, the route responds with HTTP 200 and sets the `X-User-ID` header to a fixed value `i-am-an-user`. If `tenant_id` is missing, it returns HTTP 400 with an error message.
+Create a serverless function on the `/auth` route that checks for the presence of the `tenant_id` header and confirms its value. If present, the route responds with HTTP 200.. If `tenant_id` is missing, it returns HTTP 400 with an error message.
 
 ```shell
 curl -X PUT 'http://127.0.0.1:9180/apisix/admin/routes/auth' \

--- a/docs/zh/latest/plugins/forward-auth.md
+++ b/docs/zh/latest/plugins/forward-auth.md
@@ -203,7 +203,7 @@ curl -X PUT 'http://127.0.0.1:9180/apisix/admin/routes/auth' \
 }'
 ```
 
-创建一个接受 POST 请求的路由，并使用“forward-auth”插件通过请求中的“tenant_id”调用身份验证端点。仅当身份验证检查返回 200 时，请求才会转发到上游服务。
+创建一个接受 POST 请求的路由，并使用 `forward-auth` 插件通过请求中的 `tenant_id` 调用身份验证端点。仅当身份验证检查返回 200 时，请求才会转发到上游服务。
 
 ```shell
 curl -X PUT 'http://127.0.0.1:9180/apisix/admin/routes/1' \

--- a/docs/zh/latest/plugins/forward-auth.md
+++ b/docs/zh/latest/plugins/forward-auth.md
@@ -189,11 +189,12 @@ curl -X PUT 'http://127.0.0.1:9180/apisix/admin/routes/auth' \
             "functions": [
                 "return function(conf, ctx)
                  local core = require(\"apisix.core\")
-                 if core.request.header(ctx, \"tenant_id\") then
+                 local tenant_id = core.request.header(ctx, \"tenant_id\")
+                 if tenant_id == \"123\" then
                      core.response.set_header(\"X-User-ID\", \"i-am-an-user\");
                      core.response.exit(200);
                 else
-                    core.response.exit(400, \"tenant_id is required\")
+                    core.response.exit(400, \"tenant_id is \"..tenant_id .. \" but expected 123\");
                 end
             end"
             ]
@@ -202,7 +203,7 @@ curl -X PUT 'http://127.0.0.1:9180/apisix/admin/routes/auth' \
 }'
 ```
 
-创建一个接受 POST 请求的路由，并使用 `forward-auth` 插件通过请求中的 `tenant_id` 调用身份验证端点。只有当身份验证检查返回 200 时，请求才会转发到上游服务。
+创建一个接受 POST 请求的路由，并使用“forward-auth”插件通过请求中的“tenant_id”调用身份验证端点。仅当身份验证检查返回 200 时，请求才会转发到上游服务。
 
 ```shell
 curl -X PUT 'http://127.0.0.1:9180/apisix/admin/routes/1' \
@@ -229,8 +230,8 @@ curl -X PUT 'http://127.0.0.1:9180/apisix/admin/routes/1' \
 发送带有 `tenant_id` 标头的 POST 请求：
 
 ```shell
-curl -i http://127.0.0.1:9080/post -X POST -d '{
-   "tenant_id": 123
+curl -i http://127.0.0.1:9080/post -H "Content-Type: application/json" -X POST -d '{
+   "tenant_id": "123"
 }'
 ```
 
@@ -239,38 +240,38 @@ curl -i http://127.0.0.1:9080/post -X POST -d '{
 ```json
 {
   "args": {},
-  "data": "",
+  "data": "{\n   \"tenant_id\": \"123\"\n}",
   "files": {},
-  "form": {
-    "{\n   \"tenant_id\": 123\n}": ""
-  },
+  "form": {},
   "headers": {
     "Accept": "*/*",
-    "Content-Length": "23",
-    "Content-Type": "application/x-www-form-urlencoded",
+    "Content-Length": "25",
+    "Content-Type": "application/json",
     "Host": "127.0.0.1",
     "User-Agent": "curl/8.13.0",
-    "X-Amzn-Trace-Id": "Root=1-686b6e3f-2fdeff70183e71551f5c5729",
+    "X-Amzn-Trace-Id": "Root=1-687775d8-6890073173b30c2834901e8b",
     "X-Forwarded-Host": "127.0.0.1"
   },
-  "json": null,
-  "origin": "127.0.0.1, 106.215.83.33",
+  "json": {
+    "tenant_id": "123"
+  },
+  "origin": "127.0.0.1, 106.215.82.114",
   "url": "http://127.0.0.1/post"
 }
 ```
 
-发送不带 `tenant_id` 标头的 POST 请求：
+发送带有错误 `tenant_id` 标头的 POST 请求：
 
 ```shell
- curl -i http://127.0.0.1:9080/post -X POST -d '{
-   "abc": 123
+curl -i http://127.0.0.1:9080/post -H "Content-Type: application/json" -X POST -d '{
+   "tenant_id": "asdfasd"
 }'
 ```
 
 您应该收到包含以下消息的 `HTTP/1.1 400 Bad Request` 响应：
 
 ```shell
-tenant_id is required
+tenant_id is asdfasd but expected 123
 ```
 
 ## 删除插件

--- a/t/plugin/forward-auth.t
+++ b/t/plugin/forward-auth.t
@@ -112,11 +112,24 @@ property "request_method" validation failed: matches none of the enum values
                                     [[return function(conf, ctx)
                                         local core = require("apisix.core");
                                         if core.request.header(ctx, "Authorization") == "777" then
-                                            if core.request.header(ctx, "tenant_id") then
+                                            local tenant_id = core.request.header(ctx, "tenant_id")
+                                            if tenant_id == "123" then
                                                 core.response.set_header("X-User-ID", "i-am-an-user");
                                                 core.response.exit(200);
                                             else
-                                                core.response.exit(400, "tenant_id is required");
+                                                core.response.exit(400, "tenant_id is "..tenant_id);
+                                            end
+                                        end
+                                    end]],
+                                    [[return function(conf, ctx)
+                                        local core = require("apisix.core");
+                                        if core.request.header(ctx, "Authorization") == "888" then
+                                            local tenant_id = core.request.header(ctx, "tenant_id")
+                                            if tenant_id == "abcd" then
+                                                core.response.set_header("X-User-ID", "i-am-an-user");
+                                                core.response.exit(200);
+                                            else
+                                                core.response.exit(400, "tenant_id is "..tenant_id);
                                             end
                                         end
                                     end]],
@@ -463,6 +476,7 @@ POST /ping2
 {"tenant_id": 123}
 --- more_headers
 Authorization: 777
+Content-Type: application/json
 --- response_body_like eval
 qr/\"x-user-id\":\"i-am-an-user\"/
 
@@ -472,6 +486,6 @@ qr/\"x-user-id\":\"i-am-an-user\"/
 --- request
 GET /ping3
 --- more_headers
-Authorization: 777
+Authorization: 888
 --- response_body_like eval
 qr/\"x-user-id\":\"i-am-an-user\"/


### PR DESCRIPTION
The existing regex in util.resolve_var doesn't handle all the variable cases properly. For eg: when passed with $post_arg.xyz, it fails to resolve the variable. So regex is being modified to support the aforementioned key.

This was not caught previously because the test cases didn't assert the values properly.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
