### PR TITLE
fix(ai-proxy): check type of choices/usage/content fields before use it

### DIFF
--- a/apisix/plugins/ai-drivers/openai-base.lua
+++ b/apisix/plugins/ai-drivers/openai-base.lua
@@ -163,17 +163,20 @@ local function read_response(ctx, res)
             ", it will cause token usage not available")
     else
         core.log.info("got token usage from ai service: ", core.json.delay_encode(res_body.usage))
-        ctx.ai_token_usage = {
-            prompt_tokens = res_body.usage and res_body.usage.prompt_tokens or 0,
-            completion_tokens = res_body.usage and res_body.usage.completion_tokens or 0,
-            total_tokens = res_body.usage and res_body.usage.total_tokens or 0,
-        }
-        ctx.var.llm_prompt_tokens = ctx.ai_token_usage.prompt_tokens
-        ctx.var.llm_completion_tokens = ctx.ai_token_usage.completion_tokens
-        if res_body.choices and #res_body.choices > 0 then
+        ctx.ai_token_usage = {}
+        if type(res_body.usage) == "table" then
+            ctx.ai_token_usage.prompt_tokens = res_body.usage.prompt_tokens or 0
+            ctx.ai_token_usage.completion_tokens = res_body.usage.completion_tokens or 0
+            ctx.ai_token_usage.total_tokens = res_body.usage.total_tokens or 0
+        end
+        ctx.var.llm_prompt_tokens = ctx.ai_token_usage.prompt_tokens or 0
+        ctx.var.llm_completion_tokens = ctx.ai_token_usage.completion_tokens or 0
+        if type(res_body.choices) == "table" and #res_body.choices > 0 then
             local contents = {}
             for _, choice in ipairs(res_body.choices) do
-                if choice and choice.message and choice.message.content then
+                if type(choice) == "table"
+                        and type(choice.message) == "table"
+                        and type(choice.message.content) == "string" then
                     core.table.insert(contents, choice.message.content)
                 end
             end

--- a/t/plugin/ai-proxy3.t
+++ b/t/plugin/ai-proxy3.t
@@ -1,4 +1,3 @@
-
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/t/plugin/ai-proxy3.t
+++ b/t/plugin/ai-proxy3.t
@@ -172,12 +172,12 @@ passed
 === TEST 2: send request
 --- request
 POST /anything
-{"messages":[{"role":"system","content":"You are a mathematician"},{"role":"user","content":"What is 1+1?"}], "model": "gpt-4"}
+{ "messages": [ { "role": "system", "content": "You are a mathematician" }, { "role": "user", "content": "What is 1+1?"} ] }
 --- error_code: 200
 --- response_body eval
 qr/.*completion_tokens.*/
 --- access_log eval
-qr/.*gpt-4 gpt-3.5-turbo \d+ 10 20.*/
+qr/.*gpt-3.5-turbo \d+ 10 20.*/
 
 
 

--- a/t/plugin/ai-proxy3.t
+++ b/t/plugin/ai-proxy3.t
@@ -67,7 +67,7 @@ add_block_preprocessor(sub {
                         return
                     end
 
-		    local res = [[
+            local res = [[
 {
   "id": "chatcmpl-12345",
   "object": "chat.completion",
@@ -98,7 +98,7 @@ add_block_preprocessor(sub {
                 content_by_lua_block {
                     local json = require("cjson.safe")
 
-		    local res = [[
+            local res = [[
 {
   "model": "gpt-3.5-turbo",
   "choices": [


### PR DESCRIPTION
In the user's environment, the content field returned by the LLM service may be null. Our code needs to handle this case to avoid panic:
```
apisix/plugins/ai-drivers/openai-base.lua:160: invalid value (userdata) at index 1 in table for 'concat'
```
### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
