### PR TITLE
CI: Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -18,6 +18,9 @@
 #
 name: License checker
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master, 'release/**']


### PR DESCRIPTION
Potential fix for [https://github.com/apache/apisix/security/code-scanning/10](https://github.com/apache/apisix/security/code-scanning/10)

In general, the fix is to explicitly declare minimal `GITHUB_TOKEN` permissions for this workflow, either at the workflow root (applies to all jobs) or under the specific `check-license` job. Since there is only one job, either approach works; adding it at the workflow root is clear and future-proof if more jobs are added.

The best minimal fix without changing existing functionality is to add:

```yaml
permissions:
  contents: read
```

near the top-level of the workflow, between `name:` and `on:` (or just above `jobs:`). The `apache/skywalking-eyes` action only needs to read repository contents to scan license headers; it does not need to write to the repo, issues, or PRs in the current snippet. Keeping `contents: read` ensures the workflow can still check out and read files while restricting any write capabilities. No imports or additional methods are needed, as this is purely a YAML configuration change.

Concretely, edit `.github/workflows/license-checker.yml` around lines 19–26 to insert a `permissions:` block at the root level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
