### PR TITLE
fix(fw-auth): disallow control characters in headers

### DIFF
--- a/apisix/plugins/forward-auth.lua
+++ b/apisix/plugins/forward-auth.lua
@@ -126,14 +126,22 @@ function _M.access(conf, ctx)
             end
             local resolve_value, err = core.utils.resolve_var(value, ctx.var)
             if not err then
-                auth_headers[header] = resolve_value
-            end
-            if err then
+                if type(resolve_value) == "string" then
+                    if not core.utils.validate_header_value(resolve_value) then
+                        core.log.error("illegal header value: ", resolve_value)
+                        return 400, { message = "illegal header value" }
+                    end
+                end
+                if resolve_value then
+                    auth_headers[header] = resolve_value
+                end
+            else
                 core.log.error("failed to resolve variable in extra header '",
                                 header, "': ",value,": ",err)
             end
         end
     end
+
 
     -- append headers that need to be get from the client request header
     if #conf.request_headers > 0 then

--- a/t/plugin/forward-auth.t
+++ b/t/plugin/forward-auth.t
@@ -338,6 +338,24 @@ property "request_method" validation failed: matches none of the enum values
                         "upstream_id": "u1",
                         "uri": "/ping3"
                     }]]
+                },
+                {
+                    url = "/apisix/admin/routes/11",
+                    data = [[{
+                        "plugins": {
+                            "forward-auth": {
+                                "uri": "http://127.0.0.1:1984/auth",
+                                "request_method": "GET",
+                                "request_headers": ["Authorization"],
+                                "extra_headers": {"X-User": "$arg_user"}
+                            },
+                            "proxy-rewrite": {
+                                "uri": "/echo"
+                            }
+                        },
+                        "upstream_id": "u1",
+                        "uri": "/crlf"
+                    }]]
                 }
             }
 
@@ -350,7 +368,7 @@ property "request_method" validation failed: matches none of the enum values
         }
     }
 --- response_body eval
-"passed\n" x 12
+"passed\n" x 13
 
 
 
@@ -489,3 +507,15 @@ GET /ping3
 Authorization: 888
 --- response_body_like eval
 qr/\"x-user-id\":\"i-am-an-user\"/
+
+
+
+=== TEST 16: block CRLF header injection
+--- request
+GET /crlf?user=guest%0d%0ax-user1:%20admin
+--- more_headers
+Authorization: 111
+--- error_code: 400
+--- error_log
+illegal header value: guest
+x-user1: admin


### PR DESCRIPTION
### Description

If user passes control characters in args that would be later evaluated under apisix variables to be resolved as a header for forward auth we may experience irregular and unexpected behaviours.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
