### PR TITLE
feat: add router_rebuild_min_interval to reduce CPU spikes from frequent route changes

### DIFF
--- a/apisix/cli/config.lua
+++ b/apisix/cli/config.lua
@@ -1,0 +1,395 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+local table_conact = table.concat
+
+local _M = {
+  apisix = {
+    node_listen = { 9080 },
+    enable_admin = true,
+    enable_dev_mode = false,
+    enable_reuseport = true,
+    show_upstream_status_in_response_header = false,
+    enable_ipv6 = true,
+    enable_http2 = true,
+    enable_server_tokens = true,
+    extra_lua_path = "",
+    extra_lua_cpath = "",
+    proxy_cache = {
+      cache_ttl = "10s",
+      zones = {
+        {
+          name = "disk_cache_one",
+          memory_size = "50m",
+          disk_size = "1G",
+          disk_path = "/tmp/disk_cache_one",
+          cache_levels = "1:2"
+        },
+        {
+          name = "memory_cache",
+          memory_size = "50m"
+        }
+      }
+    },
+    delete_uri_tail_slash = false,
+    normalize_uri_like_servlet = false,
+    router = {
+      http = "radixtree_host_uri",
+      ssl = "radixtree_sni",
+      router_rebuild_min_interval = 0,
+    },
+    proxy_mode = "http",
+    resolver_timeout = 5,
+    enable_resolv_search_opt = true,
+    ssl = {
+      enable = true,
+      listen = { {
+        port = 9443,
+        enable_http3 = false
+      } },
+      ssl_protocols = "TLSv1.2 TLSv1.3",
+      ssl_ciphers = table_conact({
+        "ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-RSA-AES128-GCM-SHA256",
+        "ECDHE-ECDSA-AES256-GCM-SHA384", "ECDHE-RSA-AES256-GCM-SHA384",
+        "ECDHE-ECDSA-CHACHA20-POLY1305", "ECDHE-RSA-CHACHA20-POLY1305",
+        "DHE-RSA-AES128-GCM-SHA256", "DHE-RSA-AES256-GCM-SHA384",
+      }, ":"),
+      ssl_session_tickets = false,
+      ssl_trusted_certificate = "system"
+    },
+    enable_control = true,
+    disable_sync_configuration_during_start = false,
+    worker_startup_time_threshold = 60,
+    data_encryption = {
+      enable_encrypt_fields = true,
+      keyring = { "qeddd145sfvddff3", "edd1c9f0985e76a2" }
+    },
+    lru = {
+      secret = {
+        ttl = 300,
+        count = 512,
+        neg_ttl = 60,
+        neg_count = 512
+      }
+    },
+    tracing = false
+  },
+  nginx_config = {
+    error_log = "logs/error.log",
+    error_log_level = "warn",
+    worker_processes = "auto",
+    enable_cpu_affinity = false,
+    worker_rlimit_nofile = 20480,
+    worker_shutdown_timeout = "240s",
+    max_pending_timers = 16384,
+    max_running_timers = 4096,
+    event = {
+      worker_connections = 10620
+    },
+    meta = {
+      lua_shared_dict = {
+        ["prometheus-metrics"] = "15m",
+        ["prometheus-cache"] = "10m",
+        ["standalone-config"] = "10m",
+        ["status-report"] = "1m",
+        ["upstream-healthcheck"] = "10m",
+      }
+    },
+    stream = {
+      enable_access_log = false,
+      access_log = "logs/access_stream.log",
+      -- luacheck: push max code line length 300
+      access_log_format = "$remote_addr [$time_local] $protocol $status $bytes_sent $bytes_received $session_time",
+      -- luacheck: pop
+      access_log_format_escape = "default",
+      lua_shared_dict = {
+        ["etcd-cluster-health-check-stream"] = "10m",
+        ["lrucache-lock-stream"] = "10m",
+        ["plugin-limit-conn-stream"] = "10m",
+        ["worker-events-stream"] = "10m",
+        ["tars-stream"] = "1m",
+      }
+    },
+    main_configuration_snippet = "",
+    http_configuration_snippet = "",
+    http_server_configuration_snippet = "",
+    http_server_location_configuration_snippet = "",
+    http_admin_configuration_snippet = "",
+    http_end_configuration_snippet = "",
+    stream_configuration_snippet = "",
+    http = {
+      enable_access_log = true,
+      access_log = "logs/access.log",
+      access_log_buffer = 16384,
+      -- luacheck: push max code line length 300
+      access_log_format =
+      '$remote_addr - $remote_user [$time_local] $http_host "$request" $status $body_bytes_sent $request_time "$http_referer" "$http_user_agent" $upstream_addr $upstream_status $upstream_response_time "$upstream_scheme://$upstream_host$upstream_uri" "$apisix_request_id"',
+      -- luacheck: pop
+      access_log_format_escape = "default",
+      keepalive_timeout = "60s",
+      client_header_timeout = "60s",
+      client_body_timeout = "60s",
+      client_max_body_size = 0,
+      send_timeout = "10s",
+      underscores_in_headers = "on",
+      real_ip_header = "X-Real-IP",
+      real_ip_recursive = "off",
+      real_ip_from = { "127.0.0.1", "unix:" },
+      proxy_ssl_server_name = true,
+      upstream = {
+        keepalive = 320,
+        keepalive_requests = 1000,
+        keepalive_timeout = "60s"
+      },
+      charset = "utf-8",
+      variables_hash_max_size = 2048,
+      lua_shared_dict = {
+        ["internal-status"] = "10m",
+        ["plugin-limit-req"] = "10m",
+        ["plugin-limit-count"] = "10m",
+        ["prometheus-metrics"] = "10m",
+        ["plugin-limit-conn"] = "10m",
+        ["worker-events"] = "10m",
+        ["lrucache-lock"] = "10m",
+        ["balancer-ewma"] = "10m",
+        ["balancer-ewma-locks"] = "10m",
+        ["balancer-ewma-last-touched-at"] = "10m",
+        ["plugin-limit-req-redis-cluster-slot-lock"] = "1m",
+        ["plugin-limit-count-redis-cluster-slot-lock"] = "1m",
+        ["plugin-limit-conn-redis-cluster-slot-lock"] = "1m",
+        ["plugin-ai-rate-limiting"] = "10m",
+        ["plugin-ai-rate-limiting-reset-header"] = "10m",
+        tracing_buffer = "10m",
+        ["plugin-api-breaker"] = "10m",
+        ["etcd-cluster-health-check"] = "10m",
+        discovery = "1m",
+        jwks = "1m",
+        introspection = "10m",
+        ["access-tokens"] = "1m",
+        ["ext-plugin"] = "1m",
+        tars = "1m",
+        ["cas-auth"] = "10m",
+        ["ocsp-stapling"] = "10m",
+        ["mcp-session"] = "10m",
+      }
+    }
+  },
+  graphql = {
+    max_size = 1048576
+  },
+  plugins = {
+    "real-ip",
+    "ai",
+    "client-control",
+    "proxy-control",
+    "request-id",
+    "zipkin",
+    "ext-plugin-pre-req",
+    "fault-injection",
+    "mocking",
+    "serverless-pre-function",
+    "cors",
+    "ip-restriction",
+    "ua-restriction",
+    "referer-restriction",
+    "csrf",
+    "uri-blocker",
+    "request-validation",
+    "chaitin-waf",
+    "multi-auth",
+    "openid-connect",
+    "cas-auth",
+    "authz-casbin",
+    "authz-casdoor",
+    "wolf-rbac",
+    "ldap-auth",
+    "hmac-auth",
+    "basic-auth",
+    "jwt-auth",
+    "jwe-decrypt",
+    "key-auth",
+    "consumer-restriction",
+    "attach-consumer-label",
+    "forward-auth",
+    "opa",
+    "authz-keycloak",
+    "proxy-cache",
+    "body-transformer",
+    "ai-prompt-template",
+    "ai-prompt-decorator",
+    "ai-prompt-guard",
+    "ai-rag",
+    "ai-rate-limiting",
+    "ai-proxy-multi",
+    "ai-proxy",
+    "ai-aws-content-moderation",
+    "ai-aliyun-content-moderation",
+    "proxy-mirror",
+    "proxy-rewrite",
+    "workflow",
+    "api-breaker",
+    "limit-conn",
+    "limit-count",
+    "limit-req",
+    "gzip",
+    -- deprecated and will be removed in a future release
+    -- "server-info",
+    "traffic-split",
+    "redirect",
+    "response-rewrite",
+    "mcp-bridge",
+    "degraphql",
+    "kafka-proxy",
+    "grpc-transcode",
+    "grpc-web",
+    "http-dubbo",
+    "public-api",
+    "prometheus",
+    "datadog",
+    "lago",
+    "loki-logger",
+    "elasticsearch-logger",
+    "echo",
+    "loggly",
+    "http-logger",
+    "splunk-hec-logging",
+    "skywalking-logger",
+    "google-cloud-logging",
+    "sls-logger",
+    "tcp-logger",
+    "kafka-logger",
+    "rocketmq-logger",
+    "syslog",
+    "udp-logger",
+    "file-logger",
+    "clickhouse-logger",
+    "tencent-cloud-cls",
+    "inspect",
+    "example-plugin",
+    "aws-lambda",
+    "azure-functions",
+    "openwhisk",
+    "openfunction",
+    "serverless-post-function",
+    "ext-plugin-post-req",
+    "ext-plugin-post-resp",
+    "ai-request-rewrite",
+  },
+  stream_plugins = { "ip-restriction", "limit-conn", "mqtt-proxy", "syslog", "traffic-split" },
+  plugin_attr = {
+    ["log-rotate"] = {
+      timeout = 10000,
+      interval = 3600,
+      max_kept = 168,
+      max_size = -1,
+      enable_compression = false
+    },
+    skywalking = {
+      service_name = "APISIX",
+      service_instance_name = "APISIX Instance Name",
+      endpoint_addr = "http://127.0.0.1:12800",
+      report_interval = 3
+    },
+    opentelemetry = {
+      trace_id_source = "x-request-id",
+      resource = {
+        ["service.name"] = "APISIX"
+      },
+      collector = {
+        address = "127.0.0.1:4318",
+        request_timeout = 3,
+        request_headers = {
+          Authorization = "token"
+        }
+      },
+      batch_span_processor = {
+        drop_on_queue_full = false,
+        max_queue_size = 1024,
+        batch_timeout = 2,
+        inactive_timeout = 1,
+        max_export_batch_size = tonumber(os.getenv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE")) or 16
+      },
+      set_ngx_var = false
+    },
+    prometheus = {
+      export_uri = "/apisix/prometheus/metrics",
+      metric_prefix = "apisix_",
+      enable_export_server = true,
+      export_addr = {
+        ip = "127.0.0.1",
+        port = 9091
+      },
+      refresh_interval = 15
+    },
+    ["server-info"] = {
+      report_ttl = 60
+    },
+    ["dubbo-proxy"] = {
+      upstream_multiplex_count = 32
+    },
+    ["proxy-mirror"] = {
+      timeout = {
+        connect = "60s",
+        read = "60s",
+        send = "60s"
+      }
+    },
+    inspect = {
+      delay = 3,
+      hooks_file = "/usr/local/apisix/plugin_inspect_hooks.lua"
+    },
+    zipkin = {
+      set_ngx_var = false
+    }
+  },
+  deployment = {
+    role = "traditional",
+    role_traditional = {
+      config_provider = "etcd"
+    },
+    admin = {
+      admin_key_required = true,
+      admin_key = {
+        {
+          name = "admin",
+          key = "",
+          role = "admin"
+        }
+      },
+      enable_admin_cors = true,
+      enable_admin_ui = true,
+      allow_admin = { "127.0.0.0/24" },
+      admin_listen = {
+        ip = "0.0.0.0",
+        port = 9180
+      },
+      admin_api_version = "v3"
+    },
+    etcd = {
+      host = { "http://127.0.0.1:2379" },
+      prefix = "/apisix",
+      timeout = 30,
+      watch_timeout = 50,
+      startup_retry = 2,
+      tls = {
+        verify = true
+      }
+    }
+  }
+}
+
+return _M

--- a/apisix/http/router/radixtree_host_uri.lua
+++ b/apisix/http/router/radixtree_host_uri.lua
@@ -17,8 +17,10 @@
 local require = require
 local router = require("apisix.utils.router")
 local core = require("apisix.core")
+local event = require("apisix.core.event")
 local get_services = require("apisix.http.service").services
 local service_fetch = require("apisix.http.service").get
+local ngx_now = ngx.now
 local ipairs = ipairs
 local type = type
 local tab_insert = table.insert
@@ -26,6 +28,7 @@ local loadstring = loadstring
 local pairs = pairs
 local cached_router_version
 local cached_service_version
+local last_router_rebuild_time
 local host_router
 local only_uri_router
 
@@ -104,8 +107,9 @@ local function create_radixtree_router(routes)
     local host_routes = {}
     local only_uri_routes = {}
     host_router = nil
+    routes = routes or {}
 
-    for _, route in ipairs(routes or {}) do
+    for _, route in ipairs(routes) do
         local status = core.table.try_read_attr(route, "value", "status")
         -- check the status
         if not status or status == 1 then
@@ -128,6 +132,9 @@ local function create_radixtree_router(routes)
             end
         })
     end
+
+    event.push(event.CONST.BUILD_ROUTER, routes)
+
     if #host_router_routes > 0 then
         host_router = router.new(host_router_routes)
     end
@@ -137,21 +144,37 @@ local function create_radixtree_router(routes)
     return true
 end
 
-
-    local match_opts = {}
 function _M.match(api_ctx)
     local user_routes = _M.user_routes
     local _, service_version = get_services()
     if not cached_router_version or cached_router_version ~= user_routes.conf_version
         or not cached_service_version or cached_service_version ~= service_version
     then
+        local min_interval = _M.router_rebuild_min_interval or 0
+        if min_interval > 0 and last_router_rebuild_time then
+            local elapsed = ngx_now() - last_router_rebuild_time
+            if elapsed < min_interval then
+                core.log.info("skip router rebuild, elapsed: ", elapsed,
+                              "s, min_interval: ", min_interval, "s")
+                goto MATCH
+            end
+        end
+
         create_radixtree_router(user_routes.values)
         cached_router_version = user_routes.conf_version
         cached_service_version = service_version
+        last_router_rebuild_time = ngx_now()
     end
 
+    ::MATCH::
+    return _M.matching(api_ctx)
+end
 
-    core.table.clear(match_opts)
+
+function _M.matching(api_ctx)
+    core.log.info("route match mode: radixtree_host_uri")
+
+    local match_opts = core.tablepool.fetch("route_match_opts", 0, 16)
     match_opts.method = api_ctx.var.request_method
     match_opts.remote_addr = api_ctx.var.remote_addr
     match_opts.vars = api_ctx.var
@@ -170,11 +193,13 @@ function _M.match(api_ctx)
                 api_ctx.curr_req_matched._host = api_ctx.real_curr_req_matched_host:reverse()
                 api_ctx.real_curr_req_matched_host = nil
             end
+            core.tablepool.release("route_match_opts", match_opts)
             return true
         end
     end
 
     local ok = only_uri_router:dispatch(api_ctx.var.uri, match_opts, api_ctx, match_opts)
+    core.tablepool.release("route_match_opts", match_opts)
     return ok
 end
 

--- a/apisix/http/router/radixtree_uri.lua
+++ b/apisix/http/router/radixtree_uri.lua
@@ -18,8 +18,10 @@ local require = require
 local core = require("apisix.core")
 local base_router = require("apisix.http.route")
 local get_services = require("apisix.http.service").services
+local ngx_now = ngx.now
 local cached_router_version
 local cached_service_version
+local last_router_rebuild_time
 
 
 local _M = {version = 0.2}
@@ -27,25 +29,42 @@ local _M = {version = 0.2}
 
     local uri_routes = {}
     local uri_router
-    local match_opts = {}
 function _M.match(api_ctx)
     local user_routes = _M.user_routes
     local _, service_version = get_services()
     if not cached_router_version or cached_router_version ~= user_routes.conf_version
         or not cached_service_version or cached_service_version ~= service_version
     then
+        local min_interval = _M.router_rebuild_min_interval or 0
+        if min_interval > 0 and last_router_rebuild_time then
+            local elapsed = ngx_now() - last_router_rebuild_time
+            if elapsed < min_interval then
+                core.log.info("skip router rebuild, elapsed: ", elapsed,
+                              "s, min_interval: ", min_interval, "s")
+                goto MATCH
+            end
+        end
+
         uri_router = base_router.create_radixtree_uri_router(user_routes.values,
                                                              uri_routes, false)
         cached_router_version = user_routes.conf_version
         cached_service_version = service_version
+        last_router_rebuild_time = ngx_now()
     end
 
+    ::MATCH::
     if not uri_router then
         core.log.error("failed to fetch valid `uri` router: ")
         return true
     end
 
-    return base_router.match_uri(uri_router, match_opts, api_ctx)
+    return _M.matching(api_ctx)
+end
+
+
+function _M.matching(api_ctx)
+    core.log.info("route match mode: radixtree_uri")
+    return base_router.match_uri(uri_router, api_ctx)
 end
 
 

--- a/apisix/http/router/radixtree_uri_with_parameter.lua
+++ b/apisix/http/router/radixtree_uri_with_parameter.lua
@@ -18,8 +18,10 @@ local require = require
 local core = require("apisix.core")
 local base_router = require("apisix.http.route")
 local get_services = require("apisix.http.service").services
+local ngx_now = ngx.now
 local cached_router_version
 local cached_service_version
+local last_router_rebuild_time
 
 
 local _M = {}
@@ -27,25 +29,42 @@ local _M = {}
 
     local uri_routes = {}
     local uri_router
-    local match_opts = {}
 function _M.match(api_ctx)
     local user_routes = _M.user_routes
     local _, service_version = get_services()
     if not cached_router_version or cached_router_version ~= user_routes.conf_version
         or not cached_service_version or cached_service_version ~= service_version
     then
+        local min_interval = _M.router_rebuild_min_interval or 0
+        if min_interval > 0 and last_router_rebuild_time then
+            local elapsed = ngx_now() - last_router_rebuild_time
+            if elapsed < min_interval then
+                core.log.info("skip router rebuild, elapsed: ", elapsed,
+                              "s, min_interval: ", min_interval, "s")
+                goto MATCH
+            end
+        end
+
         uri_router = base_router.create_radixtree_uri_router(user_routes.values,
                                                              uri_routes, true)
         cached_router_version = user_routes.conf_version
         cached_service_version = service_version
+        last_router_rebuild_time = ngx_now()
     end
 
+    ::MATCH::
     if not uri_router then
         core.log.error("failed to fetch valid `uri_with_parameter` router: ")
         return true
     end
 
-    return base_router.match_uri(uri_router, match_opts, api_ctx)
+    return _M.matching(api_ctx)
+end
+
+
+function _M.matching(api_ctx)
+    core.log.info("route match mode: radixtree_uri_with_parameter")
+    return base_router.match_uri(uri_router, api_ctx)
 end
 
 

--- a/apisix/router.lua
+++ b/apisix/router.lua
@@ -18,23 +18,23 @@ local require = require
 local http_route = require("apisix.http.route")
 local apisix_upstream = require("apisix.upstream")
 local core    = require("apisix.core")
-local plugin_checker = require("apisix.plugin").plugin_checker
+local set_plugins_meta_parent = require("apisix.plugin").set_plugins_meta_parent
 local str_lower = string.lower
-local error   = error
 local ipairs  = ipairs
 
-
 local _M = {version = 0.3}
+local router_rebuild_min_interval = 0
 
 
 local function filter(route)
     route.orig_modifiedIndex = route.modifiedIndex
-    route.update_count = 0
 
     route.has_domain = false
     if not route.value then
         return
     end
+
+    set_plugins_meta_parent(route.value.plugins, route)
 
     if route.value.host then
         route.value.host = str_lower(route.value.host)
@@ -45,8 +45,6 @@ local function filter(route)
     end
 
     apisix_upstream.filter_upstream(route.value.upstream, route)
-
-    core.log.info("filter route: ", core.json.delay_encode(route, true))
 end
 
 
@@ -79,29 +77,29 @@ function _M.http_init_worker()
     if conf and conf.apisix and conf.apisix.router then
         router_http_name = conf.apisix.router.http or router_http_name
         router_ssl_name = conf.apisix.router.ssl or router_ssl_name
+        router_rebuild_min_interval = conf.apisix.router.router_rebuild_min_interval
+                                      or router_rebuild_min_interval
     end
 
     local router_http = require("apisix.http.router." .. router_http_name)
     attach_http_router_common_methods(router_http)
     router_http.init_worker(filter)
+    router_http.router_rebuild_min_interval = router_rebuild_min_interval
     _M.router_http = router_http
 
     local router_ssl = require("apisix.ssl.router." .. router_ssl_name)
     router_ssl.init_worker()
     _M.router_ssl = router_ssl
 
-    _M.api = require("apisix.api_router")
-
-    local global_rules, err = core.config.new("/global_rules", {
-            automatic = true,
-            item_schema = core.schema.global_rule,
-            checker = plugin_checker,
-        })
-    if not global_rules then
-        error("failed to create etcd instance for fetching /global_rules : "
-              .. err)
+    -- Initialize stream router in HTTP workers only if stream mode is enabled
+    -- This allows the Control API (which runs in HTTP workers) to access stream routes
+    if conf and conf.apisix and conf.apisix.stream_proxy then
+        local router_stream = require("apisix.stream.router.ip_port")
+        router_stream.stream_init_worker(filter)
+        _M.router_stream = router_stream
     end
-    _M.global_rules = global_rules
+
+    _M.api = require("apisix.api_router")
 end
 
 
@@ -123,6 +121,9 @@ function _M.ssls()
 end
 
 function _M.http_routes()
+    if not _M.router_http then
+        return nil, nil
+    end
     return _M.router_http.routes()
 end
 

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -1,0 +1,742 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# CAUTION: DO NOT MODIFY DEFAULT CONFIGURATIONS IN THIS FILE.
+# Keep the custom configurations in conf/config.yaml.
+#
+
+apisix:
+  # node_listen: 9080          # APISIX listening port.
+  node_listen:                 # APISIX listening ports.
+    - 9080
+  #   - port: 9081
+  #   - ip: 127.0.0.2          # If not set, default to `0.0.0.0`
+  #     port: 9082
+  enable_admin: true           # Admin API
+  enable_dev_mode: false       # If true, set nginx `worker_processes` to 1.
+  enable_reuseport: true       # If true, enable nginx SO_REUSEPORT option.
+  show_upstream_status_in_response_header: false  # If true, include the upstream HTTP status code in
+                                                  # the response header `X-APISIX-Upstream-Status`.
+                                                  # If false, show `X-APISIX-Upstream-Status` only if
+                                                  # the upstream response code is 5xx.
+  enable_ipv6: true
+  enable_http2: true
+
+  # proxy_protocol:                    # PROXY Protocol configuration
+  #   listen_http_port: 9181           # APISIX listening port for HTTP traffic with PROXY protocol.
+  #   listen_https_port: 9182          # APISIX listening port for HTTPS traffic with PROXY protocol.
+  #   enable_tcp_pp: true              # Enable the PROXY protocol when stream_proxy.tcp is set.
+  #   enable_tcp_pp_to_upstream: true  # Enable the PROXY protocol.
+
+  enable_server_tokens: true           # If true, show APISIX version in the `Server` response header.
+  extra_lua_path: ""                   # Extend lua_package_path to load third-party code.
+  extra_lua_cpath: ""                  # Extend lua_package_cpath to load third-party code.
+  # lua_module_hook: "my_project.my_hook"  # Hook module used to inject third-party code into APISIX.
+
+  proxy_cache:      # Proxy Caching configuration
+    cache_ttl: 10s  # The default caching time on disk if the upstream does not specify a caching time.
+    zones:
+      - name: disk_cache_one    # Name of the cache.
+        memory_size: 50m        # Size of the memory to store the cache index.
+        disk_size: 1G           # Size of the disk to store the cache data.
+        disk_path: /tmp/disk_cache_one  # Path to the cache file for disk cache.
+        cache_levels: "1:2"               # Cache hierarchy levels of disk cache.
+      # - name: disk_cache_two
+      #  memory_size: 50m
+      #  disk_size: 1G
+      #  disk_path: "/tmp/disk_cache_two"
+      #  cache_levels: "1:2"
+      - name: memory_cache
+        memory_size: 50m
+
+  delete_uri_tail_slash: false        # Delete the '/' at the end of the URI
+  normalize_uri_like_servlet: false   # If true, use the same path normalization rules as the Java
+                                      # servlet specification. See https://github.com/jakartaee/servlet/blob/master/spec/src/main/asciidoc/servlet-spec-body.adoc#352-uri-path-canonicalization, which is used in Tomcat.
+
+  router:
+    http: radixtree_host_uri    # radixtree_host_uri: match route by host and URI
+                                # radixtree_uri: match route by URI
+                                # radixtree_uri_with_parameter: similar to radixtree_uri but match URI with parameters. See https://github.com/api7/lua-resty-radixtree/#parameters-in-path for more details.
+    ssl: radixtree_sni          # radixtree_sni: match route by SNI
+    # router_rebuild_min_interval: 0  # Minimum interval (in seconds) between HTTP router rebuilds.
+                                      # Under high-frequency route updates (e.g. 20-50 changes/sec),
+                                      # each change triggers a full radixtree rebuild which causes
+                                      # CPU spikes. Set to a positive value (e.g. 1 or 5) to throttle
+                                      # rebuild frequency. Default 0 means rebuild on every change.
+
+  # http is the default proxy mode. proxy_mode can be one of `http`, `stream`, or `http&stream`
+  proxy_mode: "http"
+  # stream_proxy:                 # TCP/UDP L4 proxy
+  #   tcp:
+  #     - addr: 9100              # Set the TCP proxy listening ports.
+  #       tls: true
+  #     - addr: "127.0.0.1:9101"
+  #   udp:                        # Set the UDP proxy listening ports.
+  #     - 9200
+  #     - "127.0.0.1:9201"
+
+  # dns_resolver:                 # If not set, read from `/etc/resolv.conf`
+  #   - 1.1.1.1
+  #   - 8.8.8.8
+  # dns_resolver_valid: 30        # Override the default TTL of the DNS records.
+  resolver_timeout: 5             # Set the time in seconds that the server will wait for a response from the
+                                  # DNS resolver before timing out.
+  enable_resolv_search_opt: true  # If true, use search option in the resolv.conf file in DNS lookups.
+
+  ssl:
+    enable: true
+    listen:                                       # APISIX listening port for HTTPS traffic.
+      - port: 9443
+        enable_http3: false                       # Enable HTTP/3 (with QUIC). If not set default to `false`.
+      # - ip: 127.0.0.3                           # If not set, default to `0.0.0.0`.
+      #   port: 9445
+      #   enable_http3: true
+    #ssl_trusted_certificate: system              # Specifies a file path with trusted CA certificates in the PEM format. The default value is "system".
+    ssl_protocols: TLSv1.2 TLSv1.3                # TLS versions supported.
+    ssl_ciphers: ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+    ssl_session_tickets: false  # If true, session tickets are used for SSL/TLS connections.
+                                # Disabled by default because it renders Perfect Forward Secrecy (FPS)
+                                # useless. See https://github.com/mozilla/server-side-tls/issues/135.
+
+    # fallback_sni: "my.default.domain"      # Fallback SNI to be used if the client does not send SNI during
+    #                                        # the handshake.
+
+  enable_control: true  # Control API
+  # control:
+  #  ip: 127.0.0.1
+  #  port: 9090
+
+  disable_sync_configuration_during_start: false  # Safe exit. TO BE REMOVED.
+
+  # This time will be used to distinguish whether the worker is started first time or restarted due to a crash, unit: second.
+  worker_startup_time_threshold: 60
+
+  data_encryption:                # Data encryption settings.
+    enable_encrypt_fields: true   # Whether enable encrypt fields specified in `encrypt_fields` in plugin schema.
+    keyring:                      # This field is used to encrypt the private key of SSL and the `encrypt_fields`
+                                  # in plugin schema.
+      - qeddd145sfvddff3          # Set the encryption key for AES-128-CBC. It should be a hexadecimal string
+                                  # of length 16.
+      - edd1c9f0985e76a2          # If not set, APISIX saves the original data into etcd.
+                                  # CAUTION: If you would like to update the key, add the new key as the
+                                  # first item in the array and keep the older keys below the newly added
+                                  # key, so that data can be decrypted with the older keys and encrypted
+                                  # with the new key. Removing the old keys directly can render the data
+                                  # unrecoverable.
+
+# status:                       # When enabled, APISIX will provide `/status` and `/status/ready` endpoints
+  #   ip: 127.0.0.1               # /status endpoint will return 200 status code if APISIX has successfully started and running correctly
+  #   port: 7085                  # /status/ready endpoint will return 503 status code if any of the workers do not receive config from etcd
+                                  # or (standalone mode) the config isn't loaded yet either via file or Admin API.
+  # disable_upstream_healthcheck: false # A global switch for healthcheck. Defaults to false.
+                                        # When set to true, it overrides all upstream healthcheck configurations and globally disabling healthchecks.
+# trusted_addresses:              # When configured, APISIX will trust the `X-Forwarded-*` Headers
+#   - 127.0.0.1                   # passed in requests from the IP/CIDR in the list.
+#   - 172.18.0.0/16               # CAUTION: When not configured or the request from an untrusted address,
+                                  # APISIX will override `X-Forwarded-*` headers with trusted values.
+  # fine tune the parameters of LRU cache for some features like secret
+  lru:
+    secret:
+      ttl: 300          # Global TTL fallback
+      count: 512        # Cache size
+      neg_ttl: 60       # Negative cache TTL
+      neg_count: 512    # Negative cache size
+
+  tracing: false                    # Enable comprehensive request lifecycle tracing (SSL/SNI, rewrite, access, header_filter, body_filter, and log).
+                                    # When disabled, OpenTelemetry collects only a single span per request.
+
+nginx_config:                     # Config for render the template to generate nginx.conf
+  # user: root                    # Set the execution user of the worker process. This is only
+                                  # effective if the master process runs with super-user privileges.
+  error_log: logs/error.log       # Location of the error log.
+  error_log_level:  warn          # Logging level: info, debug, notice, warn, error, crit, alert, or emerg.
+  worker_processes: auto          # Automatically determine the optimal number of worker processes based
+                                  # on the available system resources.
+                                  # If you want use multiple cores in container, you can inject the number of
+                                  # CPU cores as environment variable "APISIX_WORKER_PROCESSES".
+  enable_cpu_affinity: false      # Disable CPU affinity by default as worker_cpu_affinity affects the
+                                  # behavior of APISIX in containers. For example, multiple instances could
+                                  # be bound to one CPU core, which is not desirable.
+                                  # If APISIX is deployed on a physical machine, CPU affinity can be enabled.
+  worker_rlimit_nofile: 20480     # The number of files a worker process can open.
+                                  # The value should be larger than worker_connections.
+  worker_shutdown_timeout: 240s   # Timeout for a graceful shutdown of worker processes.
+
+  max_pending_timers: 16384       # The maximum number of pending timers that can be active at any given time.
+                                  # Error "too many pending timers" indicates the threshold is reached.
+  max_running_timers: 4096        # The maximum number of running timers that can be active at any given time.
+                                  # Error "lua_max_running_timers are not enough" error indicates the
+                                  # threshold is reached.
+
+  event:
+    worker_connections: 10620
+
+  # envs:                         # Get environment variables.
+  #  - TEST_ENV
+
+  meta:
+    lua_shared_dict:              # Nginx Lua shared memory zone. Size units are m or k.
+      prometheus-metrics: 15m
+      prometheus-cache: 10m       # Cache the calculated metrics data text.
+                                  # Please resize when the `error.log` prompts that the data is full.
+                                  # NOTE: Restart APISIX to take effect.
+      standalone-config: 10m
+      upstream-healthcheck: 10m
+
+  stream:
+    enable_access_log: false                 # Enable stream proxy access logging.
+    access_log: logs/access_stream.log       # Location of the stream access log.
+    access_log_format: |
+      "$remote_addr [$time_local] $protocol $status $bytes_sent $bytes_received $session_time" # Customize log format: http://nginx.org/en/docs/varindex.html
+    access_log_format_escape: default        # Escape default or json characters in variables.
+    lua_shared_dict:                         # Nginx Lua shared memory zone. Size units are m or k.
+      etcd-cluster-health-check-stream: 10m
+      lrucache-lock-stream: 10m
+      plugin-limit-conn-stream: 10m
+      worker-events-stream: 10m
+      tars-stream: 1m
+
+  # Add other custom Nginx configurations.
+  # Users are responsible for validating the custom configurations
+  # to ensure they are not in conflict with APISIX configurations.
+  main_configuration_snippet: |
+    # Add custom Nginx main configuration to nginx.conf.
+    # The configuration should be well indented!
+  http_configuration_snippet: |
+    # Add custom Nginx http configuration to nginx.conf.
+    # The configuration should be well indented!
+  http_server_configuration_snippet: |
+    # Add custom Nginx http server configuration to nginx.conf.
+    # The configuration should be well indented!
+  http_server_location_configuration_snippet: |
+    # Add custom Nginx http server location configuration to nginx.conf.
+    # The configuration should be well indented!
+  http_admin_configuration_snippet: |
+    # Add custom Nginx admin server configuration to nginx.conf.
+    # The configuration should be well indented!
+  http_end_configuration_snippet: |
+    # Add custom Nginx http end configuration to nginx.conf.
+    # The configuration should be well indented!
+  stream_configuration_snippet: |
+    # Add custom Nginx stream configuration to nginx.conf.
+    # The configuration should be well indented!
+
+  http:
+    enable_access_log: true             # Enable HTTP proxy access logging.
+    access_log: logs/access.log         # Location of the access log.
+    access_log_buffer: 16384            # buffer size of access log.
+    # available variables:
+    # request_type: traditional_http / ai_chat / ai_stream
+    # llm_time_to_first_token: duration from the start send request to ai server to the first token received
+    # llm_prompt_tokens: number of tokens in the prompt
+    # llm_completion_tokens: number of tokens in the chat completion
+    access_log_format: |
+      "$remote_addr - $remote_user [$time_local] $http_host \"$request\" $status $body_bytes_sent $request_time \"$http_referer\" \"$http_user_agent\" $upstream_addr $upstream_status $upstream_response_time \"$upstream_scheme://$upstream_host$upstream_uri\""
+    # Customize log format: http://nginx.org/en/docs/varindex.html
+    access_log_format_escape: default   # Escape default or json characters in variables.
+    keepalive_timeout: 60s              # Set the maximum time for which TCP connection keeps alive.
+    client_header_timeout: 60s          # Set the maximum time waiting for client to send the entire HTTP
+                                        # request header before closing the connection.
+    client_body_timeout: 60s            # Set the maximum time waiting for client to send the request body.
+    client_max_body_size: 0             # Set the maximum allowed size of the client request body.
+                                        # Default to 0, unlimited.
+                                        # Unlike Nginx, APISIX does not limit the body size by default.
+                                        # If exceeded, the 413 (Request Entity Too Large) error is returned.
+    send_timeout: 10s   # Set the maximum time for transmitting a response to the client before closing.
+    underscores_in_headers: "on"  # Allow HTTP request headers to contain underscores in their names.
+    real_ip_header: X-Real-IP     # https://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
+    real_ip_recursive: "off" # http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive
+    real_ip_from:            # http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from
+      - 127.0.0.1
+      - "unix:"
+
+    # custom_lua_shared_dict:     # Custom Nginx Lua shared memory zone for nginx.conf. Size units are m or k.
+    #  ipc_shared_dict: 100m      # Custom shared cache, format: `cache-key: cache-size`
+
+    proxy_ssl_server_name: true   # Send the server name in the SNI extension when establishing an SSL/TLS
+                                  # connection with the upstream server, allowing the upstream server to
+                                  # select the appropriate SSL/TLS certificate and configuration based on
+                                  # the requested server name.
+
+    upstream:
+      keepalive: 320              # Set the maximum time of keep-alive connections to the upstream servers.
+                                  # When the value is exceeded, the least recently used connection is closed.
+      keepalive_requests: 1000    # Set the maximum number of requests that can be served through one
+                                  # keep-alive connection.
+                                  # After the maximum number of requests is made, the connection is closed.
+      keepalive_timeout: 60s      # Set the maximum time for which TCP connection keeps alive.
+    charset: utf-8                # Add the charset to the "Content-Type" response header field.
+                                  # See http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset
+    variables_hash_max_size: 2048 # Set the maximum size of the variables hash table.
+
+    lua_shared_dict:              # Nginx Lua shared memory zone. Size units are m or k.
+      internal-status: 10m
+      plugin-limit-req: 10m
+      plugin-limit-count: 10m
+      prometheus-metrics: 10m     # In production, less than 50m is recommended
+      plugin-limit-conn: 10m
+      worker-events: 10m
+      lrucache-lock: 10m
+      balancer-ewma: 10m
+      balancer-ewma-locks: 10m
+      balancer-ewma-last-touched-at: 10m
+      plugin-limit-req-redis-cluster-slot-lock: 1m
+      plugin-limit-count-redis-cluster-slot-lock: 1m
+      plugin-limit-conn-redis-cluster-slot-lock: 1m
+      tracing_buffer: 10m
+      plugin-api-breaker: 10m
+      etcd-cluster-health-check: 10m
+      discovery: 1m
+      jwks: 1m
+      introspection: 10m
+      access-tokens: 1m
+      ext-plugin: 1m
+      tars: 1m
+      cas-auth: 10m
+      ocsp-stapling: 10m
+      mcp-session: 10m
+
+# discovery:                      # Service Discovery
+#  dns:
+#    servers:
+#      - "127.0.0.1:8600"         # Replace with the address of your DNS server.
+#    resolv_conf: /etc/resolv.conf # Replace with the path to the local DNS resolv config. Configure either "servers" or "resolv_conf".
+#    order:                       # Resolve DNS records this order.
+#      - last                     # Try the latest successful type for a hostname.
+#      - SRV
+#      - A
+#      - AAAA
+#      - CNAME
+#  eureka:                        # Eureka
+#    host:                        # Eureka address(es)
+#      - "http://127.0.0.1:8761"
+#    prefix: /eureka/
+#    fetch_interval: 30           # Default 30s
+#    weight: 100                  # Default weight for node
+#    timeout:
+#      connect: 2000              # Default 2000ms
+#      send: 2000                 # Default 2000ms
+#      read: 5000                 # Default 5000ms
+#  nacos:                         # Nacos
+#    host:                        # Nacos address(es)
+#      - "http://${username}:${password}@${host1}:${port1}"
+#    prefix: "/nacos/v1/"
+#    fetch_interval: 30    # Default 30s
+# `weight` is the `default_weight` that will be attached to each discovered node that
+# doesn't have a weight explicitly provided in nacos results
+#    weight: 100           # Default 100.
+#    timeout:
+#      connect: 2000       # Default 2000ms
+#      send: 2000          # Default 2000ms
+#      read: 5000          # Default 5000ms
+#    access_key: ""        # Nacos AccessKey ID in Alibaba Cloud, notice that it's for Nacos instances on Microservices Engine (MSE)
+#    secret_key: ""        # Nacos AccessKey Secret in Alibaba Cloud, notice that it's for Nacos instances on Microservices Engine (MSE)
+#  consul_kv:              # Consul KV
+#    servers:              # Consul KV address(es)
+#      - "http://127.0.0.1:8500"
+#      - "http://127.0.0.1:8600"
+#    prefix: "upstreams"
+#    skip_keys:                     # Skip special keys
+#      - "upstreams/unused_api/"
+#    timeout:
+#      connect: 2000                # Default 2000ms
+#      read: 2000                   # Default 2000ms
+#      wait: 60                     # Default 60s
+#    weight: 1                      # Default 1
+#    fetch_interval: 3              # Default 3s. Effective only when keepalive is false.
+#    keepalive: true                # Default to true. Use long pull to query Consul.
+#    default_server:                # Define default server to route traffic to.
+#      host: "127.0.0.1"
+#      port: 20999
+#      metadata:
+#        fail_timeout: 1            # Default 1ms
+#        weight: 1                  # Default 1
+#        max_fails: 1               # Default 1
+#    dump:                          # Dump the Consul key-value (KV) store to a file.
+#       path: "logs/consul_kv.dump" # Location of the dump file.
+#       expire: 2592000             # Specify the expiration time of the dump file in units of seconds.
+#  consul:                          # Consul
+#    servers:                       # Consul address(es)
+#      - "http://127.0.0.1:8500"
+#      - "http://127.0.0.1:8600"
+#    skip_services:                 # Skip services during service discovery.
+#      - "service_a"
+#    timeout:
+#      connect: 2000                # Default 2000ms
+#      read: 2000                   # Default 2000ms
+#      wait: 60                     # Default 60s
+#    weight: 1                      # Default 1
+#    fetch_interval: 3              # Default 3s. Effective only when keepalive is false.
+#    keepalive: true                # Default to true. Use long pull to query Consul.
+#    default_service:               # Define the default service to route traffic to.
+#      host: "127.0.0.1"
+#      port: 20999
+#      metadata:
+#        fail_timeout: 1           # Default 1ms
+#        weight: 1                 # Default 1
+#        max_fails: 1              # Default 1
+#    dump:                           # Dump the Consul key-value (KV) store to a file.
+#       path: "logs/consul_kv.dump"  # Location of the dump file.
+#       expire: 2592000              # Specify the expiration time of the dump file in units of seconds.
+#       load_on_init: true           # Default true, load the consul dump file on init
+#  kubernetes:                     # Kubernetes service discovery
+#    ### kubernetes service discovery both support single-cluster and multi-cluster mode
+#    ### applicable to the case where the service is distributed in a single or multiple kubernetes clusters.
+#    ### single-cluster mode ###
+#    service:
+#      schema: https                     # apiserver schema, options [http, https], default https
+#      host: ${KUBERNETES_SERVICE_HOST}  # apiserver host, options [ipv4, ipv6, domain, environment variable], default ${KUBERNETES_SERVICE_HOST}
+#      port: ${KUBERNETES_SERVICE_PORT}  # apiserver port, options [port number, environment variable], default ${KUBERNETES_SERVICE_PORT}
+#    client:
+#      # serviceaccount token or path of serviceaccount token_file
+#      token_file: ${KUBERNETES_CLIENT_TOKEN_FILE}
+#      # token: |-
+#       # eyJhbGciOiJSUzI1NiIsImtpZCI6Ikx5ME1DNWdnbmhQNkZCNlZYMXBsT3pYU3BBS2swYzBPSkN3ZnBESGpkUEEif
+#       # 6Ikx5ME1DNWdnbmhQNkZCNlZYMXBsT3pYU3BBS2swYzBPSkN3ZnBESGpkUEEifeyJhbGciOiJSUzI1NiIsImtpZCI
+#    # kubernetes discovery plugin support use namespace_selector
+#    # you can use one of [equal, not_equal, match, not_match] filter namespace
+#    namespace_selector:
+#      # only save endpoints with namespace equal default
+#      equal: default
+#      # only save endpoints with namespace not equal default
+#      #not_equal: default
+#      # only save endpoints with namespace match one of [default, ^my-[a-z]+$]
+#      #match:
+#      #- default
+#      #- ^my-[a-z]+$
+#      # only save endpoints with namespace not match one of [default, ^my-[a-z]+$ ]
+#      #not_match:
+#      #- default
+#      #- ^my-[a-z]+$
+#    # kubernetes discovery plugin support use label_selector
+#    # for the expression of label_selector, please refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+#    label_selector: |-
+#      first="a",second="b"
+#    # reserved lua shared memory size,1m memory can store about 1000 pieces of endpoint
+#    shared_size: 1m #default 1m
+#    ### single-cluster mode ###
+#    ### multi-cluster mode ###
+#  - id: release  # a custom name refer to the cluster, pattern ^[a-z0-9]{1,8}
+#    service:
+#      schema: https                     # apiserver schema, options [http, https], default https
+#      host: ${KUBERNETES_SERVICE_HOST}  # apiserver host, options [ipv4, ipv6, domain, environment variable]
+#      port: ${KUBERNETES_SERVICE_PORT}  # apiserver port, options [port number, environment variable]
+#    client:
+#      # serviceaccount token or path of serviceaccount token_file
+#      token_file: ${KUBERNETES_CLIENT_TOKEN_FILE}
+#      # token: |-
+#       # eyJhbGciOiJSUzI1NiIsImtpZCI6Ikx5ME1DNWdnbmhQNkZCNlZYMXBsT3pYU3BBS2swYzBPSkN3ZnBESGpkUEEif
+#       # 6Ikx5ME1DNWdnbmhQNkZCNlZYMXBsT3pYU3BBS2swYzBPSkN3ZnBESGpkUEEifeyJhbGciOiJSUzI1NiIsImtpZCI
+#    # kubernetes discovery plugin support use namespace_selector
+#    # you can use one of [equal, not_equal, match, not_match] filter namespace
+#    namespace_selector:
+#      # only save endpoints with namespace equal default
+#      equal: default
+#      # only save endpoints with namespace not equal default
+#      #not_equal: default
+#      # only save endpoints with namespace match one of [default, ^my-[a-z]+$]
+#      #match:
+#      #- default
+#      #- ^my-[a-z]+$
+#      # only save endpoints with namespace not match one of [default, ^my-[a-z]+$ ]
+#      #not_match:
+#      #- default
+#      #- ^my-[a-z]+$
+#    # kubernetes discovery plugin support use label_selector
+#    # for the expression of label_selector, please refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+#    label_selector: |-
+#      first="a",second="b"
+#    # reserved lua shared memory size,1m memory can store about 1000 pieces of endpoint
+#    shared_size: 1m #default 1m
+#    ### multi-cluster mode ###
+
+graphql:
+  max_size: 1048576                # Set the maximum size limitation of graphql in bytes. Default to 1MiB.
+
+# ext-plugin:
+#   cmd: ["ls", "-l"]
+
+plugins:                           # plugin list (sorted by priority)
+  - real-ip                        # priority: 23000
+  - ai                             # priority: 22900
+  - client-control                 # priority: 22000
+  - proxy-control                  # priority: 21990
+  - request-id                     # priority: 12015
+  - zipkin                         # priority: 12011
+  #- skywalking                    # priority: 12010
+  #- opentelemetry                 # priority: 12009
+  - ext-plugin-pre-req             # priority: 12000
+  - fault-injection                # priority: 11000
+  - mocking                        # priority: 10900
+  - serverless-pre-function        # priority: 10000
+  #- batch-requests                # priority: 4010
+  - cors                           # priority: 4000
+  - ip-restriction                 # priority: 3000
+  - ua-restriction                 # priority: 2999
+  - referer-restriction            # priority: 2990
+  - csrf                           # priority: 2980
+  - uri-blocker                    # priority: 2900
+  - request-validation             # priority: 2800
+  - chaitin-waf                    # priority: 2700
+  - multi-auth                     # priority: 2600
+  - openid-connect                 # priority: 2599
+  - cas-auth                       # priority: 2597
+  - authz-casbin                   # priority: 2560
+  - authz-casdoor                  # priority: 2559
+  - wolf-rbac                      # priority: 2555
+  - ldap-auth                      # priority: 2540
+  - hmac-auth                      # priority: 2530
+  - basic-auth                     # priority: 2520
+  - jwt-auth                       # priority: 2510
+  - jwe-decrypt                    # priority: 2509
+  - key-auth                       # priority: 2500
+  - consumer-restriction           # priority: 2400
+  - attach-consumer-label          # priority: 2399
+  - forward-auth                   # priority: 2002
+  - opa                            # priority: 2001
+  - authz-keycloak                 # priority: 2000
+  #- error-log-logger              # priority: 1091
+  - proxy-cache                    # priority: 1085
+  - body-transformer               # priority: 1080
+  - ai-prompt-template             # priority: 1071
+  - ai-prompt-decorator            # priority: 1070
+  - ai-prompt-guard                # priority: 1072
+  - ai-rag                         # priority: 1060
+  - ai-rate-limiting               # priority: 1030
+  - ai-aws-content-moderation      # priority: 1040 TODO: compare priority with other ai plugins
+  - proxy-mirror                   # priority: 1010
+  - proxy-rewrite                  # priority: 1008
+  - workflow                       # priority: 1006
+  - api-breaker                    # priority: 1005
+  - limit-conn                     # priority: 1003
+  - limit-count                    # priority: 1002
+  - limit-req                      # priority: 1001
+  #- node-status                   # priority: 1000
+  - ai-proxy                       # priority: 999
+  - ai-proxy-multi                 # priority: 998
+  #- brotli                        # priority: 996
+  - gzip                           # priority: 995
+  #- server-info                    # priority: 990
+  - traffic-split                  # priority: 966
+  - redirect                       # priority: 900
+  - response-rewrite               # priority: 899
+  - mcp-bridge                     # priority: 510
+  - degraphql                      # priority: 509
+  - kafka-proxy                    # priority: 508
+  #- dubbo-proxy                   # priority: 507
+  - grpc-transcode                 # priority: 506
+  - grpc-web                       # priority: 505
+  - http-dubbo                     # priority: 504
+  - public-api                     # priority: 501
+  - prometheus                     # priority: 500
+  - datadog                        # priority: 495
+  - lago                           # priority: 415
+  - loki-logger                    # priority: 414
+  - elasticsearch-logger           # priority: 413
+  - echo                           # priority: 412
+  - loggly                         # priority: 411
+  - http-logger                    # priority: 410
+  - splunk-hec-logging             # priority: 409
+  - skywalking-logger              # priority: 408
+  - google-cloud-logging           # priority: 407
+  - sls-logger                     # priority: 406
+  - tcp-logger                     # priority: 405
+  - kafka-logger                   # priority: 403
+  - rocketmq-logger                # priority: 402
+  - syslog                         # priority: 401
+  - udp-logger                     # priority: 400
+  - file-logger                    # priority: 399
+  - clickhouse-logger              # priority: 398
+  - tencent-cloud-cls              # priority: 397
+  - inspect                        # priority: 200
+  #- log-rotate                    # priority: 100
+  # <- recommend to use priority (0, 100) for your custom plugins
+  - example-plugin                 # priority: 0
+  #- gm                            # priority: -43
+  #- ocsp-stapling                 # priority: -44
+  - aws-lambda                     # priority: -1899
+  - azure-functions                # priority: -1900
+  - openwhisk                      # priority: -1901
+  - openfunction                   # priority: -1902
+  - serverless-post-function       # priority: -2000
+  - ext-plugin-post-req            # priority: -3000
+  - ext-plugin-post-resp           # priority: -4000
+
+stream_plugins:                    # stream plugin list (sorted by priority)
+  - ip-restriction                 # priority: 3000
+  - limit-conn                     # priority: 1003
+  - mqtt-proxy                     # priority: 1000
+  #- prometheus                    # priority: 500
+  - syslog                         # priority: 401
+  # <- recommend to use priority (0, 100) for your custom plugins
+
+
+# wasm:
+#   plugins:
+#     - name: wasm_log
+#       priority: 7999
+#       file: t/wasm/log/main.go.wasm
+
+# xrpc:
+#   protocols:
+#     - name: pingpong
+plugin_attr:          # Plugin attributes
+  log-rotate:         # Plugin: log-rotate
+    timeout: 10000    # maximum wait time for a log rotation(unit: millisecond)
+    interval: 3600    # Set the log rotate interval in seconds.
+    max_kept: 168     # Set the maximum number of log files to keep. If exceeded, historic logs are deleted.
+    max_size: -1      # Set the maximum size of log files in bytes before a rotation.
+                      # Skip size check if max_size is less than 0.
+    enable_compression: false    # Enable log file compression (gzip).
+  skywalking:                                     # Plugin: skywalking
+    service_name: APISIX                          # Set the service name for SkyWalking reporter.
+    service_instance_name: APISIX Instance Name   # Set the service instance name for SkyWalking reporter.
+    endpoint_addr: http://127.0.0.1:12800         # Set the SkyWalking HTTP endpoint.
+    report_interval: 3                            # Set the reporting interval in second.
+  opentelemetry:      # Plugin: opentelemetry
+    trace_id_source: x-request-id   # Specify the source of the trace ID for OpenTelemetry traces.
+    resource:
+      service.name: APISIX          # Set the service name for OpenTelemetry traces.
+    collector:
+      address: 127.0.0.1:4318       # Set the address of the OpenTelemetry collector to send traces to.
+      request_timeout: 3            # Set the timeout for requests to the OpenTelemetry collector in seconds.
+      request_headers:              # Set the headers to include in requests to the OpenTelemetry collector.
+        Authorization: token        # Set the authorization header to include an access token.
+    batch_span_processor:
+      drop_on_queue_full: false     # Drop spans when the export queue is full.
+      max_queue_size: 1024          # Set the maximum size of the span export queue.
+      batch_timeout: 2              # Set the timeout for span batches to wait in the export queue before
+                                    # being sent.
+      inactive_timeout: 1           # Set the timeout for spans to wait in the export queue before being sent,
+                                    # if the queue is not full.
+      max_export_batch_size: 16     # Set the maximum number of spans to include in each batch sent to the
+                                    # OpenTelemetry collector.
+    set_ngx_var: false              # Export opentelemetry variables to NGINX variables.
+  prometheus:                               # Plugin: prometheus
+    export_uri: /apisix/prometheus/metrics  # Set the URI for the Prometheus metrics endpoint.
+    metric_prefix: apisix_                  # Set the prefix for Prometheus metrics generated by APISIX.
+    enable_export_server: true              # Enable the Prometheus export server.
+    export_addr:                            # Set the address for the Prometheus export server.
+      ip: 127.0.0.1                         # Set the IP.
+      port: 9091                            # Set the port.
+    refresh_interval: 15                    # Set the interval for refreshing cached metric data. unit: second.
+    # metrics:    # Create extra labels from nginx variables: https://nginx.org/en/docs/varindex.html
+    #  http_status:
+    #    expire: 0 # The expiration time after which metrics are removed. unit: second.
+    #              # 0 means the metrics will not expire
+    #    extra_labels:
+    #      - upstream_addr: $upstream_addr
+    #      - status: $upstream_status  # The label name does not need to be the same as the variable name.
+    #  http_latency:
+    #    expire: 0 # The expiration time after which metrics are removed. unit: second.
+    #              # 0 means the metrics will not expire
+    #    extra_labels:
+    #      - upstream_addr: $upstream_addr
+    #  bandwidth:
+    #    expire: 0 # The expiration time after which metrics are removed. unit: second.
+    #              # 0 means the metrics will not expire
+    #    extra_labels:
+    #      - upstream_addr: $upstream_addr
+    #  upstream_status:
+    #    expire: 0 # The expiration time after which metrics are removed. unit: second.
+    # default_buckets:
+    #   - 10
+    #   - 50
+    #   - 100
+    #   - 200
+    #   - 500
+  server-info:                        # Plugin: server-info
+    report_ttl: 60                    # Set the TTL in seconds for server info in etcd.
+                                      # Maximum: 86400. Minimum: 3.
+  dubbo-proxy:                        # Plugin: dubbo-proxy
+    upstream_multiplex_count: 32      # Set the maximum number of connections that can be multiplexed over
+                                      # a single network connection between the Dubbo Proxy and the upstream
+                                      # Dubbo services.
+  proxy-mirror:                       # Plugin: proxy-mirror
+    timeout:                          # Set the timeout for mirrored requests.
+      connect: 60s
+      read: 60s
+      send: 60s
+  # redirect:                         # Plugin: redirect
+  #   https_port: 8443                # Set the default port used to redirect HTTP to HTTPS.
+  inspect:                            # Plugin: inspect
+    delay: 3                          # Set the delay in seconds for the frequency of checking the hooks file.
+    hooks_file: "/usr/local/apisix/plugin_inspect_hooks.lua"  # Set the path to the Lua file that defines
+                                                              # hooks. Only administrators should have
+                                                              # write access to this file for security.
+  zipkin:                             # Plugin: zipkin
+    set_ngx_var: false                # export zipkin variables to nginx variables
+
+deployment:                    # Deployment configurations
+  role: traditional            # Set deployment mode: traditional, control_plane, or data_plane.
+  role_traditional:
+    config_provider: etcd      # Set the configuration center.
+
+  #role_data_plane:            # Set data plane details if role is data_plane.
+  #  config_provider: etcd     # Set the configuration center: etcd, xds, or yaml.
+
+  #role_control_plane:         # Set control plane details if role is control_plane.
+  #  config_provider: etcd     # Set the configuration center.
+
+  admin:                       # Admin API
+    admin_key_required: true   # Enable Admin API authentication by default for security.
+    admin_key:
+      -
+        name: admin                             # admin: write access to configurations.
+        key: ''   # Set API key for the admin of Admin API.
+        role: admin
+      # -
+      #   name: viewer                            # viewer: read-only to configurations.
+      #   key: 4054f7cf07e344346cd3f287985e76a2   # Set API key for the viewer of Admin API.
+      #   role: viewer
+
+    enable_admin_cors: true       # Enable Admin API CORS response header `Access-Control-Allow-Origin`.
+    enable_admin_ui: true         # Enable embedded APISIX Dashboard UI.
+    allow_admin:                  # Limit Admin API access by IP addresses.
+      - 127.0.0.0/24              # If not set, any IP address is allowed.
+      # - "::/64"
+    admin_listen:                 # Set the Admin API listening addresses.
+      ip: 0.0.0.0                 # Set listening IP.
+      port: 9180                  # Set listening port. Beware of port conflict with node_listen.
+
+    # https_admin: true           # Enable SSL for Admin API on IP and port specified in admin_listen.
+                                  # Use admin_api_mtls.admin_ssl_cert and admin_api_mtls.admin_ssl_cert_key.
+    # admin_api_mtls:             # Set this if `https_admin` is true.
+    #   admin_ssl_cert: ""        # Set path to SSL/TLS certificate.
+    #   admin_ssl_cert_key: ""    # Set path to SSL/TLS key.
+    #   admin_ssl_ca_cert: ""     # Set path to CA certificate used to sign client certificates.
+
+    admin_api_version: v3         # Set the version of Admin API (latest: v3).
+
+  etcd:
+    host:                         # Set etcd address(es) in the same etcd cluster.
+      - "http://127.0.0.1:2379"   # If TLS is enabled for etcd, use https://127.0.0.1:2379.
+    prefix: /apisix               # Set etcd prefix.
+    timeout: 30                   # The timeout when connect/read/write to etcd, Set timeout in seconds.
+    watch_timeout: 50             # The timeout when watch etcd
+    # resync_delay: 5             # Set resync time in seconds after a sync failure.
+                                  # The actual resync time would be resync_delay plus 50% random jitter.
+    # health_check_timeout: 10    # Set timeout in seconds for etcd health check.
+                                  # Default to 10 if not set or a negative value is provided.
+    startup_retry: 2              # Set the number of retries to etcd on startup. Default to 2.
+    # user: root                  # Set the root username for etcd.
+    # password: 5tHkHhYkjr6cQ     # Set the root password for etcd.
+    tls:
+      # cert: /path/to/cert       # Set the path to certificate used by the etcd client
+      # key: /path/to/key         # Set the path to path of key used by the etcd client
+      verify: true                # Verify the etcd certificate when establishing a TLS connection with etcd.
+      # sni:                      # The SNI for etcd TLS requests.
+                                  # If not set, the host from the URL is used.

--- a/t/router/router-rebuild-min-interval.t
+++ b/t/router/router-rebuild-min-interval.t
@@ -1,0 +1,363 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+log_level('info');
+worker_connections(256);
+no_root_location();
+no_shuffle();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->yaml_config) {
+        my $yaml_config = <<_EOC_;
+apisix:
+    node_listen: 1984
+    router:
+        http: 'radixtree_uri'
+        router_rebuild_min_interval: 0
+_EOC_
+        $block->set_value("yaml_config", $yaml_config);
+    }
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: default behavior (min_interval=0) - router rebuilds on every route change
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 2: hit route to trigger router rebuild
+--- request
+GET /hello
+--- response_body
+hello world
+--- no_error_log
+skip router rebuild
+
+
+
+=== TEST 3: update route to trigger another rebuild
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1981": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 4: hit route - should rebuild immediately (min_interval=0)
+--- request
+GET /hello
+--- response_body_like eval
+qr/hello world/
+--- no_error_log
+skip router rebuild
+
+
+
+=== TEST 5: set router_rebuild_min_interval to 2 seconds and create initial route
+--- yaml_config
+apisix:
+    node_listen: 1984
+    router:
+        http: 'radixtree_uri'
+        router_rebuild_min_interval: 2
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 6: hit route to trigger initial router build
+--- yaml_config
+apisix:
+    node_listen: 1984
+    router:
+        http: 'radixtree_uri'
+        router_rebuild_min_interval: 2
+--- request
+GET /hello
+--- response_body
+hello world
+--- no_error_log
+skip router rebuild
+
+
+
+=== TEST 7: update route and request immediately - rebuild should be skipped
+--- yaml_config
+apisix:
+    node_listen: 1984
+    router:
+        http: 'radixtree_uri'
+        router_rebuild_min_interval: 2
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1981": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            -- request immediately after route change, within min_interval
+            local http = require("resty.http")
+            local httpc = http.new()
+            local res, err = httpc:request_uri("http://127.0.0.1:1984/hello")
+            if not res then
+                ngx.say("request failed: ", err)
+                return
+            end
+
+            ngx.say("status: ", res.status)
+            ngx.say("body: ", res.body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+status: 200
+body: hello world
+--- error_log
+skip router rebuild
+
+
+
+=== TEST 8: wait for min_interval to pass, then rebuild should happen
+--- yaml_config
+apisix:
+    node_listen: 1984
+    router:
+        http: 'radixtree_uri'
+        router_rebuild_min_interval: 2
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+
+            -- update route
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            -- wait for min_interval to expire
+            ngx.sleep(2.1)
+
+            -- this request should trigger a rebuild
+            local http = require("resty.http")
+            local httpc = http.new()
+            local res, err = httpc:request_uri("http://127.0.0.1:1984/hello")
+            if not res then
+                ngx.say("request failed: ", err)
+                return
+            end
+
+            ngx.say("status: ", res.status)
+            ngx.say("body: ", res.body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+status: 200
+body: hello world
+--- no_error_log
+skip router rebuild
+--- timeout: 5
+
+
+
+=== TEST 9: rapid route updates within min_interval - only one rebuild
+--- yaml_config
+apisix:
+    node_listen: 1984
+    router:
+        http: 'radixtree_uri'
+        router_rebuild_min_interval: 3
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local http = require("resty.http")
+
+            -- create initial route and trigger first build
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            -- trigger initial build
+            local httpc = http.new()
+            local res, err = httpc:request_uri("http://127.0.0.1:1984/hello")
+            if not res then
+                ngx.say("initial request failed: ", err)
+                return
+            end
+
+            -- rapid updates (simulating high-frequency route changes)
+            for i = 1, 5 do
+                t('/apisix/admin/routes/1',
+                     ngx.HTTP_PUT,
+                     [[{
+                            "upstream": {
+                                "nodes": {
+                                    "127.0.0.1:1980": 1
+                                },
+                                "type": "roundrobin"
+                            },
+                            "uri": "/hello"
+                    }]]
+                    )
+                -- request after each update
+                httpc = http.new()
+                res, err = httpc:request_uri("http://127.0.0.1:1984/hello")
+                if not res then
+                    ngx.say("request ", i, " failed: ", err)
+                    return
+                end
+            end
+
+            ngx.say("all requests succeeded")
+        }
+    }
+--- request
+GET /t
+--- response_body
+all requests succeeded
+--- error_log
+skip router rebuild


