### PR TITLE
fix: Set upstream and upstream_latency vars in ext-plugin-post-resp for logging

### DIFF
--- a/apisix/plugins/ext-plugin-post-resp.lua
+++ b/apisix/plugins/ext-plugin-post-resp.lua
@@ -147,8 +147,13 @@ end
 
 
 function _M.before_proxy(conf, ctx)
+    local start_time = ngx.now()
     local http_obj = http.new()
     local res, err = get_response(ctx, http_obj)
+
+    ctx.var.upstream_response_time = math.floor((ngx.now() - start_time) * 1000 + 0.5) / 1000
+    ctx.var.upstream_addr = ctx.picked_server.host .. ":" .. ctx.picked_server.port
+
     if not res or err then
         core.log.error("failed to request: ", err or "")
         close(http_obj)


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
When using ext-plugin-post-resp and http-logger, some values are missing from the logs, specifically the ones related to upstream - upstream and upstream_latency.
This is happening because upstream_response_time and upstream_addr nginx vars are unavailable, so when log-util.lua is trying to inject them into logs, no value is present.
This PR adds these two vars to ext-plugin-post-resp, they are now set explicitly after the call to upstream.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/apache/apisix/issues/13016

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
