### PR TITLE
fix(schema): correct minLength type for anonymous consumer

### DIFF
--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -26,7 +26,7 @@ local plugins_schema = {
 
 _M.anonymous_consumer_schema = {
     type = "string",
-    minLength = "1"
+    minLength = 1
 }
 
 function _M.get_realm_schema(default_val)


### PR DESCRIPTION
The anonymous_consumer_schema defined minLength as a string instead of a number.
This patch fixes the schema type to ensure correct validation behavior.