### PR TITLE
fix: resolve env vars before YAML parsing to preserve types in standalone mode

### DIFF
--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -90,12 +90,14 @@ local function var_sub(val)
 end
 
 
-local function exceeds_lua_precision(str)
-    local digits = str:match("^%-?(%d+)$")
-    if digits and #digits > 15 then
-        return true
+-- Substitute env vars in raw text before parsing. YAML parser then infers
+-- types naturally: `"${{VAR}}"` stays string, `${{VAR}}` infers from value.
+local function resolve_conf_var_in_text(text)
+    local new_text, _, err = var_sub(text)
+    if err then
+        return nil, err
     end
-    return false
+    return new_text
 end
 
 
@@ -133,7 +135,7 @@ local function resolve_conf_var(conf)
             end
 
             if var_used then
-                if not exceeds_lua_precision(new_val) and tonumber(new_val) ~= nil then
+                if tonumber(new_val) ~= nil then
                     new_val = tonumber(new_val)
                 elseif new_val == "true" then
                     new_val = true
@@ -152,6 +154,7 @@ end
 
 
 _M.resolve_conf_var = resolve_conf_var
+_M.resolve_conf_var_in_text = resolve_conf_var_in_text
 
 
 local function replace_by_reserved_env_vars(conf)
@@ -311,12 +314,14 @@ function _M.read_yaml_conf(apisix_home)
         local apisix_conf_path = profile:yaml_path("apisix")
         local apisix_conf_yaml, _ = util.read_file(apisix_conf_path)
         if apisix_conf_yaml then
-            local apisix_conf = yaml.load(apisix_conf_yaml)
-            if apisix_conf then
-                local ok, err = resolve_conf_var(apisix_conf)
-                if not ok then
-                    return nil, err
-                end
+            -- Pre-parse substitution: `"${{VAR}}"` stays string, `${{VAR}}` infers type from value.
+            local resolved, err = resolve_conf_var_in_text(apisix_conf_yaml)
+            if not resolved then
+                return nil, err
+            end
+            local apisix_conf = yaml.load(resolved)
+            if not apisix_conf then
+                return nil, "invalid apisix.yaml file"
             end
         end
     end

--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -90,10 +90,16 @@ local function var_sub(val)
 end
 
 
-local function resolve_conf_var(conf, enable_type_conversion)
-    if enable_type_conversion == nil then
-        enable_type_conversion = true
+local function exceeds_lua_precision(str)
+    local digits = str:match("^%-?(%d+)$")
+    if digits and #digits > 15 then
+        return true
     end
+    return false
+end
+
+
+local function resolve_conf_var(conf)
     local new_keys = {}
     for key, val in pairs(conf) do
         -- avoid re-iterating the table for already iterated key
@@ -114,7 +120,7 @@ local function resolve_conf_var(conf, enable_type_conversion)
             end
         end
         if type(val) == "table" then
-            local ok, err = resolve_conf_var(val, enable_type_conversion)
+            local ok, err = resolve_conf_var(val)
             if not ok then
                 return nil, err
             end
@@ -126,8 +132,8 @@ local function resolve_conf_var(conf, enable_type_conversion)
                 return nil, err
             end
 
-            if var_used and enable_type_conversion then
-                if tonumber(new_val) ~= nil then
+            if var_used then
+                if not exceeds_lua_precision(new_val) and tonumber(new_val) ~= nil then
                     new_val = tonumber(new_val)
                 elseif new_val == "true" then
                     new_val = true
@@ -258,7 +264,7 @@ function _M.read_yaml_conf(apisix_home)
             return nil, "invalid config.yaml file"
         end
 
-        local ok, err = resolve_conf_var(user_conf, true)
+        local ok, err = resolve_conf_var(user_conf)
         if not ok then
             return nil, err
         end
@@ -307,7 +313,7 @@ function _M.read_yaml_conf(apisix_home)
         if apisix_conf_yaml then
             local apisix_conf = yaml.load(apisix_conf_yaml)
             if apisix_conf then
