### PR TITLE
fix: reloading after any node failure in eureka will lose half of the requests

### DIFF
--- a/apisix/discovery/eureka/init.lua
+++ b/apisix/discovery/eureka/init.lua
@@ -179,7 +179,6 @@ local function fetch_full_registry(premature)
         return
     end
 
-    -- 遍历所有 eureka 端点，直到成功
     local endpoints = build_endpoints()
     if not endpoints or #endpoints == 0 then
         return
@@ -263,47 +262,6 @@ function _M.nodes(service_name)
 
     return applications[service_name]
 end
-
-
--- 注释掉文件缓存相关依赖与变量，避免写盘/读盘
--- local core_io = require("apisix.core.io")
--- local io_open = io.open
--- local cache_file = ngx.config.prefix() .. "logs/eureka_registry.json"
--- local save_registry_cache
--- local load_registry_cache
--- 将文件缓存函数整体注释掉，避免写盘与读盘
---[[
-local function save_registry_cache(apps)
-    local body, err = core.json.encode({ applications = apps, ts = ngx.now() })
-    if not body then
-        log.error("encode eureka registry cache failed: ", err)
-        return
-    end
-    local f, ferr = io_open(cache_file, "w")
-    if not f then
-        log.error("open eureka registry cache file failed: ", ferr,
-                  ", path: ", cache_file)
-        return
-    end
-    f:write(body)
-    f:close()
-end
-
-local function load_registry_cache()
-    local body = core_io.get_file(cache_file)
-    if not body then
-        return nil, "no cache file"
-    end
-    local data, err = core.json.decode(body)
-    if not data or not data.applications then
-        return nil, "invalid cache format: " .. (err or "")
-    end
-    return data.applications
-end
-]]
--- 移除保存缓存调用
--- save_registry_cache(up_apps)
-
 
 function _M.init_worker()
     default_weight = local_conf.discovery.eureka.weight or 100


### PR DESCRIPTION
Fixes https://github.com/apache/apisix/issues/12610

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
