### PR TITLE
fix(ai-prompt-decorator): prevent message accumulation across requests

### DIFF
--- a/apisix/plugins/ai-prompt-decorator.lua
+++ b/apisix/plugins/ai-prompt-decorator.lua
@@ -82,7 +82,7 @@ end
 
 local function decorate(conf, body_tab)
     local new_messages = {}
-    
+
     if conf.prepend then
         for i = 1, #conf.prepend do
             new_messages[i] = conf.prepend[i]

--- a/t/plugin/ai-prompt-decorator.t
+++ b/t/plugin/ai-prompt-decorator.t
@@ -265,7 +265,7 @@ passed
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            
+
             -- Configure route with prepend
             local code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
@@ -289,13 +289,13 @@ passed
                     }
             }]]
             )
-            
+
             if code >= 300 then
                 ngx.status = code
                 ngx.say("failed to configure route")
                 return
             end
-            
+
             -- First request
             local code1, body1, actual_resp1 = t('/echo',
                     ngx.HTTP_POST,
@@ -311,13 +311,13 @@ passed
                         ]
                     }]]
             )
-            
+
             if code1 >= 300 then
                 ngx.status = code1
                 ngx.say("first request failed")
                 return
             end
-            
+
             -- Second request should have the same structure, not accumulating history
             local code2, body2, actual_resp2 = t('/echo',
                     ngx.HTTP_POST,
@@ -333,13 +333,13 @@ passed
                         ]
                     }]]
             )
-            
+
             if code2 >= 300 then
                 ngx.status = code2
                 ngx.say("second request failed")
                 return
             end
-            
+
             ngx.say("passed")
         }
     }


### PR DESCRIPTION
### Description

The ai-prompt-decorator plugin accumulated user messages across multiple requests due to a Lua table reference issue.

  Root Cause:
```
  local new_messages = conf.prepend or EMPTY  -- Direct reference, not copy
  This caused new_messages to point to the same table as conf.prepend, so modifications accumulated in the original configuration.
```
  Solution:
```
  local messages = {}
  if conf.prepend then
      for i = 1, #conf.prepend do
          messages[i] = conf.prepend[i]  -- Deep copy instead of reference
      end
  end
```

 Changes: Created new table instead of referencing `conf.prepend`


Fiexed issue: https://github.com/apache/apisix/issues/12532

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
