### PR TITLE
chore: add ngx.flush after ngx.print

### DIFF
--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -25,6 +25,7 @@ local re_split      = require("ngx.re").split
 local ngx           = ngx
 local ngx_ok        = ngx.OK
 local ngx_print     = ngx.print
+local ngx_flush     = ngx.flush
 local crc32         = ngx.crc32_short
 local ngx_exit      = ngx.exit
 local pkg_loaded    = package.loaded
@@ -1349,6 +1350,7 @@ function _M.lua_response_filter(api_ctx, headers, body)
     if not plugins or #plugins == 0 then
         -- if there is no any plugin, just print the original body to downstream
         ngx_print(body)
+        ngx_flush()
         return
     end
     for i = 1, #plugins, 2 do
@@ -1377,6 +1379,7 @@ function _M.lua_response_filter(api_ctx, headers, body)
         ::CONTINUE::
     end
     ngx_print(body)
+    ngx_flush()
 end
 
 


### PR DESCRIPTION
### Description

Enable the response body in sse mode to be sent to downstream faster.

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
