### PR TITLE
feat: add additional handling of prometheus-cache in ngx_tpl.lua (#1212703)

### DIFF
--- a/apisix/cli/config.lua
+++ b/apisix/cli/config.lua
@@ -163,7 +163,6 @@ local _M = {
         ["plugin-limit-req"] = "10m",
         ["plugin-limit-count"] = "10m",
         ["prometheus-metrics"] = "10m",
-        ["prometheus-cache"] = "10m",
         ["plugin-limit-conn"] = "10m",
         ["upstream-healthcheck"] = "10m",
         ["worker-events"] = "10m",

--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -67,7 +67,7 @@ lua {
     {% if enabled_stream_plugins["prometheus"] then %}
     lua_shared_dict prometheus-metrics {* meta.lua_shared_dict["prometheus-metrics"] *};
     {% end %}
-    {% if enabled_stream_plugins["prometheus"] and not enable_http then %}
+    {% if enabled_plugins["prometheus"] or enabled_stream_plugins["prometheus"] then %}
     lua_shared_dict prometheus-cache {* meta.lua_shared_dict["prometheus-cache"] *};
     {% end %}
     {% if standalone_with_admin_api then %}
@@ -334,7 +334,9 @@ http {
 
     {% if enabled_plugins["prometheus"] and not enabled_stream_plugins["prometheus"] then %}
     lua_shared_dict prometheus-metrics {* http.lua_shared_dict["prometheus-metrics"] *};
-    lua_shared_dict prometheus-cache {* http.lua_shared_dict["prometheus-cache"] *};
+    {% if not use_apisix_base then %}
+    lua_shared_dict prometheus-cache {* meta.lua_shared_dict["prometheus-cache"] *};
+    {% end %}
     {% end %}
 
     {% if enabled_plugins["skywalking"] then %}


### PR DESCRIPTION
### Description

```
{% if enabled_plugins["prometheus"] and not enabled_stream_plugins["prometheus"] then %}
    lua_shared_dict prometheus-metrics {* http.lua_shared_dict["prometheus-metrics"] *};
    -- add prometheus-cache here
    lua_shared_dict prometheus-cache {* http.lua_shared_dict["prometheus-cache"] *};
{% end  #%}
```
Maybe it's better to set prometheus-cache together with prometheus-metrics in ngx_tpl.lua

Only when use_apisix_base is set to true, will the prometheus-cache take effect.
But in order to integrate with QAT, i used a custom built openresty instead of apisix-runtime, so use_apisix_base is not true, and prometheus-cache is not setted in nginx.conf even if prometheus plugin is enabled. 

#### Which issue(s) this PR fixes:
Fixes #12703

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
