### PR TITLE
fix(core): use CSPRNG for admin key auto-generation

### DIFF
--- a/apisix/core/id.lua
+++ b/apisix/core/id.lua
@@ -31,7 +31,6 @@ local smatch           = string.match
 local open             = io.open
 local type             = type
 local ipairs           = ipairs
-local string           = string
 local prefix           = ngx.config.prefix()
 local pairs            = pairs
 local ngx_exit         = ngx.exit

--- a/apisix/core/id.lua
+++ b/apisix/core/id.lua
@@ -25,12 +25,13 @@ local profile          = require("apisix.core.profile")
 local log              = require("apisix.core.log")
 local uuid             = require("resty.jit-uuid")
 local lyaml            = require("lyaml")
+local resty_random     = require("resty.random")
+local resty_str        = require("resty.string")
 local smatch           = string.match
 local open             = io.open
 local type             = type
 local ipairs           = ipairs
 local string           = string
-local math             = math
 local prefix           = ngx.config.prefix()
 local pairs            = pairs
 local ngx_exit         = ngx.exit
@@ -105,11 +106,11 @@ local function autogenerate_admin_key(default_conf)
             for i, admin_key in ipairs(admin_keys) do
                 if admin_key.role == "admin" and admin_key.key == "" then
                     changed = true
-                    admin_keys[i].key = ""
-                    for _ = 1, 32 do
-                        admin_keys[i].key = admin_keys[i].key ..
-                        string.char(math.random(65, 90) + math.random(0, 1) * 32)
+                    local random_bytes = resty_random.bytes(32, true)
+                    if not random_bytes then
+                        random_bytes = resty_random.bytes(32)
                     end
+                    admin_keys[i].key = resty_str.to_hex(random_bytes)
                 end
             end
         end

--- a/t/core/config-default.t
+++ b/t/core/config-default.t
@@ -138,3 +138,29 @@ apisix:
 GET /t
 --- response_body
 node_listen: [{"port":1985},{"port":1986}]
+
+
+
+=== TEST 7: auto-generate admin key with CSPRNG when key is empty string
+--- yaml_config
+deployment:
+    admin:
+        admin_key:
+          - name: admin
+            key: ''
+            role: admin
+--- config
+    location /t {
+        content_by_lua_block {
+            local config = require("apisix.core").config.local_conf()
+            local admin_keys = config.deployment.admin.admin_key
+            local key = admin_keys and admin_keys[1] and admin_keys[1].key or ""
+            ngx.say("key_length: ", #key)
+            ngx.say("is_hex: ", key:match("^[0-9a-f]+$") ~= nil)
+        }
+    }
+--- request
+GET /t
+--- response_body
+key_length: 64
+is_hex: true


### PR DESCRIPTION
### Description

Closes #13092

The `autogenerate_admin_key()` function in `apisix/core/id.lua` used `math.random()` to generate admin API keys character by character. `math.random()` relies on a Lua PRNG that is predictable if the seed can be inferred, which is a security concern for authentication keys.

### Changes

- Replace `math.random()` with `resty.random.bytes(32, true)` which calls OpenSSL `RAND_bytes` for cryptographically secure randomness
- Falls back to `resty.random.bytes(32)` (non-strong) if the entropy pool is insufficient
- Hex-encode the output via `resty.string.to_hex()`, producing a 64-character key

Both `resty.random` and `resty.string` are already available in the OpenResty distribution and are used elsewhere in APISIX (e.g., `apisix/patch.lua`, `apisix/plugins/csrf.lua`).