### PR TITLE
fix(ai-request-rewrite): return 400 when request body is missing

### DIFF
--- a/apisix/plugins/ai-request-rewrite.lua
+++ b/apisix/plugins/ai-request-rewrite.lua
@@ -179,7 +179,7 @@ function _M.access(conf, ctx)
 
     if not client_request_body then
         core.log.warn("missing request body")
-        return
+        return HTTP_BAD_REQUEST
     end
 
     -- Determine provider protocol

--- a/t/plugin/ai-request-rewrite2.t
+++ b/t/plugin/ai-request-rewrite2.t
@@ -272,10 +272,12 @@ passed
                 }
             )
 
-            if code == 200 then
+            if code == 400 then
                 ngx.say('passed')
                 return
             end
+
+            ngx.say('failed, got: ', code)
         }
     }
 --- error_log eval


### PR DESCRIPTION
### Description

In the `access` handler of `ai-request-rewrite`, when `core.request.get_body()` returns `nil` without an error (i.e., the body is simply empty), the function returns without a status code. This causes the request to continue through the pipeline, where downstream code expects `client_request_body` to be present and fails with confusing errors.

The fix returns `HTTP_BAD_REQUEST` (400) to reject the request early, which is consistent with the error handling path directly above it (lines 190-193).

### Before

```lua
if not client_request_body then
    core.log.warn("missing request body")
    return
end
```

### After

```lua
if not client_request_body then
    core.log.warn("missing request body")
    return HTTP_BAD_REQUEST
end
```