### PR TITLE
feat(ai-proxy-multi): add anthropic-native provider for native Anthropic Messages API

### DIFF
--- a/apisix/plugins/ai-drivers/anthropic-native.lua
+++ b/apisix/plugins/ai-drivers/anthropic-native.lua
@@ -1,0 +1,399 @@
+--
+-- anthropic-native.lua
+-- A driver for the Anthropic Messages API native protocol (/v1/messages).
+-- Handles Anthropic-specific SSE event types, response format, and token usage fields.
+-- Compatible with any endpoint that speaks the native Anthropic protocol,
+-- e.g. api.anthropic.com/v1/messages or api.deepseek.com/anthropic/v1/messages.
+--
+-- Differences from openai-base:
+--   Request:  removes stream_options (not supported), adds anthropic-version header
+--   Response: content[].text  (not choices[].message.content)
+--   SSE text: event=content_block_delta, delta.type=text_delta, delta.text
+--   SSE token: message_start -> input_tokens; message_delta -> output_tokens
+--   SSE end:  event=message_stop  (no [DONE] sentinel)
+--   Token fields: input_tokens / output_tokens  (not prompt_tokens / completion_tokens)
+--
+
+local _M = {}
+
+local mt = { __index = _M }
+
+local CONTENT_TYPE_JSON = "application/json"
+local ANTHROPIC_VERSION = "2023-06-01"
+
+local core    = require("apisix.core")
+local plugin  = require("apisix.plugin")
+local http    = require("resty.http")
+local url     = require("socket.url")
+local sse     = require("apisix.plugins.ai-drivers.sse")
+
+local ngx       = ngx
+local ngx_now   = ngx.now
+local table     = table
+local pairs     = pairs
+local type      = type
+local math      = math
+local ipairs    = ipairs
+local setmetatable = setmetatable
+local str_lower = string.lower
+
+local HTTP_INTERNAL_SERVER_ERROR = ngx.HTTP_INTERNAL_SERVER_ERROR
+local HTTP_GATEWAY_TIMEOUT       = ngx.HTTP_GATEWAY_TIMEOUT
+
+
+function _M.new(opt)
+    return setmetatable(opt or {}, mt)
+end
+
+
+-- Validate incoming request (same as openai-base: must be JSON)
+function _M.validate_request(ctx)
+    local ct = core.request.header(ctx, "Content-Type") or CONTENT_TYPE_JSON
+    if not core.string.has_prefix(ct, CONTENT_TYPE_JSON) then
+        return nil, "unsupported content-type: " .. ct
+    end
+    local request_table, err = core.request.get_json_request_body_table()
+    if not request_table then
+        return nil, err
+    end
+    return request_table, nil
+end
+
+
+local function handle_error(err)
+    if core.string.find(err, "timeout") then
+        return HTTP_GATEWAY_TIMEOUT
+    end
+    return HTTP_INTERNAL_SERVER_ERROR
+end
+
+
+-- Build forward headers, injecting Anthropic-required headers.
+-- Blacklist host/content-length; honour caller-supplied auth headers.
+local function construct_forward_headers(ext_opts_headers, ctx)
+    local blacklist = { "host", "content-length" }
+
+    local opts_headers_lower = {}
+    for k, v in pairs(ext_opts_headers or {}) do
+        opts_headers_lower[str_lower(k)] = v
+    end
+
+    local headers = core.table.merge(core.request.headers(ctx), opts_headers_lower)
+    headers["Content-Type"]       = CONTENT_TYPE_JSON
+    -- Anthropic native protocol requires this version header
+    if not headers["anthropic-version"] then
+        headers["anthropic-version"] = ANTHROPIC_VERSION
+    end
+
+    for _, h in ipairs(blacklist) do
+        headers[h] = nil
+    end
+    return headers
+end
+
+
+-- Extract text content from Anthropic non-streaming response.
+-- Response shape: { content: [{type:"text", text:"..."}], usage: {input_tokens, output_tokens} }
+local function extract_response_text(res_body)
+    if type(res_body.content) ~= "table" then
+        return ""
+    end
+    local parts = {}
+    for _, block in ipairs(res_body.content) do
+        if type(block) == "table" and block.type == "text" and type(block.text) == "string" then
+            core.table.insert(parts, block.text)
+        end
+    end
+    return table.concat(parts, "")
+end
+
+
+local function read_response(conf, ctx, res, response_filter)
+    local body_reader = res.body_reader
+    if not body_reader then
+        core.log.warn("AI service sent no response body")
+        return HTTP_INTERNAL_SERVER_ERROR
+    end
+
+    local content_type = res.headers["Content-Type"]
+    core.response.set_header("Content-Type", content_type)
+
+    -- ── Streaming path ────────────────────────────────────────────────────────
+    if content_type and core.string.find(content_type, "text/event-stream") then
+        local contents = {}
+        while true do
+            local chunk, err = body_reader()
+            ctx.var.apisix_upstream_response_time =
+                math.floor((ngx_now() - ctx.llm_request_start_time) * 1000)
+
+            if err then
+                core.log.warn("failed to read response chunk: ", err)
+                return handle_error(err)
+            end
+            if not chunk then
+                return  -- stream finished
+            end
+
+            local events = sse.decode(chunk)
+            ctx.llm_response_contents_in_chunk = {}
+
+            for _, event in ipairs(events) do
+                -- Skip empty data and ping events
+                if event.data == "" or event.type == "ping" then
+                    goto CONTINUE
+                end
+
+                -- sse.lua maps "data: [DONE]" to type="done" — some Anthropic-compatible
+                -- endpoints (e.g. DeepSeek) append this OpenAI sentinel after message_stop.
+                -- Safe to ignore; we already handled stream completion via message_stop.
+                if event.type == "done" then
+                    goto CONTINUE
+                end
+
+                -- message_stop: stream is done (standard Anthropic end-of-stream event)
+                if event.type == "message_stop" then
+                    ctx.var.llm_request_done = true
+                    goto CONTINUE
+                end
+
+                -- error event: log and surface to client
+                -- e.g. {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}
+                if event.type == "error" then
+                    core.log.warn("received error event from anthropic stream: ", event.data)
+                    goto CONTINUE
+                end
+
+                local data, decode_err = core.json.decode(event.data)
+                if not data then
+                    core.log.warn("failed to decode SSE data: ", decode_err)
+                    goto CONTINUE
+                end
+
+                -- message_start: carries input_tokens in message.usage.
+                -- NOTE: output_tokens here is a pre-allocated value (usually 1), NOT the final
+                -- count. We only store input_tokens; output_tokens is finalised in message_delta.
+                if event.type == "message_start" then
+                    local usage = data.message and data.message.usage
+                    if usage and type(usage) == "table" then
+                        ctx.llm_raw_usage = ctx.llm_raw_usage or {}
+                        ctx.llm_raw_usage.input_tokens = usage.input_tokens or 0
+                    end
+                    goto CONTINUE
+                end
+
+                -- content_block_delta: carries text chunks (text_delta) or tool input
+                -- (input_json_delta). We only collect text_delta for llm_response_text.
+                -- TTFT is recorded on the first text_delta (true "first token").
+                if event.type == "content_block_delta" then
+                    local delta = data.delta
+                    if type(delta) == "table" and delta.type == "text_delta"
+                            and type(delta.text) == "string" then
+                        -- Record TTFT on first actual text token
+                        if ctx.var.llm_time_to_first_token == "0" then
+                            ctx.var.llm_time_to_first_token =
+                                math.floor((ngx_now() - ctx.llm_request_start_time) * 1000)
+                        end
+                        core.table.insert(contents, delta.text)
+                        core.table.insert(ctx.llm_response_contents_in_chunk, delta.text)
+                    end
+                    goto CONTINUE
+                end
+
+                -- message_delta: carries the final output_tokens count in usage.
+                -- This is the authoritative token count for the completed response.
+                if event.type == "message_delta" then
+                    local usage = data.usage
+                    if usage and type(usage) == "table" then
+                        ctx.llm_raw_usage = ctx.llm_raw_usage or {}
+                        ctx.llm_raw_usage.output_tokens = usage.output_tokens or 0
+                        local u  = ctx.llm_raw_usage
+                        local pt = u.input_tokens  or 0
+                        local ct = u.output_tokens or 0
+                        ctx.ai_token_usage = {
+                            prompt_tokens     = pt,
+                            completion_tokens = ct,
+                            total_tokens      = pt + ct,
+                        }
+                        ctx.var.llm_prompt_tokens     = pt
+                        ctx.var.llm_completion_tokens = ct
+                        ctx.var.llm_response_text     = table.concat(contents, "")
+                        core.log.warn("got token usage from ai service (anthropic-native): ",
+                            core.json.delay_encode(ctx.ai_token_usage))
+                    end
+                    goto CONTINUE
+                end
+
+                -- content_block_start / content_block_stop / unknown: pass through silently
+                ::CONTINUE::
+            end
+
+            plugin.lua_response_filter(ctx, res.headers, chunk)
+        end
+        return  -- streaming done
+    end
+
+    -- ── Non-streaming path ────────────────────────────────────────────────────
+    local headers = res.headers
+    local raw_res_body, err = res:read_body()
+    if not raw_res_body then
+        core.log.warn("failed to read response body: ", err)
+        return handle_error(err)
+    end
+
+    ngx.status = res.status
+    ctx.var.llm_time_to_first_token =
+        math.floor((ngx_now() - ctx.llm_request_start_time) * 1000)
+    ctx.var.apisix_upstream_response_time = ctx.var.llm_time_to_first_token
+
+    local res_body, decode_err = core.json.decode(raw_res_body)
+    if decode_err then
+        core.log.warn("invalid response body from ai service: ", raw_res_body,
+            " err: ", decode_err, ", token usage not available")
+    else
+        if response_filter then
+            local resp = { headers = headers, body = res_body }
+            local code, ferr = response_filter(conf, ctx, resp)
+            if code then
+                return code, ferr
+            end
+            if resp.body then
+                local body, encode_err = core.json.encode(resp.body)
+                if not body then
+                    core.log.error("failed to encode response body: ", encode_err)
+                    return 500
+                end
+                raw_res_body = body
+                res_body     = resp.body
+            end
+            headers = resp.headers
+        end
+
+        -- Extract token usage: Anthropic uses input_tokens / output_tokens
+        ctx.ai_token_usage = {}
+        if type(res_body.usage) == "table" then
+            ctx.llm_raw_usage = res_body.usage
+            local pt = res_body.usage.input_tokens  or res_body.usage.prompt_tokens     or 0
+            local ct = res_body.usage.output_tokens or res_body.usage.completion_tokens or 0
+            ctx.ai_token_usage = {
+                prompt_tokens     = pt,
+                completion_tokens = ct,
+                total_tokens      = res_body.usage.total_tokens or (pt + ct),
+            }
+            core.log.warn("got token usage from ai service (anthropic-native): ",
+                core.json.delay_encode(ctx.ai_token_usage))
+        end
+        ctx.var.llm_prompt_tokens     = ctx.ai_token_usage.prompt_tokens     or 0
+        ctx.var.llm_completion_tokens = ctx.ai_token_usage.completion_tokens or 0
+
+        -- Extract response text from Anthropic content[] array
+        ctx.var.llm_response_text = extract_response_text(res_body)
+    end
+
+    plugin.lua_response_filter(ctx, headers, raw_res_body)
+end
+
+
+function _M.request(self, ctx, conf, request_table, extra_opts)
+    local httpc, err = http.new()
+    if not httpc then
+        core.log.error("failed to create http client: ", err)
+        return HTTP_INTERNAL_SERVER_ERROR
+    end
+    httpc:set_timeout(conf.timeout)
+
+    -- Anthropic native protocol does NOT support stream_options
+    -- (that is an OpenAI extension); remove it to avoid upstream errors
+    request_table.stream_options = nil
+
+    local endpoint = extra_opts.endpoint
+    local parsed_url
+    if endpoint then
+        parsed_url = url.parse(endpoint)
+    end
+
+    local scheme = parsed_url and parsed_url.scheme or "https"
+    local host   = parsed_url and parsed_url.host   or self.host or "api.anthropic.com"
+    local port   = parsed_url and parsed_url.port
+    if not port then
+        port = (scheme == "https") and 443 or 80
+    end
+
+    local auth         = extra_opts.auth or {}
+    local query_params = auth.query or {}
+
+    if type(parsed_url) == "table" and parsed_url.query and #parsed_url.query > 0 then
+        local args_tab = core.string.decode_args(parsed_url.query)
+        if type(args_tab) == "table" then
+            core.table.merge(query_params, args_tab)
+        end
+    end
+
+    local path    = (parsed_url and parsed_url.path) or self.path or "/v1/messages"
+    local headers = construct_forward_headers(auth.header or {}, ctx)
+
+    local params = {
+        method          = "POST",
+        scheme          = scheme,
+        headers         = headers,
+        ssl_verify      = conf.ssl_verify,
+        path            = path,
+        query           = query_params,
+        host            = host,
+        port            = port,
+        ssl_server_name = parsed_url and parsed_url.host or host,
+    }
+
+    -- Apply model_options (e.g. override model name)
+    if extra_opts.model_options then
+        for opt, val in pairs(extra_opts.model_options) do
+            request_table[opt] = val
+        end
+    end
+    params.body = request_table
+
+    if self.request_filter then
+        local code, ferr = self.request_filter(extra_opts.conf, ctx, params)
+        if code then
+            return code, ferr
+        end
+    end
+
+    core.log.info("sending request to LLM server (anthropic-native): ",
+        core.json.delay_encode(params, true))
+
+    local ok, conn_err = httpc:connect(params)
+    if not ok then
+        core.log.error("failed to connect to LLM server: ", conn_err)
+        return handle_error(conn_err)
+    end
+
+    local req_json, encode_err = core.json.encode(params.body)
+    if not req_json then
+        return 500, "failed to encode request body: " .. (encode_err or "unknown error")
+    end
+    params.body = req_json
+
+    local res, req_err = httpc:request(params)
+    if not res then
+        core.log.warn("failed to send request to LLM server: ", req_err)
+        return handle_error(req_err)
+    end
+
+    if res.status == 429 or (res.status >= 500 and res.status < 600) then
+        return res.status
+    end
+
+    local code, body = read_response(extra_opts.conf, ctx, res, self.response_filter)
+
+    if conf.keepalive then
+        local ok, ka_err = httpc:set_keepalive(conf.keepalive_timeout, conf.keepalive_pool)
+        if not ok then
+            core.log.warn("failed to keepalive connection: ", ka_err)
+        end
+    end
+
+    return code, body
+end
+
+
+return _M

