### PR TITLE
fix: docker entrypoint remove stream_worker_events.sock if exists

### DIFF
--- a/docker/debian-dev/docker-entrypoint.sh
+++ b/docker/debian-dev/docker-entrypoint.sh
@@ -57,6 +57,10 @@ _EOC_
         rm -f "/usr/local/apisix/logs/worker_events.sock"
     fi
 
+    if [ -e "/usr/local/apisix/logs/stream_worker_events.sock" ]; then
+        rm -f "/usr/local/apisix/logs/stream_worker_events.sock"
+    fi
+
     exec /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'
 fi
 


### PR DESCRIPTION
### Description

If the container exits abnormally, Nginx cannot properly clean up the unix domain socket files it is listening on. When the container is restarted, the startup will fail because the files still exist, preventing the container from starting.  
Therefore, we check and delete the files in the entrypoint script of the Docker container. This includes the conf server and event broker.
However, this overlooks the event broker UDS file used by the stream subsystem, so when using TCP/UDP proxies, startup may still fail.

This PR fixes the issue by checking whether the file exists and deleting it if it does.

**DEV image**

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
