### PR TITLE
feat: Add debug logging for OPA responses

### DIFF
--- a/apisix/plugins/opa.lua
+++ b/apisix/plugins/opa.lua
@@ -51,6 +51,11 @@ local schema = {
         with_route = {type = "boolean", default = false},
         with_service = {type = "boolean", default = false},
         with_consumer = {type = "boolean", default = false},
+        debug = {
+            type = "boolean",
+            default = false,
+            description = "enable debug logging of OPA responses (only for local development)"
+        },
     },
     required = {"host", "policy"}
 }
@@ -103,6 +108,10 @@ function _M.access(conf, ctx)
         return 403
     end
 
+    if conf.debug then
+        core.log.debug("[OPA] Response received, status: ", res.status, ", body: ", res.body)
+    end
+
     -- parse the results of the decision
     local data, err = core.json.decode(res.body)
 
@@ -118,6 +127,11 @@ function _M.access(conf, ctx)
     end
 
     local result = data.result
+
+    if conf.debug then
+        core.log.debug("[OPA] Decision result, allow: ", result.allow, 
+                       ", result: ", core.json.encode(result))
+    end
 
     if not result.allow then
         if result.headers then

--- a/apisix/plugins/opa.lua
+++ b/apisix/plugins/opa.lua
@@ -51,11 +51,6 @@ local schema = {
         with_route = {type = "boolean", default = false},
         with_service = {type = "boolean", default = false},
         with_consumer = {type = "boolean", default = false},
-        debug = {
-            type = "boolean",
-            default = false,
-            description = "enable debug logging of OPA responses (only for local development)"
-        },
     },
     required = {"host", "policy"}
 }
@@ -108,9 +103,7 @@ function _M.access(conf, ctx)
         return 403
     end
 
-    if conf.debug then
-        core.log.debug("[OPA] Response received, status: ", res.status, ", body: ", res.body)
-    end
+    core.log.debug("[OPA] Response received, status: ", res.status, ", body: ", res.body)
 
     -- parse the results of the decision
     local data, err = core.json.decode(res.body)
@@ -128,10 +121,8 @@ function _M.access(conf, ctx)
 
     local result = data.result
 
-    if conf.debug then
-        core.log.debug("[OPA] Decision result, allow: ", result.allow, 
-                       ", result: ", core.json.encode(result))
-    end
+    core.log.debug("[OPA] Decision result, allow: ", result.allow,
+                   ", result: ", core.json.encode(result))
 
     if not result.allow then
         if result.headers then

--- a/docs/en/latest/plugins/opa.md
+++ b/docs/en/latest/plugins/opa.md
@@ -46,6 +46,7 @@ The `opa` Plugin can be used to integrate with [Open Policy Agent (OPA)](https:/
 | with_route        | boolean | False    | false   |               | When set to true, sends information about the current Route.                                                                                                                               |
 | with_service      | boolean | False    | false   |               | When set to true, sends information about the current Service.                                                                                                                             |
 | with_consumer     | boolean | False    | false   |               | When set to true, sends information about the current Consumer. Note that this may send sensitive information like the API key. Make sure to turn it on only when you are sure it is safe. |
+| debug             | boolean | False    | false   |               | When set to true, enables debug logging of OPA responses and decisions (only for local development).                                                                                       |
 
 ## Data definition
 
@@ -238,6 +239,44 @@ Location: http://example.com/auth
 
 test
 ```
+
+### Debug mode
+
+You can enable debug logging to troubleshoot OPA decision-making in your local development environment. When `debug` is set to `true`, the plugin logs detailed information about OPA responses and the decision results, making it easier to trace authorization issues.
+
+:::warning
+The `debug` parameter should only be enabled in local development environments, as it may increase logging verbosity and expose sensitive decision data in logs.
+:::
+
+To enable debug mode, set the `debug` parameter to `true` in your plugin configuration:
+
+```shell
+curl -X PUT 'http://127.0.0.1:9180/apisix/admin/routes/r1' \
+    -H 'X-API-KEY: <api-key>' \
+    -H 'Content-Type: application/json' \
+    -d '{
+    "uri": "/*",
+    "plugins": {
+        "opa": {
+            "host": "http://127.0.0.1:8181",
+            "policy": "example1",
+            "debug": true
+        }
+    },
+    "upstream": {
+        "nodes": {
+            "httpbin.org:80": 1
+        },
+        "type": "roundrobin"
+    }
+}'
+```
+
+With debug enabled, APISIX will log:
+- The HTTP response status and body from OPA
+- The parsed decision result along with the `allow` flag and other decision fields
+
+This helps with debugging authorization policies and understanding OPA's decision-making process.
 
 ### Sending APISIX data
 

--- a/docs/en/latest/plugins/opa.md
+++ b/docs/en/latest/plugins/opa.md
@@ -273,6 +273,7 @@ curl -X PUT 'http://127.0.0.1:9180/apisix/admin/routes/r1' \
 ```
 
 With debug enabled, APISIX will log:
