### PR TITLE
fix: support extra_lua_path in test framework

### DIFF
--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -271,9 +271,34 @@ deployment:
 _EOC_
     }
 
+    my $extra_lua_path = "";
+    my $extra_lua_cpath = "";
+    
+    # Method 1: Block definition (preferred)
+    if ($block->extra_lua_path) {
+        $extra_lua_path = $block->extra_lua_path . ";";
+    }
+    if ($block->extra_lua_cpath) {
+        $extra_lua_cpath = $block->extra_lua_cpath . ";";
+    }
+    
+    # Method 2: Extract from extra_yaml_config if block definition not provided
+    if (!$extra_lua_path && $block->extra_yaml_config) {
+        my $extra_yaml = $block->extra_yaml_config;
+        if ($extra_yaml =~ m/^\s*extra_lua_path:\s*["\']?([^"\'\n]+)["\']?/m) {
+            $extra_lua_path = $1 . ";";
+        }
+    }
+    if (!$extra_lua_cpath && $block->extra_yaml_config) {
+        my $extra_yaml = $block->extra_yaml_config;
+        if ($extra_yaml =~ m/^\s*extra_lua_cpath:\s*["\']?([^"\'\n]+)["\']?/m) {
+            $extra_lua_cpath = $1 . ";";
+        }
+    }
+
     my $lua_deps_path = $block->lua_deps_path // <<_EOC_;
-    lua_package_path "$apisix_home/?.lua;$apisix_home/?/init.lua;$apisix_home/deps/share/lua/5.1/?/init.lua;$apisix_home/deps/share/lua/5.1/?.lua;$apisix_home/apisix/?.lua;$apisix_home/t/?.lua;$apisix_home/t/xrpc/?.lua;$apisix_home/t/xrpc/?/init.lua;;";
-    lua_package_cpath "$apisix_home/?.so;$apisix_home/deps/lib/lua/5.1/?.so;$apisix_home/deps/lib64/lua/5.1/?.so;;";
+    lua_package_path "$extra_lua_path$apisix_home/?.lua;$apisix_home/?/init.lua;$apisix_home/deps/share/lua/5.1/?/init.lua;$apisix_home/deps/share/lua/5.1/?.lua;$apisix_home/apisix/?.lua;$apisix_home/t/?.lua;$apisix_home/t/xrpc/?.lua;$apisix_home/t/xrpc/?/init.lua;;";
+    lua_package_cpath "$extra_lua_cpath$apisix_home/?.so;$apisix_home/deps/lib/lua/5.1/?.so;$apisix_home/deps/lib64/lua/5.1/?.so;;";
 _EOC_
 
     my $main_config = $block->main_config // <<_EOC_;

--- a/t/admin/extra-lua-path.t
+++ b/t/admin/extra-lua-path.t
@@ -1,0 +1,186 @@
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: Check extra_lua_path via block definition
+Verify that extra_lua_path block definition adds path to lua_package_path
+--- extra_lua_path: /test/custom/path/?.lua
+--- config
+    location /t {
+        content_by_lua_block {
+            local path = package.path
+            if string.find(path, "/test/custom/path/?.lua", 1, true) then
+                ngx.say("FOUND: extra_lua_path is in package.path")
+            else
+                ngx.say("NOT FOUND: extra_lua_path is missing")
+                ngx.say("package.path: ", path)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+FOUND: extra_lua_path is in package.path
+
+
+
+=== TEST 2: Check extra_lua_cpath via block definition
+Verify that extra_lua_cpath block definition adds path to lua_package_cpath
+--- extra_lua_cpath: /test/custom/path/?.so
+--- config
+    location /t {
+        content_by_lua_block {
+            local cpath = package.cpath
+            if string.find(cpath, "/test/custom/path/?.so", 1, true) then
+                ngx.say("FOUND: extra_lua_cpath is in package.cpath")
+            else
+                ngx.say("NOT FOUND: extra_lua_cpath is missing")
+                ngx.say("package.cpath: ", cpath)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+FOUND: extra_lua_cpath is in package.cpath
+
+
+
+=== TEST 3: Check extra_lua_path from extra_yaml_config
+Verify that extra_lua_path is parsed from extra_yaml_config
+--- extra_yaml_config
+apisix:
+  extra_lua_path: "/yaml/custom/path/?.lua"
+--- config
+    location /t {
+        content_by_lua_block {
+            local path = package.path
+            if string.find(path, "/yaml/custom/path/?.lua", 1, true) then
+                ngx.say("FOUND: extra_lua_path from yaml config is in package.path")
+            else
+                ngx.say("NOT FOUND: extra_lua_path from yaml config is missing")
+                ngx.say("package.path: ", path)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+FOUND: extra_lua_path from yaml config is in package.path
+
+
+
+=== TEST 4: Check extra_lua_cpath from extra_yaml_config
+Verify that extra_lua_cpath is parsed from extra_yaml_config
+--- extra_yaml_config
+apisix:
+  extra_lua_cpath: "/yaml/custom/path/?.so"
+--- config
+    location /t {
+        content_by_lua_block {
+            local cpath = package.cpath
+            if string.find(cpath, "/yaml/custom/path/?.so", 1, true) then
+                ngx.say("FOUND: extra_lua_cpath from yaml config is in package.cpath")
+            else
+                ngx.say("NOT FOUND: extra_lua_cpath from yaml config is missing")
+                ngx.say("package.cpath: ", cpath)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+FOUND: extra_lua_cpath from yaml config is in package.cpath
+
+
+
+=== TEST 5: Check both extra_lua_path and extra_lua_cpath
+Verify that both paths can be set simultaneously
+--- extra_lua_path: /test/lua/?.lua
+--- extra_lua_cpath: /test/so/?.so
+--- config
+    location /t {
+        content_by_lua_block {
+            local path = package.path
+            local cpath = package.cpath
+            local lua_found = string.find(path, "/test/lua/?.lua", 1, true)
+            local so_found = string.find(cpath, "/test/so/?.so", 1, true)
+            
+            if lua_found and so_found then
+                ngx.say("FOUND: both extra_lua_path and extra_lua_cpath")
+            else
+                ngx.say("NOT FOUND")
+                ngx.say("lua_path found: ", lua_found and "yes" or "no")
+                ngx.say("so_path found: ", so_found and "yes" or "no")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+FOUND: both extra_lua_path and extra_lua_cpath
+
+
+
+=== TEST 6: Check path is prepended (comes first)
+Verify that extra_lua_path is at the beginning of package.path
+--- extra_lua_path: /first/path/?.lua
+--- config
+    location /t {
+        content_by_lua_block {
+            local path = package.path
+            -- Check if custom path appears before apisix_home
+            local custom_pos = string.find(path, "/first/path/?.lua", 1, true)
+            local apisix_pos = string.find(path, "/apisix/?.lua", 1, true)
+            
+            if custom_pos and apisix_pos and custom_pos < apisix_pos then
+                ngx.say("SUCCESS: extra_lua_path is prepended correctly")
+            else
+                ngx.say("FAIL: extra_lua_path is not at the beginning")
+                ngx.say("custom_pos: ", custom_pos or "nil")
+                ngx.say("apisix_pos: ", apisix_pos or "nil")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+SUCCESS: extra_lua_path is prepended correctly
+
+
+
+=== TEST 7: Block definition takes precedence over yaml_config
+Verify that block definition is used when both are provided
+--- extra_lua_path: /block/path/?.lua
+--- extra_yaml_config
+apisix:
+  extra_lua_path: "/yaml/path/?.lua"
+--- config
+    location /t {
+        content_by_lua_block {
+            local path = package.path
+            local block_found = string.find(path, "/block/path/?.lua", 1, true)
+            local yaml_found = string.find(path, "/yaml/path/?.lua", 1, true)
+            
+            if block_found and not yaml_found then
+                ngx.say("SUCCESS: block definition takes precedence")
+            elseif yaml_found and not block_found then
+                ngx.say("FAIL: yaml config was used instead of block")
+            elseif block_found and yaml_found then
+                ngx.say("UNEXPECTED: both paths found")
+            else
+                ngx.say("FAIL: neither path found")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+SUCCESS: block definition takes precedence
+


### PR DESCRIPTION
### Description

This PR adds support for setting custom Lua paths (`extra_lua_path` and `extra_lua_cpath`) in test files, aligning the test framework behavior with APISIX runtime configuration.

Previously, while APISIX runtime supported `apisix.extra_lua_path` in `config.yaml` to load custom plugins from specified directories, the test framework (`t/APISIX.pm`) did not respect this configuration. This made it impossible to write tests for custom plugins located in custom directories.

This PR implements two complementary methods for setting custom Lua paths in tests:

**Method 1: Block definitions (preferred)**
--- extra_lua_path: /custom/path/?.lua
--- extra_lua_cpath: /custom/path/?.so**Method 2: Automatic parsing from extra_yaml_config**
--- extra_yaml_config
apisix:
  extra_lua_path: "/custom/path/?.lua"
  extra_lua_cpath: "/custom/path/?.so"The implementation:
- Prepends custom paths to `lua_package_path` and `lua_package_cpath` (matching runtime behavior)
- Block definitions take precedence when both methods are used
- Enables testing custom plugins without modifying core APISIX paths

#### Which issue(s) this PR fixes:

Fixes #12389

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

**Test Coverage:**
Added comprehensive test suite in `t/admin/extra-lua-path.t` covering:
- Path addition via block definitions
- YAML configuration parsing
- Simultaneous lua_path and lua_cpath configuration
- Correct path prepending behavior
- Precedence rules between configuration methods

**Backward Compatibility:**
This change is fully backward compatible. It only adds new optional block definitions (`extra_lua_path`, `extra_lua_cpath`) and parsing logic for existing `extra_yaml_config`. All existing tests continue to work without modification.