### PR TITLE
feat: add langfuse plugin for LLM observability

### DIFF
--- a/apisix/plugins/langfuse.lua
+++ b/apisix/plugins/langfuse.lua
@@ -81,7 +81,7 @@ local schema = {
 
 local _M = {
     version = 0.1,
-    priority = 398,
+    priority = 396,
     name = plugin_name,
     schema = batch_processor_manager:wrap_schema(schema),
     metadata_schema = metadata_schema,
@@ -304,7 +304,7 @@ local function create_langfuse_batch(conf, ctx, req_body, resp_body)
 
     -- Use pre-generated IDs from rewrite phase, fall back to new ones
     if not trace_id then
-        trace_id = ctx.langfuse_trace_id or uuid.generate_v4()
+        trace_id = ctx.langfuse_trace_id or uuid.generate_v4():gsub("-", "")
     end
 
     local generation_id = ctx.langfuse_generation_id or uuid.generate_v4()
@@ -589,9 +589,15 @@ function _M.rewrite(conf, ctx)
     if not trace_id then
         local request_id = core.request.header(ctx, "X-Request-Id")
         if request_id then
-            trace_id = request_id
+            -- W3C traceparent requires trace_id to be 32 lowercase hex chars.
+            -- X-Request-Id is typically a UUID (36 chars with hyphens),
+            -- so strip hyphens to produce a valid 32-char hex trace_id.
+            trace_id = request_id:gsub("-", ""):lower()
+            if #trace_id ~= 32 or not trace_id:match("^%x+$") then
+                trace_id = uuid.generate_v4():gsub("-", "")
+            end
         else
-            trace_id = uuid.generate_v4()
+            trace_id = uuid.generate_v4():gsub("-", "")
         end
     end
 

--- a/apisix/plugins/langfuse.lua
+++ b/apisix/plugins/langfuse.lua
@@ -1,0 +1,660 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+local bp_manager_mod  = require("apisix.utils.batch-processor-manager")
+local core            = require("apisix.core")
+local http            = require("resty.http")
+local url             = require("net.url")
+local uuid            = require("resty.jit-uuid")
+local ngx             = ngx
+local ngx_now         = ngx.now
+local ngx_encode_base64 = ngx.encode_base64
+local ipairs          = ipairs
+local pairs           = pairs
+local type            = type
+local math            = math
+local pcall           = pcall
+local tonumber        = tonumber
+local next            = next
+local tostring        = tostring
+local string          = string
+local os              = os
+
+local plugin_name = "langfuse"
+local batch_processor_manager = bp_manager_mod.new("langfuse logger")
+
+local schema = {
+    type = "object",
+    properties = {
+        langfuse_host = {
+            type = "string",
+            default = "https://cloud.langfuse.com",
+        },
+        langfuse_public_key = {type = "string"},
+        langfuse_secret_key = {type = "string"},
+        ssl_verify = {type = "boolean", default = true},
+        timeout = {type = "integer", minimum = 1, default = 3},
+        detect_ai_requests = {
+            type = "boolean",
+            default = true,
+            description = "Only trace AI API requests"
+        },
+        ai_endpoints = {
+            type = "array",
+            items = {type = "string"},
+            default = {
+                "/v1/chat/completions", "/v1/completions", "/generate",
+                "/v1/responses", "/v1/embeddings",
+                "/chat/completions", "/responses", "/embeddings",
+                "/v1/messages",
+            },
+            description = "AI endpoint patterns to detect"
+        },
+        include_metadata = {
+            type = "boolean",
+            default = true,
+            description = "Include request metadata (headers, route info)"
+        },
+    },
+    required = {"langfuse_public_key", "langfuse_secret_key"},
+    encrypt_fields = {"langfuse_secret_key"},
+}
+
+
+local _M = {
+    version = 0.1,
+    priority = 398,
+    name = plugin_name,
+    schema = batch_processor_manager:wrap_schema(schema),
+}
+
+
+function _M.check_schema(conf)
+    core.utils.check_tls_bool({"ssl_verify"}, conf, plugin_name)
+
+    return core.schema.check(schema, conf)
+end
+
+
+-- Inline response parser functions
+
+local function extract_content(resp_body)
+    if type(resp_body) ~= "table" then
+        return nil
+    end
+    local choices = resp_body.choices
+    if type(choices) == "table" and #choices > 0 then
+        local first = choices[1]
+        if type(first) == "table" and type(first.message) == "table" then
+            return first.message.content
+        end
+    end
+    return nil
+end
+
+
+local function extract_usage(resp_body)
+    if type(resp_body) ~= "table" then
+        return nil
+    end
+    local usage = resp_body.usage
+    if type(usage) ~= "table" then
+        return nil
+    end
+    return {
+        prompt_tokens = usage.prompt_tokens or 0,
+        completion_tokens = usage.completion_tokens or 0,
+        total_tokens = usage.total_tokens
+            or ((usage.prompt_tokens or 0) + (usage.completion_tokens or 0)),
+    }
+end
+
+
+local function extract_model(resp_body)
+    if type(resp_body) == "table" then
+        return resp_body.model
+    end
+    return nil
+end
+
+
+local function extract_finish_reason(resp_body)
+    if type(resp_body) ~= "table" then
+        return nil
+    end
+    local choices = resp_body.choices
+    if type(choices) == "table" and #choices > 0 then
+        local first = choices[1]
+        if type(first) == "table" then
+            return first.finish_reason
+        end
+    end
+    return nil
+end
+
+
+local function extract_input(req_body)
+    if type(req_body) ~= "table" then
+        return req_body
+    end
+    return req_body.messages or req_body.prompt or req_body.input or req_body
+end
+
+
+-- Helper functions
+
+local function is_ai_request(conf, ctx)
+    if not conf.detect_ai_requests then
+        return true
+    end
+
+    local uri = ctx.var.uri
+    for _, endpoint in ipairs(conf.ai_endpoints) do
+        if core.string.has_suffix(uri, endpoint) then
+            return true
+        end
+    end
+
+    return false
+end
+
+
+local function is_embedding_request(uri)
+    return core.string.has_suffix(uri, "/embeddings")
+end
+
+
+local function get_iso8601_timestamp(time)
+    time = time or ngx_now()
+    local seconds = math.floor(time)
+    local milliseconds = math.floor((time - seconds) * 1000)
+    return string.format("%s.%03dZ", os.date("!%Y-%m-%dT%H:%M:%S", seconds), milliseconds)
+end
+
+
+-- W3C traceparent format: 00-{trace_id}-{span_id}-{flags}
+local function parse_traceparent(traceparent)
+    if not traceparent then
+        return nil, nil
+    end
+
+    local version, trace_id, parent_span_id =
+        traceparent:match("^(%x%x)%-(%x+)%-(%x+)%-%x%x$")
+
+    if version == "00" and trace_id and parent_span_id then
+        return trace_id, parent_span_id
+    end
+
+    return nil, nil
+end
+
+
+local function generate_traceparent(trace_id, span_id)
+    return string.format("00-%s-%s-01", trace_id, span_id)
+end
+
+
+local function get_generation_level(status)
+    if status and status >= 400 then
+        return "ERROR"
+    end
+    return "DEFAULT"
+end
+
+
+-- Token usage priority: ctx.ai_token_usage > ctx.var > resp_body.usage
+local function extract_token_usage(ctx, resp_body)
+    if ctx.ai_token_usage then
+        local usage = ctx.ai_token_usage
+        local raw_usage = ctx.llm_raw_usage or {}
+        return {
+            prompt_tokens = usage.prompt_tokens,
+            completion_tokens = usage.completion_tokens,
+            total_tokens = usage.total_tokens or
+                ((usage.prompt_tokens or 0) + (usage.completion_tokens or 0)),
+            cache_creation_input_tokens = raw_usage.cache_creation_input_tokens,
+            cache_read_input_tokens = raw_usage.cache_read_input_tokens,
+        }
+    end
+
+    local prompt_tokens = ctx.var and tonumber(ctx.var.llm_prompt_tokens)
+    local completion_tokens = ctx.var and tonumber(ctx.var.llm_completion_tokens)
+    if prompt_tokens or completion_tokens then
+        return {
+            prompt_tokens = prompt_tokens or 0,
+            completion_tokens = completion_tokens or 0,
+            total_tokens = (prompt_tokens or 0) + (completion_tokens or 0),
+        }
+    end
+
+    return extract_usage(resp_body)
+end
+
+
+-- Completion content priority: ctx.var.llm_response_text > resp_body
+local function extract_completion_content(ctx, resp_body)
+    if ctx.var and ctx.var.llm_response_text then
+        return ctx.var.llm_response_text
+    end
+    return extract_content(resp_body)
+end
+
+
+local function get_body_data(ctx)
+    local req_body = ctx.langfuse_req_body
+    local resp_body = ctx.langfuse_resp_body
+
+    if req_body then
+        local ok, req_json = pcall(core.json.decode, req_body)
+        if ok then
+            req_body = req_json
+        end
+    end
+
+    if resp_body then
+        local ok, resp_json = pcall(core.json.decode, resp_body)
+        if ok then
+            resp_body = resp_json
+        end
+    end
+
+    return req_body, resp_body
+end
+
+
+local function create_langfuse_batch(conf, ctx, req_body, resp_body)
+    local var = ctx.var
+    local start_time = ctx.langfuse_start_time or ngx_now()
+    local end_time = ngx_now()
+    local latency = math.floor((end_time - start_time) * 1000)
+    local status = ngx.status
+
+    local incoming_traceparent = core.request.header(ctx, "traceparent")
+    local trace_id, parent_span_id = parse_traceparent(incoming_traceparent)
+
+    -- Use pre-generated IDs from rewrite phase, fall back to new ones
+    if not trace_id then
+        trace_id = ctx.langfuse_trace_id or uuid.generate_v4()
+    end
+
+    local generation_id = ctx.langfuse_generation_id or uuid.generate_v4()
+    local timestamp = get_iso8601_timestamp()
+
+    local batch = {}
+
+    local is_streaming = var.request_type == "ai_stream"
+    local is_embedding = is_embedding_request(var.uri)
+
+    -- Model priority: ctx.var.llm_model > req_body.model > resp_body.model
+    local model = var.llm_model
+    if not model and type(req_body) == "table" then
+        model = req_body.model
+    end
+    if not model then
+        model = extract_model(resp_body)
+    end
+
+    local raw_ttft = var.llm_time_to_first_token
+    local time_to_first_token = (raw_ttft and raw_ttft ~= "" and raw_ttft ~= "0")
+        and tonumber(raw_ttft) or nil
+
+    local completion_start_time
+    if time_to_first_token then
+        local completion_start_epoch = start_time + (time_to_first_token / 1000)
+        completion_start_time = get_iso8601_timestamp(completion_start_epoch)
+    end
+
+    local trace_name, generation_name
+    if is_embedding then
+        trace_name = model or "embedding"
+        generation_name = model or "Embedding"
+    else
+        trace_name = model or (var.method .. " " .. var.uri)
+        generation_name = model or "LLM Generation"
+    end
+
+    local trace_output = is_embedding and nil or extract_completion_content(ctx, resp_body)
+
+    local trace_body = {
+        id = trace_id,
+        name = trace_name,
+        userId = core.request.header(ctx, "X-User-Id"),
+        sessionId = core.request.header(ctx, "X-Session-Id"),
+        model = model or "unknown",
+        timestamp = timestamp,
+        input = extract_input(req_body),
+        output = trace_output,
+        tags = {"apisix"},
+        metadata = {},
+        public = false,
+    }
+
+    -- Append additional tags from X-Langfuse-Tags header
+    local tags_header = core.request.header(ctx, "X-Langfuse-Tags")
+    if tags_header then
+        for tag in tags_header:gmatch("[^,]+") do
+            core.table.insert(trace_body.tags, tag:match("^%s*(.-)%s*$"))
+        end
+    end
+
+    -- Build comprehensive metadata
+    if conf.include_metadata then
+        trace_body.metadata = {
+            http_method = var.method,
+            http_uri = var.uri,
+            http_status = status,
+            latency_ms = latency,
+            streaming = is_streaming,
+            time_to_first_token_ms = time_to_first_token,
+            route_id = ctx.route_id,
+            route_name = ctx.route_name,
+            service_id = ctx.service_id,
+            service_name = ctx.service_name,
+            consumer = ctx.consumer and ctx.consumer.username,
+            user_agent = var.http_user_agent,
+            remote_addr = var.remote_addr,
+            provider = (ctx.picked_ai_instance and ctx.picked_ai_instance.provider)
+                       or (model and model:match("^([^%-/]+)")) or "unknown",
+        }
+
+        if incoming_traceparent then
+            trace_body.metadata.traceparent = incoming_traceparent
+            trace_body.metadata.parent_span_id = parent_span_id
+        end
+
+        -- Add custom metadata from header (JSON)
+        local custom_metadata = core.request.header(ctx, "X-Langfuse-Metadata")
+        if custom_metadata then
+            local ok, meta = pcall(core.json.decode, custom_metadata)
+            if ok and type(meta) == "table" then
+                for k, v in pairs(meta) do
+                    trace_body.metadata[k] = v
+                end
+            end
+        end
+    end
+
+    core.table.insert(batch, {
+        id = trace_id,
+        type = "trace-create",
+        timestamp = timestamp,
+        body = trace_body,
+    })
+
+    -- Generation output
+    local generation_output
+    if is_embedding then
+        generation_output = nil
+    elseif is_streaming and ctx.llm_stream_response then
+        generation_output = ctx.llm_stream_response
+    else
+        generation_output = resp_body
+    end
+
+    local generation_body = {
+        id = generation_id,
+        traceId = trace_id,
+        parentObservationId = parent_span_id,
+        name = generation_name,
+        startTime = get_iso8601_timestamp(start_time),
+        completionStartTime = completion_start_time,
+        endTime = get_iso8601_timestamp(end_time),
+        input = req_body,
+        output = generation_output,
+        level = get_generation_level(status),
+        statusMessage = status >= 400 and ("HTTP " .. status) or nil,
+        model = model,
+        metadata = {},
+    }
+
+    if type(req_body) == "table" then
+        local params = {}
+        if req_body.temperature then params.temperature = req_body.temperature end
+        if req_body.max_tokens then params.max_tokens = req_body.max_tokens end
+        if req_body.top_p then params.top_p = req_body.top_p end
+        if req_body.top_k then params.top_k = req_body.top_k end
+        if req_body.frequency_penalty then
+            params.frequency_penalty = req_body.frequency_penalty
+        end
+        if req_body.presence_penalty then
+            params.presence_penalty = req_body.presence_penalty
+        end
+        if req_body.stop then params.stop = req_body.stop end
+        if req_body.stream then params.stream = req_body.stream end
+        if req_body.seed then params.seed = req_body.seed end
+
+        if next(params) then
+            generation_body.modelParameters = params
+        end
+    end
+
+    local token_usage = extract_token_usage(ctx, resp_body)
+    if token_usage then
+        generation_body.usage = {
+            input = token_usage.prompt_tokens,
+            output = token_usage.completion_tokens,
+            total = token_usage.total_tokens,
+            unit = "TOKENS",
+        }
+
+        if token_usage.cache_creation_input_tokens
+            or token_usage.cache_read_input_tokens then
+            generation_body.usage.inputDetails = {
+                cache_creation = token_usage.cache_creation_input_tokens,
+                cache_read = token_usage.cache_read_input_tokens,
+            }
+        end
+
+        if token_usage.completion_tokens and latency > 0 then
+            generation_body.metadata.completion_tokens_per_second =
+                math.floor(token_usage.completion_tokens / (latency / 1000))
+        end
+    end
+
+    generation_body.metadata.latency_ms = latency
+    generation_body.metadata.streaming = is_streaming
+    generation_body.metadata.call_type = is_embedding and "embedding" or "completion"
+    if time_to_first_token then
+        generation_body.metadata.time_to_first_token_ms = time_to_first_token
+    end
+    if type(resp_body) == "table" then
+        generation_body.metadata.response_id = resp_body.id
+        generation_body.metadata.system_fingerprint = resp_body.system_fingerprint
+        generation_body.metadata.finish_reason = extract_finish_reason(resp_body)
+    end
+
+    core.table.insert(batch, {
+        id = generation_id,
+        type = "generation-create",
+        timestamp = timestamp,
+        body = generation_body,
+    })
+
+    return batch
+end
+
+
+local function send_langfuse_data(conf, log_message)
+    local ingestion_url = conf.langfuse_host .. "/api/public/ingestion"
+    local url_decoded = url.parse(ingestion_url)
+    local host = url_decoded.host
+    local port = url_decoded.port
+
+    core.log.info("sending langfuse batch to ", ingestion_url)
+
+    if ((not port) and url_decoded.scheme == "https") then
+        port = 443
+    elseif not port then
+        port = 80
+    end
+
+    local httpc = http.new()
+    httpc:set_timeout(conf.timeout * 1000)
+    local ok, err = httpc:connect(host, port)
+
+    if not ok then
+        return false, "failed to connect to host[" .. host .. "] port["
+            .. tostring(port) .. "] " .. err
+    end
+
+    if url_decoded.scheme == "https" then
+        ok, err = httpc:ssl_handshake(true, host, conf.ssl_verify)
+        if not ok then
+            return false, "failed to perform SSL with host[" .. host .. "] "
+                .. "port[" .. tostring(port) .. "] " .. err
+        end
+    end
+
+    local auth = "Basic " .. ngx_encode_base64(
+        conf.langfuse_public_key .. ":" .. conf.langfuse_secret_key)
+
+    local httpc_res, httpc_err = httpc:request({
+        method = "POST",
+        path = url_decoded.path,
+        body = log_message,
+        headers = {
+            ["Host"] = host,
+            ["Content-Type"] = "application/json",
+            ["Authorization"] = auth,
+        }
+    })
+
+    if not httpc_res then
+        return false, "error while sending data to [" .. host .. "] port["
+            .. tostring(port) .. "] " .. httpc_err
+    end
+
+    if httpc_res.status >= 400 then
+        local resp_body = httpc_res:read_body()
+        return false, "server returned status code[" .. httpc_res.status .. "] host["
+            .. host .. "] port[" .. tostring(port) .. "] "
+            .. "body[" .. (resp_body or "") .. "]"
+    end
+
+    -- Read body and return connection to keepalive pool
+    httpc_res:read_body()
+    httpc:set_keepalive()
+
+    return true
+end
+
+
+function _M.rewrite(conf, ctx)
+    if not is_ai_request(conf, ctx) then
+        return
+    end
+
+    ctx.langfuse_start_time = ngx_now()
+
+    -- Pre-generate trace_id and generation_id for header_filter
+    local incoming_traceparent = core.request.header(ctx, "traceparent")
+    local trace_id = parse_traceparent(incoming_traceparent)
+
+    if not trace_id then
+        local request_id = core.request.header(ctx, "X-Request-Id")
+        if request_id then
+            trace_id = request_id
+        else
+            trace_id = uuid.generate_v4()
+        end
+    end
+
+    local generation_id = uuid.generate_v4()
+    ctx.langfuse_trace_id = trace_id
+    ctx.langfuse_generation_id = generation_id
+    ctx.langfuse_traceparent = generate_traceparent(trace_id, generation_id)
+
+    local req_body = core.request.get_body()
+    if req_body then
+        ctx.langfuse_req_body = req_body
+    end
+end
+
+
+function _M.header_filter(conf, ctx)
+    if ctx.langfuse_traceparent then
+        core.response.set_header("traceparent", ctx.langfuse_traceparent)
+    end
+end
+
+
+function _M.body_filter(conf, ctx)
+    if not ctx.langfuse_start_time then
+        return
+    end
+
+    local chunk = ngx.arg[1]
+    if chunk and chunk ~= "" then
+        local chunks = ngx.ctx.langfuse_resp_chunks
+        if not chunks then
+            chunks = {}
+            ngx.ctx.langfuse_resp_chunks = chunks
+        end
+        core.table.insert(chunks, chunk)
+    end
+
+    if ngx.arg[2] then  -- eof
+        local chunks = ngx.ctx.langfuse_resp_chunks
+        if chunks then
+            ctx.langfuse_resp_body = core.table.concat(chunks, "")
+        end
+    end
+end
+
+
+function _M.log(conf, ctx)
+    if not is_ai_request(conf, ctx) then
+        return
+    end
+
+    local req_body, resp_body = get_body_data(ctx)
+
+    local batch = create_langfuse_batch(conf, ctx, req_body, resp_body)
+
+    if batch_processor_manager:add_entry(conf, batch) then
+        return
+    end
+
+    local func = function(entries, batch_max_size)
+        -- entries is [[trace, gen], [trace, gen], ...]
+        -- Flatten into a single batch array
+        local flat_batch = {}
+        for _, entry in ipairs(entries) do
+            if type(entry) == "table" and entry.type then
+                -- single batch item
+                core.table.insert(flat_batch, entry)
+            else
+                -- array of batch items
+                for _, item in ipairs(entry) do
+                    core.table.insert(flat_batch, item)
+                end
+            end
+        end
+
+        local data, err = core.json.encode({batch = flat_batch})
+        if not data then
+            return false, "error occurred while encoding the data: " .. err
+        end
+
+        return send_langfuse_data(conf, data)
+    end
+
+    batch_processor_manager:add_entry_to_new_processor(conf, batch, ctx, func)
+end
+
+
+return _M

--- a/apisix/plugins/langfuse.lua
+++ b/apisix/plugins/langfuse.lua
@@ -58,10 +58,8 @@ local metadata_schema = {
             type = "array",
             items = {type = "string"},
             default = {
-                "/v1/chat/completions", "/v1/completions", "/generate",
-                "/v1/responses", "/v1/embeddings",
-                "/chat/completions", "/responses", "/embeddings",
-                "/v1/messages",
+                "/chat/completions", "/completions", "/generate",
+                "/responses", "/embeddings", "/messages",
             },
             description = "AI endpoint patterns to detect"
         },

--- a/apisix/plugins/langfuse.lua
+++ b/apisix/plugins/langfuse.lua
@@ -16,6 +16,7 @@
 --
 
 local bp_manager_mod  = require("apisix.utils.batch-processor-manager")
+local plugin_mod      = require("apisix.plugin")
 local core            = require("apisix.core")
 local http            = require("resty.http")
 local url             = require("net.url")
@@ -37,7 +38,7 @@ local os              = os
 local plugin_name = "langfuse"
 local batch_processor_manager = bp_manager_mod.new("langfuse logger")
 
-local schema = {
+local metadata_schema = {
     type = "object",
     properties = {
         langfuse_host = {
@@ -64,14 +65,19 @@ local schema = {
             },
             description = "AI endpoint patterns to detect"
         },
+    },
+    required = {"langfuse_public_key", "langfuse_secret_key"},
+}
+
+local schema = {
+    type = "object",
+    properties = {
         include_metadata = {
             type = "boolean",
             default = true,
             description = "Include request metadata (headers, route info)"
         },
     },
-    required = {"langfuse_public_key", "langfuse_secret_key"},
-    encrypt_fields = {"langfuse_secret_key"},
 }
 
 
@@ -80,13 +86,24 @@ local _M = {
     priority = 398,
     name = plugin_name,
     schema = batch_processor_manager:wrap_schema(schema),
+    metadata_schema = metadata_schema,
 }
 
 
-function _M.check_schema(conf)
-    core.utils.check_tls_bool({"ssl_verify"}, conf, plugin_name)
-
+function _M.check_schema(conf, schema_type)
+    if schema_type == core.schema.TYPE_METADATA then
+        return core.schema.check(metadata_schema, conf)
+    end
     return core.schema.check(schema, conf)
+end
+
+
+local function get_plugin_attr()
+    local metadata = plugin_mod.plugin_metadata(plugin_name)
+    if not metadata then
+        return nil
+    end
+    return metadata.value
 end
 
 
@@ -157,13 +174,14 @@ end
 
 -- Helper functions
 
-local function is_ai_request(conf, ctx)
-    if not conf.detect_ai_requests then
+local function is_ai_request(plugin_attr, ctx)
+    if not plugin_attr.detect_ai_requests then
         return true
     end
 
     local uri = ctx.var.uri
-    for _, endpoint in ipairs(conf.ai_endpoints) do
+    local ai_endpoints = plugin_attr.ai_endpoints or {}
+    for _, endpoint in ipairs(ai_endpoints) do
         if core.string.has_suffix(uri, endpoint) then
             return true
         end
@@ -488,8 +506,8 @@ local function create_langfuse_batch(conf, ctx, req_body, resp_body)
 end
 
 
-local function send_langfuse_data(conf, log_message)
-    local ingestion_url = conf.langfuse_host .. "/api/public/ingestion"
+local function send_langfuse_data(plugin_attr, log_message)
+    local ingestion_url = plugin_attr.langfuse_host .. "/api/public/ingestion"
     local url_decoded = url.parse(ingestion_url)
     local host = url_decoded.host
     local port = url_decoded.port
@@ -503,7 +521,7 @@ local function send_langfuse_data(conf, log_message)
     end
 
     local httpc = http.new()
-    httpc:set_timeout(conf.timeout * 1000)
+    httpc:set_timeout(plugin_attr.timeout * 1000)
     local ok, err = httpc:connect(host, port)
 
     if not ok then
@@ -512,7 +530,7 @@ local function send_langfuse_data(conf, log_message)
     end
 
     if url_decoded.scheme == "https" then
-        ok, err = httpc:ssl_handshake(true, host, conf.ssl_verify)
+        ok, err = httpc:ssl_handshake(true, host, plugin_attr.ssl_verify)
         if not ok then
             return false, "failed to perform SSL with host[" .. host .. "] "
                 .. "port[" .. tostring(port) .. "] " .. err
@@ -520,7 +538,7 @@ local function send_langfuse_data(conf, log_message)
     end
 
     local auth = "Basic " .. ngx_encode_base64(
-        conf.langfuse_public_key .. ":" .. conf.langfuse_secret_key)
+        plugin_attr.langfuse_public_key .. ":" .. plugin_attr.langfuse_secret_key)
 
     local httpc_res, httpc_err = httpc:request({
         method = "POST",
@@ -554,7 +572,13 @@ end
 
 
 function _M.rewrite(conf, ctx)
-    if not is_ai_request(conf, ctx) then
+    local plugin_attr = get_plugin_attr()
+    if not plugin_attr then
+        core.log.warn("langfuse: plugin_metadata is required, skipping")
+        return
+    end
+
+    if not is_ai_request(plugin_attr, ctx) then
         return
     end
 
@@ -617,7 +641,12 @@ end
 
 
 function _M.log(conf, ctx)
-    if not is_ai_request(conf, ctx) then
+    local plugin_attr = get_plugin_attr()
+    if not plugin_attr then
+        return
+    end
+
+    if not is_ai_request(plugin_attr, ctx) then
         return
     end
 
@@ -650,7 +679,7 @@ function _M.log(conf, ctx)
             return false, "error occurred while encoding the data: " .. err
         end
 
-        return send_langfuse_data(conf, data)
+        return send_langfuse_data(plugin_attr, data)
     end
 
     batch_processor_manager:add_entry_to_new_processor(conf, batch, ctx, func)

--- a/apisix/plugins/langfuse.lua
+++ b/apisix/plugins/langfuse.lua
@@ -65,6 +65,7 @@ local metadata_schema = {
         },
     },
     required = {"langfuse_public_key", "langfuse_secret_key"},
+    encrypt_fields = {"langfuse_secret_key"},
 }
 
 local schema = {
@@ -92,7 +93,7 @@ function _M.check_schema(conf, schema_type)
     if schema_type == core.schema.TYPE_METADATA then
         return core.schema.check(metadata_schema, conf)
     end
-    return core.schema.check(schema, conf)
+    return core.schema.check(_M.schema, conf)
 end
 
 

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -560,8 +560,8 @@ plugins:                           # plugin list (sorted by priority)
   - udp-logger                     # priority: 400
   - file-logger                    # priority: 399
   - clickhouse-logger              # priority: 398
-  - langfuse                       # priority: 396
   - tencent-cloud-cls              # priority: 397
+  - langfuse                       # priority: 396
   - inspect                        # priority: 200
   #- log-rotate                    # priority: 100
   # <- recommend to use priority (0, 100) for your custom plugins

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -607,6 +607,13 @@ plugin_attr:          # Plugin attributes
     service_instance_name: APISIX Instance Name   # Set the service instance name for SkyWalking reporter.
     endpoint_addr: http://127.0.0.1:12800         # Set the SkyWalking HTTP endpoint.
     report_interval: 3                            # Set the reporting interval in second.
+  # langfuse:                                        # Plugin: langfuse
+  #   langfuse_host: https://cloud.langfuse.com      # Set the Langfuse server host.
+  #   langfuse_public_key: ""                         # Set the Langfuse public key.
+  #   langfuse_secret_key: ""                         # Set the Langfuse secret key.
+  #   ssl_verify: true                                # Verify SSL certificate.
+  #   timeout: 3                                      # Set the timeout for requests to Langfuse in seconds.
+  #   detect_ai_requests: true                        # Only trace AI API requests.
   opentelemetry:      # Plugin: opentelemetry
     trace_id_source: x-request-id   # Specify the source of the trace ID for OpenTelemetry traces.
     resource:

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -559,6 +559,7 @@ plugins:                           # plugin list (sorted by priority)
   - syslog                         # priority: 401
   - udp-logger                     # priority: 400
   - file-logger                    # priority: 399
+  - langfuse                       # priority: 398
   - clickhouse-logger              # priority: 398
   - tencent-cloud-cls              # priority: 397
   - inspect                        # priority: 200

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -559,8 +559,8 @@ plugins:                           # plugin list (sorted by priority)
   - syslog                         # priority: 401
   - udp-logger                     # priority: 400
   - file-logger                    # priority: 399
-  - langfuse                       # priority: 398
   - clickhouse-logger              # priority: 398
+  - langfuse                       # priority: 396
   - tencent-cloud-cls              # priority: 397
   - inspect                        # priority: 200
   #- log-rotate                    # priority: 100

--- a/docs/en/latest/config.json
+++ b/docs/en/latest/config.json
@@ -215,7 +215,8 @@
                 "plugins/elasticsearch-logger",
                 "plugins/tencent-cloud-cls",
                 "plugins/loki-logger",
-                "plugins/lago"
+                "plugins/lago",
+                "plugins/langfuse"
               ]
             }
           ]

