### PR TITLE
fix(secret): refresh stale lru cache item in background

### DIFF
--- a/apisix/cli/config.lua
+++ b/apisix/cli/config.lua
@@ -79,6 +79,12 @@ local _M = {
     },
     events = {
       module = "lua-resty-events"
+    },
+    lru = {
+      secret = {
+        ttl = 300,
+        count = 512
+      }
     }
   },
   nginx_config = {

--- a/apisix/core/lrucache.lua
+++ b/apisix/core/lrucache.lua
@@ -22,6 +22,9 @@
 local lru_new = require("resty.lrucache").new
 local resty_lock = require("resty.lock")
 local log = require("apisix.core.log")
+local pairs = pairs
+local pcall = pcall
+local unpack = unpack
 local tostring = tostring
 local ngx = ngx
 local get_phase = ngx.get_phase
@@ -201,7 +204,8 @@ local function refresh_stale_objs()
             if obj ~= nil then
                 lru_obj:set(key, {val = obj, ver = new_obj.ver}, new_obj.ttl)
                 keys[key] = nil
-                log.info("successfully refresh stale obj for key ", tostring(key), " to ver ", new_obj.ver)
+                log.info("successfully refresh stale obj for key ",
+                            tostring(key), " to ver ", new_obj.ver)
             else
                 log.error("failed to refresh stale obj for key ", key, ": ", err)
             end

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -116,6 +116,8 @@ function _M.http_init_worker()
 
     require("apisix.events").init_worker()
 
+    core.lrucache.init_worker()
+
     local discovery = require("apisix.discovery.init").discovery
     if discovery and discovery.init_worker then
         discovery.init_worker()
@@ -1089,6 +1091,8 @@ function _M.stream_init_worker()
     math.randomseed(seed)
     -- for testing only
     core.log.info("random stream test in [1, 10000]: ", math.random(1, 10000))
+
+    core.lrucache.init_worker()
 
     if core.config.init_worker then
         local ok, err = core.config.init_worker()

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -141,6 +141,11 @@ apisix:
                                   # or (standalone mode) the config isn't loaded yet either via file or Admin API.
   # disable_upstream_healthcheck: false # A global switch for healthcheck. Defaults to false.
                                         # When set to true, it overrides all upstream healthcheck configurations and globally disabling healthchecks.
+  # fine tune the parameters of LRU cache for some features like secret
+  lru:
+    secret:
+      ttl: 300 # seconds
+      count: 512
 nginx_config:                     # Config for render the template to generate nginx.conf
   # user: root                    # Set the execution user of the worker process. This is only
                                   # effective if the master process runs with super-user privileges.

--- a/t/core/lrucache.t
+++ b/t/core/lrucache.t
@@ -128,41 +128,7 @@ obj: 2
 
 
 
-=== TEST 4: sanity
---- config
-    location /t {
-        content_by_lua_block {
-            local core = require("apisix.core")
-
-            local function server_release(self)
-                ngx.say("release: ", require("toolkit.json").encode(self))
-            end
-
-            local lrucache_server_picker = core.lrucache.new({
-                ttl = 300, count = 256, release = server_release,
-            })
-
-            local t1 = lrucache_server_picker("nnn", "t1",
-                function () return {name = "aaa"} end)
-
-            ngx.say("obj: ", require("toolkit.json").encode(t1))
-
-            local t2 = lrucache_server_picker("nnn", "t2",
-                function () return {name = "bbb"} end)
-
-            ngx.say("obj: ", require("toolkit.json").encode(t2))
-        }
-    }
---- request
-GET /t
---- response_body
-obj: {"name":"aaa"}
-release: {"name":"aaa"}
-obj: {"name":"bbb"}
-
-
-
-=== TEST 5: invalid_stale = true
+=== TEST 4: invalid_stale = true
 --- config
     location /t {
         content_by_lua_block {
@@ -197,7 +163,7 @@ obj: {"idx":2}
 
 
 
-=== TEST 6: when creating cached objects, use resty-lock to avoid repeated creation.
+=== TEST 5: when creating cached objects, use resty-lock to avoid repeated creation.
 --- config
     location /t {
         content_by_lua_block {
@@ -233,7 +199,7 @@ obj: {"idx":1}
 
 
 
-=== TEST 7: different `key` and `ver`, cached same one table
+=== TEST 6: different `key` and `ver`, cached same one table
 --- config
     location /t {
         content_by_lua_block {

--- a/t/router/radixtree-sni2.t
+++ b/t/router/radixtree-sni2.t
@@ -746,12 +746,10 @@ passed
 secret lrucache ttl: 2, count: 1024
 successfully refresh stale obj for key
 --- grep_error_log eval
-qr/fetching data from secret uri: \S+ context: \S+/
+qr/fetching data from secret uri: \$secret:\/\/vault\/test1\/ssl\/test2.com.crt, context: \S+/
 --- grep_error_log_out
 fetching data from secret uri: $secret://vault/test1/ssl/test2.com.crt, context: ssl_certificate_by_lua*,
-fetching data from secret uri: $secret://vault/test1/ssl/test2.com.key, context: ssl_certificate_by_lua*,
 fetching data from secret uri: $secret://vault/test1/ssl/test2.com.crt, context: ngx.timer
-fetching data from secret uri: $secret://vault/test1/ssl/test2.com.key, context: ngx.timer
 
 
 


### PR DESCRIPTION
### Description

Our secret feature includes an LRU cache to store values obtained from the secret provider (vault, AWS, GCP) to reduce the number of requests to the secret provider. However, due to without `invalid_stale` parameter, this cache never expires. https://github.com/apache/apisix/blob/9ae24032b6177daa6dfd31de04bfedc435a842d5/apisix/ssl/router/radixtree_sni.lua#L241-L242 https://github.com/apache/apisix/blob/9ae24032b6177daa6dfd31de04bfedc435a842d5/apisix/secret.lua#L188-L190 https://github.com/apache/apisix/blob/9ae24032b6177daa6dfd31de04bfedc435a842d5/apisix/core/lrucache.lua#L54-L62

However, if only the `invalid_stale` parameter is specified, when the cache entry expires, it will be necessary to query the secret provider to obtain the secret while receiving downstream requests. This can result in some high-latency long-tail requests.
To address this, an `refresh_stale` option is provided in the LRU cache to asynchronously refresh expired items within a timer, reducing the impact on downstream requests.

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