--- a/t/assets/anthropic-native-response.json
+++ b/t/assets/anthropic-native-response.json
@@ -1,0 +1,18 @@
+{
+  "id": "msg_01XFDUDYJgAACzvnptvVoYEL",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "1 + 1 = 2."
+    }
+  ],
+  "model": "claude-3-5-sonnet-20241022",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 23,
+    "output_tokens": 8
+  }
+}

--- a/t/plugin/ai-proxy-multi.anthropic-native.t
+++ b/t/plugin/ai-proxy-multi.anthropic-native.t
@@ -1,0 +1,697 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+log_level("info");
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+
+my $resp_file = 't/assets/anthropic-native-response.json';
+open(my $fh, '<', $resp_file) or die "Could not open file '$resp_file' $!";
+my $resp = do { local $/; <$fh> };
+close($fh);
+
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+    my $extra_yaml_config = <<_EOC_;
+plugins:
+  - ai-proxy-multi
+  - prometheus
+_EOC_
+    $block->set_value("extra_yaml_config", $extra_yaml_config);
+
+    # Default mock server: native Anthropic Messages API on port 6726
+    my $http_config = $block->http_config // <<_EOC_;
+        server {
+            server_name anthropic-native;
+            listen 6726;
+
+            default_type 'application/json';
+
+            location /v1/messages {
+                content_by_lua_block {
+                    local json = require("cjson.safe")
+
+                    if ngx.req.get_method() ~= "POST" then
+                        ngx.status = 400
+                        ngx.say("Unsupported request method: ", ngx.req.get_method())
+                        return
+                    end
+
+                    ngx.req.read_body()
+                    local body_str = ngx.req.get_body_data()
+                    local body, err = json.decode(body_str)
+                    if not body then
+                        ngx.status = 400
+                        ngx.say("bad json: " .. (err or ""))
+                        return
+                    end
+
+                    local header_auth = ngx.req.get_headers()["authorization"]
+
+                    if header_auth ~= "Bearer token" then
+                        ngx.status = 401
+                        ngx.say("Unauthorized")
+                        return
+                    end
+
+                    if not body.messages or #body.messages < 1 then
+                        ngx.status = 400
+                        ngx.say([[{ "error": "bad request"}]])
+                        return
+                    end
+
+                    -- test-type: inspect — echo back request details for assertion
+                    local test_type = ngx.req.get_headers()["test-type"]
+                    if test_type == "inspect" then
+                        local result = {
+                            anthropic_version = ngx.req.get_headers()["anthropic-version"],
+                            has_stream_options = (body.stream_options ~= nil),
+                        }
+                        ngx.status = 200
+                        ngx.say(json.encode(result))
+                        return
+                    end
+
+                    ngx.status = 200
+                    ngx.say([[$resp]])
+                }
+            }
+        }
+_EOC_
+
+    $block->set_value("http_config", $http_config);
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: schema accepts anthropic-native provider
+--- apisix_yaml
+routes:
+  - id: 1
+    uri: /t
+    plugins: {}
+#END
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ai-proxy-multi")
+            local ok, err = plugin.check_schema({
+                instances = {
+                    {
+                        name = "anthropic-native-instance",
+                        provider = "anthropic-native",
+                        weight = 1,
+                        auth = {
+                            header = {
+                                ["Authorization"] = "Bearer token"
+                            }
+                        },
+                        options = {
+                            model = "claude-3-5-sonnet-20241022",
+                            max_tokens = 512,
+                        },
+                        override = {
+                            endpoint = "http://localhost:6726/v1/messages"
+                        }
+                    }
+                },
+                ssl_verify = false
+            })
+
+            if not ok then
+                ngx.say(err)
+            else
+                ngx.say("passed")
+            end
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 2: non-streaming request returns Anthropic response
+--- apisix_yaml
+routes:
+  - id: 1
+    uri: /anything
+    plugins:
+      ai-proxy-multi:
+        instances:
+          - name: anthropic-native-instance
+            provider: anthropic-native
+            weight: 1
+            auth:
+              header:
+                Authorization: "Bearer token"
+            options:
+              model: claude-3-5-sonnet-20241022
+              max_tokens: 512
+            override:
+              endpoint: "http://localhost:6726/v1/messages"
+        ssl_verify: false
+#END
+--- request
+POST /anything
+{"messages":[{"role":"user","content":"What is 1+1?"}]}
+--- more_headers
+Authorization: Bearer token
+Content-Type: application/json
+--- error_code: 200
+--- response_body eval
+qr/"text":\s*"1 \+ 1 = 2\."/
+
+
+
+=== TEST 3: anthropic-version header is injected into upstream request
+--- apisix_yaml
+routes:
+  - id: 1
+    uri: /anything
+    plugins:
+      ai-proxy-multi:
+        instances:
+          - name: anthropic-native-instance
+            provider: anthropic-native
+            weight: 1
+            auth:
+              header:
+                Authorization: "Bearer token"
+            options:
+              model: claude-3-5-sonnet-20241022
+              max_tokens: 512
+            override:
+              endpoint: "http://localhost:6726/v1/messages"
+        ssl_verify: false
+#END
+--- request
+POST /anything
+{"messages":[{"role":"user","content":"hello"}]}
+--- more_headers
+Authorization: Bearer token
+Content-Type: application/json
+test-type: inspect
+--- error_code: 200
+--- response_body eval
+qr/"anthropic_version":"2023-06-01"/
+
+
+
+=== TEST 4: stream_options is stripped from upstream request
+--- apisix_yaml
+routes:
+  - id: 1
+    uri: /anything
+    plugins:
+      ai-proxy-multi:
+        instances:
+          - name: anthropic-native-instance
+            provider: anthropic-native
+            weight: 1
+            auth:
+              header:
+                Authorization: "Bearer token"
+            options:
+              model: claude-3-5-sonnet-20241022
+              max_tokens: 512
+            override:
+              endpoint: "http://localhost:6726/v1/messages"
+        ssl_verify: false
+#END
+--- request
+POST /anything
+{"messages":[{"role":"user","content":"hello"}],"stream":true,"stream_options":{"include_usage":true}}
+--- more_headers
+Authorization: Bearer token
+Content-Type: application/json
+test-type: inspect
+--- error_code: 200
+--- response_body eval
+qr/"has_stream_options":false/
+
+
+
+=== TEST 5: token usage is recorded from input_tokens / output_tokens
+--- apisix_yaml
+routes:
+  - id: 1
+    uri: /anything
+    plugins:
+      ai-proxy-multi:
+        instances:
+          - name: anthropic-native-instance
+            provider: anthropic-native
+            weight: 1
+            auth:
+              header:
+                Authorization: "Bearer token"
+            options:
+              model: claude-3-5-sonnet-20241022
+              max_tokens: 512
+            override:
+              endpoint: "http://localhost:6726/v1/messages"
+        ssl_verify: false
+#END
+--- request
+POST /anything
+{"messages":[{"role":"user","content":"What is 1+1?"}]}
+--- more_headers
+Authorization: Bearer token
+Content-Type: application/json
+--- error_code: 200
+--- error_log eval
+qr/got token usage from ai service \(anthropic-native\):.*"prompt_tokens":23.*"completion_tokens":8/
+
+
+
+=== TEST 6: streaming SSE events are forwarded correctly
+--- apisix_yaml
+routes:
+  - id: 1
+    uri: /anything
+    plugins:
+      ai-proxy-multi:
+        instances:
+          - name: anthropic-native-stream
+            provider: anthropic-native
+            weight: 1
+            auth:
+              header:
+                Authorization: "Bearer token"
+            options:
+              model: claude-3-5-sonnet-20241022
+              max_tokens: 512
+              stream: true
+            override:
+              endpoint: "http://localhost:7738/v1/messages"
+        ssl_verify: false
+#END
+--- http_config
+    server {
+        server_name anthropic-native-sse;
+        listen 7738;
+
+        location /v1/messages {
+            content_by_lua_block {
+                ngx.header["Content-Type"] = "text/event-stream"
+                ngx.header["Cache-Control"] = "no-cache"
+                ngx.header["X-Accel-Buffering"] = "no"
+
+                ngx.print("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_01\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-3-5-sonnet-20241022\",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":23,\"output_tokens\":1}}}\n\n")
+                ngx.flush(true)
+
+                ngx.print("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
+                ngx.flush(true)
+
+                ngx.print("event: ping\ndata: {\"type\":\"ping\"}\n\n")
+                ngx.flush(true)
+
+                ngx.print("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"1 + 1 = 2.\"}}\n\n")
+                ngx.flush(true)
+
+                ngx.print("event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n")
+                ngx.flush(true)
+
+                ngx.print("event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":8}}\n\n")
+                ngx.flush(true)
+
+                ngx.print("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+                ngx.flush(true)
+            }
+        }
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require("resty.http")
+            local httpc = http.new()
+            local core = require("apisix.core")
+
+            local ok, err = httpc:connect({
+                scheme = "http",
+                host = "localhost",
+                port = ngx.var.server_port,
+            })
+            if not ok then
+                ngx.status = 500
+                ngx.say(err)
+                return
+            end
+
+            local res, err = httpc:request({
+                method = "POST",
+                headers = {
+                    ["Content-Type"] = "application/json",
+                    ["Authorization"] = "Bearer token",
+                },
+                path = "/anything",
+                body = [[{"messages":[{"role":"user","content":"What is 1+1?"}],"stream":true}]],
+            })
+            if not res then
+                ngx.status = 500
+                ngx.say(err)
+                return
+            end
+
+            local chunks = {}
+            while true do
+                local chunk, err = res.body_reader()
+                if err then
+                    core.log.error("failed to read chunk: ", err)
+                    break
+                end
+                if not chunk then break end
+                core.table.insert_tail(chunks, chunk)
+            end
+
+            local full = table.concat(chunks, "")
+            if full:find("text_delta") then
+                ngx.say("streaming ok")
+            else
+                ngx.say("streaming failed: " .. full)
+            end
+        }
+    }
+--- response_body
+streaming ok
+
+
+
+=== TEST 7: streaming token usage from message_delta, not message_start output_tokens
+--- apisix_yaml
+routes:
+  - id: 1
+    uri: /anything
+    plugins:
+      ai-proxy-multi:
+        instances:
+          - name: anthropic-native-stream
+            provider: anthropic-native
+            weight: 1
+            auth:
+              header:
+                Authorization: "Bearer token"
+            options:
+              model: claude-3-5-sonnet-20241022
+              max_tokens: 512
+              stream: true
+            override:
+              endpoint: "http://localhost:7738/v1/messages"
+        ssl_verify: false
+#END
+--- http_config
+    server {
+        server_name anthropic-native-sse;
+        listen 7738;
+
+        location /v1/messages {
+            content_by_lua_block {
+                ngx.header["Content-Type"] = "text/event-stream"
+
+                -- message_start has output_tokens=1 (pre-allocated, must NOT be used as final)
+                ngx.print("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10,\"output_tokens\":1}}}\n\n")
+                ngx.flush(true)
+
+                ngx.print("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n")
+                ngx.flush(true)
+
+                -- message_delta carries the real output_tokens=5
+                ngx.print("event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":5}}\n\n")
+                ngx.flush(true)
+
+                ngx.print("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+                ngx.flush(true)
+            }
+        }
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require("resty.http")
+            local httpc = http.new()
+            local core = require("apisix.core")
+
+            local ok, err = httpc:connect({
+                scheme = "http",
+                host = "localhost",
+                port = ngx.var.server_port,
+            })
+            if not ok then
+                ngx.status = 500
+                ngx.say(err)
+                return
+            end
+
+            local res, err = httpc:request({
+                method = "POST",
+                headers = {
+                    ["Content-Type"] = "application/json",
+                    ["Authorization"] = "Bearer token",
+                },
+                path = "/anything",
+                body = [[{"messages":[{"role":"user","content":"hi"}],"stream":true}]],
+            })
+            if not res then
+                ngx.status = 500
+                ngx.say(err)
+                return
+            end
+
+            local found_text = false
+            while true do
+                local chunk, err = res.body_reader()
+                if err then break end
+                if not chunk then break end
+                if chunk:find("text_delta") then found_text = true end
+            end
+
+            -- wait for the /anything coroutine to finish writing warn logs
+            ngx.sleep(0.5)
+
+            if found_text then
+                ngx.say("streaming ok")
+            else
+                ngx.say("streaming failed")
+            end
+        }
+    }
+--- response_body
+streaming ok
+--- wait: 0.5
+--- error_log eval
+qr/got token usage from ai service \(anthropic-native\):.*"prompt_tokens":10.*"completion_tokens":5/
+
+
+
+=== TEST 8: [DONE] sentinel from compatible endpoints is silently ignored
+--- apisix_yaml
+routes:
+  - id: 1
+    uri: /anything
+    plugins:
+      ai-proxy-multi:
+        instances:
+          - name: anthropic-done-test
+            provider: anthropic-native
+            weight: 1
+            auth:
+              header:
+                Authorization: "Bearer token"
+            options:
+              model: claude-3-5-sonnet-20241022
+              max_tokens: 100
+              stream: true
+            override:
+              endpoint: "http://localhost:7739/v1/messages"
+        ssl_verify: false
+#END
+--- http_config
+    server {
+        server_name anthropic-native-sse-done;
+        listen 7739;
+
+        location /v1/messages {
+            content_by_lua_block {
+                ngx.header["Content-Type"] = "text/event-stream"
+
+                ngx.print("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}\n\n")
+                ngx.flush(true)
+
+                ngx.print("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n")
+                ngx.flush(true)
+
+                ngx.print("event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":3}}\n\n")
+                ngx.flush(true)
+
+                ngx.print("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+                ngx.flush(true)
+
+                -- OpenAI-style sentinel appended by some compatible endpoints (e.g. DeepSeek)
+                ngx.print("data: [DONE]\n\n")
+                ngx.flush(true)
+            }
+        }
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require("resty.http")
+            local httpc = http.new()
+
+            local ok, err = httpc:connect({
+                scheme = "http",
+                host = "localhost",
+                port = ngx.var.server_port,
+            })
+            if not ok then
+                ngx.status = 500
+                ngx.say(err)
+                return
+            end
+
+            local res, err = httpc:request({
+                method = "POST",
+                headers = {
+                    ["Content-Type"] = "application/json",
+                    ["Authorization"] = "Bearer token",
+                },
+                path = "/anything",
+                body = [[{"messages":[{"role":"user","content":"hi"}],"stream":true}]],
+            })
+            if not res then
+                ngx.status = 500
+                ngx.say(err)
+                return
+            end
+
+            while true do
+                local chunk = res.body_reader()
+                if not chunk then break end
+            end
+            ngx.say("no error")
+        }
+    }
+--- response_body
+no error
+--- no_error_log
+failed to decode SSE data
+
+
+
+=== TEST 9: error event in stream is logged as warn and does not crash
+--- apisix_yaml
+routes:
+  - id: 1
+    uri: /anything
+    plugins:
+      ai-proxy-multi:
+        instances:
+          - name: anthropic-error-test
+            provider: anthropic-native
+            weight: 1
+            auth:
+              header:
+                Authorization: "Bearer token"
+            options:
+              model: claude-3-5-sonnet-20241022
+              max_tokens: 100
+              stream: true
+            override:
+              endpoint: "http://localhost:7740/v1/messages"
+        ssl_verify: false
+#END
+--- http_config
+    server {
+        server_name anthropic-native-sse-err;
+        listen 7740;
+
+        location /v1/messages {
+            content_by_lua_block {
+                ngx.header["Content-Type"] = "text/event-stream"
+
+                ngx.print("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}\n\n")
+                ngx.flush(true)
+
+                -- Simulate an overloaded error mid-stream
+                ngx.print("event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}\n\n")
+                ngx.flush(true)
+
+                ngx.print("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+                ngx.flush(true)
+            }
+        }
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require("resty.http")
+            local httpc = http.new()
+
+            local ok, err = httpc:connect({
+                scheme = "http",
+                host = "localhost",
+                port = ngx.var.server_port,
+            })
+            if not ok then
+                ngx.status = 500
+                ngx.say(err)
+                return
+            end
+
+            local res, err = httpc:request({
+                method = "POST",
+                headers = {
+                    ["Content-Type"] = "application/json",
+                    ["Authorization"] = "Bearer token",
+                },
+                path = "/anything",
+                body = [[{"messages":[{"role":"user","content":"hi"}],"stream":true}]],
+            })
+            if not res then
+                ngx.status = 500
+                ngx.say(err)
+                return
+            end
+
+            while true do
+                local chunk = res.body_reader()
+                if not chunk then break end
+            end
+
+            -- wait for the /anything coroutine to finish writing warn logs
+            ngx.sleep(0.5)
+
+            ngx.say("completed")
+        }
+    }
+--- response_body
+completed
+--- wait: 0.5
+--- error_log eval
+qr/received error event from anthropic stream/


