### PR TITLE
fix: use independent lru cache with `invalid_stale` option for secret

### DIFF
--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -239,7 +239,7 @@ do
 
 local function fill_consumer_secret(consumer)
     local new_consumer = core.table.clone(consumer)
-    new_consumer.auth_conf = secret.fetch_secrets(new_consumer.auth_conf, false)
+    new_consumer.auth_conf = secret.fetch_secrets(new_consumer.auth_conf)
     return new_consumer
 end
 

--- a/apisix/plugins/ai-aws-content-moderation.lua
+++ b/apisix/plugins/ai-aws-content-moderation.lua
@@ -32,6 +32,11 @@ local HTTP_BAD_REQUEST = ngx.HTTP_BAD_REQUEST
 
 local moderation_categories_pattern = "^(PROFANITY|HATE_SPEECH|INSULT|"..
                                       "HARASSMENT_OR_ABUSE|SEXUAL|VIOLENCE_OR_THREAT)$"
+
+local secrets_lrucache = core.lrucache.new({
+    ttl = 300, count = 512, invalid_stale = true
+})
+
 local schema = {
     type = "object",
     properties = {
@@ -88,7 +93,7 @@ end
 
 
 function _M.rewrite(conf, ctx)
-    conf = fetch_secrets(conf, true, conf, "")
+    conf = fetch_secrets(conf, secrets_lrucache, conf, "")
     if not conf then
         return HTTP_INTERNAL_SERVER_ERROR, "failed to retrieve secrets from conf"
     end

--- a/apisix/plugins/authz-keycloak.lua
+++ b/apisix/plugins/authz-keycloak.lua
@@ -22,6 +22,10 @@ local ngx       = ngx
 local plugin_name = "authz-keycloak"
 local fetch_secrets    = require("apisix.secret").fetch_secrets
 
+local secrets_lrucache = core.lrucache.new({
+    ttl = 300, count = 512, invalid_stale = true
+})
+
 local log = core.log
 local pairs = pairs
 
@@ -764,7 +768,7 @@ end
 
 function _M.access(conf, ctx)
     -- resolve secrets
-    conf = fetch_secrets(conf, true, conf, "")
+    conf = fetch_secrets(conf, secrets_lrucache, conf, "")
     local headers = core.request.headers(ctx)
     local need_grant_token = conf.password_grant_token_generation_incoming_uri and
         ctx.var.request_uri == conf.password_grant_token_generation_incoming_uri and

--- a/apisix/plugins/limit-count.lua
+++ b/apisix/plugins/limit-count.lua
@@ -14,9 +14,14 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 --
+local core = require("apisix.core")
 local fetch_secrets = require("apisix.secret").fetch_secrets
 local limit_count = require("apisix.plugins.limit-count.init")
 local workflow = require("apisix.plugins.workflow")
+
+local secrets_lrucache = core.lrucache.new({
+    ttl = 300, count = 512, invalid_stale = true
+})
 
 local plugin_name = "limit-count"
 local _M = {
@@ -34,7 +39,7 @@ end
 
 
 function _M.access(conf, ctx)
-    conf = fetch_secrets(conf, true, conf, "")
+    conf = fetch_secrets(conf, secrets_lrucache, conf, "")
     return limit_count.rate_limit(conf, ctx, plugin_name, 1)
 end
 

--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -31,6 +31,10 @@ local concat            = table.concat
 
 local ngx_encode_base64 = ngx.encode_base64
 
+local secrets_lrucache = core.lrucache.new({
+    ttl = 300, count = 512, invalid_stale = true
+})
+
 local plugin_name       = "openid-connect"
 
 
@@ -556,7 +560,7 @@ end
 
 function _M.rewrite(plugin_conf, ctx)
     local conf_clone = core.table.clone(plugin_conf)
-    local conf = fetch_secrets(conf_clone, true, plugin_conf, "")
+    local conf = fetch_secrets(conf_clone, secrets_lrucache, plugin_conf, "")
 
     -- Previously, we multiply conf.timeout before storing it in etcd.
     -- If the timeout is too large, we should not multiply it again.

--- a/apisix/secret.lua
+++ b/apisix/secret.lua
@@ -185,10 +185,6 @@ local function fetch(uri)
 end
 
 
-local secrets_lrucache = core.lrucache.new({
-    ttl = 300, count = 512
-})
-
 local fetch_secrets
 do
     local retrieve_refs
@@ -211,11 +207,11 @@ do
         return retrieve_refs(new_refs)
     end
 
-    function fetch_secrets(refs, cache, key, version)
+    function fetch_secrets(refs, secrets_lrucache, key, version)
         if not refs or type(refs) ~= "table" then
             return nil
         end
-        if not cache then
+        if not secrets_lrucache then
             return retrieve(refs)
         end
         return secrets_lrucache(key, version, retrieve, refs)

--- a/apisix/ssl/router/radixtree_sni.lua
+++ b/apisix/ssl/router/radixtree_sni.lua
@@ -40,6 +40,16 @@ local _M = {
 }
 
 
+local secrets_lrucache = core.lrucache.new({
+    ttl = 3600, count = 512, invalid_stale = true
+})
+
+-- for test
+function _M.inject_secrets_lrucache(lru)
+    secrets_lrucache = lru
+end
+
+
 local function create_router(ssl_items)
     local ssl_items = ssl_items or {}
 
@@ -238,8 +248,8 @@ function _M.set(matched_ssl, sni)
     end
     ngx_ssl.clear_certs()
 
-    local new_ssl_value = secret.fetch_secrets(matched_ssl.value, true, matched_ssl.value, "")
-                            or matched_ssl.value
+    local new_ssl_value = secret.fetch_secrets(matched_ssl.value, secrets_lrucache,
+                                matched_ssl.value, "") or matched_ssl.value
 
     ok, err = _M.set_cert_and_key(sni, new_ssl_value)
     if not ok then


### PR DESCRIPTION
### Description

Our secret feature includes an LRU cache to store values obtained from the secret provider (vault, AWS, GCP) to reduce the number of requests to the secret provider. However, due to without `invalid_stale` parameter, this cache never expires. https://github.com/apache/apisix/blob/9ae24032b6177daa6dfd31de04bfedc435a842d5/apisix/ssl/router/radixtree_sni.lua#L241-L242 https://github.com/apache/apisix/blob/9ae24032b6177daa6dfd31de04bfedc435a842d5/apisix/secret.lua#L188-L190 https://github.com/apache/apisix/blob/9ae24032b6177daa6dfd31de04bfedc435a842d5/apisix/core/lrucache.lua#L54-L62 
Additionally, since all places using secrets share one LRU cache, it is impossible to finely tune parameters like `ttl` and `count`, I refactored the lru cache to be passed as a parameter into the secret function.
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
