### PR TITLE
feat(ai-proxy-multi): support client-driven model selection via models request body field

### DIFF
--- a/apisix/plugins/ai-proxy-multi.lua
+++ b/apisix/plugins/ai-proxy-multi.lua
@@ -15,6 +15,7 @@
 -- limitations under the License.
 --
 
+local ngx = ngx
 local core = require("apisix.core")
 local schema = require("apisix.plugins.ai-proxy.schema")
 local base   = require("apisix.plugins.ai-proxy.base")
@@ -299,6 +300,76 @@ local function get_instance_conf(instances, name)
 end
 
 
+local function match_client_models(instances, models)
+    local ordered_names = {}
+    local matched = {}
+
+    for _, model_pref in ipairs(models) do
+        local target_model, target_provider
+        if type(model_pref) == "string" then
+            target_model = model_pref
+        elseif type(model_pref) == "table" then
+            target_model = model_pref.model
+            target_provider = model_pref.provider
+        end
+
+        for _, instance in ipairs(instances) do
+            if not matched[instance.name] then
+                local inst_model = instance.options and instance.options.model
+                local matches = false
+                if target_provider then
+                    matches = (instance.provider == target_provider
+                               and inst_model == target_model)
+                else
+                    matches = (inst_model == target_model)
+                end
+                if matches then
+                    matched[instance.name] = true
+                    core.table.insert(ordered_names, instance.name)
+                    break
+                end
+            end
+        end
+    end
+
+    for _, instance in ipairs(instances) do
+        if not matched[instance.name] then
+            core.table.insert(ordered_names, instance.name)
+        end
+    end
+
+    return ordered_names
+end
+
+
+local function pick_preferred_instance(ctx, conf)
+    local preference = ctx.client_model_preference
+    local tried = ctx.client_model_tried or {}
+
+    for _, name in ipairs(preference) do
+        if not tried[name] then
+            local instance_conf = get_instance_conf(conf.instances, name)
+            if instance_conf then
+                if fallback_strategy_has(conf.fallback_strategy, "rate_limiting") then
+                    local ai_rate_limiting = require("apisix.plugins.ai-rate-limiting")
+                    if not ai_rate_limiting.check_instance_status(nil, ctx, name) then
+                        core.log.info("preferred instance ", name,
+                                      " rate limited, trying next")
+                        tried[name] = true
+                        goto continue
+                    end
+                end
+                ctx.client_model_tried = tried
+                return name, instance_conf
+            end
+        end
+        ::continue::
+    end
+
+    return nil, nil, "all preferred instances exhausted"
+end
+
+
 function _M.construct_upstream(instance)
     local upstream = {}
     local node = instance._dns_value
@@ -409,6 +480,33 @@ end
 
 
 function _M.access(conf, ctx)
+    if conf.allow_client_model_preference then
+        local body, err = core.request.get_body()
+        if body then
+            local request_body, decode_err = core.json.decode(body)
+            if request_body and not decode_err and request_body.models then
+                ctx.client_model_preference = match_client_models(
+                    conf.instances, request_body.models)
+                core.log.info("client model preference: ",
+                              core.json.delay_encode(ctx.client_model_preference))
+                request_body.models = nil
+                ngx.req.set_body_data(core.json.encode(request_body))
+            end
+        end
+    end
+
+    if ctx.client_model_preference then
+        local name, ai_instance, err = pick_preferred_instance(ctx, conf)
+        if err then
+            return 503, err
+        end
+        ctx.picked_ai_instance_name = name
+        ctx.picked_ai_instance = ai_instance
+        ctx.balancer_ip = name
+        ctx.bypass_nginx_upstream = true
+        return
+    end
+
     local ups_tab = {}
     local algo = core.table.try_read_attr(conf, "balancer", "algorithm")
     if algo == "chash" then
@@ -430,6 +528,25 @@ end
 
 
 local function retry_on_error(ctx, conf, code)
