### PR TITLE
feat(docker): improve debian-dev Dockerfile build caching

### DIFF
--- a/docker/debian-dev/Dockerfile
+++ b/docker/debian-dev/Dockerfile
@@ -68,7 +68,11 @@ COPY --from=build /usr/bin/apisix /usr/bin/apisix
 COPY --from=build /usr/local/brotli /usr/local/brotli
 COPY --chown=nobody:root ui/ /usr/local/apisix/ui/
 
-RUN echo /usr/local/brotli/lib | tee /etc/ld.so.conf.d/brotli.conf \
+RUN if [ -d "/usr/local/brotli/lib64" ]; then \
+        echo /usr/local/brotli/lib64 | tee /etc/ld.so.conf.d/brotli.conf; \
+    else \
+        echo /usr/local/brotli/lib | tee /etc/ld.so.conf.d/brotli.conf; \
+    fi \
     && ldconfig \
     && ln -sf /usr/local/brotli/bin/brotli /usr/bin/brotli
 


### PR DESCRIPTION
### Description

Optimize the debian-dev Dockerfile to leverage Docker layer caching more effectively.
Previously, any code change would invalidate the cache and trigger a full rebuild including `make deps` and brotli compilation.

#### What this PR does:

1. **Separate dependency files from source code**: Copy only `Makefile`, `rockspec`, `.requirements`, and `install-dependencies.sh` before running `make deps`, so dependencies are cached unless these files change.

2. **Move brotli build to build stage**: Previously, brotli was built in the runtime stage, requiring installation of ~80 build packages (gcc, cmake, etc.) every time. Now it's built once in the build stage and only the binary is copied to runtime.

#### Performance improvement:

| Scenario | Before | After | Improvement |
|----------|--------|-------|-------------|
| Source code change only | 4m 37s | 18s | **~15x faster** |

#### Which issue(s) this PR fixes:

Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
