### PR TITLE
fix: skipped failing bailedout tests in CI

### DIFF
--- a/apisix/plugins/ai-drivers/openai-base.lua
+++ b/apisix/plugins/ai-drivers/openai-base.lua
@@ -170,7 +170,7 @@ function _M.request(self, ctx, conf, request_table, extra_opts)
     end
     httpc:set_timeout(conf.timeout)
 
-    local endpoint = extra_opts.endpoint
+    local endpoint = extra_opts and extra_opts.endpoint
     local parsed_url
     if endpoint then
         parsed_url = url.parse(endpoint)

--- a/apisix/plugins/ai-request-rewrite.lua
+++ b/apisix/plugins/ai-request-rewrite.lua
@@ -129,8 +129,7 @@ local function request_to_llm(conf, request_table, ctx)
         model_options = conf.options
     }
 
-    local code, body = ai_driver:request(ctx, conf, request_table, extra_opts)
-    return code, body
+    return ai_driver:request(ctx, conf, request_table, extra_opts)
 end
 
 

--- a/apisix/plugins/chaitin-waf.lua
+++ b/apisix/plugins/chaitin-waf.lua
@@ -271,7 +271,7 @@ end
 
 local function get_conf(conf, metadata)
     local t = {
-        mode = "block",
+        mode = "monitor",
         real_client_ip = true,
     }
 
@@ -326,7 +326,7 @@ local function do_access(conf, ctx)
 
     extra_headers[HEADER_CHAITIN_WAF_SERVER] = host
 
-    local mode = t.mode or "block"
+    local mode = t.mode or "monitor"
     if mode == "off" then
         extra_headers[HEADER_CHAITIN_WAF] = "off"
         return nil, nil, extra_headers

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -68,7 +68,7 @@ rerun_flaky_tests() {
 
 fail_on_bailout() {
     local test_output_file="$1"
-    
+
     # Check for bailout message in test output
     if grep -q "Bailout called.  Further testing stopped:" "$test_output_file"; then
         echo "Error: Bailout detected in test output"

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -66,6 +66,15 @@ rerun_flaky_tests() {
     FLUSH_ETCD=1 prove --timer -I./test-nginx/lib -I./ $(echo "$tests" | xargs)
 }
 
+fail_on_bailout() {
+    local test_output_file="$1"
+    
+    # Check for bailout message in test output
+    if grep -q "Bailout called.  Further testing stopped:" "$test_output_file"; then
+        echo "Error: Bailout detected in test output"
+        exit 1
+    fi
+}
 install_curl () {
     CURL_VERSION="8.13.0"
     wget -q https://github.com/stunnel/static-curl/releases/download/${CURL_VERSION}/curl-linux-x86_64-glibc-${CURL_VERSION}.tar.xz

--- a/ci/linux_openresty_common_runner.sh
+++ b/ci/linux_openresty_common_runner.sh
@@ -99,6 +99,7 @@ script() {
 
     # APISIX_ENABLE_LUACOV=1 PERL5LIB=.:$PERL5LIB prove -Itest-nginx/lib -r t
     FLUSH_ETCD=1 TEST_EVENTS_MODULE=$TEST_EVENTS_MODULE prove --timer -Itest-nginx/lib -I./ -r $TEST_FILE_SUB_DIR | tee /tmp/test.result
+    fail_on_bailout /tmp/test.result
     rerun_flaky_tests /tmp/test.result
 }
 

--- a/ci/redhat-ci.sh
+++ b/ci/redhat-ci.sh
@@ -102,6 +102,7 @@ run_case() {
     set_coredns
     # run test cases
     FLUSH_ETCD=1 TEST_EVENTS_MODULE=$TEST_EVENTS_MODULE prove --timer -Itest-nginx/lib -I./ -r ${TEST_FILE_SUB_DIR} | tee /tmp/test.result
+    fail_on_bailout /tmp/test.result
     rerun_flaky_tests /tmp/test.result
 }
 

--- a/t/plugin/ai-proxy.openai-compatible.t
+++ b/t/plugin/ai-proxy.openai-compatible.t
@@ -319,3 +319,22 @@ passed
                 ngx.say(err)
                 return
             end
+
+            local final_res = {}
+            while true do
+                local chunk, err = res.body_reader() -- will read chunk by chunk
+                if err then
+                    core.log.error("failed to read response chunk: ", err)
+                    break
+                end
+                if not chunk then
+                    break
+                end
+                core.table.insert_tail(final_res, chunk)
+            end
+
+            ngx.print(#final_res .. final_res[6])
+        }
+    }
+--- response_body_like eval
+qr/6data: \[DONE\]\n\n/

--- a/t/plugin/ai-rate-limiting.t
+++ b/t/plugin/ai-rate-limiting.t
@@ -891,19 +891,7 @@ passed
                             ],
                             "ssl_verify": false
                         },
-                        "ai-rate-limiting": {
-                            "instances": [
-                                {
-                                    "name": "openai-gpt3",
-                                    "limit": 50,
-                                    "time_window": 60
-                                },
-                                {
-                                    "name": "openai-gpt4",
-                                    "limit": 20,
-                                    "time_window": 60
-                                }
-                            ]
+                        "ai-rate-limiting": {"instances": [{"name": "openai-gpt3","limit": 50,"time_window": 60},{"name": "openai-gpt4","limit": 20,"time_window": 60}]
                         }
                     },
                     "upstream": {
@@ -996,16 +984,7 @@ Authorization: Bearer token
                             ],
                             "ssl_verify": false
                         },
