### PR TITLE
feat(ai-proxy): add latency and usage in access log and prometheus metrics

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -806,6 +806,14 @@ http {
             set $dubbo_method                '';
             {% end %}
 
+            set $request_type               'traditional_http';
+
+            set $llm_time_to_first_token        '';
+            set $llm_model                      '';
+            set $llm_prompt_tokens              '';
+            set $llm_completion_tokens          '';
+
+
             access_by_lua_block {
                 apisix.http_access_phase()
             }

--- a/apisix/core/ctx.lua
+++ b/apisix/core/ctx.lua
@@ -233,6 +233,11 @@ do
         upstream_upgrade           = true,
         upstream_connection        = true,
         upstream_uri               = true,
+        request_type               = true,
+        llm_time_to_first_token    = true,
+        llm_model                  = true,
+        llm_prompt_tokens          = true,
+        llm_completion_tokens      = true,
 
         upstream_mirror_host       = true,
         upstream_mirror_uri        = true,

--- a/apisix/plugins/ai-proxy-multi.lua
+++ b/apisix/plugins/ai-proxy-multi.lua
@@ -217,6 +217,7 @@ function _M.access(conf, ctx)
     end
     ctx.picked_ai_instance_name = name
     ctx.picked_ai_instance = ai_instance
+    ctx.balancer_ip = name
     ctx.bypass_nginx_upstream = true
 end
 

--- a/apisix/plugins/ai-proxy.lua
+++ b/apisix/plugins/ai-proxy.lua
@@ -45,8 +45,9 @@ end
 
 
 function _M.access(conf, ctx)
-    ctx.picked_ai_instance_name = "ai-proxy"
+    ctx.picked_ai_instance_name = "ai-proxy-" .. conf.provider
     ctx.picked_ai_instance = conf
+    ctx.balancer_ip = ctx.picked_ai_instance_name
     ctx.bypass_nginx_upstream = true
 end
 

--- a/apisix/plugins/ai-proxy/base.lua
+++ b/apisix/plugins/ai-proxy/base.lua
@@ -15,8 +15,11 @@
 -- limitations under the License.
 --
 
+local ngx = ngx
 local core = require("apisix.core")
 local require = require
+local pcall   = pcall
+local exporter = require("apisix.plugins.prometheus.exporter")
 local bad_request = ngx.HTTP_BAD_REQUEST
 
 local _M = {}
@@ -41,9 +44,28 @@ function _M.before_proxy(conf, ctx)
         request_body.stream_options = {
             include_usage = true
         }
+        ctx.var.request_type = "ai_stream"
+    else
+        ctx.var.request_type = "ai_chat"
+    end
+    local model = ai_instance.options and ai_instance.options.model or request_body.model
+    if model then
+        ctx.var.llm_model = model
     end
 
-    return ai_driver:request(ctx, conf, request_body, extra_opts)
+    local do_request = function()
+        ctx.llm_request_start_time = ngx.now()
+        ctx.var.llm_request_body = request_body
+        return ai_driver:request(ctx, conf, request_body, extra_opts)
+    end
+    exporter.inc_llm_active_connections(ctx)
+    local ok, code_or_err, body = pcall(do_request)
+    exporter.dec_llm_active_connections(ctx)
+    if not ok then
+        core.log.error("failed to send request to AI service: ", code_or_err)
+        return 500
+    end
+    return code_or_err, body
 end
 
 

--- a/apisix/plugins/ai-request-rewrite.lua
+++ b/apisix/plugins/ai-request-rewrite.lua
@@ -128,7 +128,8 @@ local function request_to_llm(conf, request_table, ctx)
         headers = (conf.auth.header or {}),
         model_options = conf.options
     }
-
+    ctx.llm_request_start_time = ngx.now()
+    ctx.var.llm_request_body = request_table
     return ai_driver:request(ctx, conf, request_table, extra_opts)
 end
 

