### PR TITLE
fix(ai-prompt-template): fix malformed JSON error message

### DIFF
--- a/apisix/core/request.lua
+++ b/apisix/core/request.lua
@@ -343,7 +343,7 @@ function _M.get_json_request_body_table()
 
     local body_tab, err = json.decode(body)
     if not body_tab then
-        return nil, { message = "could not get parse JSON request body: " .. err }
+        return nil, { message = "could not parse JSON request body: " .. err }
     end
 
     return body_tab

--- a/apisix/plugins/ai-prompt-decorator.lua
+++ b/apisix/plugins/ai-prompt-decorator.lua
@@ -72,7 +72,7 @@ local function get_request_body_table()
 
     local body_tab, err = core.json.decode(body)
     if not body_tab then
-        return nil, { message = "could not get parse JSON request body: " .. err }
+        return nil, { message = "could not parse JSON request body: " .. err }
     end
 
     return body_tab

--- a/apisix/plugins/ai-prompt-template.lua
+++ b/apisix/plugins/ai-prompt-template.lua
@@ -98,7 +98,7 @@ local function get_request_body_table()
 
     local body_tab, err = core.json.decode(body)
     if not body_tab then
-        return nil, { message = "could not get parse JSON request body: ", err }
+        return nil, { message = "could not parse JSON request body: " .. err }
     end
 
     return body_tab

--- a/t/plugin/ai-proxy-multi.t
+++ b/t/plugin/ai-proxy-multi.t
@@ -345,7 +345,7 @@ GET /anything
 {}"messages": [ { "role": "system", "cont
 --- error_code: 400
 --- response_body
-{"message":"could not get parse JSON request body: Expected the end but found T_STRING at character 3"}
+{"message":"could not parse JSON request body: Expected the end but found T_STRING at character 3"}
 
 
 

--- a/t/plugin/ai-proxy.t
+++ b/t/plugin/ai-proxy.t
@@ -380,7 +380,7 @@ GET /anything
 {}"messages": [ { "role": "system", "cont
 --- error_code: 400
 --- response_body
-{"message":"could not get parse JSON request body: Expected the end but found T_STRING at character 3"}
+{"message":"could not parse JSON request body: Expected the end but found T_STRING at character 3"}
 
 
 


### PR DESCRIPTION
### Description

The error message in `get_request_body_table()` had two issues:

1. **Grammatical error**: `"could not get parse"` instead of `"could not parse"`
2. **String concatenation bug**: `err` was added as a separate table element (`{ message = "...: ", err }`) instead of being concatenated to the message string (`{ message = "...: " .. err }`), causing the error detail to be silently dropped from the response.

The correct pattern already exists in `ai-prompt-decorator.lua:76`.

### Before

```lua
return nil, { message = "could not get parse JSON request body: ", err }
```

### After

```lua
return nil, { message = "could not parse JSON request body: " .. err }
```