### PR DESCRIPTION
## Description

When routes change frequently (e.g., 20-50 changes/sec with 5000+ total routes), the data plane rebuilds the radixtree router on **every single change**, causing significant CPU spikes (up to 80%) and temporary TPS drops.

This PR adds a configurable `router_rebuild_min_interval` option that sets a minimum time interval (in seconds) between HTTP router rebuilds. When the interval has not elapsed since the last rebuild, subsequent route changes are acknowledged but the router rebuild is deferred, dramatically reducing CPU usage during bulk route updates.

### Configuration

```yaml
apisix:
  router:
    http: radixtree_host_uri
    ssl: radixtree_sni
    router_rebuild_min_interval: 0  # default: 0 (rebuild immediately, current behavior)
```

### Expected Impact

| Scenario (30s duration) | min_interval: 0 | min_interval: 1 | min_interval: 5 |
|---|---|---|---|
| 20 changes/sec | 600 rebuilds | ~31 rebuilds | ~7 rebuilds |
| 50 changes/sec | 1500 rebuilds | ~31 rebuilds | ~7 rebuilds |
| 1 change/3sec | 10 rebuilds | 10 rebuilds | 10 rebuilds |

### Changes

- **`conf/config.yaml.example`**: Added `router_rebuild_min_interval` config option
- **`apisix/cli/config.lua`**: Default value `0`
- **`apisix/router.lua`**: Reads config and passes to HTTP router modules (+3 lines)
- **`apisix/http/router/radixtree_uri.lua`**: Min interval check before rebuild
- **`apisix/http/router/radixtree_host_uri.lua`**: Min interval check before rebuild
- **`apisix/http/router/radixtree_uri_with_parameter.lua`**: Min interval check before rebuild
- **`t/router/router-rebuild-min-interval.t`**: Test cases covering default behavior, skip behavior, and deferred rebuild

### Backward Compatibility

Default value is `0`, preserving the existing behavior of rebuilding immediately on every route change. No existing configurations are affected.