--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -240,7 +240,7 @@ function _M.http_init(prometheus_enabled_in_stream)
     end
     metrics.llm_latency = prometheus:histogram("llm_latency",
         "LLM request latency in milliseconds",
-        {"route", "service", "consumer", "node",
+        {"route_id", "service_id", "consumer", "node",
         "request_type", "llm_model",
         unpack(extra_labels("llm_latency"))},
         llm_latency_buckets,
@@ -248,14 +248,14 @@ function _M.http_init(prometheus_enabled_in_stream)
 
     metrics.llm_prompt_tokens = prometheus:counter("llm_prompt_tokens",
             "LLM service consumed prompt tokens",
-            {"route", "service", "consumer", "node",
+            {"route_id", "service_id", "consumer", "node",
             "request_type", "llm_model",
             unpack(extra_labels("llm_prompt_tokens"))},
             llm_prompt_tokens_exptime)
 
     metrics.llm_completion_tokens = prometheus:counter("llm_completion_tokens",
             "LLM service consumed completion tokens",
-            {"route", "service", "consumer", "node",
+            {"route_id", "service_id", "consumer", "node",
             "request_type", "llm_model",
             unpack(extra_labels("llm_completion_tokens"))},
             llm_completion_tokens_exptime)
@@ -380,7 +380,6 @@ function _M.http_log(conf, ctx)
             vars.request_type, vars.llm_model,
             unpack(extra_labels("llm_latency", ctx))))
     end
-
     if vars.llm_prompt_tokens ~= "" then
         metrics.llm_prompt_tokens:inc(tonumber(vars.llm_prompt_tokens),
             gen_arr(route_id, service_id, consumer_name, balancer_ip,

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -218,6 +218,11 @@ nginx_config:                     # Config for render the template to generate n
     enable_access_log: true             # Enable HTTP proxy access logging.
     access_log: logs/access.log         # Location of the access log.
     access_log_buffer: 16384            # buffer size of access log.
+    # available variables:
+    # request_type: traditional_http / ai_chat / ai_stream
+    # llm_time_to_first_token: duration from the start send request to ai server to the first token received
+    # llm_prompt_tokens: number of tokens in the prompt
+    # llm_completion_tokens: number of tokens in the chat completion
     access_log_format: |
       "$remote_addr - $remote_user [$time_local] $http_host \"$request\" $status $body_bytes_sent $request_time \"$http_referer\" \"$http_user_agent\" $upstream_addr $upstream_status $upstream_response_time \"$upstream_scheme://$upstream_host$upstream_uri\""
     # Customize log format: http://nginx.org/en/docs/varindex.html

--- a/docs/en/latest/plugins/ai-proxy-multi.md
+++ b/docs/en/latest/plugins/ai-proxy-multi.md
@@ -946,12 +946,6 @@ The following example demonstrates how you can log LLM request related informati
 * `llm_prompt_tokens`: Number of tokens in the prompt.
 * `llm_completion_tokens`: Number of chat completion tokens in the prompt.
 
-:::note
-
-The usage in this example will become available in APISIX 3.13.0.
-
-:::
-
 Update the access log format in your configuration file to include additional LLM related variables:
 
 ```yaml title="conf/config.yaml"

--- a/docs/en/latest/plugins/ai-proxy-multi.md
+++ b/docs/en/latest/plugins/ai-proxy-multi.md
@@ -935,3 +935,71 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
 ```
 
 For verification, the behaviours should be consistent with the verification in [active health checks](../tutorials/health-check.md).
+
+### Include LLM Information in Access Log
+
+The following example demonstrates how you can log LLM request related information in the gateway's access log to improve analytics and audit. The following variables are available:
+
+* `request_type`: Type of request, where the value could be `traditional_http`, `ai_chat`, or `ai_stream`.
+* `llm_time_to_first_token`: Duration from request sending to the first token received from the LLM service, in milliseconds.
+* `llm_model`: LLM model.
+* `llm_prompt_tokens`: Number of tokens in the prompt.
+* `llm_completion_tokens`: Number of chat completion tokens in the prompt.
+
+:::note
+
+The usage in this example will become available in APISIX 3.13.0.
+
+:::
+
+Update the access log format in your configuration file to include additional LLM related variables:
+
+```yaml title="conf/config.yaml"
+nginx_config:
+  http:
+    access_log_format: "$remote_addr - $remote_user [$time_local] $http_host \"$request_line\" $status $body_bytes_sent $request_time \"$http_referer\" \"$http_user_agent\" $upstream_addr $upstream_status $upstream_response_time \"$upstream_scheme://$upstream_host$upstream_uri\" \"$apisix_request_id\" \"$request_type\" \"$llm_time_to_first_token\" \"$llm_model\" \"$llm_prompt_tokens\" \"$llm_completion_tokens\""
+```
+
+Reload APISIX for configuration changes to take effect.
+
+Next, create a Route with the `ai-proxy-multi` Plugin and send a request. For instance, if the request is forwarded to OpenAI and you receive the following response:
+
+```json
+{
+  ...,
+  "model": "gpt-4-0613",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "1+1 equals 2.",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 23,
+    "completion_tokens": 8,
+    "total_tokens": 31,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    ...
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}
+```
+
+In the gateway's access log, you should see a log entry similar to the following:
+
+```text
+192.168.215.1 - - [21/Mar/2025:04:28:03 +0000] api.openai.com "POST /anything HTTP/1.1" 200 804 2.858 "-" "curl/8.6.0" - - - "http://api.openai.com" "5c5e0b95f8d303cb81e4dc456a4b12d9" "ai_chat" "2858" "gpt-4" "23" "8"
+```
+
+The access log entry shows the request type is `ai_chat`, time to first token is `2858` milliseconds, LLM model is `gpt-4`, prompt token usage is `23`, and completion token usage is `8`.

--- a/docs/en/latest/plugins/ai-proxy.md
+++ b/docs/en/latest/plugins/ai-proxy.md
@@ -383,3 +383,71 @@ You should receive a response similar to the following:
   }
 }
 ```
+
+### Include LLM Information in Access Log
+
+The following example demonstrates how you can log LLM request related information in the gateway's access log to improve analytics and audit. The following variables are available:
+
+* `request_type`: Type of request, where the value could be `traditional_http`, `ai_chat`, or `ai_stream`.
+* `llm_time_to_first_token`: Duration from request sending to the first token received from the LLM service, in milliseconds.
+* `llm_model`: LLM model.
+* `llm_prompt_tokens`: Number of tokens in the prompt.
+* `llm_completion_tokens`: Number of chat completion tokens in the prompt.
+
+:::note
+
+The usage will become available in APISIX 3.13.0.
+
+:::
+
+Update the access log format in your configuration file to include additional LLM related variables:
+
+```yaml title="conf/config.yaml"
+nginx_config:
+  http:
+    access_log_format: "$remote_addr   $remote_user [$time_local] $http_host \"$request_line\" $status $body_bytes_sent $request_time \"$http_referer\" \"$http_user_agent\" $upstream_addr $upstream_status $upstream_response_time \"$upstream_scheme://$upstream_host$upstream_uri\" \"$apisix_request_id\" \"$request_type\" \"$llm_time_to_first_token\" \"$llm_model\" \"$llm_prompt_tokens\" \"$llm_completion_tokens\""
+```
+
+Reload APISIX for configuration changes to take effect.
+
+Now if you create a Route and send a request following the [Proxy to OpenAI example](#proxy-to-openai), you should receive a response similar to the following:
+
+```json
+{
+  ...,
+  "model": "gpt-4-0613",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "1+1 equals 2.",
+        "refusal": null,
+        "annotations": []
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 23,
+    "completion_tokens": 8,
+    "total_tokens": 31,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    ...
+  },
+  "service_tier": "default",
+  "system_fingerprint": null
+}
+```
+
+In the gateway's access log, you should see a log entry similar to the following:
+
+```text
+192.168.215.1   - [21/Mar/2025:04:28:03 +0000] api.openai.com "POST /anything HTTP/1.1" 200 804 2.858 "-" "curl/8.6.0"   -   "http://api.openai.com" "5c5e0b95f8d303cb81e4dc456a4b12d9" "ai_chat" "2858" "gpt-4" "23" "8"
+```
+
+The access log entry shows the request type is `ai_chat`, time to first token is `2858` milliseconds, LLM model is `gpt-4`, prompt token usage is `23`, and completion token usage is `8`.

--- a/docs/en/latest/plugins/ai-proxy.md
+++ b/docs/en/latest/plugins/ai-proxy.md
@@ -394,12 +394,6 @@ The following example demonstrates how you can log LLM request related informati
 * `llm_prompt_tokens`: Number of tokens in the prompt.
 * `llm_completion_tokens`: Number of chat completion tokens in the prompt.
 
-:::note
-
-The usage will become available in APISIX 3.13.0.
-
-:::
-
 Update the access log format in your configuration file to include additional LLM related variables:
 
 ```yaml title="conf/config.yaml"

--- a/docs/en/latest/plugins/prometheus.md
+++ b/docs/en/latest/plugins/prometheus.md
@@ -138,6 +138,8 @@ The following labels are used to differentiate `apisix_http_status` metrics.
 | service      | ID of the Service that the HTTP status originates from when `prefer_name` is `false` (default), and name of the Service when `prefer_name` to `true`. Default to the configured value of host on the Route if the matched Route does not belong to any Service. |
 | consumer     | Name of the Consumer associated with a request. Default to an empty string if no Consumer is associated with the request.                       |
 | node         | IP address of the upstream node.                                                                                          |
+| request_type       | traditional_http / ai_chat / ai_stream                                                                                          |
+| llm_model       | For non-traditional_http requests, name of the llm_model                                                                                          |
 
 ### Labels for `apisix_bandwidth`
 
@@ -150,6 +152,56 @@ The following labels are used to differentiate `apisix_bandwidth` metrics.
 | service    | ID of the Service that bandwidth corresponds to when `prefer_name` is `false` (default), and name of the Service when `prefer_name` to `true`. Default to the configured value of host on the Route if the matched Route does not belong to any Service. |
 | consumer   | Name of the Consumer associated with a request. Default to an empty string if no Consumer is associated with the request.                       |
 | node       | IP address of the upstream node.                                                                                          |
+| request_type       | traditional_http / ai_chat / ai_stream                                                                                          |
+| llm_model       | For non-traditional_http requests, name of the llm_model                                                                                          |
+
+### Labels for `apisix_llm_latency`
+
+| Name | Description                                                                                                                   |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------- |                                                                                             |
+| route_id      | ID of the Route that bandwidth corresponds to when `prefer_name` is `false` (default), and name of the Route when `prefer_name` to `true`. Default to an empty string if a request does not match any Route.                         |
+| service_id    | ID of the Service that bandwidth corresponds to when `prefer_name` is `false` (default), and name of the Service when `prefer_name` to `true`. Default to the configured value of host on the Route if the matched Route does not belong to any Service. |
+| consumer   | Name of the Consumer associated with a request. Default to an empty string if no Consumer is associated with the request.                       |
+| node       | IP address of the upstream node.                                                                                          |
+| request_type       | traditional_http / ai_chat / ai_stream                                                                                          |
+| llm_model       | For non-traditional_http requests, name of the llm_model                                                                                          |
+
+### Labels for `apisix_llm_active_connections`
+
+| Name | Description                                                                                                                   |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| route      | Name of the Route that bandwidth corresponds to. Default to an empty string if a request does not match any Route.                                                                                 |
+| route_id      | ID of the Route that bandwidth corresponds to when `prefer_name` is `false` (default), and name of the Route when `prefer_name` to `true`. Default to an empty string if a request does not match any Route.                         |
+| matched_uri  | URI of the Route that matches the request. Default to an empty string if a request does not match any Route.                              |
+| matched_host | Host of the Route that matches the request. Default to an empty string if a request does not match any Route, or host is not configured on the Route.                             |
+| service    | Name of the Service that bandwidth corresponds to. Default to the configured value of host on the Route if the matched Route does not belong to any Service. |
+| service_id    | ID of the Service that bandwidth corresponds to when `prefer_name` is `false` (default), and name of the Service when `prefer_name` to `true`. Default to the configured value of host on the Route if the matched Route does not belong to any Service. |
+| consumer   | Name of the Consumer associated with a request. Default to an empty string if no Consumer is associated with the request.                       |
+| node       | IP address of the upstream node.                                                                                          |
+| request_type       | traditional_http / ai_chat / ai_stream                                                                                          |
+| llm_model       | For non-traditional_http requests, name of the llm_model                                                                                          |
+
+### Labels for `apisix_llm_completion_tokens`
+
+| Name | Description                                                                                                                   |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------- |                                                                                             |
+| route_id      | ID of the Route that bandwidth corresponds to when `prefer_name` is `false` (default), and name of the Route when `prefer_name` to `true`. Default to an empty string if a request does not match any Route.                         |
+| service_id    | ID of the Service that bandwidth corresponds to when `prefer_name` is `false` (default), and name of the Service when `prefer_name` to `true`. Default to the configured value of host on the Route if the matched Route does not belong to any Service. |
+| consumer   | Name of the Consumer associated with a request. Default to an empty string if no Consumer is associated with the request.                       |
+| node       | IP address of the upstream node.                                                                                          |
+| request_type       | traditional_http / ai_chat / ai_stream                                                                                          |
+| llm_model       | For non-traditional_http requests, name of the llm_model                                                                                          |
+
+### Labels for `apisix_llm_prompt_tokens`
+
+| Name | Description                                                                                                                   |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------- |                                                                                             |
+| route_id      | ID of the Route that bandwidth corresponds to when `prefer_name` is `false` (default), and name of the Route when `prefer_name` to `true`. Default to an empty string if a request does not match any Route.                         |
+| service_id    | ID of the Service that bandwidth corresponds to when `prefer_name` is `false` (default), and name of the Service when `prefer_name` to `true`. Default to the configured value of host on the Route if the matched Route does not belong to any Service. |
+| consumer   | Name of the Consumer associated with a request. Default to an empty string if no Consumer is associated with the request.                       |
+| node       | IP address of the upstream node.                                                                                          |
+| request_type       | traditional_http / ai_chat / ai_stream                                                                                          |
+| llm_model       | For non-traditional_http requests, name of the llm_model                                                                                          |
 
 ### Labels for `apisix_http_latency`
 
@@ -162,6 +214,8 @@ The following labels are used to differentiate `apisix_http_latency` metrics.
 | service    | ID of the Service that latencies correspond to when `prefer_name` is `false` (default), and name of the Service when `prefer_name` to `true`. Default to the configured value of host on the Route if the matched Route does not belong to any Service. |
 | consumer   | Name of the Consumer associated with latencies. Default to an empty string if no Consumer is associated with the request.                             |
 | node       | IP address of the upstream node associated with latencies.                                                                                                |
+| request_type       | traditional_http / ai_chat / ai_stream                                                                                          |
+| llm_model       | For non-traditional_http requests, name of the llm_model                                                                                          |
 
 #### Latency Types
 
@@ -221,12 +275,12 @@ You should see an output similar to the following:
 ```text
 # HELP apisix_bandwidth Total bandwidth in bytes consumed per Service in Apisix
 # TYPE apisix_bandwidth counter
-apisix_bandwidth{type="egress",route="",service="",consumer="",node=""} 8417
-apisix_bandwidth{type="egress",route="1",service="",consumer="",node="127.0.0.1"} 1420
-apisix_bandwidth{type="egress",route="2",service="",consumer="",node="127.0.0.1"} 1420
-apisix_bandwidth{type="ingress",route="",service="",consumer="",node=""} 189
-apisix_bandwidth{type="ingress",route="1",service="",consumer="",node="127.0.0.1"} 332
-apisix_bandwidth{type="ingress",route="2",service="",consumer="",node="127.0.0.1"} 332
+apisix_bandwidth{type="egress",route="",service="",consumer="",node="",request_type="traditional_http",llm_model=""} 8417
+apisix_bandwidth{type="egress",route="1",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""} 1420
+apisix_bandwidth{type="egress",route="2",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""} 1420
+apisix_bandwidth{type="ingress",route="",service="",consumer="",node="",request_type="traditional_http",llm_model=""} 189
+apisix_bandwidth{type="ingress",route="1",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""} 332
+apisix_bandwidth{type="ingress",route="2",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""} 332
 # HELP apisix_etcd_modify_indexes Etcd modify index for APISIX keys
 # TYPE apisix_etcd_modify_indexes gauge
 apisix_etcd_modify_indexes{key="consumers"} 0

--- a/docs/zh/latest/plugins/prometheus.md
+++ b/docs/zh/latest/plugins/prometheus.md
@@ -138,6 +138,8 @@ Prometheus 中有不同类型的指标。要了解它们之间的区别，请参
 | service | HTTP 状态来源的服务 ID，当 `prefer_name` 为 `false`（默认）时，使用服务 ID，当 `prefer_name` 为 `true` 时，使用服务名称。如果匹配的路由不属于任何服务，则默认为路由上配置的主机值。 |
 | consumer | 与请求关联的消费者名称。如果请求没有与之关联的消费者，则默认为空字符串。                                             |
 | node   | 上游节点的 IP 地址。                                                                                                   |
+| request_type       | traditional_http / ai_chat / ai_stream                                                                                          |
+| llm_model       | 对于非传统的 http 请求，llm 模型的名称                                                                                          |
 
 ### `apisix_bandwidth` 的标签
 
@@ -150,6 +152,56 @@ Prometheus 中有不同类型的指标。要了解它们之间的区别，请参
 | service | 带宽对应的服务 ID，当 `prefer_name` 为 `false`（默认）时，使用服务 ID，当 `prefer_name` 为 `true` 时，使用服务名称。如果匹配的路由不属于任何服务，则默认为路由上配置的主机值。 |
 | consumer | 与请求关联的消费者名称。如果请求没有与之关联的消费者，则默认为空字符串。                                             |
 | node   | 上游节点的 IP 地址。                                                                                                   |
+| request_type       | traditional_http / ai_chat / ai_stream                                                                                          |
+| llm_model       | 对于非传统的 http 请求，llm 模型的名称                                                                                          |
+
+### Labels for `apisix_llm_latency`
+
+| Name | Description                                                                                                                   |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------- |                                                                                             |
+| route_id      | 带宽对应的路由 ID，当 `prefer_name` 为 `false`（默认）时，使用路由 ID，当 `prefer_name` 为 `true` 时，使用路由名称。如果请求不匹配任何路由，则默认为空字符串。                        |
+| service_id    | 带宽对应的服务 ID，当 `prefer_name` 为 `false`（默认）时，使用服务 ID，当 `prefer_name` 为 `true` 时，使用服务名称。如果匹配的路由不属于任何服务，则默认为路由上配置的主机值。 |
+| consumer   | 与请求关联的消费者名称。如果请求没有与之关联的消费者，则默认为空字符串。                       |
+| node       | 上游节点的 IP 地址。                                                                                          |
+| request_type       | traditional_http / ai_chat / ai_stream                                                                                          |
+| llm_model       | 对于非传统的 http 请求，llm 模型的名称                                                                                          |
+
+### Labels for `apisix_llm_active_connections`
+
+| Name | Description                                                                                                                   |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| route      | Name of the Route that bandwidth corresponds to. Default to an empty string if a request does not match any Route.                                                                                 |
+| route_id      | 带宽对应的路由 ID，当 `prefer_name` 为 `false`（默认）时，使用路由 ID，当 `prefer_name` 为 `true` 时，使用路由名称。如果请求不匹配任何路由，则默认为空字符串。                         |
+| matched_uri | 匹配请求的路由 URI。如果请求不匹配任何路由，则默认为空字符串。                                                       |
+| matched_host | 匹配请求的路由主机。如果请求不匹配任何路由，或路由未配置主机，则默认为空字符串。                                     |
+| service    | Name of the Service that bandwidth corresponds to. Default to the configured value of host on the Route if the matched Route does not belong to any Service. |
+| service_id    |  带宽对应的服务 ID，当 `prefer_name` 为 `false`（默认）时，使用服务 ID，当 `prefer_name` 为 `true` 时，使用服务名称。如果匹配的路由不属于任何服务，则默认为路由上配置的主机值。 |
+| consumer   | 与请求关联的消费者名称。如果请求没有与之关联的消费者，则默认为空字符串。                       |
+| node       | 上游节点的 IP 地址。                                                                                          |
+| request_type       | traditional_http / ai_chat / ai_stream                                                                                          |
+| llm_model       | 对于非传统的 http 请求，llm 模型的名称                                                                                          |
+
+### Labels for `apisix_llm_completion_tokens`
+
+| Name | Description                                                                                                                   |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------- |                                                                                             |
+| route_id      | 带宽对应的路由 ID，当 `prefer_name` 为 `false`（默认）时，使用路由 ID，当 `prefer_name` 为 `true` 时，使用路由名称。如果请求不匹配任何路由，则默认为空字符串。                         |
+| service_id    |  带宽对应的服务 ID，当 `prefer_name` 为 `false`（默认）时，使用服务 ID，当 `prefer_name` 为 `true` 时，使用服务名称。如果匹配的路由不属于任何服务，则默认为路由上配置的主机值。 |
+| consumer   | 与请求关联的消费者名称。如果请求没有与之关联的消费者，则默认为空字符串。                       |
+| node       | 上游节点的 IP 地址。                                                                                          |
+| request_type       | traditional_http / ai_chat / ai_stream                                                                                          |
+| llm_model       | 对于非传统的 http 请求，llm 模型的名称                                                                                          |
+
+### Labels for `apisix_llm_prompt_tokens`
+
+| Name | Description                                                                                                                   |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------- |                                                                                             |
+| route_id      | 带宽对应的路由 ID，当 `prefer_name` 为 `false`（默认）时，使用路由 ID，当 `prefer_name` 为 `true` 时，使用路由名称。如果请求不匹配任何路由，则默认为空字符串。                         |
+| service_id    |  带宽对应的服务 ID，当 `prefer_name` 为 `false`（默认）时，使用服务 ID，当 `prefer_name` 为 `true` 时，使用服务名称。如果匹配的路由不属于任何服务，则默认为路由上配置的主机值。 |
+| consumer   | 与请求关联的消费者名称。如果请求没有与之关联的消费者，则默认为空字符串。                       |
+| node       | 上游节点的 IP 地址。                                                                                          |
+| request_type       | traditional_http / ai_chat / ai_stream                                                                                          |
+| llm_model       | 对于非传统的 http 请求，llm 模型的名称                                                                                          |
 
 ### `apisix_http_latency` 的标签
 
@@ -162,6 +214,8 @@ Prometheus 中有不同类型的指标。要了解它们之间的区别，请参
 | service | 延迟对应的服务 ID，当 `prefer_name` 为 `false`（默认）时，使用服务 ID，当 `prefer_name` 为 `true` 时，使用服务名称。如果匹配的路由不属于任何服务，则默认为路由上配置的主机值。 |
 | consumer | 与延迟关联的消费者名称。如果请求没有与之关联的消费者，则默认为空字符串。                                             |
 | node   | 与延迟关联的上游节点的 IP 地址。                                                                                     |
+| request_type       | traditional_http / ai_chat / ai_stream                                                                                          |
+| llm_model       | 对于非传统的 http 请求，llm 模型的名称                                                                                          |
 
 #### 延迟类型
 
@@ -221,12 +275,12 @@ curl "http://127.0.0.1:9091/apisix/prometheus/metrics"
 ```text
 # HELP apisix_bandwidth Total bandwidth in bytes consumed per Service in Apisix
 # TYPE apisix_bandwidth counter
-apisix_bandwidth{type="egress",route="",service="",consumer="",node=""} 8417
-apisix_bandwidth{type="egress",route="1",service="",consumer="",node="127.0.0.1"} 1420
-apisix_bandwidth{type="egress",route="2",service="",consumer="",node="127.0.0.1"} 1420
-apisix_bandwidth{type="ingress",route="",service="",consumer="",node=""} 189
-apisix_bandwidth{type="ingress",route="1",service="",consumer="",node="127.0.0.1"} 332
-apisix_bandwidth{type="ingress",route="2",service="",consumer="",node="127.0.0.1"} 332
+apisix_bandwidth{type="egress",route="",service="",consumer="",node="",request_type="traditional_http",llm_model=""} 8417
+apisix_bandwidth{type="egress",route="1",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""} 1420
+apisix_bandwidth{type="egress",route="2",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""} 1420
+apisix_bandwidth{type="ingress",route="",service="",consumer="",node="",request_type="traditional_http",llm_model=""} 189
+apisix_bandwidth{type="ingress",route="1",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""} 332
+apisix_bandwidth{type="ingress",route="2",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""} 332
 # HELP apisix_etcd_modify_indexes Etcd modify index for APISIX keys
 # TYPE apisix_etcd_modify_indexes gauge
 apisix_etcd_modify_indexes{key="consumers"} 0

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -673,7 +673,7 @@ _EOC_
         require("apisix").http_exit_worker()
     }
 
