### PR TITLE
fix: standalone mode status api

### DIFF
--- a/apisix/core/config_yaml.lua
+++ b/apisix/core/config_yaml.lua
@@ -567,6 +567,10 @@ function _M.init_worker()
     -- sync data in each non-master process
     ngx.timer.every(1, read_apisix_config)
 
+    if apisix_yaml then
+        update_config(apisix_yaml, apisix_yaml_mtime)
+    end
+
     return true
 end
 

--- a/t/cli/test_status_api_standalone.sh
+++ b/t/cli/test_status_api_standalone.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+. ./t/cli/common.sh
+
+standalone() {
+    clean_up
+    git checkout conf/apisix.yaml
+}
+
+trap standalone EXIT
+
+# support environment variables
+echo '
+apisix:
+  enable_admin: false
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+nginx_config:
+  error_log_level: warn
+apisix:
+  status:
+    ip: 127.0.0.1
+    port: 7085
+' > conf/config.yaml
+
+echo '
+routes:
+  -
+    uri: /get
+    upstream:
+      nodes:
+        "httpbin.local:8280": 1
+      type: roundrobin
+#END
+' > conf/apisix.yaml
+
+# check for resolve variables
+make run
+
+sleep 0.5
+
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:7085/status/ready | grep 200 \
+|| (echo "failed: status/ready api didn't return 200"; exit 1)
+
+sleep 0.5
+
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:7085/status | grep 200 \
+|| (echo "failed: status api didn't return 200"; exit 1)


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

The status API would not work in standalone mode, this has been fixed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #12662

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
