### PR TITLE
fix: elasticsearch-logger plugin support elasticsaerch data_stream

### DIFF
--- a/apisix/plugins/elasticsearch-logger.lua
+++ b/apisix/plugins/elasticsearch-logger.lua
@@ -180,7 +180,7 @@ end
 local function get_logger_entry(conf, ctx)
     local entry = log_util.get_log_entry(plugin_name, conf, ctx)
     local body = {
-        index = {
+        create = {
             _index = conf.field.index
         }
     }


### PR DESCRIPTION
### Description
Elasticsearch Data streams are well-suited for logs, events, metrics, and other continuously generated data. However data_stream only support op_type=create for _bulk API. 

reference：https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-bulk



### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