+
 - The HTTP response status and body from OPA
 - The parsed decision result along with the `allow` flag and other decision fields
 

--- a/docs/en/latest/plugins/opa.md
+++ b/docs/en/latest/plugins/opa.md
@@ -46,7 +46,6 @@ The `opa` Plugin can be used to integrate with [Open Policy Agent (OPA)](https:/
 | with_route        | boolean | False    | false   |               | When set to true, sends information about the current Route.                                                                                                                               |
 | with_service      | boolean | False    | false   |               | When set to true, sends information about the current Service.                                                                                                                             |
 | with_consumer     | boolean | False    | false   |               | When set to true, sends information about the current Consumer. Note that this may send sensitive information like the API key. Make sure to turn it on only when you are sure it is safe. |
-| debug             | boolean | False    | false   |               | When set to true, enables debug logging of OPA responses and decisions (only for local development).                                                                                       |
 
 ## Data definition
 
@@ -239,45 +238,6 @@ Location: http://example.com/auth
 
 test
 ```
-
-### Debug mode
-
-You can enable debug logging to troubleshoot OPA decision-making in your local development environment. When `debug` is set to `true`, the plugin logs detailed information about OPA responses and the decision results, making it easier to trace authorization issues.
-
-:::warning
-The `debug` parameter should only be enabled in local development environments, as it may increase logging verbosity and expose sensitive decision data in logs.
-:::
-
-To enable debug mode, set the `debug` parameter to `true` in your plugin configuration:
-
-```shell
-curl -X PUT 'http://127.0.0.1:9180/apisix/admin/routes/r1' \
-    -H 'X-API-KEY: <api-key>' \
-    -H 'Content-Type: application/json' \
-    -d '{
-    "uri": "/*",
-    "plugins": {
-        "opa": {
-            "host": "http://127.0.0.1:8181",
-            "policy": "example1",
-            "debug": true
-        }
-    },
-    "upstream": {
-        "nodes": {
-            "httpbin.org:80": 1
-        },
-        "type": "roundrobin"
-    }
-}'
-```
-
-With debug enabled, APISIX will log:
-
-- The HTTP response status and body from OPA
-- The parsed decision result along with the `allow` flag and other decision fields
-
-This helps with debugging authorization policies and understanding OPA's decision-making process.
 
 ### Sending APISIX data
 


### PR DESCRIPTION
## Description

This PR introduces an optional debug logging configuration for Open Policy Agent (OPA) responses to improve observability during development and troubleshooting.

---

## Changes

### When `debug` is enabled in apisix:

* Logs the raw OPA response, including HTTP status and body.
* Logs the evaluated decision result (`allow`) along with the full decoded response payload.
* Logging is performed using `core.log.debug`, ensuring no impact on production environments unless explicitly enabled.

---

## Motivation

OPA policy evaluation can be difficult to debug due to limited visibility into the responses returned by the OPA server. This change provides developers with detailed insights into:

* The raw response returned by OPA
* The parsed decision output used by APISIX

This significantly improves the ability to diagnose misconfigurations, policy errors, or unexpected authorization behavior during local development.

---

## Checklist

* [x] I have explained the need for this PR and the problem it solves
* [x] I have explained the changes or the new features added to this PR
* [ ] I have added tests corresponding to this change
* [x] I have updated the documentation to reflect this change
* [x] I have verified that this change is backward compatible (If not, please discuss on the APISIX mailing list first)
