### PR TITLE
fix(docker): Modify permissions for the docker file to run in Openshift without anyuid

### DIFF
--- a/docker/debian-dev/Dockerfile
+++ b/docker/debian-dev/Dockerfile
@@ -58,7 +58,9 @@ COPY --chown=nobody:root ui/ /usr/local/apisix/ui/
 
 COPY ${INSTALL_BROTLI} /install-brotli.sh
 RUN chmod +x /install-brotli.sh \
-    && cd / && ./install-brotli.sh && rm -rf /install-brotli.sh
+    && cd / && ./install-brotli.sh && rm -rf /install-brotli.sh \
+    && chgrp -R 0 /usr/local/apisix \
+    && chmod -R g=u /usr/local/apisix
 
 ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
 


### PR DESCRIPTION
This pull request makes a minor change to the Docker build process to improve file permissions for the `/usr/local/apisix` directory. This helps ensure that the directory is accessible to users in group 0, which can be important for running containers with non-root users.

- Dockerfile permissions update:
  * Modified the `docker/debian-dev/Dockerfile` to recursively change the group ownership of `/usr/local/apisix` to group 0 and set group permissions to match user permissions.

This PR closes #11714
