### PR TITLE
fix: use apisix_request_id only in http subsystem log format

### DIFF
--- a/apisix/cli/config.lua
+++ b/apisix/cli/config.lua
@@ -111,7 +111,7 @@ local _M = {
       enable_access_log = false,
       access_log = "logs/access_stream.log",
       -- luacheck: push max code line length 300
-      access_log_format = "$remote_addr [$time_local] $protocol $status $bytes_sent $bytes_received $session_time $apisix_request_id",
+      access_log_format = "$remote_addr [$time_local] $protocol $status $bytes_sent $bytes_received $session_time",
       -- luacheck: pop
       access_log_format_escape = "default",
       lua_shared_dict = {
@@ -136,7 +136,7 @@ local _M = {
       access_log_buffer = 16384,
       -- luacheck: push max code line length 300
       access_log_format =
-      '$remote_addr - $remote_user [$time_local] $http_host "$request" $status $body_bytes_sent $request_time "$http_referer" "$http_user_agent" $upstream_addr $upstream_status $upstream_response_time "$upstream_scheme://$upstream_host$upstream_uri"',
+      '$remote_addr - $remote_user [$time_local] $http_host "$request" $status $body_bytes_sent $request_time "$http_referer" "$http_user_agent" $upstream_addr $upstream_status $upstream_response_time "$upstream_scheme://$upstream_host$upstream_uri" "$apisix_request_id"',
       -- luacheck: pop
       access_log_format_escape = "default",
       keepalive_timeout = "60s",

--- a/t/cli/test_access_log.sh
+++ b/t/cli/test_access_log.sh
@@ -158,7 +158,7 @@ curl http://127.0.0.1:9080/hello2
 sleep 4
 tail -n 1 logs/access.log > output.log
 
-if [ `grep -E '[0-9|.]+ - - \[[^]]+\] [0-9|.:]+ "[^"]+" [0-9]+ [0-9]+ [0|.]+ "-" "[^"]+" - - - "[^"]+" ".{36}"' output.log` -eq '0' ]; then
+if [ `grep -E '"[0-9a-zA-Z]{32}"$' output.log` -eq '0' ]; then
     echo "failed: access log don't match default log format"
     exit 1
 fi


### PR DESCRIPTION
### Description

The `apisix_request_id` variable is only available in the http subsystem but it was wrongly included in the `access_log_format` and the regex evaluation in the tests didn't detect this issue.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