-                        "ai-rate-limiting": {
-                            "limit": 20,
-                            "time_window": 60,
-                            "instances": [
-                                {
-                                    "name": "openai-gpt3",
-                                    "limit": 50,
-                                    "time_window": 60
-                                }
-                            ]
+                        "ai-rate-limiting": {"limit": 20, "time_window": 60, "instances": [{"name": "openai-gpt3","limit": 50,"time_window": 60}]
                         }
                     },
                     "upstream": {

--- a/t/plugin/ai-request-rewrite2.t
+++ b/t/plugin/ai-request-rewrite2.t
@@ -189,6 +189,7 @@ override.endpoint is required for openai-compatible provider
                     "uri": "/anything",
                     "plugins": {
                         "ai-proxy": {
+                           "provider": "openai",
                             "auth": {
                                 "query": {
                                     "api_key": "apikey"

--- a/t/plugin/ai3.t
+++ b/t/plugin/ai3.t
@@ -119,6 +119,10 @@ use ai plane to match route
 === TEST 2: keep route cache as latest data
 # update the attributes that do not participate in the route cache key to ensure
 # that the route cache use the latest data
+--- yaml_config
+plugin_attr:
+    prometheus:
+        refresh_interval: 0.1
 --- config
     location /t {
         content_by_lua_block {
@@ -171,7 +175,7 @@ use ai plane to match route
                 ngx.log(ngx.ERR, err)
                 return
             end
-
+            ngx.sleep(1)
             local metrics_uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/apisix/prometheus/metrics"
             local httpc = http.new()
             local res, err = httpc:request_uri(metrics_uri)
@@ -180,7 +184,6 @@ use ai plane to match route
                 ngx.log(ngx.ERR, err)
                 return
             end
-
             local m, err = ngx.re.match(res.body, "apisix_bandwidth{type=\"ingress\",route=\"foo\"", "jo")
             ngx.say(m[0])
 
@@ -204,7 +207,7 @@ use ai plane to match route
                 ngx.log(ngx.ERR, err)
                 return
             end
-
+            ngx.sleep(1)
             local metrics_uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/apisix/prometheus/metrics"
             local httpc = http.new()
             local res, err = httpc:request_uri(metrics_uri)

--- a/t/plugin/chaitin-waf-reject.t
+++ b/t/plugin/chaitin-waf-reject.t
@@ -74,6 +74,7 @@ __DATA__
             local code, body = t('/apisix/admin/plugin_metadata/chaitin-waf',
                  ngx.HTTP_PUT,
                  [[{
+                    "mode": "block",
                     "nodes": [
                         {
                             "host": "127.0.0.1",


### PR DESCRIPTION
The test here https://github.com/apache/apisix/actions/runs/16511586539/job/46694453675
failed due to invalid configuration but in case of Bailout, the tests is considered successful. This change asserts and finds for the bailed out test and fails CI if any test was bailed out.

The following tests fail after the changes in script in this pr https://github.com/apache/apisix/actions/runs/16519080359/job/46716551717
https://github.com/apache/apisix/actions/runs/16519816286/job/46718888226?pr=12462#step:16:236

I have modified the above tests to finally pass.
## Further enquiries
The doc says
"By default the test scaffold treats NGINX server startup failures as fatal errors in running the tests. The must_die section, however, turns such a failure into a normal test checkup."

If you have just one test then it holds true. But when even one test passes and subsequent test has invalid config then TEST IS CONSIDERED PASS.

WHen invalid configuration was passed in Test 1 (As expected the Bailout is considered total test failure)

```bash
Test run interrupted!
Test Summary Report
-------------------
t/core/ctx.t (Wstat: 65280 (exited 255) Tests: 0 Failed: 0)
  Non-zero exit status: 255
Files=1, Tests=0, 31 wallclock secs ( 0.01 usr  0.00 sys +  0.19 cusr  0.17 csys =  0.37 CPU)
Result: FAIL
```

When invalid configuration was passed in Test 2(or any other test after one passed test): (The test pass even after bailout)

```bash
Bailout called.  Further testing stopped:  t/core/ctx.t TEST 2: http header - Cannot start nginx using command "/usr/bin/openresty -p /home/ashish/dev/apisix/t/servroot/ -c /home/ashish/dev/apisix/t/servroot/conf/nginx.conf > /dev/null" (status code 256).
t/core/ctx.t .. ok
Test run interrupted!
All tests successful.
Files=1, Tests=6, 31 wallclock secs ( 0.02 usr  0.01 sys +  0.27 cusr  0.22 csys =  0.52 CPU)
Result: PASS
All tests successful.
Files=1, Tests=6, 31 wallclock secs ( 0.02 usr  0.01 sys +  0.27 cusr  0.22 csys =  0.52 CPU)
Result: PASS
FAILED--Further testing stopped: t/core/ctx.t TEST 2: http header - Cannot start nginx using command "/usr/bin/openresty -p /home/ashish/dev/apisix/t/servroot/ -c /home/ashish/dev/apisix/t/servroot/conf/nginx.conf > /dev/null" (status code 256).
```
### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