-                local ok, err = resolve_conf_var(apisix_conf, false)
+                local ok, err = resolve_conf_var(apisix_conf)
                 if not ok then
                     return nil, err
                 end

--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -90,7 +90,10 @@ local function var_sub(val)
 end
 
 
-local function resolve_conf_var(conf)
+local function resolve_conf_var(conf, enable_type_conversion)
+    if enable_type_conversion == nil then
+        enable_type_conversion = true
+    end
     local new_keys = {}
     for key, val in pairs(conf) do
         -- avoid re-iterating the table for already iterated key
@@ -111,7 +114,7 @@ local function resolve_conf_var(conf)
             end
         end
         if type(val) == "table" then
-            local ok, err = resolve_conf_var(val)
+            local ok, err = resolve_conf_var(val, enable_type_conversion)
             if not ok then
                 return nil, err
             end
@@ -123,7 +126,7 @@ local function resolve_conf_var(conf)
                 return nil, err
             end
 
-            if var_used then
+            if var_used and enable_type_conversion then
                 if tonumber(new_val) ~= nil then
                     new_val = tonumber(new_val)
                 elseif new_val == "true" then
@@ -255,7 +258,7 @@ function _M.read_yaml_conf(apisix_home)
             return nil, "invalid config.yaml file"
         end
 
-        local ok, err = resolve_conf_var(user_conf)
+        local ok, err = resolve_conf_var(user_conf, true)
         if not ok then
             return nil, err
         end
@@ -304,7 +307,7 @@ function _M.read_yaml_conf(apisix_home)
         if apisix_conf_yaml then
             local apisix_conf = yaml.load(apisix_conf_yaml)
             if apisix_conf then
-                local ok, err = resolve_conf_var(apisix_conf)
+                local ok, err = resolve_conf_var(apisix_conf, false)
                 if not ok then
                     return nil, err
                 end

--- a/apisix/core/config_yaml.lua
+++ b/apisix/core/config_yaml.lua
@@ -153,7 +153,7 @@ local function update_config(table, conf_version)
         return
     end
 
-    local ok, err = file.resolve_conf_var(table, false)
+    local ok, err = file.resolve_conf_var(table)
     if not ok then
         log.error("failed to resolve variables:" .. err)
         return

--- a/apisix/core/config_yaml.lua
+++ b/apisix/core/config_yaml.lua
@@ -153,7 +153,7 @@ local function update_config(table, conf_version)
         return
     end
 
-    local ok, err = file.resolve_conf_var(table)
+    local ok, err = file.resolve_conf_var(table, false)
     if not ok then
         log.error("failed to resolve variables:" .. err)
         return

--- a/apisix/core/config_yaml.lua
+++ b/apisix/core/config_yaml.lua
@@ -96,7 +96,13 @@ local config_yaml = {
         local raw_config = f:read("*a")
         f:close()
 
-        return yaml.load(raw_config), nil
+        -- substitute env vars in the raw YAML text before parsing so that
+        -- YAML quoting decides types (see apisix/cli/file.lua).
+        local resolved, err = file.resolve_conf_var_in_text(raw_config)
+        if not resolved then
+            return nil, err
+        end
+        return yaml.load(resolved), nil
     end
 }
 
