### PR TITLE
docs: add etcd host config to decoupled mode docs

### DIFF
--- a/docs/en/latest/deployment-modes.md
+++ b/docs/en/latest/deployment-modes.md
@@ -84,6 +84,9 @@ deployment:
     role: data_plane
     role_data_plane:
        config_provider: etcd
+    etcd:
+       host:
+           - https://${etcd_IP}:${etcd_Port}
 #END
 ```
 


### PR DESCRIPTION
### Description

In the decoupled mode docs https://apisix.apache.org/docs/apisix/deployment-modes/#decoupled, the example configuration file for the CP instance includes the `etcd.host` block, which is not present in the DP example configuration.

This can be misleading, as it may suggest that the DP does not need to communicate with etcd. When `etcd.host` is not configured, APISIX falls back to use `http://127.0.0.1:2379`:

```text
nginx: [warn] [lua] health_check.lua:114: report_failure(): update endpoint: http://127.0.0.1:2379/ to unhealthy
nginx: [error] [lua] init.lua:102: http_init(): failed to load the configuration: http://127.0.0.1:2379/: connection refused
```

Better that the doc adds the `etcd.host` to DP example configuration.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