+    if ctx.client_model_preference then
+        ctx.client_model_tried = ctx.client_model_tried or {}
+        ctx.client_model_tried[ctx.picked_ai_instance_name] = true
+        if (code == 429 and fallback_strategy_has(conf.fallback_strategy, "http_429")) or
+           (code >= 500 and code < 600 and
+           fallback_strategy_has(conf.fallback_strategy, "http_5xx")) then
+            local name, ai_instance, err = pick_preferred_instance(ctx, conf)
+            if err then
+                core.log.error("all preferred instances failed: ", err)
+                return 502
+            end
+            ctx.balancer_ip = name
+            ctx.picked_ai_instance_name = name
+            ctx.picked_ai_instance = ai_instance
+            return
+        end
+        return code
+    end
+
     if not ctx.server_picker then
         return code
     end

--- a/apisix/plugins/ai-proxy/schema.lua
+++ b/apisix/plugins/ai-proxy/schema.lua
@@ -234,6 +234,12 @@ _M.ai_proxy_multi_schema = {
         },
         instances = ai_instance_schema,
         logging = logging_schema,
+        allow_client_model_preference = {
+            type = "boolean",
+            default = false,
+            description = "When enabled, clients can specify preferred model ordering "
+                .. "via a `models` array in the request body.",
+        },
         fallback_strategy = {
             anyOf = {
               {

--- a/docs/en/latest/plugins/ai-proxy-multi.md
+++ b/docs/en/latest/plugins/ai-proxy-multi.md
@@ -46,11 +46,13 @@ In addition, the Plugin also supports logging LLM request information in the acc
 | `messages`         | Array  | True      | An array of message objects.                        |
 | `messages.role`    | String | True      | Role of the message (`system`, `user`, `assistant`).|
 | `messages.content` | String | True      | Content of the message.                             |
+| `models`           | Array  | False     | Preferred model ordering. Only used when `allow_client_model_preference` is `true`. Each element can be a string (model name) or an object with `provider` and `model` fields. |
 
 ## Attributes
 
 | Name                               | Type            | Required | Default                           | Valid Values | Description |
 |------------------------------------|----------------|----------|-----------------------------------|--------------|-------------|
+| allow_client_model_preference      | boolean        | False    | false                           |              | When enabled, clients can include a `models` array in the request body to specify preferred model ordering. Each element can be a model name string or an object with `provider` and `model` fields. The plugin matches entries against configured instances and reorders them accordingly. Unrecognized entries are ignored. When disabled, the `models` field is ignored. |
 | fallback_strategy                  | string or array         | False    |  | string: "instance_health_and_rate_limiting", "http_429", "http_5xx"<br />array: ["rate_limiting", "http_429", "http_5xx"] | Fallback strategy. When set, the Plugin will check whether the specified instance’s token has been exhausted when a request is forwarded. If so, forward the request to the next instance regardless of the instance priority. When not set, the Plugin will not forward the request to low priority instances when token of the high priority instance is exhausted. |
 | balancer                           | object         | False    |                                   |              | Load balancing configurations. |
 | balancer.algorithm                 | string         | False    | roundrobin                     | [roundrobin, chash] | Load balancing algorithm. When set to `roundrobin`, weighted round robin algorithm is used. When set to `chash`, consistent hashing algorithm is used. |
@@ -1006,3 +1008,108 @@ In the gateway's access log, you should see a log entry similar to the following
 ```
 
 The access log entry shows the request type is `ai_chat`, Apisix upstream response time is `5765` milliseconds, time to first token is `2858` milliseconds, Requested LLM model is `gpt-4`. LLM model is `gpt-4`, prompt token usage is `23`, and completion token usage is `8`.
+
+### Client-Driven Model Selection
+
+The following example demonstrates how you can allow clients to specify their preferred model ordering in the request body. This is useful when multiple teams share a single gateway but have different model preferences.
+
+Create a Route with `allow_client_model_preference` enabled and multiple model instances:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "ai-proxy-multi-route",
+    "uri": "/anything",
+    "methods": ["POST"],
+    "plugins": {
+      "ai-proxy-multi": {
+        "allow_client_model_preference": true,
+        "fallback_strategy": ["http_429", "http_5xx"],
+        "instances": [
+          {
+            "name": "openai-instance",
+            "provider": "openai",
+            "priority": 1,
+            "weight": 0,
+            "auth": {
+              "header": {
+                "Authorization": "Bearer '"$OPENAI_API_KEY"'"
+              }
+            },
+            "options": {
+              "model": "gpt-4"
+            }
+          },
+          {
+            "name": "deepseek-instance",
+            "provider": "deepseek",
+            "priority": 0,
+            "weight": 0,
+            "auth": {
+              "header": {
+                "Authorization": "Bearer '"$DEEPSEEK_API_KEY"'"
+              }
+            },
+            "options": {
+              "model": "deepseek-chat"
+            }
+          }
+        ]
+      }
+    }
+  }'
+```
+
+The server-configured priority makes OpenAI the default. Clients that prefer DeepSeek can override the ordering by including a `models` array in the request body.
+
+Send a request with model preference using string shorthand:
+
+```shell
+curl "http://127.0.0.1:9080/anything" -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      { "role": "user", "content": "What is 1+1?" }
+    ],
+    "models": ["deepseek-chat", "gpt-4"]
+  }'
+```
+
+The request is forwarded to DeepSeek first. If DeepSeek returns an error matching the `fallback_strategy`, the request falls back to OpenAI.
+
+You can also use the object form for disambiguation when multiple instances share the same model name:
+
+```shell
+curl "http://127.0.0.1:9080/anything" -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      { "role": "user", "content": "What is 1+1?" }
+    ],
+    "models": [
+      { "provider": "deepseek", "model": "deepseek-chat" },
+      { "provider": "openai", "model": "gpt-4" }
+    ]
+  }'
+```
+
+Requests without a `models` field use the server-configured priority as usual:
+
+```shell
+curl "http://127.0.0.1:9080/anything" -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      { "role": "user", "content": "What is 1+1?" }
+    ]
+  }'
+```
+
+This request is forwarded to OpenAI (priority 1) by default.
+
+:::note
+
+The `models` field is always stripped from the request body before forwarding to the upstream provider. Clients cannot introduce models or providers that are not configured on the route — unrecognized entries are silently ignored.
+
+:::

--- a/t/plugin/ai-proxy-multi.client-model-preference.t
+++ b/t/plugin/ai-proxy-multi.client-model-preference.t
@@ -1,0 +1,371 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+log_level("info");
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+    my $user_yaml_config = <<_EOC_;
+plugins:
+  - ai-proxy-multi
+  - prometheus
+_EOC_
+    $block->set_value("extra_yaml_config", $user_yaml_config);
+
+    my $http_config = $block->http_config // <<_EOC_;
+        server {
+            server_name openai;
+            listen 6724;
+
+            default_type 'application/json';
+
+            location /v1/chat/completions {
+                content_by_lua_block {
+                    local json = require("cjson.safe")
+
+                    ngx.req.read_body()
+                    local body, err = ngx.req.get_body_data()
+                    body, err = json.decode(body)
+
+                    local header_auth = ngx.req.get_headers()["authorization"]
+                    if not header_auth then
+                        ngx.status = 401
+                        ngx.say("Unauthorized")
+                        return
+                    end
+
+                    -- Return different model names based on auth to identify which instance was picked
+                    local model = "unknown"
+                    if header_auth == "Bearer openai-key" then
+                        model = "gpt-4"
+                    elseif header_auth == "Bearer deepseek-key" then
+                        model = "deepseek-chat"
+                    elseif header_auth == "Bearer anthropic-key" then
+                        model = "claude-sonnet"
+                    end
+
+                    -- Check that models field was stripped from request body
+                    if body.models then
+                        ngx.status = 400
+                        ngx.say('{"error": "models field should have been stripped"}')
+                        return
+                    end
+
+                    ngx.status = 200
+                    ngx.say('{"id":"chatcmpl-test","object":"chat.completion","model":"' .. model .. '","choices":[{"index":0,"message":{"role":"assistant","content":"Hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":5,"total_tokens":10}}')
+                }
+            }
+        }
+_EOC_
+
+    $block->set_value("http_config", $http_config);
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: schema validation - allow_client_model_preference defaults to false
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ai-proxy-multi")
+            local ok, err = plugin.check_schema({
+                instances = {
+                    {
+                        name = "openai-instance",
+                        provider = "openai",
+                        weight = 1,
+                        auth = {
+                            header = {
+                                Authorization = "Bearer token"
+                            }
+                        },
+                        options = {
+                            model = "gpt-4"
+                        }
+                    }
+                }
+            })
+
+            if not ok then
+                ngx.say(err)
+            else
+                ngx.say("passed")
+            end
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 2: schema validation - allow_client_model_preference set to true
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ai-proxy-multi")
+            local ok, err = plugin.check_schema({
+                allow_client_model_preference = true,
+                instances = {
+                    {
+                        name = "openai-instance",
+                        provider = "openai",
+                        weight = 1,
+                        auth = {
+                            header = {
+                                Authorization = "Bearer token"
+                            }
+                        },
+                        options = {
+                            model = "gpt-4"
+                        }
+                    }
+                }
+            })
+
+            if not ok then
+                ngx.say(err)
+            else
+                ngx.say("passed")
+            end
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 3: set up route with client model preference enabled
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/anything",
+                    "plugins": {
+                        "ai-proxy-multi": {
+                            "allow_client_model_preference": true,
+                            "instances": [
+                                {
+                                    "name": "openai-instance",
+                                    "provider": "openai",
+                                    "priority": 1,
+                                    "weight": 0,
+                                    "auth": {
+                                        "header": {
+                                            "Authorization": "Bearer openai-key"
+                                        }
+                                    },
+                                    "options": {
+                                        "model": "gpt-4"
+                                    },
+                                    "override": {
+                                        "endpoint": "http://localhost:6724/v1/chat/completions"
+                                    }
+                                },
+                                {
+                                    "name": "deepseek-instance",
+                                    "provider": "openai",
+                                    "priority": 0,
+                                    "weight": 0,
+                                    "auth": {
+                                        "header": {
+                                            "Authorization": "Bearer deepseek-key"
+                                        }
+                                    },
+                                    "options": {
+                                        "model": "deepseek-chat"
+                                    },
+                                    "override": {
+                                        "endpoint": "http://localhost:6724/v1/chat/completions"
+                                    }
+                                },
+                                {
+                                    "name": "anthropic-instance",
+                                    "provider": "openai",
+                                    "priority": -1,
+                                    "weight": 0,
+                                    "auth": {
+                                        "header": {
+                                            "Authorization": "Bearer anthropic-key"
+                                        }
+                                    },
+                                    "options": {
+                                        "model": "claude-sonnet"
+                                    },
+                                    "override": {
+                                        "endpoint": "http://localhost:6724/v1/chat/completions"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 4: client specifies model preference with string shorthand - picks deepseek first
+--- request
+POST /anything
+{"messages":[{"role":"user","content":"hello"}],"models":["deepseek-chat","gpt-4"]}
+--- more_headers
+Content-Type: application/json
+--- response_body_like
+"model":"deepseek-chat"
+
+
+
+=== TEST 5: client specifies model preference with object form - picks anthropic first
+--- request
+POST /anything
+{"messages":[{"role":"user","content":"hello"}],"models":[{"provider":"openai","model":"claude-sonnet"},{"provider":"openai","model":"gpt-4"}]}
+--- more_headers
+Content-Type: application/json
+--- response_body_like
+"model":"claude-sonnet"
+
+
+
+=== TEST 6: without models field - falls back to server-configured priority (openai first)
+--- request
+POST /anything
+{"messages":[{"role":"user","content":"hello"}]}
+--- more_headers
+Content-Type: application/json
+--- response_body_like
+"model":"gpt-4"
+
+
+
+=== TEST 7: unrecognized model in preference - ignored, remaining instances used
+--- request
+POST /anything
+{"messages":[{"role":"user","content":"hello"}],"models":["nonexistent-model","deepseek-chat"]}
+--- more_headers
+Content-Type: application/json
+--- response_body_like
+"model":"deepseek-chat"
+
+
+
+=== TEST 8: models field is stripped from request body before forwarding
+--- request
+POST /anything
+{"messages":[{"role":"user","content":"hello"}],"models":["gpt-4"]}
+--- more_headers
+Content-Type: application/json
+--- response_body_like
+"model":"gpt-4"
+--- error_code: 200
+
+
+
+=== TEST 9: set up route with client model preference disabled (default)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/anything",
+                    "plugins": {
+                        "ai-proxy-multi": {
+                            "instances": [
+                                {
+                                    "name": "openai-instance",
+                                    "provider": "openai",
+                                    "priority": 1,
+                                    "weight": 0,
+                                    "auth": {
+                                        "header": {
+                                            "Authorization": "Bearer openai-key"
+                                        }
+                                    },
+                                    "options": {
+                                        "model": "gpt-4"
+                                    },
+                                    "override": {
+                                        "endpoint": "http://localhost:6724/v1/chat/completions"
+                                    }
+                                },
+                                {
+                                    "name": "deepseek-instance",
+                                    "provider": "openai",
+                                    "priority": 0,
+                                    "weight": 0,
+                                    "auth": {
+                                        "header": {
+                                            "Authorization": "Bearer deepseek-key"
+                                        }
+                                    },
+                                    "options": {
+                                        "model": "deepseek-chat"
+                                    },
+                                    "override": {
+                                        "endpoint": "http://localhost:6724/v1/chat/completions"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 10: models field ignored when allow_client_model_preference is false - uses server priority
+--- request
+POST /anything
+{"messages":[{"role":"user","content":"hello"}],"models":["deepseek-chat"]}
+--- more_headers
+Content-Type: application/json
+--- response_body_like
+"model":"gpt-4"


### PR DESCRIPTION
## Description

When `allow_client_model_preference` is enabled on the plugin config, clients can include a `models` array in the request body to specify their preferred model/instance ordering. This enables multiple teams sharing a single gateway to express different model preferences without requiring separate routes.

### Changes

**Schema** (`apisix/plugins/ai-proxy/schema.lua`):
- Added `allow_client_model_preference` boolean field (default: `false`) to `ai_proxy_multi_schema`

**Plugin logic** (`apisix/plugins/ai-proxy-multi.lua`):
- `match_client_models()` — matches client `models` entries against configured instances by model name and optionally provider
- `pick_preferred_instance()` — sequential picker that respects client ordering with rate-limiting awareness
- Modified `access()` to read request body, extract `models`, reorder instances, and strip `models` before forwarding
- Modified `retry_on_error()` to fall back through client-preferred order on HTTP 429/5xx

**Request body `models` field supports:**
- String shorthand: `["gpt-4", "deepseek-chat"]`
- Object form: `[{"provider": "openai", "model": "gpt-4"}]`
- Mixed: both in the same array

**Behavior:**
- Unrecognized model entries are silently ignored
- Instances not in the client's list are appended in original priority order
- `models` field is always stripped before forwarding upstream
- When disabled (default), `models` field is ignored — fully backward compatible

**Docs** (`docs/en/latest/plugins/ai-proxy-multi.md`):
- Added `allow_client_model_preference` to attributes table
- Added `models` to request format table
- Added "Client-Driven Model Selection" example section

**Tests** (`t/plugin/ai-proxy-multi.client-model-preference.t`):
- Schema validation (default false, explicit true)
- String shorthand model preference
- Object form model preference
- Fallback to server priority without `models` field
- Unrecognized models ignored
- `models` field stripped from forwarded request
- Feature disabled when `allow_client_model_preference` is false

Resolves #13083