### PR TITLE
change(openid-connect): when `bearer_only` is `false`, require the user to fill in `session.secret`

### DIFF
--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -18,7 +18,6 @@
 local core              = require("apisix.core")
 local ngx_re            = require("ngx.re")
 local openidc           = require("resty.openidc")
-local random            = require("resty.random")
 local fetch_secrets     = require("apisix.secret").fetch_secrets
 local jsonschema        = require('jsonschema')
 local string            = string

--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -347,12 +347,7 @@ function _M.check_schema(conf)
     end
 
     if not conf.bearer_only and not conf.session then
-        core.log.warn("when bearer_only = false, " ..
-                       "you'd better complete the session configuration manually")
-        conf.session = {
-            -- generate a secret when bearer_only = false and no secret is configured
-            secret = ngx_encode_base64(random.bytes(32, true) or random.bytes(32))
-        }
+        return false, "property \"session.secret\" is required when \"bearer_only\" is false"
     end
 
     local check = {"discovery", "introspection_endpoint", "redirect_uri",

--- a/docs/en/latest/plugins/openid-connect.md
+++ b/docs/en/latest/plugins/openid-connect.md
@@ -64,7 +64,7 @@ The `openid-connect` Plugin supports the integration with [OpenID Connect (OIDC)
 | set_userinfo_header                  | boolean  | False    | true                  |              | If true and if user info data is available, set the value in the `X-Userinfo` request header.    |
 | set_refresh_token_header             | boolean  | False    | false                 |              | If true and if the refresh token is available, set the value in the `X-Refresh-Token` request header.        |
 | session            | object   | False    |     |              | Session configuration used when `bearer_only` is `false` and the Plugin uses Authorization Code flow.              |
-| session.secret     | string   | True     |  | 16 or more characters | Key used for session encryption and HMAC operation when `bearer_only` is `false`. It is automatically generated and saved to etcd if not configured. When using APISIX in the standalone mode where etcd is no longer the configuration center, the `secret` should be configured.         |
+| session.secret     | string   | True     |  | 16 or more characters | Key used for session encryption and HMAC operation when `bearer_only` is `false`.         |
 | session.cookie     | object   | False    |     |             |   Cookie configurations.    |
 | session.cookie.lifetime              | integer   | False    | 3600                  |             | Cookie lifetime in seconds. |
 | session_contents   | object   | False    |                   |             | Session content configurations. If unconfigured, all data will be stored in the session. |

--- a/docs/en/latest/plugins/openid-connect.md
+++ b/docs/en/latest/plugins/openid-connect.md
@@ -231,17 +231,11 @@ To properly configure the redirection URI, make sure that the `redirect_uri` mat
 
 You should also ensure that the `redirect_uri` include the scheme, such as `http` or `https`.
 
-#### 2. Missing Session Secret
-
-If you deploy APISIX in the [standalone mode](/apisix/production/deployment-modes#standalone-mode), make sure that `session.secret` is configured.
-
-User sessions are stored in browser as cookies and encrypted with session secret. The secret is automatically generated and saved to etcd if no secret is configured through the `session.secret` attribute. However, in standalone mode, etcd is no longer the configuration center. Therefore, you should explicitly configure `session.secret` for this Plugin in the YAML configuration center `apisix.yaml`.
-
-#### 3. Cookie Not Sent or Absent
+#### 2. Cookie Not Sent or Absent
 
 Check if the [`SameSite`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) cookie attribute is properly set (i.e. if your application needs to send the cookie cross sites) to see if this could be a factor that prevents the cookie being saved to the browser's cookie jar or being sent from the browser.
 
-#### 4. Upstream Sent Too Big Header
+#### 3. Upstream Sent Too Big Header
 
 If you have NGINX sitting in front of APISIX to proxy client traffic, see if you observe the following error in NGINX's `error.log`:
 
@@ -253,11 +247,11 @@ If so, try adjusting `proxy_buffers`, `proxy_buffer_size`, and `proxy_busy_buffe
 
 Another option is to configure the `session_content` attribute to adjust which data to store in session. For instance, you can set `session_content.access_token` to `true`.
 
-#### 5. Invalid Client Secret
+#### 4. Invalid Client Secret
 
 Verify if `client_secret` is valid and correct. An invalid `client_secret` would lead to an authentication failure and no token shall be returned and stored in session.
 
-#### 6. PKCE IdP Configuration
+#### 5. PKCE IdP Configuration
 
 If you are enabling PKCE with the authorization code flow, make sure you have configured the IdP client to use PKCE. For example, in Keycloak, you should configure the PKCE challenge method in the client's advanced settings:
 

--- a/docs/en/latest/tutorials/keycloak-oidc.md
+++ b/docs/en/latest/tutorials/keycloak-oidc.md
@@ -177,6 +177,9 @@ curl -i "http://127.0.0.1:9180/apisix/admin/routes" -X PUT -d '
   "plugins": {
     "openid-connect": {
       "bearer_only": false,
+      "session": {
+        "secret": "change_to_whatever_secret_you_want"
+      },
       "client_id": "'"$OIDC_CLIENT_ID"'",
       "client_secret": "'"$OIDC_CLIENT_SECRET"'",
       "discovery": "'"$OIDC_DISCOVERY"'",
@@ -203,6 +206,9 @@ curl -i "http://127.0.0.1:9180/apisix/admin/routes" -X PUT -d '
   "plugins": {
     "openid-connect": {
       "bearer_only": false,
+      "session": {
+        "secret": "change_to_whatever_secret_you_want"
+      },
       "use_pkce": true,
       "client_id": "'"$OIDC_CLIENT_ID"'",
       "client_secret": "'"$OIDC_CLIENT_SECRET"'",

--- a/docs/zh/latest/plugins/openid-connect.md
+++ b/docs/zh/latest/plugins/openid-connect.md
@@ -232,17 +232,11 @@ the error request to the redirect_uri path, but there's no session state found
 
 您还应该确保 `redirect_uri` 包含 scheme，例如 `http` 或 `https` 。
 
-#### 2. 缺少 Session Secret
-
-如果您在[standalone 模式](../../../en/latest/deployment-modes.md#standalone)下部署 APISIX，请确保配置了 `session.secret`。
-
-用户 session 作为 cookie 存储在浏览器中，并使用 session 密钥进行加密。如果没有通过 `session.secret` 属性配置机密，则会自动生成机密并将其保存到 etcd。然而，在独立模式下，etcd 不再是配置中心。因此，您应该在 YAML 配置中心 `apisix.yaml` 中为此插件显式配置 `session.secret`。
-
-#### 3. Cookie 未发送或不存在
+#### 2. Cookie 未发送或不存在
 
 检查 [`SameSite`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) cookie 属性是否已正确设置（即您的应用程序是否需要跨站点发送 cookie），看看这是否会成为阻止 cookie 保存到浏览器的 cookie jar 或从浏览器发送的因素。
 
-#### 4. 上游发送的标头太大
+#### 3. 上游发送的标头太大
 
 如果您有 NGINX 位于 APISIX 前面来代理客户端流量，请查看 NGINX 的 `error.log` 中是否观察到以下错误：
 
@@ -254,11 +248,11 @@ upstream sent too big header while reading response header from upstream
 
 另一个选项是配置 `session_content` 属性来调整在会话中存储哪些数据。例如，你可以将 `session_content.access_token` 设置为 `true`。
 
-#### 5. 无效的客户端密钥
+#### 4. 无效的客户端密钥
 
 验证 `client_secret` 是否有效且正确。无效的 `client_secret` 将导致身份验证失败，并且不会返回任何令牌并将其存储在 session 中。
 
-#### 6. PKCE IdP 配置
+#### 5. PKCE IdP 配置
 
 如果您使用授权码流程启用 PKCE，请确保您已将 IdP 客户端配置为使用 PKCE。例如，在 Keycloak 中，您应该在客户端的高级设置中配置 PKCE 质询方法：
 

--- a/docs/zh/latest/plugins/openid-connect.md
+++ b/docs/zh/latest/plugins/openid-connect.md
@@ -64,7 +64,7 @@ description: openid-connect 插件支持与 OpenID Connect (OIDC) 身份提供�
 | set_userinfo_header | boolean | 否 | true | | 如果为 true 并且用户信息数据可用，则在 `X-Userinfo` 请求标头中设置值。 |
 | set_refresh_token_header | boolean | 否 | false | | 如果为 true 并且刷新令牌可用，则在 `X-Refresh-Token` 请求标头中设置值。 |
 | session | object | 否 | | | 当 `bearer_only` 为 `false` 且插件使用 Authorization Code 流程时使用的 Session 配置。 |
-| session.secret | string | 是 | | 16 个字符以上 | 当 `bearer_only` 为 `false` 时，用于 session 加密和 HMAC 运算的密钥，若未配置则自动生成并保存到 etcd。当在独立模式下使用 APISIX 时，etcd 不再是配置中心，需要配置 `secret`。 |
+| session.secret | string | 是 | | 16 个字符以上 | 当 `bearer_only` 为 `false` 时，用于 session 加密和 HMAC 运算的密钥。|
 | session.cookie | object | 否 | | | Cookie 配置。 |
 | session.cookie.lifetime | integer | 否 | 3600 | | Cookie 生存时间（秒）。|
 | unauth_action | string | 否 | auth | ["auth","deny","pass"] | 未经身份验证的请求的操作。设置为 `auth` 时，重定向到 OpenID 提供程序的身份验证端点。设置为 `pass` 时，允许请求而无需身份验证。设置为 `deny` 时，返回 401 未经身份验证的响应，而不是启动授权代码授予流程。|

--- a/docs/zh/latest/tutorials/keycloak-oidc.md
+++ b/docs/zh/latest/tutorials/keycloak-oidc.md
@@ -177,6 +177,9 @@ curl -i "http://127.0.0.1:9180/apisix/admin/routes" -X PUT -d '
   "plugins": {
     "openid-connect": {
       "bearer_only": false,
+      "session": {
+        "secret": "change_to_whatever_secret_you_want"
+      },
       "client_id": "'"$OIDC_CLIENT_ID"'",
       "client_secret": "'"$OIDC_CLIENT_SECRET"'",
       "discovery": "'"$OIDC_DISCOVERY"'",
@@ -203,6 +206,9 @@ curl -i "http://127.0.0.1:9180/apisix/admin/routes" -X PUT -d '
   "plugins": {
     "openid-connect": {
       "bearer_only": false,
+      "session": {
+        "secret": "change_to_whatever_secret_you_want"
+      },
       "use_pkce": true,
       "client_id": "'"$OIDC_CLIENT_ID"'",
       "client_secret": "'"$OIDC_CLIENT_SECRET"'",

--- a/t/plugin/openid-connect.t
+++ b/t/plugin/openid-connect.t
@@ -940,6 +940,7 @@ OIDC introspection failed: invalid token
 {"accept_none_alg":false,"accept_unsupported_alg":true,"access_token_expires_leeway":0,"access_token_in_authorization_header":false,"bearer_only":false,"client_id":"kbyuFDidLLm280LIwVFiazOqjO3ty8KH","client_jwt_assertion_expires_in":60,"client_secret":"60Op4HFM0I8ajz0WdiStAbziZ-VFQttXuxixHHs2R7r7-CW8GR79l-mmLqMhc-Sa","discovery":"http://127.0.0.1:1980/.well-known/openid-configuration","force_reauthorize":false,"iat_slack":120,"introspection_endpoint_auth_method":"client_secret_basic","introspection_interval":0,"jwk_expires_in":86400,"jwt_verification_cache_ignore":false,"logout_path":"/logout","realm":"apisix","renew_access_token_on_expiry":true,"revoke_tokens_on_logout":false,"scope":"openid","session":{"secret":"jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"},"set_access_token_header":true,"set_id_token_header":true,"set_refresh_token_header":false,"set_userinfo_header":true,"ssl_verify":false,"timeout":3,"token_endpoint_auth_method":"client_secret_basic","unauth_action":"auth","use_nonce":false,"use_pkce":false}
 
 
+
 === TEST 26: Update plugin with ID provider jwks endpoint for token verification.
 --- config
     location /t {

--- a/t/plugin/openid-connect.t
+++ b/t/plugin/openid-connect.t
@@ -43,9 +43,9 @@ __DATA__
         content_by_lua_block {
             local plugin = require("apisix.plugins.openid-connect")
             local ok, err = plugin.check_schema({
-                client_id = "a", 
-                client_secret = "b", 
-                discovery = "c", 
+                client_id = "a",
+                client_secret = "b",
+                discovery = "c",
                 session = {secret = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"}
             })
             if not ok then
@@ -66,8 +66,8 @@ done
         content_by_lua_block {
             local plugin = require("apisix.plugins.openid-connect")
             local ok, err = plugin.check_schema({
-                client_secret = "b", 
-                discovery = "c", 
+                client_secret = "b",
+                discovery = "c",
                 session = {secret = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"}
             })
             if not ok then
@@ -89,9 +89,9 @@ done
         content_by_lua_block {
             local plugin = require("apisix.plugins.openid-connect")
             local ok, err = plugin.check_schema({
-                client_id = 123, 
-                client_secret = "b", 
-                discovery = "c", 
+                client_id = 123,
+                client_secret = "b",
+                discovery = "c",
                 session = {secret = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"}
             })
             if not ok then
@@ -937,8 +937,7 @@ OIDC introspection failed: invalid token
         }
     }
 --- response_body
-{"accept_none_alg":false,"accept_unsupported_alg":true,"access_token_expires_leeway":0,"access_token_in_authorization_header":false,"bearer_only":false,"client_id":"kbyuFDidLLm280LIwVFiazOqjO3ty8KH","client_jwt_assertion_expires_in":60,"client_secret":"60Op4HFM0I8ajz0WdiStAbziZ-VFQttXuxixHHs2R7r7-CW8GR79l-mmLqMhc-Sa","discovery":"http://127.0.0.1:1980/.well-known/openid-configuration","force_reauthorize":false,"iat_slack":120,"introspection_endpoint_auth_method":"client_secret_basic","introspection_interval":0,"jwk_expires_in":86400,"jwt_verification_cache_ignore":false,"logout_path":"/logout","realm":"apisix","renew_access_token_on_expiry":true,"revoke_tokens_on_logout":false,"scope":"openid","set_access_token_header":true,"set_id_token_header":true,"set_refresh_token_header":false,"set_userinfo_header":true,"session":{"secret":"jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"},"ssl_verify":false,"timeout":3,"token_endpoint_auth_method":"client_secret_basic","unauth_action":"auth","use_nonce":false,"use_pkce":false}
-
+{"accept_none_alg":false,"accept_unsupported_alg":true,"access_token_expires_leeway":0,"access_token_in_authorization_header":false,"bearer_only":false,"client_id":"kbyuFDidLLm280LIwVFiazOqjO3ty8KH","client_jwt_assertion_expires_in":60,"client_secret":"60Op4HFM0I8ajz0WdiStAbziZ-VFQttXuxixHHs2R7r7-CW8GR79l-mmLqMhc-Sa","discovery":"http://127.0.0.1:1980/.well-known/openid-configuration","force_reauthorize":false,"iat_slack":120,"introspection_endpoint_auth_method":"client_secret_basic","introspection_interval":0,"jwk_expires_in":86400,"jwt_verification_cache_ignore":false,"logout_path":"/logout","realm":"apisix","renew_access_token_on_expiry":true,"revoke_tokens_on_logout":false,"scope":"openid","session":{"secret":"jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"},"set_access_token_header":true,"set_id_token_header":true,"set_refresh_token_header":false,"set_userinfo_header":true,"ssl_verify":false,"timeout":3,"token_endpoint_auth_method":"client_secret_basic","unauth_action":"auth","use_nonce":false,"use_pkce":false}
 
 
 === TEST 26: Update plugin with ID provider jwks endpoint for token verification.
@@ -1615,8 +1614,8 @@ token validate successfully by jwks
             local plugin = require("apisix.plugins.openid-connect")
             local ok, err = plugin.check_schema({
                 client_id = "a",
-                client_secret = "b", 
-                discovery = "c", 
+                client_secret = "b",
+                discovery = "c",
             })
             if not ok then
                 ngx.say(err)
@@ -1626,5 +1625,5 @@ token validate successfully by jwks
         }
     }
 --- response_body
-property "session.secret" is required
+property "session.secret" is required when "bearer_only" is false
 done

--- a/t/plugin/openid-connect.t
+++ b/t/plugin/openid-connect.t
@@ -42,7 +42,12 @@ __DATA__
     location /t {
         content_by_lua_block {
             local plugin = require("apisix.plugins.openid-connect")
-            local ok, err = plugin.check_schema({client_id = "a", client_secret = "b", discovery = "c"})
+            local ok, err = plugin.check_schema({
+                client_id = "a", 
+                client_secret = "b", 
+                discovery = "c", 
+                session = {secret = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"}
+            })
             if not ok then
                 ngx.say(err)
             end
@@ -60,7 +65,11 @@ done
     location /t {
         content_by_lua_block {
             local plugin = require("apisix.plugins.openid-connect")
-            local ok, err = plugin.check_schema({client_secret = "b", discovery = "c"})
+            local ok, err = plugin.check_schema({
+                client_secret = "b", 
+                discovery = "c", 
+                session = {secret = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"}
+            })
             if not ok then
                 ngx.say(err)
             end
@@ -79,7 +88,12 @@ done
     location /t {
         content_by_lua_block {
             local plugin = require("apisix.plugins.openid-connect")
-            local ok, err = plugin.check_schema({client_id = 123, client_secret = "b", discovery = "c"})
+            local ok, err = plugin.check_schema({
+                client_id = 123, 
+                client_secret = "b", 
+                discovery = "c", 
+                session = {secret = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"}
+            })
             if not ok then
                 ngx.say(err)
             end
@@ -111,7 +125,10 @@ done
                                 "ssl_verify": false,
                                 "timeout": 10,
                                 "scope": "apisix",
-                                "use_pkce": false
+                                "use_pkce": false,
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                                }
                             }
                         },
                         "upstream": {
@@ -204,7 +221,10 @@ true
                                 "access_token_in_authorization_header": false,
                                 "set_id_token_header": true,
                                 "set_userinfo_header": true,
-                                "set_refresh_token_header": true
+                                "set_refresh_token_header": true,
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                                }
                             }
                         },
                         "upstream": {
@@ -308,7 +328,10 @@ x-userinfo: ey.*
                                 "set_access_token_header": true,
                                 "access_token_in_authorization_header": true,
                                 "set_id_token_header": false,
-                                "set_userinfo_header": false
+                                "set_userinfo_header": false,
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                                }
                             }
                         },
                         "upstream": {
@@ -901,22 +924,20 @@ OIDC introspection failed: invalid token
                 client_id = "kbyuFDidLLm280LIwVFiazOqjO3ty8KH",
                 client_secret = "60Op4HFM0I8ajz0WdiStAbziZ-VFQttXuxixHHs2R7r7-CW8GR79l-mmLqMhc-Sa",
                 discovery = "http://127.0.0.1:1980/.well-known/openid-configuration",
+                session = {
+                    secret = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                },
             }
             local ok, err = plugin.check_schema(s)
             if not ok then
                 ngx.say(err)
             end
 
-            -- ensure session secret generated when bearer_only = false
-            -- then remove it from table, because it's a random value that I cannot verify it by response body
-            assert(s.session and s.session.secret, "no session secret generated")
-            s.session = nil
-
             ngx.say(json.encode(s))
         }
     }
 --- response_body
-{"accept_none_alg":false,"accept_unsupported_alg":true,"access_token_expires_leeway":0,"access_token_in_authorization_header":false,"bearer_only":false,"client_id":"kbyuFDidLLm280LIwVFiazOqjO3ty8KH","client_jwt_assertion_expires_in":60,"client_secret":"60Op4HFM0I8ajz0WdiStAbziZ-VFQttXuxixHHs2R7r7-CW8GR79l-mmLqMhc-Sa","discovery":"http://127.0.0.1:1980/.well-known/openid-configuration","force_reauthorize":false,"iat_slack":120,"introspection_endpoint_auth_method":"client_secret_basic","introspection_interval":0,"jwk_expires_in":86400,"jwt_verification_cache_ignore":false,"logout_path":"/logout","realm":"apisix","renew_access_token_on_expiry":true,"revoke_tokens_on_logout":false,"scope":"openid","set_access_token_header":true,"set_id_token_header":true,"set_refresh_token_header":false,"set_userinfo_header":true,"ssl_verify":false,"timeout":3,"token_endpoint_auth_method":"client_secret_basic","unauth_action":"auth","use_nonce":false,"use_pkce":false}
+{"accept_none_alg":false,"accept_unsupported_alg":true,"access_token_expires_leeway":0,"access_token_in_authorization_header":false,"bearer_only":false,"client_id":"kbyuFDidLLm280LIwVFiazOqjO3ty8KH","client_jwt_assertion_expires_in":60,"client_secret":"60Op4HFM0I8ajz0WdiStAbziZ-VFQttXuxixHHs2R7r7-CW8GR79l-mmLqMhc-Sa","discovery":"http://127.0.0.1:1980/.well-known/openid-configuration","force_reauthorize":false,"iat_slack":120,"introspection_endpoint_auth_method":"client_secret_basic","introspection_interval":0,"jwk_expires_in":86400,"jwt_verification_cache_ignore":false,"logout_path":"/logout","realm":"apisix","renew_access_token_on_expiry":true,"revoke_tokens_on_logout":false,"scope":"openid","set_access_token_header":true,"set_id_token_header":true,"set_refresh_token_header":false,"set_userinfo_header":true,"session":{"secret":"jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"},"ssl_verify":false,"timeout":3,"token_endpoint_auth_method":"client_secret_basic","unauth_action":"auth","use_nonce":false,"use_pkce":false}
 
 
 
@@ -1076,7 +1097,10 @@ OIDC introspection failed: invalid jwt: invalid jwt string
                                 "access_token_in_authorization_header": false,
                                 "set_id_token_header": true,
                                 "set_userinfo_header": true,
-                                "post_logout_redirect_uri": "http://127.0.0.1:]] .. ngx.var.server_port .. [[/hello"
+                                "post_logout_redirect_uri": "http://127.0.0.1:]] .. ngx.var.server_port .. [[/hello",
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                                }
                             }
                         },
                         "upstream": {
@@ -1183,7 +1207,10 @@ http://127.0.0.1:.*/hello
                                 "ssl_verify": false,
                                 "timeout": 10,
                                 "scope": "apisix",
-                                "use_pkce": true
+                                "use_pkce": true,
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                                }
                             }
                         },
                         "upstream": {
@@ -1360,7 +1387,10 @@ x-userinfo: ey.*
                                 "discovery": "https://samples.auth0.com/.well-known/openid-configuration",
                                 "redirect_uri": "https://iresty.com",
                                 "post_logout_redirect_uri": "https://iresty.com",
-                                "scope": "openid profile"
+                                "scope": "openid profile",
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                                }
                             }
                         },
                         "upstream": {
@@ -1421,7 +1451,10 @@ true
                                 "discovery": "https://accounts.google.com/.well-known/openid-configuration",
                                 "redirect_uri": "https://iresty.com",
                                 "post_logout_redirect_uri": "https://iresty.com",
-                                "scope": "openid profile"
+                                "scope": "openid profile",
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                                }
                             }
                         },
                         "upstream": {
@@ -1485,6 +1518,9 @@ true
                                 "ssl_verify": false,
                                 "timeout": 10,
                                 "bearer_only": false,
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                                },
                                 "use_jwks": true,
                                 "realm": "University",
                                 "introspection_endpoint_auth_method": "client_secret_post",
@@ -1569,3 +1605,26 @@ true
 qr/token validate successfully by \w+/
 --- grep_error_log_out
 token validate successfully by jwks
+
+
+
+=== TEST 41: Missing `session.secret`.
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.openid-connect")
+            local ok, err = plugin.check_schema({
+                client_id = "a",
+                client_secret = "b", 
+                discovery = "c", 
+            })
+            if not ok then
+                ngx.say(err)
+            end
+
+            ngx.say("done")
+        }
+    }
+--- response_body
+property "session.secret" is required
+done

--- a/t/plugin/openid-connect2.t
+++ b/t/plugin/openid-connect2.t
@@ -49,10 +49,23 @@ __DATA__
                     end,
                 },
                 {
-                    name = "sanity (bearer_only = false)",
+                    name = "sanity (bearer_only = false, session.secret is not set)",
                     data = {client_id = "a", client_secret = "b", discovery = "c", bearer_only = false},
                     cb = function(ok, err, case)
-                        assert(ok and case.session and case.session.secret, "no session secret generated")
+                        assert(
+                            not ok and err == "property \"session.secret\" is required when \"bearer_only\" is false",
+                            "session secret should be required"
+                        )
+                    end,
+                },
+                {
+                    name = "sanity (bearer_only = false, session.secret is set)",
+                    data = {client_id = "a", client_secret = "b", discovery = "c", bearer_only = false, session = {secret = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"}},
+                    cb = function(ok, err, case)
+                        assert(
+                            ok and case.session and case.session.secret and case.session.secret == "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK",
+                            "session secret should be set"
+                        )
                     end,
                 },
                 {
@@ -105,7 +118,10 @@ apisix:
                                 "ssl_verify": false,
                                 "timeout": 10,
                                 "scope": "apisix",
-                                "use_pkce": false
+                                "use_pkce": false,
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                                }
                             }
                         },
                         "upstream": {
@@ -168,7 +184,10 @@ xMlerg8pE2lPSDlQdPi+MsAwBnzqpyLRar3lUhP2Tdc2oXnWmit92p8cannhDYkBPc6P/Hlx0wSA0T2w
                                 "timeout": 10,
                                 "scope": "apisix",
                                 "unauth_action": "auth",
-                                "use_pkce": false
+                                "use_pkce": false,
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                                }
                             }
                         },
                         "upstream": {
@@ -235,7 +254,10 @@ true
                                 "timeout": 10,
                                 "scope": "apisix",
                                 "unauth_action": "deny",
-                                "use_pkce": false
+                                "use_pkce": false,
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                                }
                             }
                         },
                         "upstream": {
@@ -295,7 +317,10 @@ true
                                 "timeout": 10,
                                 "scope": "apisix",
                                 "unauth_action": "pass",
-                                "use_pkce": false
+                                "use_pkce": false,
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                                }
                             }
                         },
                         "upstream": {
@@ -354,7 +379,10 @@ true
                                 "timeout": 10,
                                 "scope": "apisix",
                                 "unauth_action": "auth",
-                                "use_pkce": false
+                                "use_pkce": false,
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                                }
                             }
                         },
                         "upstream": {
@@ -436,6 +464,9 @@ true
                                         "user": { "type" : "object"}
                                     },
                                     "required" : ["access_token","id_token","user"]
+                                },
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
                                 }
                             }
                         },
@@ -551,6 +582,9 @@ x-userinfo: ey.*
                                         "user1": { "type" : "object"}
                                     },
                                     "required" : ["access_token","id_token","user","user1"]
+                                },
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
                                 }
                             }
                         },
@@ -652,6 +686,9 @@ property "user1" is required
                                         "user": { "type" : "invalid_type"}
                                     },
                                     "required" : ["access_token","id_token","user"]
+                                },
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
                                 }
                             }
                         },

--- a/t/plugin/openid-connect3.t
+++ b/t/plugin/openid-connect3.t
@@ -59,7 +59,10 @@ __DATA__
                                     "http_proxy": "http://127.0.0.1:8080",
                                     "http_proxy_authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQK"
                                 },
-                                "use_pkce": false
+                                "use_pkce": false,
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                                }
                             }
                         },
                         "upstream": {

--- a/t/plugin/openid-connect4.t
+++ b/t/plugin/openid-connect4.t
@@ -62,7 +62,10 @@ __DATA__
                                     "http_proxy": "http://127.0.0.1:8080",
                                     "http_proxy_authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQK"
                                 },
-                                "use_pkce": false
+                                "use_pkce": false,
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                                }
                             }
                         },
                         "upstream": {

--- a/t/plugin/openid-connect5.t
+++ b/t/plugin/openid-connect5.t
@@ -72,6 +72,9 @@ __DATA__
                                 "redirect_uri": "http://127.0.0.1:]] .. ngx.var.server_port .. [[/authenticated",
                                 "ssl_verify": false,
                                 "bearer_only" : false,
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                                },
                                 "timeout": 10,
                                 "introspection_endpoint_auth_method": "client_secret_post",
                                 "introspection_endpoint": "http://127.0.0.1:8080/realms/University/protocol/openid-connect/token/introspect",
@@ -164,7 +167,10 @@ hello world
                                 "client_secret": "d1ec69e9-55d2-4109-a3ea-befa071579d5",
                                 "redirect_uri": "http://127.0.0.1:]] .. ngx.var.server_port .. [[/authenticated",
                                 "ssl_verify": false,
-                                "unauth_action": "deny"
+                                "unauth_action": "deny",
+                                "session": {
+                                    "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                                }
                             }
                         },
                         "upstream": {

--- a/t/plugin/security-warning2.t
+++ b/t/plugin/security-warning2.t
@@ -64,7 +64,6 @@ Using opa host with no TLS is a security risk
 
 
 === TEST 3: openid-connect with no TLS
---- ONLY
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/security-warning2.t
+++ b/t/plugin/security-warning2.t
@@ -78,6 +78,9 @@ Using opa host with no TLS is a security risk
                 post_logout_redirect_uri = "http://d.com",
                 proxy_opts = {
                     http_proxy = "http://e.com"
+                },
+                "session" = {
+                    "secret" = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
                 }
             })
             if not ok then
@@ -113,6 +116,9 @@ Using openid-connect proxy_opts.http_proxy with no TLS is a security risk
                 post_logout_redirect_uri = "https://d.com",
                 proxy_opts = {
                     http_proxy = "https://e.com"
+                },
+                "session" = {
+                    "secret" = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
                 }
             })
 

--- a/t/plugin/security-warning2.t
+++ b/t/plugin/security-warning2.t
@@ -64,6 +64,7 @@ Using opa host with no TLS is a security risk
 
 
 === TEST 3: openid-connect with no TLS
+--- ONLY
 --- config
     location /t {
         content_by_lua_block {
@@ -79,8 +80,8 @@ Using opa host with no TLS is a security risk
                 proxy_opts = {
                     http_proxy = "http://e.com"
                 },
-                "session" = {
-                    "secret" = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                session = {
+                    secret = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
                 }
             })
             if not ok then
@@ -117,8 +118,8 @@ Using openid-connect proxy_opts.http_proxy with no TLS is a security risk
                 proxy_opts = {
                     http_proxy = "https://e.com"
                 },
-                "session" = {
-                    "secret" = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
+                session = {
+                    secret = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
                 }
             })
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

This PR is a part of #12603 and is separated out due to breaking changes.

Currently, the openid-connect plugin generates a random value for
`conf.session.secret` in the `check_schema` function when both
conditions: "`conf.bearer_only` is false" and "`conf.session` does not
exist" are met.

Modifying the user-provided configuration can easily lead to user
confusion, which is clearly not best practice.

This also affects the diff logic in the adc that the apisix ingress
controller depends on.

I believe this generation behavior should be removed. To solve this problem, This PR removed the corresponding code and
instead return an error message, requiring users to fill in the
corresponding configuration themselves.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
	- https://lists.apache.org/thread/yx61kfhdql1y429tgdw7myo99x7h36jv

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->



Fixes #9306
