### PR TITLE
fix(healthcheck): use immediate clear() to ensure k8s endpoint change…

### DIFF
--- a/t/node/healthcheck-leak-bugfix.t
+++ b/t/node/healthcheck-leak-bugfix.t
@@ -31,8 +31,13 @@ __DATA__
     local new = healthcheck.new
     healthcheck.new = function(...)
         local obj = new(...)
-        local clear = obj.delayed_clear
+        local delayed_clear = obj.delayed_clear
         obj.delayed_clear = function(...)
+            ngx.log(ngx.WARN, "clear checker")
+            return delayed_clear(...)
+        end
+        local clear = obj.clear
+        obj.clear = function(...)
             ngx.log(ngx.WARN, "clear checker")
             return clear(...)
         end


### PR DESCRIPTION
…s take effect

Replace delayed_clear() with immediate clear() in healthcheck_manager to fix an issue where k8s endpoint changes would not take effect immediately. The delayed clear could cause healthcheck to continue using stale IP addresses after endpoint updates.

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