### PR DESCRIPTION
## Summary

Add a new `anthropic-native` driver that speaks the native Anthropic Messages API protocol (`/v1/messages`) directly.

The existing `anthropic` provider uses the OpenAI-compatible driver, which works for basic use cases but cannot handle Anthropic-specific protocol details. The new `anthropic-native` provider addresses this.

## Key differences from `openai-base` driver

- **SSE event types**: handles `message_start`, `content_block_delta`, `message_delta`, `message_stop` (no `[DONE]` sentinel)
- **Token usage fields**: reads `input_tokens`/`output_tokens` instead of `prompt_tokens`/`completion_tokens`
- **Request format**: removes `stream_options` (not supported by Anthropic), injects `anthropic-version` header automatically
- **Response format**: extracts text from `content[].text` array instead of `choices[].message.content`
- **System prompt**: accepts top-level `system` field and flexible `content` types (string or array of content blocks)

## Changes

- `apisix/plugins/ai-drivers/anthropic-native.lua`: new driver implementation
- `apisix/plugins/ai-drivers/schema.lua`: register `anthropic-native` provider with its own request schema
- `t/assets/anthropic-native-response.json`: mock response fixture for tests
- `t/plugin/ai-proxy-multi.anthropic-native.t`: 26 test cases covering non-streaming, streaming, token usage, TTFT, error handling, and schema validation
- `docs/en/latest/plugins/ai-proxy-multi.md`: document the new provider with a usage example

## Testing

All 26 tests pass:
