### PR TITLE
fix(etcd): load full data from etcd while worker restart

### DIFF
--- a/apisix/cli/config.lua
+++ b/apisix/cli/config.lua
@@ -72,6 +72,7 @@ local _M = {
     },
     enable_control = true,
     disable_sync_configuration_during_start = false,
+    worker_startup_time_threshold = 60,
     data_encryption = {
       enable_encrypt_fields = true,
       keyring = { "qeddd145sfvddff3", "edd1c9f0985e76a2" }

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -74,6 +74,7 @@ if not is_http then
 end
 local created_obj  = {}
 local loaded_configuration = {}
+local configuration_loaded_time
 local watch_ctx
 
 
@@ -1125,6 +1126,22 @@ local function create_formatter(prefix)
 end
 
 
+local function init_loaded_configuration()
+    loaded_configuration = {}
+    local etcd_cli, prefix, err = etcd_apisix.new_without_proxy()
+    if not etcd_cli then
+        return "failed to start a etcd instance: " .. err
+    end
+
+    local res, err = readdir(etcd_cli, prefix, create_formatter(prefix))
+    if not res then
+        return err
+    end
+
+    configuration_loaded_time = ngx_time()
+end
+
+
 function _M.init()
     local local_conf, err = config_local.local_conf()
     if not local_conf then
@@ -1135,14 +1152,8 @@ function _M.init()
         return true
     end
 
-    -- don't go through proxy during start because the proxy is not available
-    local etcd_cli, prefix, err = etcd_apisix.new_without_proxy()
-    if not etcd_cli then
-        return nil, "failed to start a etcd instance: " .. err
-    end
-
-    local res, err = readdir(etcd_cli, prefix, create_formatter(prefix))
-    if not res then
+    local err = init_loaded_configuration()
+    if err then
         return nil, err
     end
 
@@ -1157,8 +1168,14 @@ function _M.init_worker()
         return nil, err
     end
 
-    if table.try_read_attr(local_conf, "apisix", "disable_sync_configuration_during_start") then
-        return true
+    -- if the startup time of a worker differs significantly from that of the master process,
+    -- we consider it to have restarted, and at this point,
+    -- it is necessary to reload the full configuration from etcd.
+    if configuration_loaded_time and ngx_time() - configuration_loaded_time > 60 then
+        local err = init_loaded_configuration()
+        if err then
+            return nil, err
+        end
     end
 
     return true

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -1168,10 +1168,14 @@ function _M.init_worker()
         return nil, err
     end
 
+    local threshold = table.try_read_attr(local_conf, "apisix",
+                                    "worker_startup_time_threshold") or 60
     -- if the startup time of a worker differs significantly from that of the master process,
     -- we consider it to have restarted, and at this point,
     -- it is necessary to reload the full configuration from etcd.
-    if configuration_loaded_time and ngx_time() - configuration_loaded_time > 60 then
+    if configuration_loaded_time and ngx_time() - configuration_loaded_time > threshold then
+        log.warn("master process has been running for a long time, ",
+                     "reloading the full configuration from etcd for this new worker")
         local err = init_loaded_configuration()
         if err then
             return nil, err

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -116,7 +116,7 @@ apisix:
 
   disable_sync_configuration_during_start: false  # Safe exit. TO BE REMOVED.
 
-  # This time will be used to distiguish whether the worker is started first time or restarted due to a crash, unit: second.
+  # This time will be used to distinguish whether the worker is started first time or restarted due to a crash, unit: second.
   worker_startup_time_threshold: 60
 
   data_encryption:                # Data encryption settings.

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -116,6 +116,9 @@ apisix:
 
   disable_sync_configuration_during_start: false  # Safe exit. TO BE REMOVED.
 
+  # This time will be used to distiguish whether the worker is started first time or restarted due to a crash, unit: second.
+  worker_startup_time_threshold: 60
+
   data_encryption:                # Data encryption settings.
     enable_encrypt_fields: true   # Whether enable encrypt fields specified in `encrypt_fields` in plugin schema.
     keyring:                      # This field is used to encrypt the private key of SSL and the `encrypt_fields`

--- a/t/cli/test_load_full_data_init_worker.sh
+++ b/t/cli/test_load_full_data_init_worker.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+. ./t/cli/common.sh
+
+git checkout conf/config.yaml
+
+echo '
+apisix:
+  worker_startup_time_threshold: 3
+' > conf/config.yaml
+
+make run
+
+sleep 5
+
+MASTER_PID=$(cat logs/nginx.pid)
+
+worker_pids=$(pgrep -P "$MASTER_PID" -f "nginx: worker process" || true)
+
+if [ -n "$worker_pids" ]; then
+    pid=$(echo "$worker_pids" | shuf -n 1)
+    echo "killing worker $pid (master $MASTER_PID)"
+    kill "$pid"
+else
+    echo "failed: no worker process found for master $MASTER_PID"
+    exit 1
+fi
+
+sleep 2
+
+if ! grep 'master process has been running for a long time, reloading the full configuration from etcd for this new worker' logs/error.log; then
+    echo "failed: could not detect new worker be started"
+    exit 1
+fi
+
+echo "passed: load full configuration for new worker"
+
+make stop


### PR DESCRIPTION
### Description

When using etcd as the config server, the apisix master process performs a full data load during the init phase and saves the result in `loaded_configuration`. After the master forks other worker processes, these worker processes will directly initialize configurations based on `loaded_configuration`:
https://github.com/apache/apisix/blob/1b0bb84ccf343bd1aedc4bfff1afa9fcefb7c4d5/apisix/core/config_etcd.lua#L1023-L1031
Since `loaded_configuration` in the master process is not continuously updated, after running for some time, `loaded_configuration` may become outdated. If a worker restarts at this point, it will use an outdated configuration for initialization. If any requests are sent to this worker at that time, these requests may be processed by incorrect confiurations.

### Benchmark

Because the issue addressed by this PR only becomes apparent when APISIX is continuously handling high QPS requests, I am unable to provide effective automated integration tests. 
So I conducted a continuous  one hour stability test, here are the testing steps and results.

#### Steps
1. start APISIX with two workers
```
nginx_config:
  worker_processes: 2
```
2. create 1000 routes after APISIX startup
```
#!/usr/bin/env bash
set -euo pipefail

APISIX_HOST="http://127.0.0.1:9180"
ADMIN_API_KEY="${ADMIN_API_KEY:-edd1c9f034335f136f87ad84b625c8f1}"

for i in $(seq 1 1000); do
  echo ">>> creating upstream $i"
  curl -s -o /dev/null -X PUT "$APISIX_HOST/apisix/admin/upstreams/$i" \
    -H "X-API-KEY: $ADMIN_API_KEY" \
    -H "Content-Type: application/json" \
    -d "{
      \"id\": $i,
      \"nodes\": {\"127.0.0.1:1980\": 1},
      \"type\": \"roundrobin\"
    }"

  echo ">>> creating route $i"
  curl -s -o /dev/null -X PUT "$APISIX_HOST/apisix/admin/routes/$i" \
    -H "X-API-KEY: $ADMIN_API_KEY" \
    -H "Content-Type: application/json" \
    -d "{
      \"id\": $i,
      \"uri\": \"/$i\",
      \"upstream_id\": $i
    }"
done

echo ">>> All routes and upstreams created"
```
3. kill one worker process randomly every 60s
```
#!/usr/bin/env bash
set -euo pipefail

MASTER_PID="${NGINX_MASTER_PID:?must set NGINX_MASTER_PID}"

while true; do
  worker_pids=$(pgrep -P "$MASTER_PID" -f "nginx: worker process" || true)

  if [ -n "$worker_pids" ]; then
    pid=$(echo "$worker_pids" | shuf -n 1)
    echo ">>> killing worker $pid (master $MASTER_PID)"
    kill "$pid"
  else
    echo ">>> no worker process found for master $MASTER_PID"
  fi

  sleep 60
done
```
4. use wrk to continuously request APISIX
```
wrk -t2 -c100 -R6000 -d1h -s request.lua http://127.0.0.1:9080
```

#### Result
```
❯ wrk -t2 -c100 -R6000 -d1h -s request.lua http://127.0.0.1:9080

Running 60m test @ http://127.0.0.1:9080
  2 threads and 100 connections
  Thread calibration: mean lat.: 1.313ms, rate sampling interval: 10ms
  Thread calibration: mean lat.: 1.331ms, rate sampling interval: 10ms
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.60ms    9.28ms 337.15ms   99.31%
    Req/Sec     2.92k   508.56    18.00k    74.18%
  19835460 requests in 60.00m, 3.31GB read
  Socket errors: connect 0, read 2623, write 0, timeout 14660
Requests/sec:   5509.85
Transfer/sec:      0.94MB
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
3. Always add/update tests for any changes unless you have a good reason.
4. Always update the documentation to reflect the changes made in the PR.
5. Make a new commit to resolve conversations instead of `push -f`.
6. To resolve merge conflicts, merge master instead of rebasing.
7. Use "request review" to notify the reviewer after making changes.
8. Only a reviewer can mark a conversation as resolved.

-->
