### PR TITLE
fix: eliminate deepcopy when destroying prometheus

### DIFF
--- a/apisix/plugins/prometheus/exporter.lua
+++ b/apisix/plugins/prometheus/exporter.lua
@@ -809,7 +809,7 @@ end
 
 function _M.destroy()
     if prometheus ~= nil then
-        prometheus_bkp = core.table.deepcopy(prometheus)
+        prometheus_bkp = prometheus
         prometheus = nil
     end
 end


### PR DESCRIPTION
### Description

This PR: https://github.com/apache/apisix/pull/11117 introduced a bug: deep-copying the prometheus table when destroying prometheus. Which would lead to the following failure:

```log
2026/01/13 15:42:35 [error] 255#255: exit_worker_by_lua error: /usr/local/apisix/apisix/core/table.lua:144: table overflow
stack traceback:
    /usr/local/apisix/apisix/core/table.lua:131: in function '_deepcopy'
    /usr/local/apisix/apisix/core/table.lua:141: in function '_deepcopy'
    /usr/local/apisix/apisix/core/table.lua:141: in function '_deepcopy'
    /usr/local/apisix/apisix/core/table.lua:141: in function '_deepcopy'
    /usr/local/apisix/apisix/core/table.lua:166: in function 'deepcopy'
    /usr/local/apisix/apisix/plugins/prometheus/exporter.lua:917: in function 'destroy'
    /usr/local/apisix/apisix/plugin.lua:128: in function 'unload_plugin'
    /usr/local/apisix/apisix/plugin.lua:477: in function 'exit_worker'
    /usr/local/apisix/apisix/init.lua:183: in function 'http_exit_worker'
    exit_worker_by_lua:2: in main chunk
```

Deep-copying in this scenario is not necessary as nullifying the source table won't nullify the backup table

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
