### PR TITLE
feat: support set default value in resolve_var

### DIFF
--- a/apisix/core/utils.lua
+++ b/apisix/core/utils.lua
@@ -296,15 +296,21 @@ local resolve_var
 do
     local _ctx
     local n_resolved
-    local pat = [[(?<!\\)\$(\{([\w\.]+)\}|([\w\.]+))]]
+    local pat = [[(?<!\\)\$(\{\s*([^}]+?)\s*\}|([\w\.]+))]]
     local _escaper
 
     local function resolve(m)
         local variable = m[2] or m[3]
-        local v = _ctx[variable]
+        -- handle the default value with ?? operator
+        local segs, err = ngx_re.split(variable, [[\s*\?\?\s*]])
+        if not segs then
+            log.error("failed to split variable ", variable, ": ", err)
+            return ""
+        end
+        local v = _ctx[segs[1]]
 
         if v == nil then
-            return ""
+            return segs[2] or ""
         end
         n_resolved = n_resolved + 1
         if _escaper then

--- a/t/core/utils.t
+++ b/t/core/utils.t
@@ -215,6 +215,16 @@ close: 1 nil}
                 "${you}_${me}",
                 "${you}${me}",
                 "${you}$me",
+                "${you??}$me",
+                "${you??Rose}$me",
+                "${she??Rose}$me",
+                "${she ??Rose}$me",
+                "${she?? Rose}$me",
+                "${she ?? Rose}$me",
+                "${she   ??     Rose}$me",
+                "${ she ?? Rose }$me",
+                "${you ?? Rose}$he??",
+                "${you ?? Rose}$he??Jack",
             }
             local ctx = {
                 you = "John",
@@ -241,6 +251,16 @@ res:John and \$me
 res:John_David
 res:JohnDavid
 res:JohnDavid
+res:JohnDavid
+res:JohnDavid
+res:RoseDavid
+res:RoseDavid
+res:RoseDavid
+res:RoseDavid
+res:RoseDavid
+res:RoseDavid
+res:John??
+res:John??Jack
 
 
 


### PR DESCRIPTION
### Description

Enhance the `resolve_var` function to use a default value when the variable does not exist.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
