### PR TITLE
fix(ai-proxy-multi): panic when instance dont have custom endpoint

### DIFF
--- a/apisix/plugins/ai-proxy-multi.lua
+++ b/apisix/plugins/ai-proxy-multi.lua
@@ -170,14 +170,24 @@ end
 
 
 local function resolve_endpoint(instance_conf)
+    local scheme, host, port
     local endpoint = core.table.try_read_attr(instance_conf, "override", "endpoint")
-    local scheme, host, port, _ = endpoint:match(endpoint_regex)
-    if port == "" then
-        port = (scheme == "https") and "443" or "80"
+    if endpoint then
+        scheme, host, port = endpoint:match("^(https?)://([^:/]+):?(%d*)/?.*$")
+        if port == "" then
+            port = (scheme == "https") and "443" or "80"
+        end
+        port = tonumber(port)
+    else
+        local ai_driver = require("apisix.plugins.ai-drivers." .. instance_conf.provider)
+        -- built-in ai driver always use https
+        scheme = "https"
+        host = ai_driver.host
+        port = ai_driver.port
     end
     local node = {
         host = host,
-        port = tonumber(port),
+        port = port,
         scheme = scheme,
     }
     parse_domain_for_node(node)
@@ -216,7 +226,7 @@ local function fetch_health_instances(conf, checkers)
             if ok then
                 transform_instances(new_instances, ins)
             elseif err then
-                core.log.error("failed to get health check target status, addr: ",
+                core.log.warn("failed to get health check target status, addr: ",
                     node.host, ":", port or node.port, ", host: ", host, ", err: ", err)
             end
         else

--- a/apisix/plugins/ai-proxy-multi.lua
+++ b/apisix/plugins/ai-proxy-multi.lua
@@ -173,7 +173,7 @@ local function resolve_endpoint(instance_conf)
     local scheme, host, port
     local endpoint = core.table.try_read_attr(instance_conf, "override", "endpoint")
     if endpoint then
-        scheme, host, port = endpoint:match("^(https?)://([^:/]+):?(%d*)/?.*$")
+        scheme, host, port = endpoint:match(endpoint_regex)
         if port == "" then
             port = (scheme == "https") and "443" or "80"
         end

--- a/t/plugin/ai-proxy-multi3.t
+++ b/t/plugin/ai-proxy-multi3.t
@@ -879,7 +879,7 @@ passed
                                         }
                                     }
                                 },
-                                {"name":"openai-gpt3","provider":"openai","weight":1,"priority":1,"auth":{"header":{"Authorization":"Bearertoken"}},"options":{"model":"gpt-3"}}
+                                {"name":"openai-gpt3","provider":"openai","weight":1,"priority":1,"auth":{"header":{"Authorization":"Bearer token"}},"options":{"model":"gpt-3"}}
                             ],
                             "ssl_verify": false
                         }


### PR DESCRIPTION
## Description
```
local endpoint = core.table.try_read_attr(instance_conf, "override", "endpoint")
```
endpoint will be nil when user use official ai service as instance.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