--- a/docs/en/latest/plugins/langfuse.md
+++ b/docs/en/latest/plugins/langfuse.md
@@ -1,0 +1,138 @@
+---
+title: langfuse
+keywords:
+  - Apache APISIX
+  - API Gateway
+  - Plugin
+  - Langfuse
+  - LLM Observability
+description: This document contains information about the Apache APISIX langfuse Plugin.
+---
+
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+## Description
+
+The `langfuse` Plugin enables LLM observability by sending traces of AI API requests to [Langfuse](https://langfuse.com/). It captures request/response data, token usage, model information, and latency for each LLM call, making it easy to monitor and debug AI-powered applications.
+
+## Plugin Metadata
+
+The global configuration shared across all routes is managed through plugin metadata. You can set it using the Admin API endpoint `apisix/admin/plugin_metadata/langfuse`.
+
+| Name | Type | Required | Default | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| langfuse_host | string | False | `https://cloud.langfuse.com` | Langfuse server host URL. |
+| langfuse_public_key | string | True | | Langfuse project public key. |
+| langfuse_secret_key | string | True | | Langfuse project secret key. |
+| ssl_verify | boolean | False | true | Whether to verify the Langfuse server's SSL certificate. |
+| timeout | integer | False | 3 | Timeout in seconds for requests sent to Langfuse. |
+| detect_ai_requests | boolean | False | true | When set to `true`, only traces requests whose path matches one of the patterns in `ai_endpoints`. |
+| ai_endpoints | array[string] | False | `["/chat/completions", "/completions", "/generate", "/responses", "/embeddings", "/messages"]` | List of path patterns used to detect AI API requests when `detect_ai_requests` is `true`. |
+
+## Attributes
+
+| Name | Type | Required | Default | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| include_metadata | boolean | False | true | When set to `true`, includes request metadata (headers, route info) in the Langfuse trace. |
+
+## Enable Plugin
+
+First, configure the plugin metadata with your Langfuse credentials:
+
+:::note
+You can fetch the `admin_key` from `config.yaml` and save to an environment variable with the following command:
+
+```bash
+admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
+```
+
+:::
+
+```bash
+curl http://127.0.0.1:9180/apisix/admin/plugin_metadata/langfuse \
+  -H "X-API-KEY: $admin_key" -X PUT -d '
+{
+    "langfuse_public_key": "pk-lf-...",
+    "langfuse_secret_key": "sk-lf-...",
+    "langfuse_host": "https://cloud.langfuse.com",
+    "detect_ai_requests": true
+}'
+```
+
+Then, enable the plugin on a Route:
+
+```bash
+curl http://127.0.0.1:9180/apisix/admin/routes/1 \
+  -H "X-API-KEY: $admin_key" -X PUT -d '
+{
+    "uri": "/v1/chat/completions",
+    "plugins": {
+        "langfuse": {
+            "include_metadata": true
+        },
+        "ai-proxy": {
+            "auth": {
+                "header": {
+                    "Authorization": "Bearer sk-..."
+                }
+            },
+            "model": {
+                "provider": "openai",
+                "name": "gpt-4o"
+            }
+        }
+    },
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "api.openai.com:443": 1
+        }
+    }
+}'
+```
+
+## Example usage
+
+After enabling the plugin and making an LLM request, you can view the traces in the Langfuse dashboard. Each request generates a trace with the following information:
+
+- **Input/Output**: The prompt messages and the model's response
+- **Token usage**: Prompt tokens, completion tokens, and total tokens
+- **Model**: The LLM model name used
+- **Latency**: Total request duration
+- **Metadata**: Route ID, service ID, request headers (when `include_metadata` is `true`)
+
+## Disable Plugin
+
+To remove the `langfuse` Plugin from a Route, delete the plugin configuration from the route:
+
+```bash
+curl http://127.0.0.1:9180/apisix/admin/routes/1 \
+  -H "X-API-KEY: $admin_key" -X PUT -d '
+{
+    "uri": "/v1/chat/completions",
+    "plugins": {},
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "api.openai.com:443": 1
+        }
+    }
+}'
+```

--- a/t/plugin/langfuse.t
+++ b/t/plugin/langfuse.t
@@ -1,0 +1,513 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+log_level('debug');
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+    if (!defined $block->http_config) {
+        my $http_config = <<_EOC_;
+    server {
+        listen 10421;
+
+        location /api/public/ingestion {
+            content_by_lua_block {
+                ngx.req.read_body()
+                local data = ngx.req.get_body_data()
+                local headers = ngx.req.get_headers()
+                ngx.log(ngx.WARN, "langfuse body: ", data)
+                ngx.log(ngx.WARN, "langfuse auth: ", headers["Authorization"] or "none")
+                ngx.say('{"successes":[],"errors":[]}')
+            }
+        }
+    }
+_EOC_
+        $block->set_value("http_config", $http_config);
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: schema validation - missing required fields
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.langfuse")
+            local ok, err = plugin.check_schema({})
+            if not ok then
+                ngx.say(err)
+            else
+                ngx.say("done")
+            end
+        }
+    }
+--- response_body eval
+qr/property "langfuse_public_key" is required/
+
+
+
+=== TEST 2: schema validation - valid minimal config
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.langfuse")
+            local ok, err = plugin.check_schema({
+                langfuse_public_key = "pk-lf-test",
+                langfuse_secret_key = "sk-lf-test",
+            })
+            if not ok then
+                ngx.say(err)
+            else
+                ngx.say("done")
+            end
+        }
+    }
+--- response_body
+done
+
+
+
+=== TEST 3: schema validation - full config
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.langfuse")
+            local ok, err = plugin.check_schema({
+                langfuse_host = "http://127.0.0.1:10421",
+                langfuse_public_key = "pk-lf-test",
+                langfuse_secret_key = "sk-lf-test",
+                ssl_verify = false,
+                timeout = 5,
+                detect_ai_requests = true,
+                include_metadata = true,
+                batch_max_size = 10,
+                max_retry_count = 3,
+                retry_delay = 1,
+                buffer_duration = 60,
+                inactive_timeout = 5,
+            })
+            if not ok then
+                ngx.say(err)
+            else
+                ngx.say("done")
+            end
+        }
+    }
+--- response_body
+done
+
+
+
+=== TEST 4: add route with langfuse plugin - AI endpoint
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "langfuse": {
+                                "langfuse_host": "http://127.0.0.1:10421",
+                                "langfuse_public_key": "pk-lf-test",
+                                "langfuse_secret_key": "sk-lf-test",
+                                "ssl_verify": false,
+                                "batch_max_size": 1,
+                                "inactive_timeout": 1,
+                                "detect_ai_requests": true
+                            },
+                            "mocking": {
+                                "content_type": "application/json",
+                                "response_status": 200,
+                                "response_example": "{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"Hello!\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}"
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/v1/chat/completions"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 5: AI request triggers langfuse batch with correct auth and data
+--- request
+POST /v1/chat/completions
+{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}
+--- more_headers
+Content-Type: application/json
+--- error_log
+Batch Processor[langfuse logger] successfully processed the entries
+langfuse body:
+langfuse auth: Basic cGstbGYtdGVzdDpzay1sZi10ZXN0
+--- wait: 3
+
+
+
+=== TEST 6: non-AI endpoint with detect_ai_requests=true should not trigger
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/2',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "langfuse": {
+                                "langfuse_host": "http://127.0.0.1:10421",
+                                "langfuse_public_key": "pk-lf-test",
+                                "langfuse_secret_key": "sk-lf-test",
+                                "ssl_verify": false,
+                                "batch_max_size": 1,
+                                "inactive_timeout": 1,
+                                "detect_ai_requests": true
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1982": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 7: access non-AI endpoint - no langfuse trace
+--- request
+GET /hello
+--- response_body
+hello world
+--- no_error_log
+Batch Processor[langfuse logger]
+--- wait: 1
+
+
+
+=== TEST 8: detect_ai_requests=false traces all requests
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/3',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "langfuse": {
+                                "langfuse_host": "http://127.0.0.1:10421",
+                                "langfuse_public_key": "pk-lf-test",
+                                "langfuse_secret_key": "sk-lf-test",
+                                "ssl_verify": false,
+                                "batch_max_size": 1,
+                                "inactive_timeout": 1,
+                                "detect_ai_requests": false
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1982": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/opentracing"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 9: non-AI endpoint with detect_ai_requests=false should trigger
+--- request
+GET /opentracing
+--- response_body
+opentracing
+--- error_log
+Batch Processor[langfuse logger] successfully processed the entries
+--- wait: 3
+
+
+
+=== TEST 10: traceparent header propagation setup
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "langfuse": {
+                                "langfuse_host": "http://127.0.0.1:10421",
+                                "langfuse_public_key": "pk-lf-test",
+                                "langfuse_secret_key": "sk-lf-test",
+                                "ssl_verify": false,
+                                "batch_max_size": 1,
+                                "inactive_timeout": 1
+                            },
+                            "mocking": {
+                                "content_type": "application/json",
+                                "response_status": 200,
+                                "response_example": "{\"id\":\"chatcmpl-123\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"Hi\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2,\"total_tokens\":7}}"
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/v1/chat/completions"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 11: request with traceparent returns traceparent in response
+--- request
+POST /v1/chat/completions
+{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}
+--- more_headers
+Content-Type: application/json
+traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
+--- response_headers_like
+traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-.+-01
+--- error_log
+Batch Processor[langfuse logger] successfully processed the entries
+--- wait: 3
+
+
+
+=== TEST 12: request without traceparent gets auto-generated traceparent
+--- request
+POST /v1/chat/completions
+{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}
+--- more_headers
+Content-Type: application/json
+--- response_headers_like
+traceparent: 00-.+-.+-01
+--- error_log
+Batch Processor[langfuse logger] successfully processed the entries
+--- wait: 3
+
+
+
+=== TEST 13: embedding endpoint detection
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/4',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "langfuse": {
+                                "langfuse_host": "http://127.0.0.1:10421",
+                                "langfuse_public_key": "pk-lf-test",
+                                "langfuse_secret_key": "sk-lf-test",
+                                "ssl_verify": false,
+                                "batch_max_size": 1,
+                                "inactive_timeout": 1
+                            },
+                            "mocking": {
+                                "content_type": "application/json",
+                                "response_status": 200,
+                                "response_example": "{\"object\":\"list\",\"model\":\"text-embedding-ada-002\",\"data\":[{\"object\":\"embedding\",\"embedding\":[0.1,0.2,0.3],\"index\":0}],\"usage\":{\"prompt_tokens\":5,\"total_tokens\":5}}"
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/v1/embeddings"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 14: embedding request triggers langfuse
+--- request
+POST /v1/embeddings
+{"model":"text-embedding-ada-002","input":"hello world"}
+--- more_headers
+Content-Type: application/json
+--- error_log
+Batch Processor[langfuse logger] successfully processed the entries
+--- wait: 3
+
+
+
+=== TEST 15: error response setup
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/5',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "langfuse": {
+                                "langfuse_host": "http://127.0.0.1:10421",
+                                "langfuse_public_key": "pk-lf-test",
+                                "langfuse_secret_key": "sk-lf-test",
+                                "ssl_verify": false,
+                                "batch_max_size": 1,
+                                "inactive_timeout": 1
+                            },
+                            "mocking": {
+                                "content_type": "application/json",
+                                "response_status": 429,
+                                "response_example": "{\"error\":{\"message\":\"Rate limit exceeded\",\"type\":\"rate_limit_error\"}}"
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/v1/completions"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 16: error response triggers langfuse with batch processing
+--- request
+POST /v1/completions
+{"model":"gpt-4","prompt":"hello"}
+--- more_headers
+Content-Type: application/json
+--- error_code: 429
+--- error_log
+Batch Processor[langfuse logger] successfully processed the entries
+--- wait: 3
+
+
+
+=== TEST 17: X-Langfuse-Tags header processing
+--- request
+POST /v1/chat/completions
+{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}
+--- more_headers
+Content-Type: application/json
+X-Langfuse-Tags: prod, gateway, test-tag
+--- error_log
+Batch Processor[langfuse logger] successfully processed the entries
+langfuse body:
+--- wait: 3
+
+
+
+=== TEST 18: X-Langfuse-Metadata header processing
+--- request
+POST /v1/chat/completions
+{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}
+--- more_headers
+Content-Type: application/json
+X-Langfuse-Metadata: {"environment":"staging","team":"backend"}
+--- error_log
+Batch Processor[langfuse logger] successfully processed the entries
+langfuse body:
+--- wait: 3
+
+
+
+=== TEST 19: cleanup routes
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            for i = 1, 5 do
+                t('/apisix/admin/routes/' .. i, ngx.HTTP_DELETE)
+            end
+            ngx.say("done")
+        }
+    }
+--- response_body
+done

