### PR TITLE
fix: missing ctx.llm_raw_usage in non-stream mode

### DIFF
--- a/apisix/plugins/ai-drivers/openai-base.lua
+++ b/apisix/plugins/ai-drivers/openai-base.lua
@@ -165,6 +165,7 @@ local function read_response(ctx, res)
         core.log.info("got token usage from ai service: ", core.json.delay_encode(res_body.usage))
         ctx.ai_token_usage = {}
         if type(res_body.usage) == "table" then
+            ctx.llm_raw_usage = res_body.usage
             ctx.ai_token_usage.prompt_tokens = res_body.usage.prompt_tokens or 0
             ctx.ai_token_usage.completion_tokens = res_body.usage.completion_tokens or 0
             ctx.ai_token_usage.total_tokens = res_body.usage.total_tokens or 0


### PR DESCRIPTION
In the previously merged PR, `ctx.llm_raw_usage` was being set in the stream mode but missed in non stream mode. 
https://github.com/apache/apisix/pull/12530/files


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
