### PR TITLE
fix(brotli): Preserve `ETag` and `Last-Modified` headers in Brotli-compressed response

### DIFF
--- a/apisix/plugins/brotli.lua
+++ b/apisix/plugins/brotli.lua
@@ -222,8 +222,8 @@ function _M.header_filter(conf, ctx)
 
     ctx.brotli_matched = true
     ctx.compressor = compressor
-    core.response.clear_header_as_body_modified()
-    core.response.add_header("Content-Encoding", "br")
+    ngx.header.content_length = nil
+    ngx.header.content_encoding = 'br'
 end
 
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
Preserve `ETag` and `Last-Modified` headers in Brotli-compressed response.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #12707 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