-    log_format main escape=default '\$remote_addr - \$remote_user [\$time_local] \$http_host "\$request" \$status \$body_bytes_sent \$request_time "\$http_referer" "\$http_user_agent" \$upstream_addr \$upstream_status \$upstream_response_time "\$upstream_scheme://\$upstream_host\$upstream_uri"';
+    log_format main escape=default '\$remote_addr - \$remote_user [\$time_local] \$http_host "\$request" \$status \$body_bytes_sent \$request_time "\$http_referer" "\$http_user_agent" \$upstream_addr \$upstream_status \$upstream_response_time "\$upstream_scheme://\$upstream_host\$upstream_uri" \$llm_model \$llm_time_to_first_token \$llm_prompt_tokens \$llm_completion_tokens';
 
     # fake server, only for test
     server {
@@ -855,6 +855,15 @@ _EOC_
             proxy_cache_key                     \$upstream_cache_key;
             proxy_no_cache                      \$upstream_no_cache;
             proxy_cache_bypass                  \$upstream_cache_bypass;
+
+            set \$request_type               'traditional_http';
+
+            set \$llm_time_to_first_token        '';
+            set \$llm_model                      '';
+            set \$llm_prompt_tokens              '';
+            set \$llm_completion_tokens          '';
+
+            access_log $apisix_home/t/servroot/logs/access.log main;
 
             access_by_lua_block {
                 -- wait for etcd sync

--- a/t/plugin/ai-proxy-multi.balancer.t
+++ b/t/plugin/ai-proxy-multi.balancer.t
@@ -285,19 +285,9 @@ deepseek.deepseek.openai.openai.openai.openai.openai.openai.openai.openai
                                     "name": "deepseek",
                                     "provider": "deepseek",
                                     "weight": 1,
-                                    "auth": {
-                                        "header": {
-                                            "Authorization": "Bearer token"
-                                        }
-                                    },
-                                    "options": {
-                                        "model": "deepseek-chat",
-                                        "max_tokens": 512,
-                                        "temperature": 1.0
-                                    },
-                                    "override": {
-                                        "endpoint": "http://localhost:6724/chat/completions"
-                                    }
+                                    "auth": {"header": {"Authorization": "Bearer token"}},
+                                    "options": {"model": "deepseek-chat","max_tokens": 512,"temperature": 1.0},
+                                    "override": {"endpoint": "http://localhost:6724/chat/completions"}
                                 }
                             ],
                             "ssl_verify": false

