### PR TITLE
fix: treat default value in variable as resolved

### DIFF
--- a/apisix/core/utils.lua
+++ b/apisix/core/utils.lua
@@ -310,7 +310,10 @@ do
         local v = _ctx[segs[1]]
 
         if v == nil then
-            return segs[2] or ""
+            if #segs == 1 then
+                return ""
+            end
+            v = segs[2]
         end
         n_resolved = n_resolved + 1
         if _escaper then

--- a/t/plugin/limit-count-rules.t
+++ b/t/plugin/limit-count-rules.t
@@ -532,3 +532,63 @@ apisix-count: 3
 X-2-RateLimit-Limit: 3
 X-2-RateLimit-Remaining: 2
 X-2-RateLimit-Reset: 60
+
+
+
+=== TEST 18: use variable with default value in rules.key
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "methods": ["GET"],
+                        "plugins": {
+                            "limit-count": {
+                                "rejected_code": 503,
+                                "rules": [
+                                    {
+                                        "count": 1,
+                                        "time_window": 10,
+                                        "key": "${http_project ?? apisix}"
+                                    }
+                                ]
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 19: with project header
+--- request
+GET /hello
+--- more_headers
+project: kubernetes
+--- error_log eval
+qr/limit key: \/apisix\/routes\/1:[^:]+:kubernetes/
+
+
+
+=== TEST 20: without project header
+--- request
+GET /hello
+--- error_log eval
+qr/limit key: \/apisix\/routes\/1:[^:]+:apisix/


### PR DESCRIPTION
### Description

In the rules field of plugins like limit-count-advanced, if the key field does not match any variables (n_resolved == 0), we consider this rule as not matched.
However, when a variable is configured with a default value, even if the variable does not exist, it should still be considered as successfully variable replaced and execute this rule.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
