### PR TITLE
fix(cli): remove stale key after resolving env var in config keys

### DIFF
--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -105,7 +105,7 @@ local function resolve_conf_var(conf)
             end
             if new_key ~= key then
                 new_keys[new_key] = "dummy" -- we only care about checking the key
-                conf.key = nil
+                conf[key] = nil
                 conf[new_key] = val
                 key = new_key
             end

--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -91,25 +91,8 @@ end
 
 
 local function resolve_conf_var(conf)
-    local new_keys = {}
+    local renamed_keys
     for key, val in pairs(conf) do
-        -- avoid re-iterating the table for already iterated key
-        if new_keys[key] then
-            goto continue
-        end
-        -- substitute environment variables from conf keys
-        if type(key) == "string" then
-            local new_key, _, err = var_sub(key)
-            if err then
-                return nil, err
-            end
-            if new_key ~= key then
-                new_keys[new_key] = "dummy" -- we only care about checking the key
-                conf[key] = nil
-                conf[new_key] = val
-                key = new_key
-            end
-        end
         if type(val) == "table" then
             local ok, err = resolve_conf_var(val)
             if not ok then
@@ -135,7 +118,27 @@ local function resolve_conf_var(conf)
 
             conf[key] = new_val
         end
-        ::continue::
+
+        -- substitute environment variables from conf keys. The rename is
+        -- deferred because inserting a new key while iterating with pairs()
+        -- is undefined behavior.
+        if type(key) == "string" then
+            local new_key, _, err = var_sub(key)
+            if err then
+                return nil, err
+            end
+            if new_key ~= key then
+                renamed_keys = renamed_keys or {}
+                renamed_keys[key] = new_key
+            end
+        end
+    end
+
+    if renamed_keys then
+        for key, new_key in pairs(renamed_keys) do
+            conf[new_key] = conf[key]
+            conf[key] = nil
+        end
     end
 
     return true

--- a/t/cli/test_http_config.sh
+++ b/t/cli/test_http_config.sh
@@ -39,6 +39,31 @@ echo "passed: define custom shdict"
 
 git checkout conf/config.yaml
 
+# resolve environment variable used as a config key: the resolved key must be
+# rendered and the stale unresolved key must be removed from the config table
+echo '
+nginx_config:
+  http:
+    custom_lua_shared_dict:
+      "${{DICT_NAME}}": 1m
+' > conf/config.yaml
+
+DICT_NAME=env_dict make init
+
+if ! grep "lua_shared_dict env_dict 1m;" conf/nginx.conf > /dev/null; then
+    echo "failed: resolve env var used as config key"
+    exit 1
+fi
+
+if grep -F '${{DICT_NAME}}' conf/nginx.conf > /dev/null; then
+    echo "failed: stale unresolved env var key should be removed"
+    exit 1
+fi
+
+echo "passed: resolve env var used as config key"
+
+git checkout conf/config.yaml
+
 echo "
 plugins:
     - ip-restriction

--- a/t/config-center-json/route-upstream.t
+++ b/t/config-center-json/route-upstream.t
@@ -21,6 +21,8 @@ log_level('info');
 no_root_location();
 no_shuffle();
 
+$ENV{TEST_UPSTREAM_NODE} = '127.0.0.1:1980';
+
 run_tests();
 
 __DATA__
@@ -242,3 +244,29 @@ GET /hello
 test: one
 --- error_log
 proxy request to 127.0.0.1:1980
+
+
+
+=== TEST 8: env var used as a node key is resolved, stale key is removed
+--- yaml_config eval: $::yaml_config
+--- apisix_json
+{
+  "routes": [
+    {
+      "id": 1,
+      "uri": "/hello",
+      "upstream": {
+        "nodes": {
+          "${{TEST_UPSTREAM_NODE}}": 1
+        },
+        "type": "roundrobin"
+      }
+    }
+  ]
+}
+--- request
+GET /hello
+--- response_body
+hello world
+--- no_error_log
+failed to parse domain


### PR DESCRIPTION
### Description

There is a little bug in function `local function resolve_conf_var(conf)` in `cli/file.lua`
`conf.key = nil` deletes entry from conf with name "key"
but  after variable substitution, old entry with name contained in variable `key` should be removed.
so it needs to be rewritten to `conf[key] = nil`

`conf.key = nil` results in adding entry with resolved variable to conf, but doesn't remove entry with unresolved variable name.
In case of using it in routes->upstream->nodes it results in two node entries. one is correct and one with unresolved variable name in it, that results in dns error in logs. I suppose that another places will result in different consequences. 

#### Which issue(s) this PR fixes:

Fixes #12884

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)



Fixes #10505
