### PR TITLE
fix: batch processor cache not working when configure plugin in service

### DIFF
--- a/apisix/utils/batch-processor-manager.lua
+++ b/apisix/utils/batch-processor-manager.lua
@@ -15,6 +15,7 @@
 -- limitations under the License.
 --
 local core = require("apisix.core")
+local plugin = require("apisix.plugin")
 local batch_processor = require("apisix.utils.batch-processor")
 local timer_at = ngx.timer.at
 local pairs = pairs
@@ -107,7 +108,7 @@ function _M:add_entry(conf, entry, max_pending_entries)
     end
     check_stale(self)
 
-    local log_buffer = self.buffers[conf]
+    local log_buffer = self.buffers[plugin.conf_version(conf)]
     if not log_buffer then
         return false
     end
@@ -149,7 +150,7 @@ function _M:add_entry_to_new_processor(conf, entry, ctx, func, max_pending_entri
     end
 
     log_buffer:push(entry)
-    self.buffers[conf] = log_buffer
+    self.buffers[plugin.conf_version(conf)] = log_buffer
     self.total_pushed_entries = self.total_pushed_entries + 1
     return true
 end

--- a/apisix/utils/batch-processor.lua
+++ b/apisix/utils/batch-processor.lua
@@ -157,6 +157,9 @@ function batch_processor:new(func, config)
         return nil, "Invalid argument, arg #1 must be a function"
     end
 
+    core.log.debug("creating new batch processor with config: ",
+        core.json.delay_encode(config, true))
+
     local processor = {
         func = func,
         buffer_duration = config.buffer_duration,


### PR DESCRIPTION
### Description

When merging the configurations of service and route, APISIX will first perform a deepcopy on the configuration of the service. 
https://github.com/apache/apisix/blob/e3e5a99d0fab06d920707a8731401b72341aabfa/apisix/plugin.lua#L585-L586
This results in each route associated with this service getting an independent plugin configuration table, causing the cache in `batch-processor-manager.lua` that is based on table memory addresses as keys to not work properly.

### Note
After this fix, every logger plugin that integrated with `batch-processor-manager.lua` can share the same batch processor object as long as the plugin configuration is identical. For example, with kafka-logger, even if the exact same kafka-logger plugin is configured on different services, the batch processor object and kafka producer will be the same and will not be created multiple times.

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
