### PR TITLE
fix: Populate the protocol version of the original request to the ups…

### DIFF
--- a/apisix/plugins/ext-plugin-post-resp.lua
+++ b/apisix/plugins/ext-plugin-post-resp.lua
@@ -82,6 +82,7 @@ local function get_response(ctx, http_obj)
         query = args or ctx.var.args,
         headers = include_req_headers(ctx),
         method = core.request.get_method(),
+        version = core.request.get_http_version(),
     }
 
     local body, err = core.request.get_body()


### PR DESCRIPTION
### Description

fix: Populate the protocol version of the original request to the ups…
If the version is not passed, upstream may use the default version, leading to inconsistent behavior or compatibility issues.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
