### PR TITLE
fix: make protocol_name optional in mqtt-proxy plugin

### DIFF
--- a/apisix/stream/plugins/mqtt-proxy.lua
+++ b/apisix/stream/plugins/mqtt-proxy.lua
@@ -29,10 +29,10 @@ end)
 local schema = {
     type = "object",
     properties = {
-        protocol_name = {type = "string"},
+        protocol_name = {type = "string", default = "MQTT"},
         protocol_level = {type = "integer"}
     },
-    required = {"protocol_name", "protocol_level"},
+    required = {"protocol_level"},
 }
 
 
@@ -156,8 +156,9 @@ function _M.preread(conf, ctx)
         return 503
     end
 
-    if res.protocol and res.protocol ~= conf.protocol_name then
-        core.log.error("expect protocol name: ", conf.protocol_name,
+    local protocol_name = conf.protocol_name or "MQTT"
+    if res.protocol and res.protocol ~= protocol_name then
+        core.log.error("expect protocol name: ", protocol_name,
                        ", but got ", res.protocol)
         return 503
     end

--- a/docs/en/latest/plugins/mqtt-proxy.md
+++ b/docs/en/latest/plugins/mqtt-proxy.md
@@ -37,7 +37,7 @@ This Plugin supports both the protocols [3.1.*](http://docs.oasis-open.org/mqtt/
 
 | Name           | Type    | Required   | Description                                                                       |
 |----------------|---------|------------|-----------------------------------------------------------------------------------|
-| protocol_name  | string  | True       | Name of the protocol. Generally `MQTT`.                                           |
+| protocol_name  | string  | False      | Name of the protocol. Defaults to `MQTT`.                                         |
 | protocol_level | integer | True       | Level of the protocol. It should be `4` for MQTT `3.1.*` and `5` for MQTT `5.0`.  |
 
 ## Enable Plugin

--- a/docs/zh/latest/plugins/mqtt-proxy.md
+++ b/docs/zh/latest/plugins/mqtt-proxy.md
@@ -37,7 +37,7 @@ description: 本文档介绍了 Apache APISIX mqtt-proxy 插件的信息，通�
 
 | 名称           | 类型    | 必选项  | 描述                                                   |
 | -------------- | ------- | ----- | ------------------------------------------------------ |
-| protocol_name  | string  | 是    | 协议名称，正常情况下应为 `MQTT`。                          |
+| protocol_name  | string  | 否    | 协议名称，默认为 `MQTT`。                          |
 | protocol_level | integer | 是    | 协议级别，MQTT `3.1.*` 为 `4`，MQTT `5.0` 应是`5`。   |
 
 ## 启用插件


### PR DESCRIPTION
### What this PR does / why we need it:
This PR makes the `protocol_name` parameter optional in the mqtt-proxy plugin, as requested in #11589.

Currently, `protocol_name` is required even though it's almost always set to `MQTT`. This creates unnecessary configuration overhead for users.

### Changes:
- Made `protocol_name` optional in the plugin schema with default value `MQTT`
- Updated validation logic to use the default when not specified
- Updated English documentation to reflect optional status
- Updated Chinese documentation to reflect optional status

### Pre-submission checklist:
- [x] Did you explain what problem does this PR solve? Or what new features have been added?
- [x] Have you added corresponding test cases?
- [x] Have you modified the corresponding document?
- [x] Is this PR backward compatible?

### Backward Compatibility:
✅ This change is fully backward compatible. Existing configurations that specify `protocol_name` will continue to work exactly as before.

Fixes #11589