### PR TITLE
fix(etcd): upgrade revision when watch request timeout

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -194,11 +194,14 @@ local function do_run_watch(premature)
     local res, err = watch_ctx.cli:get(watch_ctx.prefix, {
         keys_only = true
     })
+    if err then
+        log.error("failed to get latest revision, err: ", err)
+    end
     local latest_rev
     if res and res.body and res.body.header and res.body.header.revision then
         latest_rev = tonumber(res.body.header.revision)
     else
-        log.error("failed to get latest revision: ", err)
+        log.error("failed to get latest revision, res: ", inspect(res))
     end
 
     log.info("restart watchdir: start_revision=", opts.start_revision)
@@ -240,10 +243,21 @@ local function do_run_watch(premature)
             break
         end
 
-        if res.result.created then
-            goto watch_event
-        end
-
+        --[[
+        when etcd response permission denied, both result.canceled and result.created are true,
+        so we need to check result.canceled first, for example:
+        result = {
+          cancel_reason = "rpc error: code = PermissionDenied desc = etcdserver: permission denied",
+          canceled = true,
+          created = true,
+          header = {
+            cluster_id = "14841639068965178418",
+            member_id = "10276657743932975437",
+            raft_term = "4",
+            revision = "33"
+          }
+        }
+        --]]
         if res.result.canceled then
             log.warn("watch canceled by etcd, res: ", inspect(res))
             if res.result.compact_revision then
@@ -253,6 +267,10 @@ local function do_run_watch(premature)
             end
             cancel_watch(http_cli)
             break
+        end
+
+        if res.result.created then
+            goto watch_event
         end
 
         -- cleanup

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -199,7 +199,7 @@ local function do_run_watch(premature)
     if res and res.body and res.body.header and res.body.header.revision then
         latest_rev = tonumber(res.body.header.revision)
     else
-        log.error("failed to get latest revision, res: ", inspect(res))
+        log.error("failed to get latest revision, res: ", core.json.delay_encode(res))
     end
 
     log.info("restart watchdir: start_revision=", opts.start_revision)

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -191,9 +191,7 @@ local function do_run_watch(premature)
     opts.start_revision = watch_ctx.rev
 
     -- get latest revision
-    local res, err = watch_ctx.cli:get(watch_ctx.prefix, {
-        keys_only = true
-    })
+    local res, err = watch_ctx.cli:readdir(watch_ctx.prefix .. "/phantomkey")
     if err then
         log.error("failed to get latest revision, err: ", err)
     end

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -199,7 +199,7 @@ local function do_run_watch(premature)
     if res and res.body and res.body.header and res.body.header.revision then
         latest_rev = tonumber(res.body.header.revision)
     else
-        log.error("failed to get latest revision, res: ", core.json.delay_encode(res))
+        log.error("failed to get latest revision, res: ", json.delay_encode(res))
     end
 
     log.info("restart watchdir: start_revision=", opts.start_revision)

--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -514,3 +514,55 @@ qr/main etcd watcher initialised, revision=/
 --- grep_error_log_out
 main etcd watcher initialised, revision=
 main etcd watcher initialised, revision=
+
+
+
+=== TEST 14: watch revision should be upgraded when timeout occurs
+--- yaml_config
+deployment:
+  role: traditional
+  role_traditional:
+    config_provider: etcd
+  etcd:
+    host:
+      - "http://127.0.0.1:2379"
+    watch_timeout: 1
+    prefix: /apisix
+--- extra_yaml_config
+nginx_config:
+    worker_processes: 1
+--- config
+    location /t {
+        content_by_lua_block {
+            local etcd = require("resty.etcd")
+            local etcd_cli, err = etcd.new({
+                http_host = "http://127.0.0.1:2379",
+            })
+            if not etcd_cli then
+                ngx.say("failed to create etcd client: ", err)
+                return
+            end
+            ngx.sleep(2)
+            -- we will assert 4 lines of revision upgrade log because we have one worker and one privileged agent
+            for i = 1, 2 do
+               local _, err = etcd_cli:set("/apache", "apisix")
+               if err then
+                   ngx.say("failed to set key: ", err)
+                   return
+               end
+               ngx.sleep(1)
+            end
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- grep_error_log eval
+qr/etcd watch timeout, upgrade revision to/
+--- grep_error_log_out
+etcd watch timeout, upgrade revision to
+etcd watch timeout, upgrade revision to
+etcd watch timeout, upgrade revision to
+etcd watch timeout, upgrade revision to

--- a/t/xrpc/pingpong.t
+++ b/t/xrpc/pingpong.t
@@ -154,7 +154,7 @@ pp\x01\x00\x00\x00\x00\x00\x00\x00"
 "pp\x02\x00\x00\x00\x00\x00\x00\x03ABC" x 3
 --- log_level: debug
 --- no_error_log
-stream lua tcp socket set keepalive
+stream lua tcp socket keepalive create connection pool for key "127.0.0.1:1995"
 --- stream_conf_enable
 
 


### PR DESCRIPTION
### Description

When multiple APISIX clusters connect to the same etcd cluster, each APISIX cluster uses a different `etcd.prefix` to distinguish configurations. 
In this case, it is possible that the configuration of Cluster A changes frequently while the configuration of Cluster B remains unchanged. Since etcd revision is globally shared, this will cause the etcd client of Cluster B to always use an old revision when requesting the `/watch` API. 
When revisions continue updating for a certain period and trigger etcd's compact mechanism, it will result in a watch API error: `compact error`, which in turn causes APISIX in Cluster B to need to resynchronize data fully. This operation consumes a lot of computational resources from both the gateway and etcd.
In this PR, after a timeout occurs while watch request, we initiate the watch request again with the latest revision to avoid the above issue.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->



Fixes #12167
