### PR TITLE
chore: remove fast return to flush current queue log data during shutdown

### DIFF
--- a/apisix/utils/batch-processor.lua
+++ b/apisix/utils/batch-processor.lua
@@ -54,7 +54,7 @@ local function schedule_func_exec(self, delay, batch)
         if err == "process exiting" then
             -- it is allowed to create zero-delay timers even when
             -- the Nginx worker process starts shutting down
-            hdl = timer_at(0, execute_func, self)
+            timer_at(0, execute_func, self)
         else
             core.log.error("failed to create process timer: ", err)
             return
@@ -139,7 +139,7 @@ function create_buffer_timer(self)
     local hdl, err = timer_at(self.inactive_timeout, flush_buffer, self)
     if not hdl then
         if err == "process exiting" then
-            hdl = timer_at(0, flush_buffer, self)
+            timer_at(0, flush_buffer, self)
         else
             core.log.error("failed to create buffer timer: ", err)
             return


### PR DESCRIPTION

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
