### PR TITLE
fix: Remove redundant field for rate limit plugins

### DIFF
--- a/apisix/plugins/ai-rate-limiting.lua
+++ b/apisix/plugins/ai-rate-limiting.lua
@@ -113,7 +113,6 @@ local function transform_limit_conf(plugin_conf, instance_conf, instance_name)
         policy = "local",
         key_type = "constant",
         allow_degradation = false,
-        sync_interval = -1,
 
         limit_header = "X-AI-RateLimit-Limit-" .. name,
         remaining_header = "X-AI-RateLimit-Remaining-" .. name,

--- a/t/admin/global-rules-conflict.t
+++ b/t/admin/global-rules-conflict.t
@@ -221,7 +221,6 @@ passed
                     plugins = {
                         ["limit-count"] = {
                             key_type = "var",
-                            sync_interval = -1,
                             show_limit_quota_header = true,
                             rejected_code = 503,
                             policy = "local",


### PR DESCRIPTION
### Description

ai-rate-limiting and limit-count plugins have a redundant field `sync_interval`, this pr fix this.
