### PR TITLE
fix: run init_worker of apisix.admin module in stream subsystem

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -1173,6 +1173,9 @@ function _M.stream_init_worker()
 
     require("apisix.events").init_worker()
 
+    -- for admin api of standalone mode, we need to startup background timer and patch schema etc.
+    require("apisix.admin.init").init_worker()
+
     local discovery = require("apisix.discovery.init").discovery
     if discovery and discovery.init_worker then
         discovery.init_worker()


### PR DESCRIPTION
### Description

In order for the admin API  standalone mode to work properly in the stream subsystem, we need to execute the `apisix.admin` module initialization function like in the HTTP subsystem: https://github.com/apache/apisix/blob/5e804cf26e4d283a417c40698219ff99ddeda4c4/apisix/admin/standalone.lua#L415-L455. The previous test cases called `/apisix/admin/configs` API in a prior test case and then test-nginx performed a reload, which led to executing the following code and failed to detect that the backend timer was not started correctly. https://github.com/apache/apisix/blob/5e804cf26e4d283a417c40698219ff99ddeda4c4/apisix/core/config_yaml.lua#L395-L429
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