--- a/t/plugin/ai-proxy-multi.balancer.t
+++ b/t/plugin/ai-proxy-multi.balancer.t
@@ -42,6 +42,7 @@ add_block_preprocessor(sub {
     my $user_yaml_config = <<_EOC_;
 plugins:
   - ai-proxy-multi
+  - prometheus
 _EOC_
     $block->set_value("extra_yaml_config", $user_yaml_config);
 

--- a/t/plugin/ai-proxy-multi.openai-compatible.t
+++ b/t/plugin/ai-proxy-multi.openai-compatible.t
@@ -42,6 +42,7 @@ add_block_preprocessor(sub {
     my $user_yaml_config = <<_EOC_;
 plugins:
   - ai-proxy-multi
+  - prometheus
 _EOC_
     $block->set_value("extra_yaml_config", $user_yaml_config);
 

--- a/t/plugin/ai-proxy-multi.t
+++ b/t/plugin/ai-proxy-multi.t
@@ -42,6 +42,7 @@ add_block_preprocessor(sub {
     my $user_yaml_config = <<_EOC_;
 plugins:
   - ai-proxy-multi
+  - prometheus
 _EOC_
     $block->set_value("extra_yaml_config", $user_yaml_config);
 

--- a/t/plugin/ai-proxy-multi2.t
+++ b/t/plugin/ai-proxy-multi2.t
@@ -42,6 +42,7 @@ add_block_preprocessor(sub {
     my $user_yaml_config = <<_EOC_;
 plugins:
   - ai-proxy-multi
+  - prometheus
 _EOC_
     $block->set_value("extra_yaml_config", $user_yaml_config);
 

--- a/t/plugin/ai-proxy3.t
+++ b/t/plugin/ai-proxy3.t
@@ -1,0 +1,155 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+log_level("info");
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+
+my $resp_file = 't/assets/ai-proxy-response.json';
+open(my $fh, '<', $resp_file) or die "Could not open file '$resp_file' $!";
+my $resp = do { local $/; <$fh> };
+close($fh);
+
+print "Hello, World!\n";
+print $resp;
+
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+    my $http_config = $block->http_config // <<_EOC_;
+        server {
+            server_name openai;
+            listen 6724;
+
+            default_type 'application/json';
+
+            location /v1/chat/completions {
+                content_by_lua_block {
+                    local json = require("cjson.safe")
+
+                    if ngx.req.get_method() ~= "POST" then
+                        ngx.status = 400
+                        ngx.say("Unsupported request method: ", ngx.req.get_method())
+                    end
+                    ngx.req.read_body()
+                    local body, err = ngx.req.get_body_data()
+                    body, err = json.decode(body)
+
+                    local query_auth = ngx.req.get_uri_args()["api_key"]
+
+                    if query_auth ~= "apikey" then
+                        ngx.status = 401
+                        ngx.say("Unauthorized")
+                        return
+                    end
+
+		    local res = [[
+{
+  "id": "chatcmpl-12345",
+  "object": "chat.completion",
+  "created": 1691234567,
+  "model": "gpt-3.5-turbo",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "这是一个示例回复。"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 20,
+    "total_tokens": 30
+  }
+}]]
+                    ngx.status = 200
+                    ngx.say(res)
+                }
+            }
+        }
+_EOC_
+
+    $block->set_value("http_config", $http_config);
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: set access log
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "uri": "/anything",
+                    "plugins": {
+                        "ai-proxy": {
+                            "provider": "openai",
+                            "auth": {
+                                "query": {
+                                    "api_key": "apikey"
+                                }
+                            },
+                            "options": {
+														    "model": "gpt-3.5-turbo",
+                                "max_tokens": 512,
+                                "temperature": 1.0
+                            },
+                            "override": {
+                                "endpoint": "http://localhost:6724/v1/chat/completions"
+                            },
+                            "ssl_verify": false
+                        }
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 2: send request
+--- request
+POST /anything
+{ "messages": [ { "role": "system", "content": "You are a mathematician" }, { "role": "user", "content": "What is 1+1?"} ] }
+--- error_code: 200
+--- response_body eval
+qr/.*completion_tokens.*/
+--- access_log eval
+qr/.*gpt-3.5-turbo \d+ 10 20.*/

--- a/t/plugin/ai-proxy3.t
+++ b/t/plugin/ai-proxy3.t
@@ -66,7 +66,7 @@ add_block_preprocessor(sub {
                         return
                     end
 
-		    local res = [[
+            local res = [[
 {
   "id": "chatcmpl-12345",
   "object": "chat.completion",
@@ -120,7 +120,7 @@ __DATA__
                                 }
                             },
                             "options": {
-														    "model": "gpt-3.5-turbo",
+                                "model": "gpt-3.5-turbo",
                                 "max_tokens": 512,
                                 "temperature": 1.0
                             },

--- a/t/plugin/ai-rate-limiting.t
+++ b/t/plugin/ai-rate-limiting.t
@@ -608,17 +608,9 @@ Authorization: Bearer token
                                     "provider": "openai",
                                     "weight": 1,
                                     "priority": 0,
-                                    "auth": {
-                                        "header": {
-                                            "Authorization": "Bearer token"
-                                        }
-                                    },
-                                    "options": {
-                                        "model": "gpt-3"
-                                    },
-                                    "override": {
-                                        "endpoint": "http://localhost:16724"
-                                    }
+                                    "auth": {"header": {"Authorization": "Bearer token"}},
+                                    "options": {"model": "gpt-3"},
+                                    "override": {"endpoint": "http://localhost:16724"}
                                 }
                             ],
                             "ssl_verify": false
@@ -736,34 +728,18 @@ passed
                                     "provider": "openai",
                                     "weight": 1,
                                     "priority": 1,
-                                    "auth": {
-                                        "header": {
-                                            "Authorization": "Bearer token"
-                                        }
-                                    },
-                                    "options": {
-                                        "model": "gpt-4"
-                                    },
-                                    "override": {
-                                        "endpoint": "http://localhost:16724"
-                                    }
+                                    "auth": {"header": {"Authorization": "Bearer token"}},
+                                    "options": {"model": "gpt-4"},
+                                    "override": {"endpoint": "http://localhost:16724"}
                                 },
                                 {
                                     "name": "openai-gpt3",
                                     "provider": "openai",
                                     "weight": 1,
                                     "priority": 0,
-                                    "auth": {
-                                        "header": {
-                                            "Authorization": "Bearer token"
-                                        }
-                                    },
-                                    "options": {
-                                        "model": "gpt-3"
-                                    },
-                                    "override": {
-                                        "endpoint": "http://localhost:16724"
-                                    }
+                                    "auth": {"header": {"Authorization": "Bearer token"}},
+                                    "options": {"model": "gpt-3"},
+                                    "override": {"endpoint": "http://localhost:16724"}
                                 }
                             ],
                             "ssl_verify": false
@@ -876,17 +852,9 @@ passed
                                     "provider": "openai",
                                     "weight": 1,
                                     "priority": 0,
-                                    "auth": {
-                                        "header": {
-                                            "Authorization": "Bearer token"
-                                        }
-                                    },
-                                    "options": {
-                                        "model": "gpt-3"
-                                    },
-                                    "override": {
-                                        "endpoint": "http://localhost:16724"
-                                    }
+                                    "auth": {"header": {"Authorization": "Bearer token"}},
+                                    "options": {"model": "gpt-3"},
+                                    "override": {"endpoint": "http://localhost:16724"}
                                 }
                             ],
                             "ssl_verify": false
@@ -969,17 +937,9 @@ Authorization: Bearer token
                                     "provider": "openai",
                                     "weight": 1,
                                     "priority": 0,
-                                    "auth": {
-                                        "header": {
-                                            "Authorization": "Bearer token"
-                                        }
-                                    },
-                                    "options": {
-                                        "model": "gpt-3"
-                                    },
-                                    "override": {
-                                        "endpoint": "http://localhost:16724"
-                                    }
+                                    "auth": {"header": {"Authorization": "Bearer token"}},
+                                    "options": {"model": "gpt-3"},
+                                    "override": {"endpoint": "http://localhost:16724"}
                                 }
                             ],
                             "ssl_verify": false

--- a/t/plugin/ai-rate-limiting.t
+++ b/t/plugin/ai-rate-limiting.t
@@ -419,9 +419,9 @@ POST /ai
 --- more_headers
 Authorization: Bearer token
 --- response_headers
-X-AI-RateLimit-Limit-ai-proxy: 30
-X-AI-RateLimit-Remaining-ai-proxy: 29
-X-AI-RateLimit-Reset-ai-proxy: 60
+X-AI-RateLimit-Limit-ai-proxy-openai: 30
+X-AI-RateLimit-Remaining-ai-proxy-openai: 29
+X-AI-RateLimit-Reset-ai-proxy-openai: 60
 
 
 
@@ -439,10 +439,10 @@ Authorization: Bearer token
 [200, 200, 200, 403]
 --- response_headers eval
 [
-    "X-AI-RateLimit-Remaining-ai-proxy: 29",
-    "X-AI-RateLimit-Remaining-ai-proxy: 19",
-    "X-AI-RateLimit-Remaining-ai-proxy: 9",
-    "X-AI-RateLimit-Remaining-ai-proxy: 0",
+    "X-AI-RateLimit-Remaining-ai-proxy-openai: 29",
+    "X-AI-RateLimit-Remaining-ai-proxy-openai: 19",
+    "X-AI-RateLimit-Remaining-ai-proxy-openai: 9",
+    "X-AI-RateLimit-Remaining-ai-proxy-openai: 0",
 ]
 
 
@@ -523,9 +523,9 @@ POST /ai2
 --- more_headers
 Authorization: Bearer token
 --- response_headers
-X-AI-RateLimit-Limit-ai-proxy: 20
-X-AI-RateLimit-Remaining-ai-proxy: 19
-X-AI-RateLimit-Reset-ai-proxy: 45
+X-AI-RateLimit-Limit-ai-proxy-openai: 20
+X-AI-RateLimit-Remaining-ai-proxy-openai: 19
+X-AI-RateLimit-Reset-ai-proxy-openai: 45
 
 
 
@@ -544,11 +544,11 @@ Authorization: Bearer token
 [200, 200, 200, 200, 503]
 --- response_headers eval
 [
-    "X-AI-RateLimit-Remaining-ai-proxy: 19",
-    "X-AI-RateLimit-Remaining-ai-proxy: 14",
-    "X-AI-RateLimit-Remaining-ai-proxy: 9",
-    "X-AI-RateLimit-Remaining-ai-proxy: 4",
-    "X-AI-RateLimit-Remaining-ai-proxy: 0",
+    "X-AI-RateLimit-Remaining-ai-proxy-openai: 19",
+    "X-AI-RateLimit-Remaining-ai-proxy-openai: 14",
+    "X-AI-RateLimit-Remaining-ai-proxy-openai: 9",
+    "X-AI-RateLimit-Remaining-ai-proxy-openai: 4",
+    "X-AI-RateLimit-Remaining-ai-proxy-openai: 0",
 ]
 
 

--- a/t/plugin/prometheus-ai-proxy.t
+++ b/t/plugin/prometheus-ai-proxy.t
@@ -1,0 +1,314 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+BEGIN {
+    if ($ENV{TEST_NGINX_CHECK_LEAK}) {
+        $SkipReason = "unavailable for the hup tests";
+
+    } else {
+        $ENV{TEST_NGINX_USE_HUP} = 1;
+        undef $ENV{TEST_NGINX_USE_STAP};
+    }
+}
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_shuffle();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+    my $http_config = $block->http_config // <<_EOC_;
+        server {
+            listen 6724;
+
+            default_type 'application/json';
+
+            location /v1/chat/completions {
+                content_by_lua_block {
+                    ngx.exec("\@chat")
+                }
+            }
+
+
+            location /delay/v1/chat/completions {
+                content_by_lua_block {
+                    ngx.sleep(2)
+                    ngx.exec("\@chat")
+                }
+            }
+
+            location \@chat {
+                content_by_lua_block {
+                    ngx.status = 200
+                    ngx.say([[
+{
+  "choices": [
+    {
+      "message": {
+        "content": "1 + 1 = 2.",
+        "role": "assistant"
+      }
+    }
+  ],
+  "usage": {
+    "completion_tokens": 5,
+    "prompt_tokens": 8,
+    "total_tokens": 13
+  }
+}
+                    ]])
+                }
+            }
+        }
+_EOC_
+
+    $block->set_value("http_config", $http_config);
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: create a route with prometheus and ai-proxy-multi plugin
+--- config
+    location /t {
+        content_by_lua_block {
+            local data = {
+                {
+                    url = "/apisix/admin/routes/1",
+                    data = [[{
+                        "plugins": {
+                            "prometheus": {},
+                            "ai-proxy-multi": {
+                                "instances": [
+                                    {
+                                        "name": "openai-gpt4",
+                                        "provider": "openai",
+                                        "weight": 1,
+                                        "auth": {
+                                            "header": {
+                                                "Authorization": "Bearer token"
+                                            }
+                                        },
+                                        "options": {
+                                            "model": "gpt-4"
+                                        },
+                                        "override": {
+                                            "endpoint": "http://localhost:6724"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "uri": "/chat"
+                    }]],
+                },
+                {
+                    url = "/apisix/admin/routes/metrics",
+                    data = [[{
+                        "plugins": {
+                            "public-api": {}
+                        },
+                        "uri": "/apisix/prometheus/metrics"
+                    }]]
+                },
+            }
+
+            local t = require("lib.test_admin").test
+
+            for _, data in ipairs(data) do
+                local _, body = t(data.url, ngx.HTTP_PUT, data.data)
+                ngx.say(body)
+            end
+        }
+    }
+--- response_body eval
+"passed\n" x 2
+
+
+
+=== TEST 2: send a chat request
+--- request
+POST /chat
+{"messages":[{"role":"user","content":"What is 1+1?"}]}
+--- error_code: 200
+
+
+
+=== TEST 3: assert llm_lantency_bucket metric
+--- request
+GET /apisix/prometheus/metrics
+--- response_body eval
+qr/apisix_llm_latency_bucket\{.*route_id="1",.*,node="openai-gpt4".*.*request_type="ai_chat",llm_model="gpt-4",le="\d+"\} 1/
+
+
+
+=== TEST 4: assert llm_lantency_count metric
+--- request
+GET /apisix/prometheus/metrics
+--- response_body eval
+qr/apisix_llm_latency_count\{.*route_id="1",.*,node="openai-gpt4".*.*request_type="ai_chat",llm_model="gpt-4"\} 1/
+
+
+
+=== TEST 5: assert llm_lantency_sum metric
+--- request
+GET /apisix/prometheus/metrics
+--- response_body eval
+qr/apisix_llm_latency_count\{.*route_id="1",.*,node="openai-gpt4".*.*request_type="ai_chat",llm_model="gpt-4"\} \d+/
+
+
+
+=== TEST 6: assert llm_prompt_tokens metric
+--- request
+GET /apisix/prometheus/metrics
+--- response_body eval
+qr/apisix_llm_prompt_tokens\{.*route_id="1",.*,node="openai-gpt4".*.*request_type="ai_chat",llm_model="gpt-4"\} 8/
+
+
+
+=== TEST 7: assert llm_completion_tokens metric
+--- request
+GET /apisix/prometheus/metrics
+--- response_body eval
+qr/apisix_llm_completion_tokens\{.*route_id="1",.*,node="openai-gpt4".*.*request_type="ai_chat",llm_model="gpt-4"\} 5/
+
+
+
+=== TEST 8: assert llm_active_connections metric
+--- request
+GET /apisix/prometheus/metrics
+--- response_body eval
+qr/apisix_llm_active_connections\{.*route_id="1",.*,node="openai-gpt4".*.*request_type="ai_chat",llm_model="gpt-4"\} 0/
+
+
+
+=== TEST 9: change ai-proxy-multi to use a slower ai endpoint
+--- config
+    location /t {
+        content_by_lua_block {
+            local data = {
+                {
+                    url = "/apisix/admin/routes/1",
+                    data = [[{
+                        "plugins": {
+                            "prometheus": {},
+                            "ai-proxy-multi": {
+                                "instances": [
+                                    {
+                                        "name": "openai-gpt4",
+                                        "provider": "openai",
+                                        "weight": 1,
+                                        "auth": {
+                                            "header": {
+                                                "Authorization": "Bearer token"
+                                            }
+                                        },
+                                        "options": {
+                                            "model": "gpt-4"
+                                        },
+                                        "override": {
+                                            "endpoint": "http://localhost:6724/delay/v1/chat/completions"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "uri": "/chat"
+                    }]],
+                },
+            }
+
+            local t = require("lib.test_admin").test
+
+            for _, data in ipairs(data) do
+                local _, body = t(data.url, ngx.HTTP_PUT, data.data)
+                ngx.say(body)
+            end
+        }
+    }
+--- response_body eval
+"passed\n"
+
+
+
+=== TEST 10: assert llm_active_connections metric when the ai endpoint is slow
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+
+            local res_list = {}
+            for i = 1, 3 do
+                local url = "http://127.0.0.1:" .. ngx.var.server_port .. "/chat"
+                local function send_chat_request(idx)
+                    local http = require "resty.http"
+                    local httpc = http.new()
+                    local res = httpc:request_uri(
+                        url,
+                        {
+                            method = "POST",
+                            body = [[ {"messages":[{"role":"user","content":"What is 1+1?"}]} ]],
+                        })
+                    res_list[idx] = res
+                end
+                ngx.timer.at(0, send_chat_request, i)
+            end
+
+            ngx.sleep(1)
+
+            local http = require "resty.http"
+            local httpc = http.new()
+            local metric_resp = httpc:request_uri("http://127.0.0.1:" .. ngx.var.server_port .. "/apisix/prometheus/metrics")
+
+            if not string.find(metric_resp.body, [[apisix_llm_active_connections{.*} 3]]) then
+                ngx.say(metric_resp.body)
+                ngx.say("llm_active_connections should be 3")
+                return
+            end
+
+            ngx.sleep(1)
+
+            for _, res in ipairs(res_list) do
+                if res.status ~= 200 then
+                    ngx.say("failed to send chat request")
+                    return
+                end
+            end
+
+            metric_resp = httpc:request_uri("http://127.0.0.1:" .. ngx.var.server_port .. "/apisix/prometheus/metrics")
+
+            if not string.find(metric_resp.body, [[apisix_llm_active_connections{.*} 0]]) then
+                ngx.say(metric_resp.body)
+                ngx.say("llm_active_connections should be 0 after all requests are done")
+                return
+            end
+
+            ngx.say("success")
+        }
+    }
+--- request
+GET /t
+--- response_body
+success

--- a/t/plugin/prometheus.t
+++ b/t/plugin/prometheus.t
@@ -141,7 +141,7 @@ apisix_etcd_reachable 1
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_bandwidth\{type="egress",route="1",service="",consumer="",node="127.0.0.1"\} \d+/
+qr/apisix_bandwidth\{type="egress",route="1",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""\} \d+/
 
 
 
@@ -198,7 +198,7 @@ passed
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_bandwidth\{type="egress",route="1",service="",consumer="",node="127.0.0.1"\} \d+/
+qr/apisix_bandwidth\{type="egress",route="1",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""\} \d+/
 
 
 
@@ -206,7 +206,7 @@ qr/apisix_bandwidth\{type="egress",route="1",service="",consumer="",node="127.0.
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_http_latency_count\{type="request",route="1",service="",consumer="",node="127.0.0.1"\} \d+/
+qr/apisix_http_latency_count\{type="request",route="1",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""\} \d+/
 
 
 
@@ -277,7 +277,7 @@ passed
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_bandwidth\{type="egress",route="2",service="1",consumer="",node="127.0.0.1"\} \d+/
+qr/apisix_bandwidth\{type="egress",route="2",service="1",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""\} \d+/
 
 
 
@@ -394,7 +394,7 @@ passed
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_http_status\{code="404",route="3",matched_uri="\/hello3",matched_host="",service="",consumer="",node="127.0.0.1"\} 2/
+qr/apisix_http_status\{code="404",route="3",matched_uri="\/hello3",matched_host="",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""\} 2/
 
 
 

--- a/t/plugin/prometheus2.t
+++ b/t/plugin/prometheus2.t
@@ -134,7 +134,7 @@ passed
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_bandwidth\{type="egress",route="1",service="",consumer="",node=""\} \d+/
+qr/apisix_bandwidth\{type="egress",route="1",service="",consumer="",node="",request_type="traditional_http",llm_model=""\} \d+/
 
 
 
@@ -180,7 +180,7 @@ apikey: auth-one
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_http_status\{code="200",route="1",matched_uri="\/hello",matched_host="",service="",consumer="jack",node="127.0.0.1"\} \d+/
+qr/apisix_http_status\{code="200",route="1",matched_uri="\/hello",matched_host="",service="",consumer="jack",node="127.0.0.1",request_type="traditional_http",llm_model=""\} \d+/
 
 
 
@@ -256,7 +256,7 @@ GET /not_found
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_http_status\{code="404",route="",matched_uri="",matched_host="",service="",consumer="",node=""\} \d+/
+qr/apisix_http_status\{code="404",route="",matched_uri="",matched_host="",service="",consumer="",node="",request_type="traditional_http",llm_model=""\} \d+/
 
 
 
@@ -275,7 +275,7 @@ qr/404 Not Found/
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_http_status\{code="404",route="9",matched_uri="\/foo\*",matched_host="foo.com",service="",consumer="",node="127.0.0.1"\} \d+/
+qr/apisix_http_status\{code="404",route="9",matched_uri="\/foo\*",matched_host="foo.com",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""\} \d+/
 
 
 
@@ -294,7 +294,7 @@ qr/404 Not Found/
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_http_status\{code="404",route="9",matched_uri="\/bar\*",matched_host="bar.com",service="",consumer="",node="127.0.0.1"\} \d+/
+qr/apisix_http_status\{code="404",route="9",matched_uri="\/bar\*",matched_host="bar.com",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""\} \d+/
 
 
 
@@ -767,7 +767,7 @@ GET /hello
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_bandwidth\{type="egress",route="route_name",service="service_name",consumer="",node="127.0.0.1"\} \d+/
+qr/apisix_bandwidth\{type="egress",route="route_name",service="service_name",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""\} \d+/
 
 
 
@@ -810,7 +810,7 @@ GET /hello
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_bandwidth\{type="egress",route="route_name",service="1",consumer="",node="127.0.0.1"\} \d+/
+qr/apisix_bandwidth\{type="egress",route="route_name",service="1",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""\} \d+/
 
 
 
@@ -873,7 +873,7 @@ GET /hello
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_bandwidth\{type="egress",route="1",service="service_name",consumer="",node="127.0.0.1"\} \d+/
+qr/apisix_bandwidth\{type="egress",route="1",service="service_name",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""\} \d+/
 
 
 
@@ -917,7 +917,7 @@ GET /hello
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_bandwidth\{type="egress",route="1",service="service_name",consumer="",node="127.0.0.1"\} \d+/
+qr/apisix_bandwidth\{type="egress",route="1",service="service_name",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""\} \d+/
 
 
 

--- a/t/plugin/prometheus3.t
+++ b/t/plugin/prometheus3.t
@@ -270,4 +270,4 @@ opentracing
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_http_status\{code="200",route="1",matched_uri="\/opentracing",matched_host="",service="",consumer="",node="127.0.0.1\"} 1/
+qr/apisix_http_status\{code="200",route="1",matched_uri="\/opentracing",matched_host="",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model=""\} 1/

--- a/t/plugin/prometheus4.t
+++ b/t/plugin/prometheus4.t
@@ -121,7 +121,7 @@ GET /hello
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_bandwidth\{type="egress",route="10",service="",consumer="",node="127.0.0.1",upstream_addr="127.0.0.1:1980",upstream_status="200"\} \d+/
+qr/apisix_bandwidth\{type="egress",route="10",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model="",upstream_addr="127.0.0.1:1980",upstream_status="200"\} \d+/
 
 
 
@@ -143,7 +143,7 @@ GET /hello
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_http_status\{code="200",route="10",matched_uri="\/hello",matched_host="",service="",consumer="",node="127.0.0.1",dummy=""\} \d+/
+qr/apisix_http_status\{code="200",route="10",matched_uri="\/hello",matched_host="",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model="",dummy=""\} \d+/
 
 
 
@@ -195,11 +195,11 @@ plugin_attr:
 --- request
 GET /apisix/prometheus/metrics
 --- response_body eval
-qr/apisix_http_latency_bucket\{type="upstream",route="1",service="",consumer="",node="127.0.0.1",le="15"\} \d+
-apisix_http_latency_bucket\{type="upstream",route="1",service="",consumer="",node="127.0.0.1",le="55"\} \d+
-apisix_http_latency_bucket\{type="upstream",route="1",service="",consumer="",node="127.0.0.1",le="105"\} \d+
-apisix_http_latency_bucket\{type="upstream",route="1",service="",consumer="",node="127.0.0.1",le="205"\} \d+
-apisix_http_latency_bucket\{type="upstream",route="1",service="",consumer="",node="127.0.0.1",le="505"\} \d+/
+qr/apisix_http_latency_bucket\{type="upstream",route="1",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model="",le="15"\} \d+
+apisix_http_latency_bucket\{type="upstream",route="1",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model="",le="55"\} \d+
+apisix_http_latency_bucket\{type="upstream",route="1",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model="",le="105"\} \d+
+apisix_http_latency_bucket\{type="upstream",route="1",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model="",le="205"\} \d+
+apisix_http_latency_bucket\{type="upstream",route="1",service="",consumer="",node="127.0.0.1",request_type="traditional_http",llm_model="",le="505"\} \d+/
 
 
 


### PR DESCRIPTION
### Description
This PR adds two things:
1. It adds latency and token info for ai-proxy plugin in the access log for easy debugging.
2. It adds prometheus metrics for ai related requests and adds two more labels `request_type` to distinguish between normal requests and ai related requests & `llm_model`
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
3. Always add/update tests for any changes unless you have a good reason.
4. Always update the documentation to reflect the changes made in the PR.
5. Make a new commit to resolve conversations instead of `push -f`.
6. To resolve merge conflicts, merge master instead of rebasing.
7. Use "request review" to notify the reviewer after making changes.
8. Only a reviewer can mark a conversation as resolved.

-->
