### PR TITLE
fix: correct spelling error in get_healthcheck_events_module function name

### DIFF
--- a/apisix/events.lua
+++ b/apisix/events.lua
@@ -127,7 +127,7 @@ function _M.post(self, ...)
 end
 
 
-function _M.get_healthcheck_events_modele(self)
+function _M.get_healthcheck_events_module(self)
     if self.events_module == _M.EVENTS_MODULE_LUA_RESTY_EVENTS then
         return "resty.events"
     else

--- a/apisix/healthcheck_manager.lua
+++ b/apisix/healthcheck_manager.lua
@@ -132,7 +132,7 @@ local function create_checker(up_conf)
         name = get_healthchecker_name(up_conf),
         shm_name = healthcheck_shdict_name,
         checks = up_conf.checks,
-        events_module = events:get_healthcheck_events_modele(),
+        events_module = events:get_healthcheck_events_module(),
     })
 
     if not checker then


### PR DESCRIPTION
### Description

This PR fixes a spelling error in the function name `get_healthcheck_events_modele` to `get_healthcheck_events_module`. The typo in the function name ("modele" instead of "module") could cause confusion and potential issues when calling this function.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
