### PR TITLE
feat: Add Bearer Token Support to key-auth Plugin

### DIFF
--- a/apisix/plugins/key-auth.lua
+++ b/apisix/plugins/key-auth.lua
@@ -35,6 +35,10 @@ local schema = {
             type = "boolean",
             default = false,
         },
+        bearer_token = {
+            type = "boolean",
+            default = false,
+        },
         anonymous_consumer = schema_def.anonymous_consumer_schema,
     },
 }
@@ -69,7 +73,13 @@ end
 
 local function find_consumer(ctx, conf)
     local from_header = true
-    local key = core.request.header(ctx, conf.header)
+    local header_name = conf.header
+
+    if conf.bearer_token then
+        header_name = "Authorization"
+    end
+
+    local key = core.request.header(ctx, header_name)
 
     if not key then
         local uri_args = core.request.get_uri_args(ctx) or {}
@@ -81,6 +91,15 @@ local function find_consumer(ctx, conf)
         return nil, nil, "Missing API key in request"
     end
 
+    if conf.bearer_token and from_header then
+        local bearer_prefix = "Bearer "
+        if key:sub(1, #bearer_prefix) == bearer_prefix then
+            key = key:sub(#bearer_prefix + 1)
+        else
+            return nil, nil, "Invalid Bearer token format"
+        end
+    end
+
     local consumer, consumer_conf, err = consumer_mod.find_consumer(plugin_name, "key", key)
     if not consumer then
         core.log.warn("failed to find consumer: ", err or "invalid api key")
@@ -89,7 +108,7 @@ local function find_consumer(ctx, conf)
 
     if conf.hide_credentials then
         if from_header then
-            core.request.set_header(ctx, conf.header, nil)
+            core.request.set_header(ctx, header_name, nil)
         else
             local args = core.request.get_uri_args(ctx)
             args[conf.query] = nil
@@ -105,14 +124,16 @@ function _M.rewrite(conf, ctx)
     local consumer, consumer_conf, err = find_consumer(ctx, conf)
     if not consumer then
         if not conf.anonymous_consumer then
-            core.response.set_header("WWW-Authenticate", "apikey realm=\"" .. conf.realm .. "\"")
+            local auth_scheme = conf.bearer_token and "Bearer" or "apikey"
+            core.response.set_header("WWW-Authenticate", auth_scheme .. " realm=\"" .. conf.realm .. "\"")
             return 401, { message = err}
         end
         consumer, consumer_conf, err = consumer_mod.get_anonymous_consumer(conf.anonymous_consumer)
         if not consumer then
             err = "key-auth failed to authenticate the request, code: 401. error: " .. err
             core.log.error(err)
-            core.response.set_header("WWW-Authenticate", "apikey realm=\"" .. conf.realm .. "\"")
+            local auth_scheme = conf.bearer_token and "Bearer" or "apikey"
+            core.response.set_header("WWW-Authenticate", auth_scheme .. " realm=\"" .. conf.realm .. "\"")
             return 401, { message = "Invalid user authorization"}
         end
     end

--- a/apisix/plugins/key-auth.lua
+++ b/apisix/plugins/key-auth.lua
@@ -125,7 +125,8 @@ function _M.rewrite(conf, ctx)
     if not consumer then
         if not conf.anonymous_consumer then
             local auth_scheme = conf.bearer_token and "Bearer" or "apikey"
-            core.response.set_header("WWW-Authenticate", auth_scheme .. " realm=\"" .. conf.realm .. "\"")
+            local www_auth_value = auth_scheme .. " realm=\"" .. conf.realm .. "\""
+            core.response.set_header("WWW-Authenticate", www_auth_value)
             return 401, { message = err}
         end
         consumer, consumer_conf, err = consumer_mod.get_anonymous_consumer(conf.anonymous_consumer)
@@ -133,7 +134,8 @@ function _M.rewrite(conf, ctx)
             err = "key-auth failed to authenticate the request, code: 401. error: " .. err
             core.log.error(err)
             local auth_scheme = conf.bearer_token and "Bearer" or "apikey"
-            core.response.set_header("WWW-Authenticate", auth_scheme .. " realm=\"" .. conf.realm .. "\"")
+            local www_auth_value = auth_scheme .. " realm=\"" .. conf.realm .. "\""
+            core.response.set_header("WWW-Authenticate", www_auth_value)
             return 401, { message = "Invalid user authorization"}
         end
     end

--- a/t/plugin/key-auth-bearer.t
+++ b/t/plugin/key-auth-bearer.t
@@ -1,0 +1,179 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: add consumer with key
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack",
+                    "plugins": {
+                        "key-auth": {
+                            "key": "auth-bearer-token"
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 2: enable key-auth plugin with bearer_token option
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "key-auth": {
+                            "bearer_token": true
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 3: verify Bearer token authentication works
+--- request
+GET /hello
+--- more_headers
+Authorization: Bearer auth-bearer-token
+--- response_body
+hello world
+
+
+
+=== TEST 4: verify authentication fails without Bearer prefix
+--- request
+GET /hello
+--- more_headers
+Authorization: auth-bearer-token
+--- error_code: 401
+--- response_body
+{"message":"Invalid Bearer token format"}
+
+
+
+=== TEST 5: verify authentication fails with missing token
+--- request
+GET /hello
+--- error_code: 401
+--- response_body
+{"message":"Missing API key in request"}
+--- response_headers
+WWW-Authenticate: Bearer realm="key"
+
+
+
+=== TEST 6: verify authentication fails with wrong token
+--- request
+GET /hello
+--- more_headers
+Authorization: Bearer wrong-token
+--- error_code: 401
+--- response_body
+{"message":"Invalid API key in request"}
+
+
+
+=== TEST 7: verify hide_credentials removes Bearer token header
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "key-auth": {
+                            "bearer_token": true,
+                            "hide_credentials": true
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/echo"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 8: verify Authorization header is removed upstream
+--- request
+GET /echo
+--- more_headers
+Authorization: Bearer auth-bearer-token
+--- response_headers
+!Authorization


### PR DESCRIPTION
### Description

This PR adds support for OAuth 2.0 Bearer token authentication format to the `key-auth` plugin. When enabled, the plugin validates tokens in the standard `Authorization: Bearer <token>` format, following RFC 6750 specifications.

#### Which issue(s) this PR fixes:

Fixes #12908

### Checklist

- [X] I have explained the need for this PR and the problem it solves
- [X] I have explained the changes or the new features added to this PR
- [X] I have added tests corresponding to this change
- [X] I have updated the documentation to reflect this change
- [X] I have verified that this change is backward compatible 
- 
<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
