### PR TITLE
Fix: Add missing empty spaces in exit / die message for invalid certificate path

### DIFF
--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -328,7 +328,7 @@ function _M.read_yaml_conf(apisix_home)
             -- Therefore we need to check the absolute version instead
             local cert_path = pl_path.abspath(apisix_ssl.ssl_trusted_certificate)
             if not pl_path.exists(cert_path) then
-                util.die("certificate path", cert_path, "doesn't exist\n")
+                util.die("certificate path ", cert_path, " doesn't exist\n")
             end
             apisix_ssl.ssl_trusted_certificate = cert_path
         end


### PR DESCRIPTION
Add missing empty spaces in error message

### Description

Two missing spaces were added to the exit / die message for invalid certificate paths.
Improves readability of error message and included file path.

#### Which issue(s) this PR fixes:
-

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
