### PR TITLE
fix: embedded UI redirect error when behind proxy

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -651,6 +651,11 @@ http {
 
         {% if enable_admin_ui then %}
         location = /ui {
+            # Fixes incorrect redirect URLs when Nginx is behind a reverse proxy.
+            # By default, Nginx generates an absolute URL (e.g., http://backend:9180/ui/).
+            # Setting this to "off" generates a relative URL (e.g., /ui/), which the browser
+            # correctly resolves against the public-facing domain.
+            absolute_redirect off;
             return 301 /ui/;
         }
         location ^~ /ui/ {

--- a/t/cli/test_admin_ui.sh
+++ b/t/cli/test_admin_ui.sh
@@ -33,11 +33,18 @@ fi
 
 make run
 
-## check /ui redirects to /ui/
-
+## check /ui redirects to /ui/ with 301
 code=$(curl -v -k -i -m 20 -o /dev/null -s -w %{http_code} http://127.0.0.1:9180/ui)
 if [ ! $code -eq 301 ]; then
     echo "failed: failed to redirect /ui to /ui/"
+    exit 1
+fi
+
+## check /ui redirects to /ui/ with correct Location header
+location_header=$(curl -k -i -m 20 -s http://127.0.0.1:9180/ui | grep -i '^Location:' | awk -F': ' '{print $2}' | tr -d '\r')
+
+if [ "${location_header}" != "/ui/" ]; then
+    echo "failed: incorrect redirect Location header when accessing /ui, expected /ui/, got ${location_header}"
     exit 1
 fi
 


### PR DESCRIPTION
### Description

add absolute_redirect off; in /ui location to fix redirect port err

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #12511 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)


