### PR TITLE
fix(plugin/redirect): ensure redirect when scheme is not `https`

### DIFF
--- a/apisix/plugins/redirect.lua
+++ b/apisix/plugins/redirect.lua
@@ -191,7 +191,7 @@ function _M.rewrite(conf, ctx)
 
     local proxy_proto = core.request.header(ctx, "X-Forwarded-Proto")
     local _scheme = proxy_proto or core.request.get_scheme(ctx)
-    if conf.http_to_https and _scheme == "http" then
+    if conf.http_to_https and _scheme ~= "https" then
         if ret_port == nil or ret_port == 443 or ret_port <= 0 or ret_port > 65535  then
             uri = "https://$host$request_uri"
         else

--- a/t/plugin/redirect.t
+++ b/t/plugin/redirect.t
@@ -1046,7 +1046,19 @@ Location: https://foo.com:9443/hello
 
 
 
-=== TEST 47: wrong configure, enable http_to_https with append_query_string
+=== TEST 47: pass wrong X-Forwarded-Proto, should not affect the redirect
+--- request
+GET /hello
+--- more_headers
+Host: foo.com
+X-Forwarded-Proto: any
+--- error_code: 301
+--- response_headers
+Location: https://foo.com:9443/hello
+
+
+
+=== TEST 48: wrong configure, enable http_to_https with append_query_string
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
### Description

In the original logic, using values like `X-Forwarded-Proto: any_value` could bypass the redirect.

Obviously, this logic is incorrect, so in this PR it's adjusted to redirect when `X-Forwarded-Proto` is not `https`.

part of #12500 

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
