### PR TITLE
fix(ai-drivers): handle SSE events split across multiple chunks

### DIFF
--- a/apisix/plugins/ai-drivers/openai-base.lua
+++ b/apisix/plugins/ai-drivers/openai-base.lua
@@ -86,6 +86,7 @@ local function read_response(conf, ctx, res, response_filter)
 
     if content_type and core.string.find(content_type, "text/event-stream") then
         local contents = {}
+        local sse_buffer = nil
         while true do
             local chunk, err = body_reader() -- will read chunk by chunk
             ctx.var.apisix_upstream_response_time = math.floor((ngx_now() -
@@ -103,7 +104,8 @@ local function read_response(conf, ctx, res, response_filter)
                                                 (ngx_now() - ctx.llm_request_start_time) * 1000)
             end
 
-            local events = sse.decode(chunk)
+            local events
+            events, sse_buffer = sse.decode(chunk, sse_buffer)
             ctx.llm_response_contents_in_chunk = {}
             for _, event in ipairs(events) do
                 if event.type == "message" then

--- a/apisix/plugins/ai-drivers/sse.lua
+++ b/apisix/plugins/ai-drivers/sse.lua
@@ -22,66 +22,141 @@ local ipairs = ipairs
 local _M = {}
 
 local ngx_re = require("ngx.re")
+local re_gsub = ngx.re.gsub
 
-function _M.decode(chunk)
+-- Character code constants for SSE parsing
+local CHAR_NEWLINE = string.byte("\n")
+local CHAR_COLON = string.byte(":")
+local CHAR_SPACE = string.byte(" ")
+
+-- Check if the event is a termination event (contains [DONE])
+-- @param event: The event object to check
+-- @return boolean: True if event is done, false otherwise
+local function is_event_done(event)
+    if event and event.raw_event then
+        return core.string.find(event.raw_event, "data: %[DONE%]")
+    end
+    return false
+end
+
+-- Parse event value from body string
+-- @param body: The body string containing the event
+-- @param start_idx: Start index of the value
+-- @param end_idx: End index of the value
+-- @return string: The parsed value or empty string if indices are invalid
+local function parse_event_value(body, start_idx, end_idx)
+    if not start_idx or not end_idx then
+        return ""
+    end
+    return string.sub(body, start_idx, end_idx)
+end
+
+-- Decode SSE chunk into events
+-- @param chunk: The incoming chunk of data
+-- @param buffer: The buffer from previous chunks (may be nil)
+-- @return table: Array of parsed events
+-- @return string|nil: New buffer for next chunk (may be nil)
+function _M.decode(chunk, buffer)
     local events = {}
 
     if not chunk then
-        return events
+        return events, buffer
     end
 
-    -- Split chunk into individual SSE events
-    local raw_events, err = ngx_re.split(chunk, "\n\n")
-    if not raw_events then
-        core.log.warn("failed to split SSE chunk: ", err)
-        return events
+    -- Combine buffer with current chunk if buffer exists
+    local body = chunk
+    if buffer and #buffer > 0 then
+        body = buffer .. chunk
     end
-    for _, raw_event in ipairs(raw_events) do
-        local event = {
-            type = "message",  -- default event type
-            data = {},
-            id = nil,
-            retry = nil
-        }
-        if core.string.find(raw_event, "data: [DONE]") then
-            event.type = "done"
-            event.data = "[DONE]\n\n"
-            table.insert(events, event)
-            goto CONTINUE
-        end
-        local lines, err = ngx_re.split(raw_event, "\n")
-        if not lines then
-            core.log.warn("failed to split event lines: ", err)
-            goto CONTINUE
-        end
 
-        for _, line in ipairs(lines) do
-            local name, value = line:match("^([^:]+): ?(.+)$")
-            if not name then goto NEXT_LINE end
+    -- Track parsing state
+    local event_start_index = nil
+    local line_start_index = nil
+    local value_start_index = nil
+    local current_key = ""
+    local current_event = {
+        type = "message",
+        data = {},
+        id = nil,
+        retry = nil
+    }
 
-            name = name:lower()
-
-            if name == "event" then
-                event.type = value
-            elseif name == "data" then
-                table.insert(event.data, value)
-            elseif name == "id" then
-                event.id = value
-            elseif name == "retry" then
-                event.retry = tonumber(value)
+    -- Parse the body character by character
+    local i = 1
+    local length = #body
+    while i <= length do
+        local ch = string.byte(body, i)
+        
+        -- Process non-newline characters
+        if ch ~= CHAR_NEWLINE then
+            if not line_start_index then
+                if not event_start_index then
+                    event_start_index = i
+                end
+                line_start_index = i
+                value_start_index = nil
             end
-
-            ::NEXT_LINE::
+            if not value_start_index then
+                if ch == CHAR_COLON then
+                    value_start_index = i + 1
+                    current_key = string.sub(body, line_start_index, i - 1)
+                end
+            elseif value_start_index == i and ch == CHAR_SPACE then
+                value_start_index = i + 1
+            end
+            i = i + 1
+            goto CONTINUE
         end
 
-        -- Join data lines with newline
-        event.data = table.concat(event.data, "\n")
-        table.insert(events, event)
+        -- Process line when newline is encountered
+        if line_start_index then
+            if value_start_index then
+                local value = parse_event_value(body, value_start_index, i - 1)
+                if current_key == "event" then
+                    current_event.type = value
+                elseif current_key == "data" then
+                    table.insert(current_event.data, value)
+                elseif current_key == "id" then
+                    current_event.id = value
+                elseif current_key == "retry" then
+                    current_event.retry = tonumber(value)
+                end
+            end
+        else
+            -- Empty line indicates end of event
+            current_event.raw_event = string.sub(body, event_start_index or 1, i)
+            if is_event_done(current_event) then
+                current_event.type = "done"
+                current_event.data = "[DONE]\n\n"
+            else
+                current_event.data = table.concat(current_event.data, "\n")
+            end
+            table.insert(events, current_event)
+            event_start_index = nil
+            current_event = {
+                type = "message",
+                data = {},
+                id = nil,
+                retry = nil
+            }
+        end
+
+        -- Reset line parsing state
+        line_start_index = nil
+        value_start_index = nil
+        current_key = ""
 
         ::CONTINUE::
+        i = i + 1
     end
 
-    return events
+    -- Save incomplete event to buffer for next chunk
+    local new_buffer = nil
+    if event_start_index and event_start_index <= length then
+        new_buffer = string.sub(body, event_start_index)
+    end
+
+    return events, new_buffer
 end
 
 function _M.encode(event)

--- a/apisix/plugins/ai-drivers/sse.lua
+++ b/apisix/plugins/ai-drivers/sse.lua
@@ -34,7 +34,7 @@ local CHAR_SPACE = string.byte(" ")
 -- @return boolean: True if event is done, false otherwise
 local function is_event_done(event)
     if event and event.raw_event then
-        return core.string.find(event.raw_event, "data: %[DONE%]")
+        return core.string.find(event.raw_event, "data: [DONE]")
     end
     return false
 end
@@ -86,8 +86,7 @@ function _M.decode(chunk, buffer)
     local length = #body
     while i <= length do
         local ch = string.byte(body, i)
-        
-        -- Process non-newline characters
+
         if ch ~= CHAR_NEWLINE then
             if not line_start_index then
                 if not event_start_index then
@@ -99,54 +98,48 @@ function _M.decode(chunk, buffer)
             if not value_start_index then
                 if ch == CHAR_COLON then
                     value_start_index = i + 1
-                    current_key = string.sub(body, line_start_index, i - 1)
+                    current_key = string.lower(string.sub(body, line_start_index, i - 1))
                 end
             elseif value_start_index == i and ch == CHAR_SPACE then
                 value_start_index = i + 1
             end
-            i = i + 1
-            goto CONTINUE
-        end
-
-        -- Process line when newline is encountered
-        if line_start_index then
-            if value_start_index then
-                local value = parse_event_value(body, value_start_index, i - 1)
-                if current_key == "event" then
-                    current_event.type = value
-                elseif current_key == "data" then
-                    table.insert(current_event.data, value)
-                elseif current_key == "id" then
-                    current_event.id = value
-                elseif current_key == "retry" then
-                    current_event.retry = tonumber(value)
-                end
-            end
         else
-            -- Empty line indicates end of event
-            current_event.raw_event = string.sub(body, event_start_index or 1, i)
-            if is_event_done(current_event) then
-                current_event.type = "done"
-                current_event.data = "[DONE]\n\n"
+            if line_start_index then
+                if value_start_index then
+                    local value = parse_event_value(body, value_start_index, i - 1)
+                    if current_key == "event" then
+                        current_event.type = value
+                    elseif current_key == "data" then
+                        table.insert(current_event.data, value)
+                    elseif current_key == "id" then
+                        current_event.id = value
+                    elseif current_key == "retry" then
+                        current_event.retry = tonumber(value)
+                    end
+                end
             else
-                current_event.data = table.concat(current_event.data, "\n")
+                current_event.raw_event = string.sub(body, event_start_index or 1, i)
+                if is_event_done(current_event) then
+                    current_event.type = "done"
+                    current_event.data = "[DONE]\n\n"
+                else
+                    current_event.data = table.concat(current_event.data, "\n")
+                end
+                table.insert(events, current_event)
+                event_start_index = nil
+                current_event = {
+                    type = "message",
+                    data = {},
+                    id = nil,
+                    retry = nil
+                }
             end
-            table.insert(events, current_event)
-            event_start_index = nil
-            current_event = {
-                type = "message",
-                data = {},
-                id = nil,
-                retry = nil
-            }
+
+            line_start_index = nil
+            value_start_index = nil
+            current_key = ""
         end
 
-        -- Reset line parsing state
-        line_start_index = nil
-        value_start_index = nil
-        current_key = ""
-
-        ::CONTINUE::
         i = i + 1
     end
 

--- a/apisix/plugins/ai-drivers/sse.lua
+++ b/apisix/plugins/ai-drivers/sse.lua
@@ -18,11 +18,10 @@ local core = require("apisix.core")
 local table = require("apisix.core.table")
 local tonumber = tonumber
 local tostring = tostring
-local ipairs = ipairs
+local string = string
+local string_sub = string.sub
 local _M = {}
 
-local ngx_re = require("ngx.re")
-local re_gsub = ngx.re.gsub
 
 -- Character code constants for SSE parsing
 local CHAR_NEWLINE = string.byte("\n")
@@ -48,7 +47,7 @@ local function parse_event_value(body, start_idx, end_idx)
     if not start_idx or not end_idx then
         return ""
     end
-    return string.sub(body, start_idx, end_idx)
+    return string_sub(body, start_idx, end_idx)
 end
 
 -- Decode SSE chunk into events
@@ -98,7 +97,7 @@ function _M.decode(chunk, buffer)
             if not value_start_index then
                 if ch == CHAR_COLON then
                     value_start_index = i + 1
-                    current_key = string.lower(string.sub(body, line_start_index, i - 1))
+                    current_key = string_sub(body, line_start_index, i - 1)
                 end
             elseif value_start_index == i and ch == CHAR_SPACE then
                 value_start_index = i + 1
@@ -118,7 +117,7 @@ function _M.decode(chunk, buffer)
                     end
                 end
             else
-                current_event.raw_event = string.sub(body, event_start_index or 1, i)
+                current_event.raw_event = string_sub(body, event_start_index or 1, i)
                 if is_event_done(current_event) then
                     current_event.type = "done"
                     current_event.data = "[DONE]\n\n"
@@ -146,7 +145,7 @@ function _M.decode(chunk, buffer)
     -- Save incomplete event to buffer for next chunk
     local new_buffer = nil
     if event_start_index and event_start_index <= length then
-        new_buffer = string.sub(body, event_start_index)
+        new_buffer = string_sub(body, event_start_index)
     end
 
     return events, new_buffer

--- a/t/plugin/ai-proxy-sse-split.t
+++ b/t/plugin/ai-proxy-sse-split.t
@@ -1,0 +1,384 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+log_level("info");
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+    my $http_config = $block->http_config // <<_EOC_;
+        server {
+            server_name openai;
+            listen 6725;
+
+            default_type 'text/event-stream';
+
+            location /v1/chat/completions {
+                content_by_lua_block {
+                    local json = require("cjson.safe")
+
+                    if ngx.req.get_method() ~= "POST" then
+                        ngx.status = 400
+                        ngx.say("Unsupported request method: ", ngx.req.get_method())
+                    end
+                    ngx.req.read_body()
+                    local body, err = ngx.req.get_body_data()
+                    body, err = json.decode(body)
+
+                    local header_auth = ngx.req.get_headers()["authorization"]
+                    if header_auth ~= "Bearer token" then
+                        ngx.status = 401
+                        ngx.say("Unauthorized")
+                        return
+                    end
+
+                    ngx.header["Content-Type"] = "text/event-stream"
+
+                    local test_type = ngx.req.get_headers()["test-type"]
+                    
+                    if test_type == "split_event" then
+                        ngx.say([[data: {"choices":[{"delta":{"content":"He]])
+                        ngx.flush(true)
+                        ngx.sleep(0.01)
+                        ngx.say([[llo"},"index":0}]}
+]])
+                        ngx.flush(true)
+                        ngx.sleep(0.01)
+                        ngx.say([[data: {"choices":[{"delta":{"content":" World"},"index":0}]}
+
+]])
+                        ngx.flush(true)
+                        ngx.sleep(0.01)
+                        ngx.say([[data: [DONE]
+
+]])
+                        return
+                    end
+
+                    if test_type == "split_event_multiline" then
+                        ngx.say([[data: {"choices":[{"delta":{"content":"First]])
+                        ngx.flush(true)
+                        ngx.sleep(0.01)
+                        ngx.say([[ line]])
+                        ngx.flush(true)
+                        ngx.sleep(0.01)
+                        ngx.say([["},"index":0}]}
+
+data: {"choices":[{"delta":{"content":"Second"},"index":0}]}
+
+]])
+                        ngx.flush(true)
+                        ngx.sleep(0.01)
+                        ngx.say([[data: [DONE]
+
+]])
+                        return
+                    end
+
+                    if test_type == "split_across_chunks" then
+                        ngx.say([[data: {"choices":[{"delta":{"content":"A]])
+                        ngx.flush(true)
+                        ngx.sleep(0.01)
+                        ngx.say([[B]])
+                        ngx.flush(true)
+                        ngx.sleep(0.01)
+                        ngx.say([[C"},"index":0}]}
+
+data: {"choices]])
+                        ngx.flush(true)
+                        ngx.sleep(0.01)
+                        ngx.say([[:[{"delta":{"content":"D"},"index":0}]}
+
+]])
+                        ngx.flush(true)
+                        ngx.sleep(0.01)
+                        ngx.say([[data: [DONE]
+
+]])
+                        return
+                    end
+
+                    ngx.say([[data: {"choices":[{"delta":{"content":"Hello"},"index":0}]}
+
+]])
+                    ngx.flush(true)
+                    ngx.sleep(0.01)
+                    ngx.say([[data: [DONE]
+
+]])
+                }
+            }
+        }
+_EOC_
+
+    $block->set_value("http_config", $http_config);
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: set route with stream = true (SSE)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "uri": "/anything",
+                    "plugins": {
+                        "ai-proxy": {
+                            "provider": "openai",
+                            "auth": {
+                                "header": {
+                                    "Authorization": "Bearer token"
+                                }
+                            },
+                            "options": {
+                                "model": "gpt-35-turbo-instruct",
+                                "max_tokens": 512,
+                                "temperature": 1.0,
+                                "stream": true
+                            },
+                            "override": {
+                                "endpoint": "http://localhost:6725"
+                            },
+                            "ssl_verify": false
+                        }
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 2: test SSE event split across chunks
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require("resty.http")
+            local httpc = http.new()
+            local core = require("apisix.core")
+
+            local ok, err = httpc:connect({
+                scheme = "http",
+                host = "localhost",
+                port = ngx.var.server_port,
+            })
+
+            if not ok then
+                ngx.status = 500
+                ngx.say(err)
+                return
+            end
+
+            local params = {
+                method = "POST",
+                headers = {
+                    ["Content-Type"] = "application/json",
+                    ["test-type"] = "split_event",
+                },
+                path = "/anything",
+                body = [[{
+                    "messages": [
+                        { "role": "system", "content": "some content" }
+                    ]
+                }]],
+            }
+
+            local res, err = httpc:request(params)
+            if not res then
+                ngx.status = 500
+                ngx.say(err)
+                return
+            end
+
+            local final_res = {}
+            while true do
+                local chunk, err = res.body_reader()
+                if err then
+                    core.log.error("failed to read response chunk: ", err)
+                    break
+                end
+                if not chunk then
+                    break
+                end
+                core.table.insert_tail(final_res, chunk)
+            end
+
+            local full_response = table.concat(final_res, "")
+            if string.find(full_response, "He") and string.find(full_response, "llo") and string.find(full_response, "World") and string.find(full_response, "DONE") then
+                ngx.say("SSE split event handled correctly")
+            else
+                ngx.say("Failed to handle SSE split event: ", full_response)
+            end
+        }
+    }
+--- response_body
+SSE split event handled correctly
+
+
+
+=== TEST 3: test SSE multiple events split across chunks
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require("resty.http")
+            local httpc = http.new()
+            local core = require("apisix.core")
+
+            local ok, err = httpc:connect({
+                scheme = "http",
+                host = "localhost",
+                port = ngx.var.server_port,
+            })
+
+            if not ok then
+                ngx.status = 500
+                ngx.say(err)
+                return
+            end
+
+            local params = {
+                method = "POST",
+                headers = {
+                    ["Content-Type"] = "application/json",
+                    ["test-type"] = "split_event_multiline",
+                },
+                path = "/anything",
+                body = [[{
+                    "messages": [
+                        { "role": "system", "content": "some content" }
+                    ]
+                }]],
+            }
+
+            local res, err = httpc:request(params)
+            if not res then
+                ngx.status = 500
+                ngx.say(err)
+                return
+            end
+
+            local final_res = {}
+            while true do
+                local chunk, err = res.body_reader()
+                if err then
+                    core.log.error("failed to read response chunk: ", err)
+                    break
+                end
+                if not chunk then
+                    break
+                end
+                core.table.insert_tail(final_res, chunk)
+            end
+
+            local full_response = table.concat(final_res, "")
+            if string.find(full_response, "First") and string.find(full_response, "line") and string.find(full_response, "Second") then
+                ngx.say("SSE multiline events handled correctly")
+            else
+                ngx.say("Failed to handle SSE multiline events: ", full_response)
+            end
+        }
+    }
+--- response_body
+SSE multiline events handled correctly
+
+
+
+=== TEST 4: test SSE event split in middle of data field
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require("resty.http")
+            local httpc = http.new()
+            local core = require("apisix.core")
+
+            local ok, err = httpc:connect({
+                scheme = "http",
+                host = "localhost",
+                port = ngx.var.server_port,
+            })
+
+            if not ok then
+                ngx.status = 500
+                ngx.say(err)
+                return
+            end
+
+            local params = {
+                method = "POST",
+                headers = {
+                    ["Content-Type"] = "application/json",
+                    ["test-type"] = "split_across_chunks",
+                },
+                path = "/anything",
+                body = [[{
+                    "messages": [
+                        { "role": "system", "content": "some content" }
+                    ]
+                }]],
+            }
+
+            local res, err = httpc:request(params)
+            if not res then
+                ngx.status = 500
+                ngx.say(err)
+                return
+            end
+
+            local final_res = {}
+            while true do
+                local chunk, err = res.body_reader()
+                if err then
+                    core.log.error("failed to read response chunk: ", err)
+                    break
+                end
+                if not chunk then
+                    break
+                end
+                core.table.insert_tail(final_res, chunk)
+            end
+
+            local full_response = table.concat(final_res, "")
+            if string.find(full_response, "A") and string.find(full_response, "B") and string.find(full_response, "C") and string.find(full_response, "D") and string.find(full_response, "DONE") then
+                ngx.say("SSE event split in data field handled correctly")
+            else
+                ngx.say("Failed to handle SSE event split in data field: ", full_response)
+            end
+        }
+    }
+--- response_body
+SSE event split in data field handled correctly

--- a/t/plugin/ai-proxy-sse-split.t
+++ b/t/plugin/ai-proxy-sse-split.t
@@ -58,23 +58,18 @@ add_block_preprocessor(sub {
                     ngx.header["Content-Type"] = "text/event-stream"
 
                     local test_type = ngx.req.get_headers()["test-type"]
-                    
+
                     if test_type == "split_event" then
                         ngx.say([[data: {"choices":[{"delta":{"content":"He]])
                         ngx.flush(true)
                         ngx.sleep(0.01)
-                        ngx.say([[llo"},"index":0}]}
-]])
+                        ngx.say([[llo"},"index":0}]}\n\n]])
                         ngx.flush(true)
                         ngx.sleep(0.01)
-                        ngx.say([[data: {"choices":[{"delta":{"content":" World"},"index":0}]}
-
-]])
+                        ngx.say([[data: {"choices":[{"delta":{"content":" World"},"index":0}]}]])
                         ngx.flush(true)
                         ngx.sleep(0.01)
-                        ngx.say([[data: [DONE]
-
-]])
+                        ngx.say([[data: [DONE]\n\n]])
                         return
                     end
 
@@ -85,16 +80,10 @@ add_block_preprocessor(sub {
                         ngx.say([[ line]])
                         ngx.flush(true)
                         ngx.sleep(0.01)
-                        ngx.say([["},"index":0}]}
-
-data: {"choices":[{"delta":{"content":"Second"},"index":0}]}
-
-]])
+                        ngx.say([["},"index":0}]}\n\ndata: {"choices":[{"delta":{"content":"Second"},"index":0}]}\n\n]])
                         ngx.flush(true)
                         ngx.sleep(0.01)
-                        ngx.say([[data: [DONE]
-
-]])
+                        ngx.say([[data: [DONE]\n\n]])
                         return
                     end
 
@@ -105,30 +94,20 @@ data: {"choices":[{"delta":{"content":"Second"},"index":0}]}
                         ngx.say([[B]])
                         ngx.flush(true)
                         ngx.sleep(0.01)
-                        ngx.say([[C"},"index":0}]}
-
-data: {"choices]])
+                        ngx.say([[C"},"index":0}]}\n\ndata: {"choices]])
                         ngx.flush(true)
                         ngx.sleep(0.01)
-                        ngx.say([[:[{"delta":{"content":"D"},"index":0}]}
-
-]])
+                        ngx.say([[:[{"delta":{"content":"D"},"index":0}]}\n\n]])
                         ngx.flush(true)
                         ngx.sleep(0.01)
-                        ngx.say([[data: [DONE]
-
-]])
+                        ngx.say([[data: [DONE]\n\n]])
                         return
                     end
 
-                    ngx.say([[data: {"choices":[{"delta":{"content":"Hello"},"index":0}]}
-
-]])
+                    ngx.say([[data: {"choices":[{"delta":{"content":"Hello"},"index":0}]}\n\n]])
                     ngx.flush(true)
                     ngx.sleep(0.01)
-                    ngx.say([[data: [DONE]
-
-]])
+                    ngx.say([[data: [DONE]\n\n]])
                 }
             }
         }


### PR DESCRIPTION


## Problem
The original SSE parser used `ngx.re.split("\n\n")`, which failed when events were fragmented across HTTP chunks. This caused data parse fail（but will not lead client got wrong data）.
fix: https://github.com/apache/apisix/issues/12733

## Solution
- **State Machine Parser:** Replaced split logic with a character-by-character state machine.
  - event_start_index: Start of current SSE event
  - line_start_index: Start of current line within event
  - value_start_index: Start of value after : separator
- **Buffer Management:** Preserves incomplete events between chunks to ensure correct reassembly.
- **Spec Compliant:** Properly handles multi-line `data:` fields and `[DONE]` markers.

## Testing
- Added `t/plugin/ai-proxy-sse-split.t` with 3 scenarios:
  - Single event split across chunks
  - Multi-line `data` fields
  - JSON fragmentation within events

## Changes
- `apisix/plugins/ai-drivers/sse.lua`: New parser logic
- `apisix/plugins/ai-drivers/openai-base.lua`: Buffer state propagation
- `t/plugin/ai-proxy-sse-split.t`: New test suite

## Compatibility
✅ Fully backward compatible. Buffer parameter is optional.