### PR TITLE
fix: add exptime to ewma shared dict items

### DIFF
--- a/apisix/balancer/ewma.lua
+++ b/apisix/balancer/ewma.lua
@@ -18,6 +18,7 @@ local next = next
 local error = error
 
 local DECAY_TIME = 10 -- this value is in seconds
+local SHM_TTL = 60
 local LOCK_KEY = ":ewma_key"
 
 local shm_ewma = ngx_shared["balancer-ewma"]
@@ -58,7 +59,7 @@ local function decay_ewma(ewma, last_touched_at, rtt, now)
 end
 
 local function store_stats(upstream, ewma, now)
-    local success, err, forcible = shm_last_touched_at:set(upstream, now)
+    local success, err, forcible = shm_last_touched_at:set(upstream, now, SHM_TTL)
     if not success then
         core.log.error("shm_last_touched_at:set failed: ", err)
     end
@@ -66,7 +67,7 @@ local function store_stats(upstream, ewma, now)
         core.log.warn("shm_last_touched_at:set valid items forcibly overwritten")
     end
 
-    success, err, forcible = shm_ewma:set(upstream, ewma)
+    success, err, forcible = shm_ewma:set(upstream, ewma, SHM_TTL)
     if not success then
         core.log.error("shm_ewma:set failed: ", err)
     end


### PR DESCRIPTION
### Description

Because the current ewma load balancer uses two shared memory and has no recycling mechanism, when the user's upstream IP address changes frequently, the shared memory will be quickly consumed, resulting in the following error:
```
2024/11/19 19:29:04 [error] 42#42: *7149052434 [lua] ewma.lua:63: store_stats(): shm_last_touched_at:set failed: no memory while logging request...
```
This PR sets expiration times for the two shared memory items used by ewma to record upstream latency data, so that when executing the `set` and `get` functions of sharedict, openresty will attempt to reclaim 1~2 expired entries.
https://github.com/openresty/lua-nginx-module/blob/c47084b5d719ce507d2419d8660f39544a9d1fea/src/ngx_http_lua_shdict.c#L1595-L1599
https://github.com/openresty/lua-nginx-module/blob/c47084b5d719ce507d2419d8660f39544a9d1fea/src/ngx_http_lua_shdict.c#L1368
https://github.com/openresty/lua-nginx-module/blob/c47084b5d719ce507d2419d8660f39544a9d1fea/src/ngx_http_lua_shdict.c#L250-L254
This ensures that the shared memory space is released.

**The choice of TTL**
According to the current ewma algorithm parameters: https://github.com/apache/apisix/blob/3260931f301f741d5551af895cbfd6b12d1aff31/apisix/balancer/ewma.lua#L51-L58
https://github.com/apache/apisix/blob/49a48eb808780ba97854f10740f1fb16ae341e39/apisix/balancer/ewma.lua#L20
set ttl to 60s is more appropriate because when the current time exceeds 60s from the `last_touched_at `, the weight of that historical "score" is already close to 0. Therefore, whether or not this historical "score" exists does not matter.
<img width="1697" height="1101" alt="image" src="https://github.com/user-attachments/assets/d50e1278-88e7-4f38-8c52-e73dc03a1915" />



<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
