### PR TITLE
chore: add test for verifying lua-resty-openssl bug fix

### DIFF
--- a/t/plugin/jwt-auth4.t
+++ b/t/plugin/jwt-auth4.t
@@ -398,7 +398,7 @@ JWT found in ctx. Payload key: user-key
                                   (original_parsed.kty == exported_parsed.kty)
 
             if not jwk_consistent then
-                ngx.say("FAIL: JWK parameters inconsistent - Original crv: ", original_parsed.crv, 
+                ngx.say("FAIL: JWK parameters inconsistent - Original crv: ", original_parsed.crv,
                        ", Exported crv: ", exported_parsed.crv)
                 return
             end


### PR DESCRIPTION
### Description
Previous version of lua-resty-openssl introduced a bug in jwt verification in how the Ed448 public key is being handled by lua-resty-openssl (base64 encode-decode). The newer version of APISIX uses recent version of lua-resty-openssl which doesn't have this bug. The following added test just confirms the fix.

With version lua-resty-openssl 1.6.1
<img width="2876" height="557" alt="Screenshot From 2025-10-08 22-43-33" src="https://github.com/user-attachments/assets/c13c9508-34c7-4b1c-86ad-b0b02294d406" />


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
