### PR TITLE
fix(admin): use local config to fetch global rules in standalone mode

### DIFF
--- a/apisix/admin/global_rules.lua
+++ b/apisix/admin/global_rules.lua
@@ -23,10 +23,10 @@ local pairs    = pairs
 local ipairs   = ipairs
 local tostring = tostring
 
-
 local function is_local_config_provider()
     return core.config.type ~= "etcd"
 end
+
 
 local function get_global_rules()
     if is_local_config_provider() then

--- a/apisix/admin/global_rules.lua
+++ b/apisix/admin/global_rules.lua
@@ -24,6 +24,11 @@ local ipairs   = ipairs
 local tostring = tostring
 
 local function get_global_rules()
+    local local_conf = core.config.local_conf()
+    if local_conf.deployment.config_provider == "yaml" then
+        return nil
+    end
+
     local g = core.etcd.get("/global_rules", true)
     if not g then
         return nil

--- a/apisix/admin/global_rules.lua
+++ b/apisix/admin/global_rules.lua
@@ -26,7 +26,11 @@ local tostring = tostring
 local function get_global_rules()
     local local_conf = core.config.local_conf()
     if local_conf.deployment.config_provider == "yaml" then
-        return nil
+        local obj = core.config.fetch_created_obj("/global_rules")
+        if not obj then
+            return nil
+        end
+        return obj.values
     end
 
     local g = core.etcd.get("/global_rules", true)
@@ -35,6 +39,7 @@ local function get_global_rules()
     end
     return core.table.try_read_attr(g, "body", "list")
 end
+
 
 local function check_conf(id, conf, need_id, schema)
     local ok, err = core.schema.check(schema, conf)

--- a/apisix/admin/global_rules.lua
+++ b/apisix/admin/global_rules.lua
@@ -23,9 +23,13 @@ local pairs    = pairs
 local ipairs   = ipairs
 local tostring = tostring
 
+
+local function is_local_config_provider()
+    return core.config.type ~= "etcd"
+end
+
 local function get_global_rules()
-    local local_conf = core.config.local_conf()
-    if local_conf.deployment.config_provider == "yaml" then
+    if is_local_config_provider() then
         local obj = core.config.fetch_created_obj("/global_rules")
         if not obj then
             return nil

--- a/t/admin/standalone.t
+++ b/t/admin/standalone.t
@@ -371,7 +371,7 @@ report_failure(): update endpoint: http://127.0.0.1:2379 to unhealthy
 === TEST 17: updating existing global_rules should not call etcd
 --- request
 PUT /apisix/admin/configs
-{"global_rules":[{"id":"1","plugins":{"limit-count":{"count":5,"time_window":60,"rejected_code":429,"key":"remote_addr","policy":"local"}}}]}  
+{"global_rules":[{"id":"1","plugins":{"limit-count":{"count":5,"time_window":60,"rejected_code":429,"key":"remote_addr","policy":"local"}}}]}
 --- more_headers
 X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
 X-Digest: t17

--- a/t/admin/standalone.t
+++ b/t/admin/standalone.t
@@ -352,3 +352,16 @@ GET /stream_request
 hello world
 receive stream response error: connection reset by peer
 hello world
+
+
+
+=== TEST 16: global_rules validation in standalone mode should not call etcd
+--- request
+PUT /apisix/admin/configs
+{"global_rules":[{"id":"1","plugins":{"limit-count":{"count":2,"time_window":30,"rejected_code":503,"key":"remote_addr","policy":"local"}}}]}
+--- more_headers
+X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
+X-Digest: t16
+--- error_code: 202
+--- no_error_log
+report_failure(): update endpoint: http://127.0.0.1:2379 to unhealthy

--- a/t/admin/standalone.t
+++ b/t/admin/standalone.t
@@ -355,13 +355,26 @@ hello world
 
 
 
-=== TEST 16: global_rules validation in standalone mode should not call etcd
+=== TEST 16: creating global_rules should not call etcd
 --- request
 PUT /apisix/admin/configs
 {"global_rules":[{"id":"1","plugins":{"limit-count":{"count":2,"time_window":30,"rejected_code":503,"key":"remote_addr","policy":"local"}}}]}
 --- more_headers
 X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
 X-Digest: t16
+--- error_code: 202
+--- no_error_log
+report_failure(): update endpoint: http://127.0.0.1:2379 to unhealthy
+
+
+
+=== TEST 17: updating existing global_rules should not call etcd
+--- request
+PUT /apisix/admin/configs
+{"global_rules":[{"id":"1","plugins":{"limit-count":{"count":5,"time_window":60,"rejected_code":429,"key":"remote_addr","policy":"local"}}}]}  
+--- more_headers
+X-API-KEY: edd1c9f034335f136f87ad84b625c8f1
+X-Digest: t17
 --- error_code: 202
 --- no_error_log
 report_failure(): update endpoint: http://127.0.0.1:2379 to unhealthy


### PR DESCRIPTION
### Description

In standalone mode (`config_provider: yaml`), the `get_global_rules()` function in `apisix/admin/global_rules.lua` unconditionally calls `core.etcd.get("/global_rules")` to check for duplicate plugin conflicts whenever a global rule is validated. This is triggered on every `PUT /apisix/admin/configs` request from the ingress-controller that contains a `global_rules` entry, causing repeated etcd connection errors in the logs even though etcd is not used in standalone mode.                                                                                         

Root cause: `check_conf` calls `get_global_rules()` which has no awareness of the current config provider, so it always attempts an etcd read regardless of deployment mode.                                             

Fix: guard `get_global_rules()` to return `nil` immediately when `local_conf.deployment.config_provider == "yaml"`, skipping the etcd call entirely. This is safe because returning `nil` causes `check_conf` to skip the conflict loop (already guarded by `if global_rules then`), and in standalone mode the ingress-controller is responsible for sending a consistent config atomically.                                                            

<!--
Also adds a guard in `reload_plugins()` in `apisix/admin/init.lua` to skip `sync_local_conf_to_etcd()` in standalone mode, consistent with the existing guard in `init_worker()`.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #12989

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
