### PR TITLE
fix: ensure UI directory is created when building debian-dev image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -427,7 +427,7 @@ release-src: compress-tar
 	gpg --batch --yes --armor --detach-sig $(project_release_name).tgz
 	shasum -a 512 $(project_release_name).tgz > $(project_release_name).tgz.sha512
 
-	$(call func_check_folder,release)
+	$(call func_check_folder, release)
 	mv $(project_release_name).tgz release/$(project_release_name).tgz
 	mv $(project_release_name).tgz.asc release/$(project_release_name).tgz.asc
 	mv $(project_release_name).tgz.sha512 release/$(project_release_name).tgz.sha512
@@ -496,6 +496,7 @@ ci-env-stop:
 .PHONY: build-on-debian-dev
 build-on-debian-dev:
 	@$(call func_echo_status, "$@ -> [ Start ]")
+	$(call func_check_folder, ui)
 	$(ENV_DOCKER) build -t $(ENV_APISIX_IMAGE_TAG_NAME)-debian-dev \
 		--build-arg TARGETARCH=$(ENV_OS_ARCH) \
 		--build-arg CODE_PATH=. \


### PR DESCRIPTION
### Description

This PR fixes a build failure when running `make build-on-debian-dev`.

The debian-dev image build failed at:

[2/2] STEP 9/21: COPY --chown=nobody:root ui/ /usr/local/apisix/ui/
Error: building at STEP "COPY --chown=nobody:root ui/ /usr/local/apisix/ui/": checking on sources under "/var/tmp/libpod_builder971763380/build": copier: stat: "/ui": no such file or directorybecause the `ui` directory does not exist in the build context.

To resolve this, the build script now ensures that an (empty) `ui` directory is created before building the debian-dev image, so the `COPY ui/ /usr/local/apisix/ui/` step always succeeds even when no UI assets are present.

#### Which issue(s) this PR fixes:

Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