--- a/t/plugin/langfuse.t
+++ b/t/plugin/langfuse.t
@@ -53,7 +53,7 @@ run_tests;
 
 __DATA__
 
-=== TEST 1: schema validation - missing required fields
+=== TEST 1: schema validation - per-route schema accepts empty config
 --- config
     location /t {
         content_by_lua_block {
@@ -66,19 +66,18 @@ __DATA__
             end
         }
     }
---- response_body eval
-qr/property "langfuse_public_key" is required/
+--- response_body
+done
 
 
 
-=== TEST 2: schema validation - valid minimal config
+=== TEST 2: schema validation - per-route schema with include_metadata
 --- config
     location /t {
         content_by_lua_block {
             local plugin = require("apisix.plugins.langfuse")
             local ok, err = plugin.check_schema({
-                langfuse_public_key = "pk-lf-test",
-                langfuse_secret_key = "sk-lf-test",
+                include_metadata = false,
             })
             if not ok then
                 ngx.say(err)
@@ -92,7 +91,25 @@ done
 
 
 
-=== TEST 3: schema validation - full config
+=== TEST 3: metadata schema validation - missing required fields
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.langfuse")
+            local ok, err = plugin.check_schema({}, core.schema.TYPE_METADATA)
+            if not ok then
+                ngx.say(err)
+            else
+                ngx.say("done")
+            end
+        }
+    }
+--- response_body eval
+qr/property "langfuse_public_key" is required/
+
+
+
+=== TEST 4: metadata schema validation - valid config
 --- config
     location /t {
         content_by_lua_block {
@@ -101,16 +118,7 @@ done
                 langfuse_host = "http://127.0.0.1:10421",
                 langfuse_public_key = "pk-lf-test",
                 langfuse_secret_key = "sk-lf-test",
-                ssl_verify = false,
-                timeout = 5,
-                detect_ai_requests = true,
-                include_metadata = true,
-                batch_max_size = 10,
-                max_retry_count = 3,
-                retry_delay = 1,
-                buffer_duration = 60,
-                inactive_timeout = 5,
-            })
+            }, core.schema.TYPE_METADATA)
             if not ok then
                 ngx.say(err)
             else
