### PR TITLE
fix(ai-proxy): support Anthropic token field names in openai-base driver

### DIFF
--- a/apisix/plugins/ai-drivers/openai-base.lua
+++ b/apisix/plugins/ai-drivers/openai-base.lua
@@ -131,12 +131,12 @@ local function read_response(conf, ctx, res, response_filter)
                         core.log.info("got token usage from ai service: ",
                                             core.json.delay_encode(data.usage))
                         ctx.llm_raw_usage = data.usage
+                        local pt = data.usage.prompt_tokens or data.usage.input_tokens or 0
+                        local ct = data.usage.completion_tokens or data.usage.output_tokens or 0
                         ctx.ai_token_usage = {
-                            prompt_tokens = data.usage.prompt_tokens
-                                            or data.usage.input_tokens or 0,
-                            completion_tokens = data.usage.completion_tokens
-                                               or data.usage.output_tokens or 0,
-                            total_tokens = data.usage.total_tokens or 0,
+                            prompt_tokens = pt,
+                            completion_tokens = ct,
+                            total_tokens = data.usage.total_tokens or (pt + ct),
                         }
                         ctx.var.llm_prompt_tokens = ctx.ai_token_usage.prompt_tokens
                         ctx.var.llm_completion_tokens = ctx.ai_token_usage.completion_tokens

--- a/apisix/plugins/ai-drivers/openai-base.lua
+++ b/apisix/plugins/ai-drivers/openai-base.lua
@@ -132,8 +132,10 @@ local function read_response(conf, ctx, res, response_filter)
                                             core.json.delay_encode(data.usage))
                         ctx.llm_raw_usage = data.usage
                         ctx.ai_token_usage = {
-                            prompt_tokens = data.usage.prompt_tokens or 0,
-                            completion_tokens = data.usage.completion_tokens or 0,
+                            prompt_tokens = data.usage.prompt_tokens
+                                            or data.usage.input_tokens or 0,
+                            completion_tokens = data.usage.completion_tokens
+                                               or data.usage.output_tokens or 0,
                             total_tokens = data.usage.total_tokens or 0,
                         }
                         ctx.var.llm_prompt_tokens = ctx.ai_token_usage.prompt_tokens
@@ -188,8 +190,10 @@ local function read_response(conf, ctx, res, response_filter)
         ctx.ai_token_usage = {}
         if type(res_body.usage) == "table" then
             ctx.llm_raw_usage = res_body.usage
-            ctx.ai_token_usage.prompt_tokens = res_body.usage.prompt_tokens or 0
-            ctx.ai_token_usage.completion_tokens = res_body.usage.completion_tokens or 0
+            ctx.ai_token_usage.prompt_tokens = res_body.usage.prompt_tokens
+                                               or res_body.usage.input_tokens or 0
+            ctx.ai_token_usage.completion_tokens = res_body.usage.completion_tokens
+                                                   or res_body.usage.output_tokens or 0
             ctx.ai_token_usage.total_tokens = res_body.usage.total_tokens or 0
         end
         ctx.var.llm_prompt_tokens = ctx.ai_token_usage.prompt_tokens or 0

--- a/apisix/plugins/ai-drivers/openai-base.lua
+++ b/apisix/plugins/ai-drivers/openai-base.lua
@@ -194,7 +194,9 @@ local function read_response(conf, ctx, res, response_filter)
                                                or res_body.usage.input_tokens or 0
             ctx.ai_token_usage.completion_tokens = res_body.usage.completion_tokens
                                                    or res_body.usage.output_tokens or 0
-            ctx.ai_token_usage.total_tokens = res_body.usage.total_tokens or 0
+            ctx.ai_token_usage.total_tokens = res_body.usage.total_tokens
+                                              or (ctx.ai_token_usage.prompt_tokens
+                                                 + ctx.ai_token_usage.completion_tokens)
         end
         ctx.var.llm_prompt_tokens = ctx.ai_token_usage.prompt_tokens or 0
         ctx.var.llm_completion_tokens = ctx.ai_token_usage.completion_tokens or 0


### PR DESCRIPTION
## Summary

When using `openai-compatible` provider with Anthropic-format endpoints
(e.g. DeepSeek's `/anthropic/v1/messages`), the upstream returns
`input_tokens`/`output_tokens` instead of `prompt_tokens`/`completion_tokens`.

This causes `$llm_prompt_tokens` and `$llm_completion_tokens` to always be 0.

## Changes

Add fallback support for Anthropic field names in both streaming and
non-streaming paths of `openai-base.lua`:

- `prompt_tokens = usage.prompt_tokens or usage.input_tokens or 0`
- `completion_tokens = usage.completion_tokens or usage.output_tokens or 0`

This is fully backward compatible — OpenAI-format responses are unaffected.
