### PR TITLE
docs(getting-started): fix '502 Bad Gateway' error in the getting sta…

### DIFF
--- a/docs/en/latest/getting-started/configure-routes.md
+++ b/docs/en/latest/getting-started/configure-routes.md
@@ -47,7 +47,8 @@ curl -i "http://127.0.0.1:9180/apisix/admin/routes" -X PUT -d '
     "type": "roundrobin",
     "nodes": {
       "httpbin.org:80": 1
-    }
+    },
+    "pass_host": "node"
   }
 }'
 ```

--- a/docs/zh/latest/getting-started/configure-routes.md
+++ b/docs/zh/latest/getting-started/configure-routes.md
@@ -45,7 +45,8 @@ curl -i "http://127.0.0.1:9180/apisix/admin/routes" -X PUT -d '
     "type": "roundrobin",
     "nodes": {
       "httpbin.org:80": 1
-    }
+    },
+    "pass_host": "node"
   }
 }'
 ```


### PR DESCRIPTION
…rted tutorial

### Description

When following the getting-started guide, a 502 Bad Gateway response is returned.


root@28d6b762434f:/workspace#  curl "http://127.0.0.1:9080/ip 

<html>
<head><title>502 Bad Gateway</title></head>
<body>
<center><h1>502 Bad Gateway</h1></center>
<hr><center>openresty</center>
<p><em>Powered by <a href="https://apisix.apache.org/">APISIX</a>.</em></p></body>
</html>


Based on my validation, I found that the `pass_host: "node"` configuration must be added to the route to make APISIX send right `Host` header to httpbin.org  to get a correct response (instead of 502 errors).

root@28d6b762434f:/workspace#  curl -m 5 -v "http://httpbin.org/ip"
\* Connected to httpbin.org (100.29.246.92) port 80
\> GET /ip HTTP/1.1
\> **Host: httpbin.org**
\> User-Agent: curl/8.5.0
\> Accept: \*/\*
\>
< HTTP/1.1 200 OK
< Connection: close
< Content-Length: 34
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Origin: \*
< Content-Type: application/json
< Date: Thu, 27 Nov 2025 04:33:11 GMT
< Server: gunicorn/19.9.0
<
{
  "origin": "101.x.x.177"
}


root@28d6b762434f:/workspace# curl -m 5 -v "http://httpbin.org/ip" -H "Host: 127.0.0.1:9080"
\* Connected to httpbin.org (3.219.87.227) port 80
\> GET /ip HTTP/1.1
\> **Host: 127.0.0.1:9080**
\> User-Agent: curl/8.5.0
\> Accept: \*/\*
\>
\* Operation timed out after 5002 milliseconds with 0 bytes received
curl: (28) Operation timed out after 5002 milliseconds with 0 bytes received


root@28d6b762434f:/workspace# curl -m 5 -v "http://httpbin.org/ip" -H "Host: 127.0.0.1:9080"
\* Connected to httpbin.org (100.29.246.92) port 80
\> GET /ip HTTP/1.1
\> **Host: 127.0.0.1:9080**
\> User-Agent: curl/8.5.0
\> Accept: \*/\*
>
\* Empty reply from server
\* Closing connection
curl: (52) Empty reply from server

#### Which issue(s) this PR fixes:


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