@@ -123,7 +131,32 @@ done
 
 
 
-=== TEST 4: add route with langfuse plugin - AI endpoint
+=== TEST 5: set plugin_metadata for langfuse
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/plugin_metadata/langfuse',
+                ngx.HTTP_PUT,
+                [[{
+                    "langfuse_host": "http://127.0.0.1:10421",
+                    "langfuse_public_key": "pk-lf-test",
+                    "langfuse_secret_key": "sk-lf-test"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 6: add route with langfuse plugin - AI endpoint
 --- config
     location /t {
         content_by_lua_block {
@@ -132,15 +165,7 @@ done
                  ngx.HTTP_PUT,
                  [[{
                         "plugins": {
-                            "langfuse": {
-                                "langfuse_host": "http://127.0.0.1:10421",
-                                "langfuse_public_key": "pk-lf-test",
-                                "langfuse_secret_key": "sk-lf-test",
-                                "ssl_verify": false,
-                                "batch_max_size": 1,
-                                "inactive_timeout": 1,
-                                "detect_ai_requests": true
-                            },
+                            "langfuse": {},
                             "mocking": {
                                 "content_type": "application/json",
                                 "response_status": 200,
@@ -168,7 +193,7 @@ passed
 
 
 
-=== TEST 5: AI request triggers langfuse batch with correct auth and data
+=== TEST 7: AI request triggers langfuse batch with correct auth
 --- request
 POST /v1/chat/completions
 {"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}
@@ -182,7 +207,7 @@ langfuse auth: Basic cGstbGYtdGVzdDpzay1sZi10ZXN0
 
 
 
-=== TEST 6: non-AI endpoint with detect_ai_requests=true should not trigger
+=== TEST 8: non-AI endpoint with detect_ai_requests=true (default) should not trigger
 --- config
     location /t {
         content_by_lua_block {
@@ -191,15 +216,7 @@ langfuse auth: Basic cGstbGYtdGVzdDpzay1sZi10ZXN0
                  ngx.HTTP_PUT,
                  [[{
                         "plugins": {
-                            "langfuse": {
-                                "langfuse_host": "http://127.0.0.1:10421",
-                                "langfuse_public_key": "pk-lf-test",
-                                "langfuse_secret_key": "sk-lf-test",
-                                "ssl_verify": false,
-                                "batch_max_size": 1,
-                                "inactive_timeout": 1,
-                                "detect_ai_requests": true
-                            }
+                            "langfuse": {}
                         },
                         "upstream": {
                             "nodes": {
@@ -222,7 +239,7 @@ passed
 
 
 
-=== TEST 7: access non-AI endpoint - no langfuse trace
+=== TEST 9: access non-AI endpoint - no langfuse trace
 --- request
 GET /hello
 --- response_body
@@ -233,7 +250,33 @@ Batch Processor[langfuse logger]
 
 
 
-=== TEST 8: detect_ai_requests=false traces all requests
+=== TEST 10: set plugin_metadata with detect_ai_requests=false
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/plugin_metadata/langfuse',
+                ngx.HTTP_PUT,
+                [[{
+                    "langfuse_host": "http://127.0.0.1:10421",
+                    "langfuse_public_key": "pk-lf-test",
+                    "langfuse_secret_key": "sk-lf-test",
+                    "detect_ai_requests": false
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 11: add route for non-AI endpoint with detect_ai_requests=false
 --- config
     location /t {
         content_by_lua_block {
@@ -242,15 +285,7 @@ Batch Processor[langfuse logger]
                  ngx.HTTP_PUT,
                  [[{
                         "plugins": {
-                            "langfuse": {
-                                "langfuse_host": "http://127.0.0.1:10421",
-                                "langfuse_public_key": "pk-lf-test",
-                                "langfuse_secret_key": "sk-lf-test",
-                                "ssl_verify": false,
-                                "batch_max_size": 1,
-                                "inactive_timeout": 1,
-                                "detect_ai_requests": false
-                            }
+                            "langfuse": {}
                         },
                         "upstream": {
                             "nodes": {
@@ -273,7 +308,7 @@ passed
 
 
 
-=== TEST 9: non-AI endpoint with detect_ai_requests=false should trigger
+=== TEST 12: non-AI endpoint with detect_ai_requests=false should trigger
 --- request
 GET /opentracing
 --- response_body
@@ -284,36 +319,18 @@ Batch Processor[langfuse logger] successfully processed the entries
 
 
 
-=== TEST 10: traceparent header propagation setup
+=== TEST 13: restore plugin_metadata with detect_ai_requests=true
 --- config
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/routes/1',
-                 ngx.HTTP_PUT,
-                 [[{
-                        "plugins": {
-                            "langfuse": {
-                                "langfuse_host": "http://127.0.0.1:10421",
-                                "langfuse_public_key": "pk-lf-test",
-                                "langfuse_secret_key": "sk-lf-test",
-                                "ssl_verify": false,
-                                "batch_max_size": 1,
-                                "inactive_timeout": 1
-                            },
-                            "mocking": {
-                                "content_type": "application/json",
-                                "response_status": 200,
-                                "response_example": "{\"id\":\"chatcmpl-123\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"Hi\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2,\"total_tokens\":7}}"
-                            }
-                        },
-                        "upstream": {
-                            "nodes": {
-                                "127.0.0.1:1980": 1
-                            },
-                            "type": "roundrobin"
-                        },
-                        "uri": "/v1/chat/completions"
+            local code, body = t('/apisix/admin/plugin_metadata/langfuse',
+                ngx.HTTP_PUT,
+                [[{
+                    "langfuse_host": "http://127.0.0.1:10421",
+                    "langfuse_public_key": "pk-lf-test",
+                    "langfuse_secret_key": "sk-lf-test",
+                    "detect_ai_requests": true
                 }]]
                 )
 
@@ -328,7 +345,7 @@ passed
 
 
 
-=== TEST 11: request with traceparent returns traceparent in response
+=== TEST 14: request with traceparent returns traceparent in response
 --- request
 POST /v1/chat/completions
 {"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}
@@ -343,7 +360,7 @@ Batch Processor[langfuse logger] successfully processed the entries
 
 
 
-=== TEST 12: request without traceparent gets auto-generated traceparent
+=== TEST 15: request without traceparent gets auto-generated traceparent
 --- request
 POST /v1/chat/completions
 {"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}
@@ -357,7 +374,7 @@ Batch Processor[langfuse logger] successfully processed the entries
 
 
 
-=== TEST 13: embedding endpoint detection
+=== TEST 16: embedding endpoint detection
 --- config
     location /t {
         content_by_lua_block {
@@ -366,14 +383,7 @@ Batch Processor[langfuse logger] successfully processed the entries
                  ngx.HTTP_PUT,
                  [[{
                         "plugins": {
-                            "langfuse": {
-                                "langfuse_host": "http://127.0.0.1:10421",
-                                "langfuse_public_key": "pk-lf-test",
-                                "langfuse_secret_key": "sk-lf-test",
-                                "ssl_verify": false,
-                                "batch_max_size": 1,
-                                "inactive_timeout": 1
-                            },
+                            "langfuse": {},
                             "mocking": {
                                 "content_type": "application/json",
                                 "response_status": 200,
@@ -401,7 +411,7 @@ passed
 
 
 
-=== TEST 14: embedding request triggers langfuse
+=== TEST 17: embedding request triggers langfuse
 --- request
 POST /v1/embeddings
 {"model":"text-embedding-ada-002","input":"hello world"}
@@ -413,7 +423,7 @@ Batch Processor[langfuse logger] successfully processed the entries
 
 
 
-=== TEST 15: error response setup
+=== TEST 18: error response setup
 --- config
     location /t {
         content_by_lua_block {
@@ -422,14 +432,7 @@ Batch Processor[langfuse logger] successfully processed the entries
                  ngx.HTTP_PUT,
                  [[{
                         "plugins": {
-                            "langfuse": {
-                                "langfuse_host": "http://127.0.0.1:10421",
-                                "langfuse_public_key": "pk-lf-test",
-                                "langfuse_secret_key": "sk-lf-test",
-                                "ssl_verify": false,
-                                "batch_max_size": 1,
-                                "inactive_timeout": 1
-                            },
+                            "langfuse": {},
                             "mocking": {
                                 "content_type": "application/json",
                                 "response_status": 429,
@@ -457,7 +460,7 @@ passed
 
 
 
-=== TEST 16: error response triggers langfuse with batch processing
+=== TEST 19: error response triggers langfuse
 --- request
 POST /v1/completions
 {"model":"gpt-4","prompt":"hello"}
@@ -470,7 +473,7 @@ Batch Processor[langfuse logger] successfully processed the entries
 
 
 
-=== TEST 17: X-Langfuse-Tags header processing
+=== TEST 20: X-Langfuse-Tags header processing
 --- request
 POST /v1/chat/completions
 {"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}
@@ -484,7 +487,7 @@ langfuse body:
 
 
 
-=== TEST 18: X-Langfuse-Metadata header processing
+=== TEST 21: X-Langfuse-Metadata header processing
 --- request
 POST /v1/chat/completions
 {"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}
@@ -498,14 +501,68 @@ langfuse body:
 
 
 
-=== TEST 19: cleanup routes
+=== TEST 22: without plugin_metadata, langfuse should skip
 --- config
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            for i = 1, 5 do
+            t('/apisix/admin/plugin_metadata/langfuse', ngx.HTTP_DELETE)
+
+            local code, body = t('/apisix/admin/routes/6',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "langfuse": {},
+                            "mocking": {
+                                "content_type": "application/json",
+                                "response_status": 200,
+                                "response_example": "{\"id\":\"chatcmpl-123\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"Hi\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2,\"total_tokens\":7}}"
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/v1/chat/no-metadata"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 23: request without plugin_metadata skips langfuse
+--- request
+POST /v1/chat/no-metadata
+{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}
+--- more_headers
+Content-Type: application/json
+--- error_log
+langfuse: plugin_metadata is required, skipping
+--- no_error_log
+Batch Processor[langfuse logger]
+--- wait: 1
+
+
+
+=== TEST 24: cleanup
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            for i = 1, 6 do
                 t('/apisix/admin/routes/' .. i, ngx.HTTP_DELETE)
             end
+            t('/apisix/admin/plugin_metadata/langfuse', ngx.HTTP_DELETE)
             ngx.say("done")
         }
     }

--- a/t/plugin/langfuse.t
+++ b/t/plugin/langfuse.t
@@ -95,6 +95,7 @@ done
 --- config
     location /t {
         content_by_lua_block {
+            local core = require("apisix.core")
             local plugin = require("apisix.plugins.langfuse")
             local ok, err = plugin.check_schema({}, core.schema.TYPE_METADATA)
             if not ok then
@@ -113,6 +114,7 @@ qr/property "langfuse_public_key" is required/
 --- config
     location /t {
         content_by_lua_block {
+            local core = require("apisix.core")
             local plugin = require("apisix.plugins.langfuse")
             local ok, err = plugin.check_schema({
                 langfuse_host = "http://127.0.0.1:10421",


### PR DESCRIPTION
### Description

Add a new `langfuse` plugin that sends LLM request traces to [Langfuse](https://langfuse.com) for AI observability. The plugin uses the batch-processor-manager pattern (same as http-logger) to send trace data via Langfuse's ingestion API.

Key features:
- Auto-detect AI endpoints via configurable URI suffix patterns
- Generate `trace-create` and `generation-create` batch items per request
- W3C `traceparent` header parsing and propagation for distributed tracing
- Token usage extraction with priority: `ctx.ai_token_usage` (ai-proxy) > nginx vars > response body parsing
- Support `X-Langfuse-Tags` and `X-Langfuse-Metadata` custom headers
- `encrypt_fields` for secret key protection in etcd
- Connection keepalive for Langfuse API calls

#### Which issue(s) this PR fixes:

Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)