### PR TITLE
fix: metrics reporting when LLM plugin is not enabled

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -816,10 +816,10 @@ http {
             set $request_type               'traditional_http';
             set $request_llm_model              '';
 
-            set $llm_time_to_first_token        '0';
+            set $llm_time_to_first_token        '';
             set $llm_model                      '';
-            set $llm_prompt_tokens              '0';
-            set $llm_completion_tokens          '0';
+            set $llm_prompt_tokens              '';
+            set $llm_completion_tokens          '';
 
 
             access_by_lua_block {

--- a/apisix/plugins/ai-drivers/openai-base.lua
+++ b/apisix/plugins/ai-drivers/openai-base.lua
@@ -100,7 +100,7 @@ local function read_response(ctx, res)
                 return
             end
 
-            if ctx.var.llm_time_to_first_token == "0" then
+            if ctx.var.llm_time_to_first_token == "" then
                 ctx.var.llm_time_to_first_token = math.floor(
                                                 (ngx_now() - ctx.llm_request_start_time) * 1000)
             end


### PR DESCRIPTION
## Summary
Fix incorrect metrics reporting when LLM plugin is not enabled.

## Problem
When the LLM plugin is not enabled, the nginx variables for LLM metrics were defaulting to '0', which caused the metrics to be incorrectly reported as active even when no LLM functionality was being used.

## Solution
Changed the default values from '0' to '' (empty string) for the following nginx variables:
- `llm_time_to_first_token`
- `llm_prompt_tokens`
- `llm_completion_tokens`

Also updated the condition check in `openai-base.lua` to properly detect when LLM functionality is not active.

## Changes
- `apisix/cli/ngx_tpl.lua`: Changed default values from '0' to ''
- `apisix/plugins/ai-drivers/openai-base.lua`: Updated condition check

🤖 Generated with [Claude Code](https://claude.com/claude-code)