@@ -115,6 +121,12 @@ local config_json = {
         local config, err = json.decode(raw_config)
         if err then
             return nil, "failed to decode json: " .. err
+        end
+        -- JSON has explicit types, so env var substitution is applied
+        -- post-parse (same behavior as before).
+        local ok, err = file.resolve_conf_var(config)
+        if not ok then
+            return nil, err
         end
         return config, nil
     end
@@ -150,12 +162,6 @@ end
 local function update_config(table, conf_version)
     if not table then
         log.error("failed update config: empty table")
-        return
-    end
-
-    local ok, err = file.resolve_conf_var(table)
-    if not ok then
-        log.error("failed to resolve variables:" .. err)
         return
     end
 

--- a/t/cli/test_standalone.sh
+++ b/t/cli/test_standalone.sh
@@ -409,5 +409,256 @@ fi
 
 echo "passed: config.yaml still converts numeric env vars correctly"
 
+# test: small numeric env var inside quoted string should stay as string
+# (the exact scenario from issue #12932 — key-auth key expects a string,
+#  previously substituted numeric values were coerced to numbers and failed
+#  schema validation)
+echo '
+apisix:
+  enable_admin: false
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+' > conf/config.yaml
+
+echo '
+routes:
+  -
+    uri: /test-quoted-numeric
+    plugins:
+      key-auth: {}
+      proxy-rewrite:
+        uri: /apisix/nginx_status
+    upstream:
+      nodes:
+        "127.0.0.1:9091": 1
+      type: roundrobin
+consumers:
+  -
+    username: testuser
+    plugins:
+      key-auth:
+        key: "${{TEST_KEY}}"
+#END
+' > conf/apisix.yaml
+
+TEST_KEY="12345" make init
+
+if ! TEST_KEY="12345" make run > output.log 2>&1; then
+    cat output.log
+    echo "failed: quoted numeric env var should stay string and pass schema validation"
+    exit 1
+fi
+
+sleep 0.1
+
+# With correct key header → 200
+code=$(curl -o /dev/null -s -m 5 -w %{http_code} -H "apikey: 12345" http://127.0.0.1:9080/test-quoted-numeric)
+if [ "$code" -ne 200 ]; then
+    echo "failed: expected 200 with correct apikey, but got: $code"
+    cat logs/error.log
+    exit 1
+fi
+
+# Without header → 401
+code=$(curl -o /dev/null -s -m 5 -w %{http_code} http://127.0.0.1:9080/test-quoted-numeric)
+if [ "$code" -ne 401 ]; then
+    echo "failed: expected 401 without apikey, but got: $code"
+    exit 1
+fi
+
+make stop
+sleep 0.5
+
+echo "passed: quoted numeric env var preserved as string for key-auth consumer key"
+
+# test: boolean env var inside quoted string should stay as string
+# (previously a quoted "${{V}}" with V=true got post-parse coerced to a Lua
+#  boolean, which failed schema validation for string-typed plugin fields)
+echo '
+apisix:
+  enable_admin: false
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+' > conf/config.yaml
+
+echo '
+routes:
+  -
+    uri: /test-quoted-bool
+    plugins:
+      response-rewrite:
+        body: "${{BODY_VAL}}"
+        status_code: 200
+    upstream:
+      nodes:
+        "127.0.0.1:9091": 1
+      type: roundrobin
+#END
+' > conf/apisix.yaml
+
+BODY_VAL="true" make init
+
+if ! BODY_VAL="true" make run > output.log 2>&1; then
+    cat output.log
+    echo "failed: quoted boolean env var should stay string"
+    exit 1
+fi
+
+sleep 0.1
+
+code=$(curl -o /tmp/response_body -s -m 5 -w %{http_code} http://127.0.0.1:9080/test-quoted-bool)
+body=$(cat /tmp/response_body)
+if [ "$code" -ne 200 ]; then
+    echo "failed: expected 200 for /test-quoted-bool, but got: $code, body: $body"
+    exit 1
+fi
+if [ "$body" != "true" ]; then
+    echo "failed: quoted bool env var was not preserved as string, got: $body"
+    exit 1
+fi
+
+make stop
+sleep 0.5
+
+echo "passed: quoted boolean env var preserved as string in apisix.yaml"
+
+# test: default value fallback still works for unset env var
+echo '
+apisix:
+  enable_admin: false
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+' > conf/config.yaml
+
+echo '
+routes:
+  -
+    uri: /test-default-val
+    plugins:
+      response-rewrite:
+        body: "hello"
+        status_code: ${{UNSET_STATUS:=202}}
+    upstream:
+      nodes:
+        "127.0.0.1:9091": 1
+      type: roundrobin
+#END
+' > conf/apisix.yaml
+
+unset UNSET_STATUS
+make init
+
+if ! make run > output.log 2>&1; then
+    cat output.log
+    echo "failed: default value fallback should work"
+    exit 1
+fi
+
+sleep 0.1
+
+code=$(curl -o /dev/null -s -m 5 -w %{http_code} http://127.0.0.1:9080/test-default-val)
+if [ "$code" -ne 202 ]; then
+    echo "failed: expected 202 from default fallback, but got: $code"
+    exit 1
+fi
+
+make stop
+sleep 0.5
+
+echo "passed: default value fallback (\${{VAR:=default}}) works"
+
+# test: env var substitution inside a YAML key
+echo '
+apisix:
+  enable_admin: false
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+' > conf/config.yaml
+
+echo '
+routes:
+  -
+    uri: /test-key-sub
+    plugins:
+      "${{PLUGIN_NAME}}":
+        body: "key-sub-ok"
+        status_code: 200
+    upstream:
+      nodes:
+        "127.0.0.1:9091": 1
+      type: roundrobin
+#END
+' > conf/apisix.yaml
+
+PLUGIN_NAME="response-rewrite" make init
+
+if ! PLUGIN_NAME="response-rewrite" make run > output.log 2>&1; then
+    cat output.log
+    echo "failed: env var in YAML key should be substituted before parsing"
+    exit 1
+fi
+
+sleep 0.1
+
+code=$(curl -o /tmp/response_body -s -m 5 -w %{http_code} http://127.0.0.1:9080/test-key-sub)
+body=$(cat /tmp/response_body)
+if [ "$code" -ne 200 ] || [ "$body" != "key-sub-ok" ]; then
+    echo "failed: expected 200/key-sub-ok for /test-key-sub, got code: $code body: $body"
+    exit 1
+fi
+
+make stop
+sleep 0.5
+
+echo "passed: env var substitution inside YAML key"
+
+# test: missing env var (no default) should produce a clear startup error
+echo '
+apisix:
+  enable_admin: false
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+' > conf/config.yaml
+
+echo '
+routes:
+  -
+    uri: /test-missing-var
+    plugins:
+      response-rewrite:
+        body: "hello"
+        status_code: ${{DEFINITELY_NOT_SET_VAR}}
+    upstream:
+      nodes:
+        "127.0.0.1:9091": 1
+      type: roundrobin
+#END
+' > conf/apisix.yaml
+
+unset DEFINITELY_NOT_SET_VAR
+if make init > output.log 2>&1; then
+    echo "failed: make init should fail when required env var is missing"
+    cat output.log
+    exit 1
+fi
+
+if ! grep "can't find environment variable DEFINITELY_NOT_SET_VAR" output.log > /dev/null; then
+    echo "failed: expected missing-env-var error message in init output"
+    cat output.log
+    exit 1
+fi
+
+echo "passed: missing env var produces clear startup error"
+
 git checkout conf/config.yaml
 git checkout conf/apisix.yaml

--- a/t/cli/test_standalone.sh
+++ b/t/cli/test_standalone.sh
@@ -176,6 +176,7 @@ routes:
     plugins:
       response-rewrite:
         body: "${{APISIX_CLIENT_ID}}"
+        status_code: 200
     upstream:
       nodes:
         "127.0.0.1:9091": 1
@@ -195,7 +196,12 @@ fi
 sleep 0.1
 
 # Verify the response body matches the exact large numeric string
-body=$(curl -s -m 5 http://127.0.0.1:9080/test-large-number)
+code=$(curl -o /tmp/response_body -s -m 5 -w %{http_code} http://127.0.0.1:9080/test-large-number)
+body=$(cat /tmp/response_body)
+if [ "$code" -ne 200 ]; then
+    echo "failed: expected 200 for /test-large-number, but got: $code, body: $body"
+    exit 1
+fi
 if [ "$body" != "356002209726529540" ]; then
     echo "failed: large number env var was not preserved as string, got: $body"
     exit 1
@@ -223,6 +229,7 @@ routes:
     plugins:
       response-rewrite:
         body: "${{NUMERIC_ID}}"
+        status_code: 200
     upstream:
       nodes:
         "127.0.0.1:9091": 1
@@ -234,7 +241,12 @@ NUMERIC_ID="12345" make init
 NUMERIC_ID="12345" make run
 sleep 0.1
 
-body=$(curl -s -m 5 http://127.0.0.1:9080/test-quoted)
+code=$(curl -o /tmp/response_body -s -m 5 -w %{http_code} http://127.0.0.1:9080/test-quoted)
+body=$(cat /tmp/response_body)
+if [ "$code" -ne 200 ]; then
+    echo "failed: expected 200 for /test-quoted, but got: $code, body: $body"
+    exit 1
+fi
 if [ "$body" != "12345" ]; then
     echo "failed: quoted numeric env var in apisix.yaml was not preserved as string, got: $body"
     exit 1
@@ -270,8 +282,8 @@ sleep 0.1
 # If type conversion works, enable_admin is boolean false and admin API is disabled (404)
 # If type conversion fails, enable_admin stays string "false" which is truthy, admin API is enabled
 code=$(curl -o /dev/null -s -m 5 -w %{http_code} http://127.0.0.1:9080/apisix/admin/routes)
-if [ "$code" -eq 200 ]; then
-    echo "failed: boolean env var in config.yaml was not converted, admin API should be disabled"
+if [ "$code" -ne 404 ]; then
+    echo "failed: expected 404 when admin API is disabled, but got: $code"
     exit 1
 fi
 

--- a/t/cli/test_standalone.sh
+++ b/t/cli/test_standalone.sh
@@ -212,7 +212,7 @@ sleep 0.5
 
 echo "passed: large number in env var preserved as string in apisix.yaml"
 
-# test: quoted numeric env vars in apisix.yaml should remain strings
+# test: small numeric env vars in apisix.yaml should still be converted to number
 echo '
 apisix:
   enable_admin: false
@@ -225,11 +225,11 @@ deployment:
 echo '
 routes:
   -
-    uri: /test-quoted
+    uri: /test-small-number
     plugins:
       response-rewrite:
-        body: "${{NUMERIC_ID}}"
-        status_code: 200
+        body: "hello"
+        status_code: ${{REWRITE_STATUS}}
     upstream:
       nodes:
         "127.0.0.1:9091": 1
@@ -237,25 +237,27 @@ routes:
 #END
 ' > conf/apisix.yaml
 
-NUMERIC_ID="12345" make init
-NUMERIC_ID="12345" make run
-sleep 0.1
+REWRITE_STATUS="200" make init
 
-code=$(curl -o /tmp/response_body -s -m 5 -w %{http_code} http://127.0.0.1:9080/test-quoted)
-body=$(cat /tmp/response_body)
-if [ "$code" -ne 200 ]; then
-    echo "failed: expected 200 for /test-quoted, but got: $code, body: $body"
+if ! REWRITE_STATUS="200" make run > output.log 2>&1; then
+    cat output.log
+    echo "failed: small numeric env var should be converted to number in apisix.yaml"
     exit 1
 fi
-if [ "$body" != "12345" ]; then
-    echo "failed: quoted numeric env var in apisix.yaml was not preserved as string, got: $body"
+
+sleep 0.1
+
+code=$(curl -o /tmp/response_body -s -m 5 -w %{http_code} http://127.0.0.1:9080/test-small-number)
+body=$(cat /tmp/response_body)
+if [ "$code" -ne 200 ]; then
+    echo "failed: expected 200 for /test-small-number, but got: $code, body: $body"
     exit 1
 fi
 
 make stop
 sleep 0.5
 
-echo "passed: quoted numeric env var preserved as string in apisix.yaml"
+echo "passed: small numeric env var converted to number in apisix.yaml"
 
 # test: config.yaml should still support type conversion (boolean)
 echo '
@@ -291,6 +293,121 @@ make stop
 sleep 0.5
 
 echo "passed: config.yaml still converts boolean env vars correctly"
+
+# test: numeric env vars for upstream weight and retries in apisix.yaml
+echo '
+apisix:
+  enable_admin: false
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+' > conf/config.yaml
+
+echo '
+routes:
+  -
+    uri: /test-upstream-env
+    plugins:
+      proxy-rewrite:
+        uri: /apisix/nginx_status
+    upstream:
+      nodes:
+        "127.0.0.1:9091": ${{WEIGHT}}
+      type: roundrobin
+      retries: ${{RETRIES}}
+#END
+' > conf/apisix.yaml
+
+WEIGHT="1" RETRIES="3" make init
+
+if ! WEIGHT="1" RETRIES="3" make run > output.log 2>&1; then
+    cat output.log
+    echo "failed: numeric env vars for weight/retries should be converted to number"
+    exit 1
+fi
+
+sleep 0.1
+
+code=$(curl -o /dev/null -s -m 5 -w %{http_code} http://127.0.0.1:9080/test-upstream-env)
+if [ "$code" -ne 200 ]; then
+    echo "failed: expected 200 for /test-upstream-env, but got: $code"
+    exit 1
+fi
+
+make stop
+sleep 0.5
+
+echo "passed: numeric env vars for upstream weight and retries converted to number in apisix.yaml"
+
+# test: boolean env vars in apisix.yaml should be converted to boolean
+echo '
+apisix:
+  enable_admin: false
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+' > conf/config.yaml
+
+echo '
+routes:
+  -
+    uri: /test-bool-env
+    plugins:
+      redirect:
+        http_to_https: ${{REDIRECT_HTTPS}}
+    upstream:
+      nodes:
+        "127.0.0.1:9091": 1
+      type: roundrobin
+#END
+' > conf/apisix.yaml
+
+REDIRECT_HTTPS="true" make init
+
+if ! REDIRECT_HTTPS="true" make run > output.log 2>&1; then
+    cat output.log
+    echo "failed: boolean env var should be converted to boolean in apisix.yaml"
+    exit 1
+fi
+
+sleep 0.1
+
+# If boolean conversion works, redirect plugin returns 301
+code=$(curl -o /dev/null -s -m 5 -w %{http_code} http://127.0.0.1:9080/test-bool-env)
+if [ "$code" -ne 301 ]; then
+    echo "failed: expected 301 redirect for /test-bool-env, but got: $code"
+    exit 1
+fi
+
+make stop
+sleep 0.5
+
+echo "passed: boolean env var converted to boolean in apisix.yaml"
+
+# test: config.yaml should still support numeric type conversion
+echo '
+routes: []
+#END
+' > conf/apisix.yaml
+
+echo '
+apisix:
+  resolver_timeout: ${{RESOLVER_TIMEOUT}}
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+' > conf/config.yaml
+
+if ! RESOLVER_TIMEOUT=5 make init > output.log 2>&1; then
+    cat output.log
+    echo "failed: config.yaml should convert numeric env vars to number"
+    exit 1
+fi
+
+echo "passed: config.yaml still converts numeric env vars correctly"
 
 git checkout conf/config.yaml
 git checkout conf/apisix.yaml

--- a/t/cli/test_standalone.sh
+++ b/t/cli/test_standalone.sh
@@ -155,3 +155,120 @@ if [ $expected_config_reloads -ne $actual_config_reloads ]; then
     exit 1
 fi
 echo "passed: apisix.yaml was not reloaded"
+
+
+# test: environment variable with large number should be preserved as string
+echo '
+apisix:
+  enable_admin: false
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+' > conf/config.yaml
+
+echo '
+routes:
+  -
+    uri: /test-large-number
+    plugins:
+      openid-connect:
+        client_id: "${{APISIX_CLIENT_ID}}"
+        client_secret: "secret"
+        discovery: "http://example.com/.well-known/openid-configuration"
+    upstream:
+      nodes:
+        "127.0.0.1:9091": 1
+      type: roundrobin
+#END
+' > conf/apisix.yaml
+
+# Test with large number that exceeds Lua double precision
+APISIX_CLIENT_ID="356002209726529540" make init
+
+if ! APISIX_CLIENT_ID="356002209726529540" make run > output.log 2>&1; then
+    cat output.log
+    echo "failed: large number in env var should not cause type conversion error"
+    exit 1
+fi
+
+sleep 0.1
+
+# Verify the service is running (should not have validation errors)
+code=$(curl -o /dev/null -s -m 5 -w %{http_code} http://127.0.0.1:9080/test-large-number)
+if [ $code -eq 500 ]; then
+    echo "failed: large number env var was converted to scientific notation"
+    exit 1
+fi
+
+make stop
+sleep 0.5
+
+echo "passed: large number in env var preserved as string in apisix.yaml"
+
+# test: quoted numeric env vars in apisix.yaml should remain strings
+echo '
+apisix:
+  enable_admin: false
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+' > conf/config.yaml
+
+echo '
+routes:
+  -
+    uri: /test-quoted
+    plugins:
+      proxy-rewrite:
+        headers:
+          X-Custom-ID: "${{NUMERIC_ID}}"
+    upstream:
+      nodes:
+        "127.0.0.1:9091": 1
+      type: roundrobin
+#END
+' > conf/apisix.yaml
+
+NUMERIC_ID="12345" make init
+NUMERIC_ID="12345" make run
+sleep 0.1
+
+code=$(curl -s -H "Host: test.com" http://127.0.0.1:9080/test-quoted -o /dev/null -w %{http_code})
+if [ ! $code -eq 404 ] && [ ! $code -eq 200 ]; then
+    echo "failed: quoted numeric env var in apisix.yaml should work"
+    exit 1
+fi
+
+make stop
+sleep 0.5
+
+echo "passed: quoted numeric env var preserved as string in apisix.yaml"
+
+# test: config.yaml should still support type conversion
+echo '
+routes: []
+#END
+' > conf/apisix.yaml
+
+echo '
+apisix:
+  node_listen: ${{NODE_PORT}}
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+' > conf/config.yaml
+
+NODE_PORT=9080 make init
+
+if ! grep "listen 0.0.0.0:9080" conf/nginx.conf > /dev/null; then
+    echo "failed: numeric env var in config.yaml should be converted to number"
+    exit 1
+fi
+
+echo "passed: config.yaml still converts numeric env vars correctly"
+
+git checkout conf/config.yaml
+git checkout conf/apisix.yaml

--- a/t/cli/test_standalone.sh
+++ b/t/cli/test_standalone.sh
@@ -156,6 +156,8 @@ if [ $expected_config_reloads -ne $actual_config_reloads ]; then
 fi
 echo "passed: apisix.yaml was not reloaded"
 
+make stop
+sleep 0.5
 
 # test: environment variable with large number should be preserved as string
 echo '
@@ -172,10 +174,8 @@ routes:
   -
     uri: /test-large-number
     plugins:
-      openid-connect:
-        client_id: "${{APISIX_CLIENT_ID}}"
-        client_secret: "secret"
-        discovery: "http://example.com/.well-known/openid-configuration"
+      response-rewrite:
+        body: "${{APISIX_CLIENT_ID}}"
     upstream:
       nodes:
         "127.0.0.1:9091": 1
@@ -194,10 +194,10 @@ fi
 
 sleep 0.1
 
-# Verify the service is running (should not have validation errors)
-code=$(curl -o /dev/null -s -m 5 -w %{http_code} http://127.0.0.1:9080/test-large-number)
-if [ $code -eq 500 ]; then
-    echo "failed: large number env var was converted to scientific notation"
+# Verify the response body matches the exact large numeric string
+body=$(curl -s -m 5 http://127.0.0.1:9080/test-large-number)
+if [ "$body" != "356002209726529540" ]; then
+    echo "failed: large number env var was not preserved as string, got: $body"
     exit 1
 fi
 
@@ -221,9 +221,8 @@ routes:
   -
     uri: /test-quoted
     plugins:
-      proxy-rewrite:
-        headers:
-          X-Custom-ID: "${{NUMERIC_ID}}"
+      response-rewrite:
+        body: "${{NUMERIC_ID}}"
     upstream:
       nodes:
         "127.0.0.1:9091": 1
@@ -235,9 +234,9 @@ NUMERIC_ID="12345" make init
 NUMERIC_ID="12345" make run
 sleep 0.1
 
-code=$(curl -s -H "Host: test.com" http://127.0.0.1:9080/test-quoted -o /dev/null -w %{http_code})
-if [ ! $code -eq 404 ] && [ ! $code -eq 200 ]; then
-    echo "failed: quoted numeric env var in apisix.yaml should work"
+body=$(curl -s -m 5 http://127.0.0.1:9080/test-quoted)
+if [ "$body" != "12345" ]; then
+    echo "failed: quoted numeric env var in apisix.yaml was not preserved as string, got: $body"
     exit 1
 fi
 
@@ -246,7 +245,7 @@ sleep 0.5
 
 echo "passed: quoted numeric env var preserved as string in apisix.yaml"
 
-# test: config.yaml should still support type conversion
+# test: config.yaml should still support type conversion (boolean)
 echo '
 routes: []
 #END
@@ -254,21 +253,32 @@ routes: []
 
 echo '
 apisix:
-  node_listen: ${{NODE_PORT}}
+  enable_admin: ${{ENABLE_ADMIN}}
 deployment:
-  role: data_plane
-  role_data_plane:
+  role: traditional
+  role_traditional:
     config_provider: yaml
+  etcd:
+    host:
+      - "http://127.0.0.1:2379"
 ' > conf/config.yaml
 
-NODE_PORT=9080 make init
+ENABLE_ADMIN=false make init
+ENABLE_ADMIN=false make run
+sleep 0.1
 
-if ! grep "listen 0.0.0.0:9080" conf/nginx.conf > /dev/null; then
-    echo "failed: numeric env var in config.yaml should be converted to number"
+# If type conversion works, enable_admin is boolean false and admin API is disabled (404)
+# If type conversion fails, enable_admin stays string "false" which is truthy, admin API is enabled
+code=$(curl -o /dev/null -s -m 5 -w %{http_code} http://127.0.0.1:9080/apisix/admin/routes)
+if [ "$code" -eq 200 ]; then
+    echo "failed: boolean env var in config.yaml was not converted, admin API should be disabled"
     exit 1
 fi
 
-echo "passed: config.yaml still converts numeric env vars correctly"
+make stop
+sleep 0.5
+
+echo "passed: config.yaml still converts boolean env vars correctly"
 
 git checkout conf/config.yaml
 git checkout conf/apisix.yaml


### PR DESCRIPTION
- Add `exceeds_lua_precision()` in `resolve_conf_var()`:
  - if env value is a pure integer and length > 15 digits, skip `tonumber()` and keep it as string
  - otherwise keep existing conversion behavior (number/boolean conversion still works)
- Add CLI regression tests for:
  - large integer env vars preserved as string in `apisix.yaml`
  - small numeric env vars still converted to number in `apisix.yaml`
  - boolean env vars still converted to boolean in `apisix.yaml`
  - numeric/boolean env vars still converted correctly in `config.yaml`

This fixes the issue where large numeric env vars in standalone mode were converted to Lua numbers and lost precision (scientific notation), which could break schema validation for string fields.

Fixes #12932

### Description

This PR fixes env var substitution precision loss in standalone `apisix.yaml` with a targeted strategy instead of disabling type conversion globally.

Previously, values like `356002209726529540` were passed to `tonumber()`, converted to a Lua double, and potentially represented in scientific notation, causing type/schema issues for fields that must remain exact strings.

The final solution is:

1. Detect precision-risk values (digit length > 15).
2. Skip `tonumber()` only for those values, preserving original string.
3. Keep existing behavior for normal numbers and booleans, so backward compatibility is maintained.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #12932

### Checklist

- [ x ] I have explained the need for this PR and the problem it solves
- [ x ] I have explained the changes or the new features added to this PR
- [ x ] I have added tests corresponding to this change
- [ x ] I have updated the documentation to reflect this change
          (No documentation update needed - this is an internal bug fix with no user-facing configuration changes)
- [ x ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->