### PR TITLE
Feat/openid foward original id token

### DIFF
--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -176,8 +176,8 @@ local schema = {
             type = "boolean",
             default = true
         },
-        set_id_token_encoded_header = {
-            description = "Whether the encoded ID token should be added in the X-ID-Token-Encoded header to " ..
+        set_original_id_token_header = {
+            description = "Whether the ID token should be added in the X-ID-Token-Original header to " ..
                 "the request for downstream.",
             type = "boolean",
             default = true
@@ -697,14 +697,9 @@ function _M.rewrite(plugin_conf, ctx)
             add_access_token_header(ctx, conf, response.access_token)
 
             -- Add X-ID-Token header, maybe.
-            if response.id_token and conf.set_id_token_header then
-                local token = core.json.encode(response.id_token)
-                core.request.set_header(ctx, "X-ID-Token", ngx.encode_base64(token))
-            end
-
-            -- Add X-ID-Token-Encoded header, maybe.
-            if session.data.id_token_enc and conf.set_id_token_encoded_header then
-                core.request.set_header(ctx, "X-ID-Token-Encoded", session.data.id_token_enc)
+            if session and session.data and session.data.enc_id_token and conf.set_original_id_token_header then
+                local token = session.data.enc_id_token
+                core.request.set_header(ctx, "X-ID-Token-Original", token)
             end
 
             -- Add X-Userinfo header, maybe.

--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -176,6 +176,12 @@ local schema = {
             type = "boolean",
             default = true
         },
+        set_id_token_encoded_header = {
+            description = "Whether the encoded ID token should be added in the X-ID-Token-Encoded header to " ..
+                "the request for downstream.",
+            type = "boolean",
+            default = true
+        },
         set_userinfo_header = {
             description = "Whether the user info token should be added in the X-Userinfo " ..
                 "header to the request for downstream.",
@@ -694,6 +700,11 @@ function _M.rewrite(plugin_conf, ctx)
             if response.id_token and conf.set_id_token_header then
                 local token = core.json.encode(response.id_token)
                 core.request.set_header(ctx, "X-ID-Token", ngx.encode_base64(token))
+            end
+
+            -- Add X-ID-Token-Encoded header, maybe.
+            if session.data.id_token_enc and conf.set_id_token_encoded_header then
+                core.request.set_header(ctx, "X-ID-Token-Encoded", session.data.id_token_enc)
             end
 
             -- Add X-Userinfo header, maybe.


### PR DESCRIPTION
### Description

Issue: https://github.com/apache/apisix/issues/10275
Summary: add a config option "set original id token header" so that the original id_token that was stored in the sesssion (enc_id_token) gets fowarded as the new header "X-Id-Token-Original".

In my company, we have a use case, where the donwstream needs the original id_token so that it can perform a token exchange.

#### Which issue(s) this PR fixes:
Fixes #10275

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
