### PR TITLE
fix(cli): add IPv6 listen support for admin, control, status and prom…

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -108,6 +108,9 @@ http {
 
     server {
         listen {* prometheus_server_addr *} reuseport;
+        {% if prometheus_server_ipv6 then %}
+        listen {* prometheus_server_ipv6 *}:{* prometheus_server_port *} reuseport;
+        {% end %}
 
         access_log off;
 
@@ -541,6 +544,9 @@ http {
     {% if enable_control then %}
     server {
         listen {* control_server_addr *};
+        {% if control_server_ipv6 then %}
+        listen {* control_server_ipv6 *}:{* control_server_port *};
+        {% end %}
 
         access_log off;
 
@@ -555,6 +561,9 @@ http {
     {% if status then %}
     server {
         listen {* status_server_addr *} enable_process=privileged_agent;
+        {% if status_server_ipv6 then %}
+        listen {* status_server_ipv6 *}:{* status_server_port *} enable_process=privileged_agent;
+        {% end %}
         access_log off;
         location /status {
             content_by_lua_block {
@@ -572,6 +581,9 @@ http {
     {% if enabled_plugins["prometheus"] and prometheus_server_addr then %}
     server {
         listen {* prometheus_server_addr *} reuseport;
+        {% if prometheus_server_ipv6 then %}
+        listen {* prometheus_server_ipv6 *}:{* prometheus_server_port *} reuseport;
+        {% end %}
 
         access_log off;
 
@@ -594,6 +606,9 @@ http {
     server {
         {%if https_admin then%}
         listen {* admin_server_addr *} ssl;
+        {% if admin_server_ipv6 then %}
+        listen {* admin_server_ipv6 *}:{* admin_server_port *} ssl;
+        {% end %}
 
         ssl_certificate      {* admin_api_mtls.admin_ssl_cert *};
         ssl_certificate_key  {* admin_api_mtls.admin_ssl_cert_key *};
@@ -614,6 +629,9 @@ http {
 
         {% else %}
         listen {* admin_server_addr *};
+        {% if admin_server_ipv6 then %}
+        listen {* admin_server_ipv6 *}:{* admin_server_port *};
+        {% end %}
         {%end%}
         log_not_found off;
 

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -430,42 +430,57 @@ Please modify "admin_key" in conf/config.yaml .
             util.die(port_name .. " ", port, " conflicts with ", ports_to_check[port], "\n")
         end
         ports_to_check[port] = port_name
-        return ip .. ":" .. port
+
+        -- determine IPv6 address when enable_ipv6 is true and no custom IP was configured
+        local ipv6_addr
+        if yaml_conf.apisix.enable_ipv6
+            and (not configured_ip or configured_ip == default_ip) then
+            if ip == "127.0.0.1" then
+                ipv6_addr = "[::1]"
+            else
+                ipv6_addr = "[::]"
+            end
+        end
+
+        return ip .. ":" .. port, port, ipv6_addr
     end
 
     -- listen in admin use a separate port, support specific IP, compatible with the original style
-    local admin_server_addr
+    local admin_server_addr, admin_server_port, admin_server_ipv6
     if yaml_conf.apisix.enable_admin then
         local ip = yaml_conf.deployment.admin.admin_listen.ip
         local port = yaml_conf.deployment.admin.admin_listen.port
-        admin_server_addr = validate_and_get_listen_addr("admin port", "0.0.0.0", ip,
-                                                          9180, port)
+        admin_server_addr, admin_server_port, admin_server_ipv6 =
+            validate_and_get_listen_addr("admin port", "0.0.0.0", ip, 9180, port)
     end
 
-    local status_server_addr
+    local status_server_addr, status_server_port, status_server_ipv6
     if yaml_conf.apisix.status then
-        status_server_addr = validate_and_get_listen_addr("status port", "127.0.0.1",
+        status_server_addr, status_server_port, status_server_ipv6 =
+            validate_and_get_listen_addr("status port", "127.0.0.1",
                              yaml_conf.apisix.status.ip, 7085,
                              yaml_conf.apisix.status.port)
     end
 
-    local control_server_addr
+    local control_server_addr, control_server_port, control_server_ipv6
     if yaml_conf.apisix.enable_control then
         if not yaml_conf.apisix.control then
-            control_server_addr = validate_and_get_listen_addr("control port", "127.0.0.1", nil,
-                                          9090, nil)
+            control_server_addr, control_server_port, control_server_ipv6 =
+                validate_and_get_listen_addr("control port", "127.0.0.1", nil, 9090, nil)
         else
-            control_server_addr = validate_and_get_listen_addr("control port", "127.0.0.1",
+            control_server_addr, control_server_port, control_server_ipv6 =
+                validate_and_get_listen_addr("control port", "127.0.0.1",
                                           yaml_conf.apisix.control.ip,
                                           9090, yaml_conf.apisix.control.port)
         end
     end
 
-    local prometheus_server_addr
+    local prometheus_server_addr, prometheus_server_port, prometheus_server_ipv6
     if yaml_conf.plugin_attr.prometheus then
         local prometheus = yaml_conf.plugin_attr.prometheus
         if prometheus.enable_export_server then
-            prometheus_server_addr = validate_and_get_listen_addr("prometheus port", "127.0.0.1",
+            prometheus_server_addr, prometheus_server_port, prometheus_server_ipv6 =
+                validate_and_get_listen_addr("prometheus port", "127.0.0.1",
                                              prometheus.export_addr.ip,
                                              9091, prometheus.export_addr.port)
         end
@@ -691,10 +706,18 @@ Please modify "admin_key" in conf/config.yaml .
         enabled_stream_plugins = enabled_stream_plugins,
         dubbo_upstream_multiplex_count = dubbo_upstream_multiplex_count,
         status_server_addr = status_server_addr,
+        status_server_port = status_server_port,
+        status_server_ipv6 = status_server_ipv6,
         tcp_enable_ssl = tcp_enable_ssl,
         admin_server_addr = admin_server_addr,
+        admin_server_port = admin_server_port,
+        admin_server_ipv6 = admin_server_ipv6,
         control_server_addr = control_server_addr,
+        control_server_port = control_server_port,
+        control_server_ipv6 = control_server_ipv6,
         prometheus_server_addr = prometheus_server_addr,
+        prometheus_server_port = prometheus_server_port,
+        prometheus_server_ipv6 = prometheus_server_ipv6,
         proxy_mirror_timeouts = proxy_mirror_timeouts,
         zipkin_set_ngx_var = zipkin_set_ngx_var
     }

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -1002,3 +1002,291 @@ if ! grep "access-tokens 2m;" conf/nginx.conf > /dev/null; then
 fi
 
 echo "passed: found the http lua_shared_dict related parameter in nginx.conf"
+
+# check admin IPv6 listen directive with enable_ipv6
+echo '
+apisix:
+  enable_ipv6: true
+  enable_admin: true
+deployment:
+  admin:
+    admin_listen:
+      ip: 0.0.0.0
+      port: 9180
+' > conf/config.yaml
+
+make init
+
+if ! grep "listen 0.0.0.0:9180;" conf/nginx.conf > /dev/null; then
+    echo "failed: admin IPv4 listen not in nginx.conf"
+    exit 1
+fi
+
+if ! grep "listen \[::\]:9180;" conf/nginx.conf > /dev/null; then
+    echo "failed: admin IPv6 listen not in nginx.conf"
+    exit 1
+fi
+
+echo "passed: admin IPv6 listen directive is correct"
+
+# check admin does not get IPv6 when enable_ipv6 is false
+echo '
+apisix:
+  enable_ipv6: false
+  enable_admin: true
+deployment:
+  admin:
+    admin_listen:
+      ip: 0.0.0.0
+      port: 9180
+' > conf/config.yaml
+
+make init
+
+if ! grep "listen 0.0.0.0:9180;" conf/nginx.conf > /dev/null; then
+    echo "failed: admin IPv4 listen not in nginx.conf when ipv6 disabled"
+    exit 1
+fi
+
+if grep "listen \[::\]:9180;" conf/nginx.conf > /dev/null; then
+    echo "failed: admin IPv6 listen should not be in nginx.conf when ipv6 disabled"
+    exit 1
+fi
+
+echo "passed: admin does not have IPv6 when enable_ipv6 is false"
+
+# check admin does not get IPv6 when explicit IP is set
+echo '
+apisix:
+  enable_ipv6: true
+  enable_admin: true
+deployment:
+  admin:
+    admin_listen:
+      ip: 10.0.0.1
+      port: 9180
+' > conf/config.yaml
+
+make init
+
+if ! grep "listen 10.0.0.1:9180;" conf/nginx.conf > /dev/null; then
+    echo "failed: admin explicit IP listen not in nginx.conf"
+    exit 1
+fi
+
+if grep "listen \[::\]:9180;" conf/nginx.conf > /dev/null; then
+    echo "failed: admin IPv6 should not be added when explicit IP is set"
+    exit 1
+fi
+
+echo "passed: admin does not have IPv6 when explicit IP is set"
+
+# check control IPv6 listen directive (loopback -> [::1])
+echo '
+apisix:
+  enable_ipv6: true
+  enable_control: true
+' > conf/config.yaml
+
+make init
+
+if ! grep "listen 127.0.0.1:9090;" conf/nginx.conf > /dev/null; then
+    echo "failed: control IPv4 listen not in nginx.conf"
+    exit 1
+fi
+
+if ! grep "listen \[::1\]:9090;" conf/nginx.conf > /dev/null; then
+    echo "failed: control IPv6 listen not in nginx.conf"
+    exit 1
+fi
+
+echo "passed: control IPv6 listen directive uses [::1]"
+
+# check status IPv6 listen directive (loopback -> [::1])
+echo '
+apisix:
+  enable_ipv6: true
+  status:
+    ip: 127.0.0.1
+    port: 7085
+' > conf/config.yaml
+
+make init
+
+if ! grep "listen 127.0.0.1:7085" conf/nginx.conf > /dev/null; then
+    echo "failed: status IPv4 listen not in nginx.conf"
+    exit 1
+fi
+
+if ! grep "listen \[::1\]:7085" conf/nginx.conf > /dev/null; then
+    echo "failed: status IPv6 listen not in nginx.conf"
+    exit 1
+fi
+
+echo "passed: status IPv6 listen directive uses [::1]"
+
+# check prometheus IPv6 listen directive (loopback -> [::1])
+echo '
+apisix:
+  enable_ipv6: true
+plugin_attr:
+  prometheus:
+    enable_export_server: true
+    export_addr:
+      ip: 127.0.0.1
+      port: 9091
+' > conf/config.yaml
+
+make init
+
+if ! grep "listen 127.0.0.1:9091" conf/nginx.conf > /dev/null; then
+    echo "failed: prometheus IPv4 listen not in nginx.conf"
+    exit 1
+fi
+
+if ! grep "listen \[::1\]:9091" conf/nginx.conf > /dev/null; then
+    echo "failed: prometheus IPv6 listen not in nginx.conf"
+    exit 1
+fi
+
+echo "passed: prometheus IPv6 listen directive uses [::1]"
+
+# check no IPv6 for any endpoint when enable_ipv6 is false
+echo '
+apisix:
+  enable_ipv6: false
+  enable_admin: true
+  enable_control: true
+  status:
+    ip: 127.0.0.1
+    port: 7085
+deployment:
+  admin:
+    admin_listen:
+      ip: 0.0.0.0
+      port: 9180
+plugin_attr:
+  prometheus:
+    enable_export_server: true
+    export_addr:
+      ip: 127.0.0.1
+      port: 9091
+' > conf/config.yaml
+
+make init
+
+if grep "listen \[::\]:9180;" conf/nginx.conf > /dev/null; then
+    echo "failed: admin IPv6 should not be present when ipv6 disabled"
+    exit 1
+fi
+
+if grep "listen \[::1\]:9090;" conf/nginx.conf > /dev/null; then
+    echo "failed: control IPv6 should not be present when ipv6 disabled"
+    exit 1
+fi
+
+if grep "listen \[::1\]:7085" conf/nginx.conf > /dev/null; then
+    echo "failed: status IPv6 should not be present when ipv6 disabled"
+    exit 1
+fi
+
+if grep "listen \[::1\]:9091" conf/nginx.conf > /dev/null; then
+    echo "failed: prometheus IPv6 should not be present when ipv6 disabled"
+    exit 1
+fi
+
+echo "passed: no IPv6 listen directives when enable_ipv6 is false"
+
+# check control does not get IPv6 when explicit IP is set
+echo '
+apisix:
+  enable_ipv6: true
+  enable_control: true
+  control:
+    ip: 10.0.0.1
+    port: 9090
+' > conf/config.yaml
+
+make init
+
+if ! grep "listen 10.0.0.1:9090;" conf/nginx.conf > /dev/null; then
+    echo "failed: control explicit IP listen not in nginx.conf"
+    exit 1
+fi
+
+if grep "listen \[::1\]:9090;" conf/nginx.conf > /dev/null; then
+    echo "failed: control IPv6 should not be added when explicit IP is set"
+    exit 1
+fi
+
+echo "passed: control does not have IPv6 when explicit IP is set"
+
+# check status does not get IPv6 when explicit IP is set
+echo '
+apisix:
+  enable_ipv6: true
+  status:
+    ip: 10.0.0.1
+    port: 7085
+' > conf/config.yaml
+
+make init
+
+if ! grep "listen 10.0.0.1:7085" conf/nginx.conf > /dev/null; then
+    echo "failed: status explicit IP listen not in nginx.conf"
+    exit 1
+fi
+
+if grep "listen \[::1\]:7085" conf/nginx.conf > /dev/null; then
+    echo "failed: status IPv6 should not be added when explicit IP is set"
+    exit 1
+fi
+
+echo "passed: status does not have IPv6 when explicit IP is set"
+
+# check prometheus does not get IPv6 when explicit IP is set
+echo '
+apisix:
+  enable_ipv6: true
+plugin_attr:
+  prometheus:
+    enable_export_server: true
+    export_addr:
+      ip: 10.0.0.1
+      port: 9091
+' > conf/config.yaml
+
+make init
+
+if ! grep "listen 10.0.0.1:9091" conf/nginx.conf > /dev/null; then
+    echo "failed: prometheus explicit IP listen not in nginx.conf"
+    exit 1
+fi
+
+if grep "listen \[::1\]:9091" conf/nginx.conf > /dev/null; then
+    echo "failed: prometheus IPv6 should not be added when explicit IP is set"
+    exit 1
+fi
+
+echo "passed: prometheus does not have IPv6 when explicit IP is set"
+
+# check admin IPv6 with default config (no explicit IP)
+echo '
+apisix:
+  enable_ipv6: true
+  enable_admin: true
+' > conf/config.yaml
+
+make init
+
+if ! grep "listen 0.0.0.0:9180;" conf/nginx.conf > /dev/null; then
+    echo "failed: admin default IPv4 listen not in nginx.conf"
+    exit 1
+fi
+
+if ! grep "listen \[::\]:9180;" conf/nginx.conf > /dev/null; then
+    echo "failed: admin default IPv6 listen not in nginx.conf"
+    exit 1
+fi
+
+echo "passed: admin IPv6 works with default config (no explicit IP)"


### PR DESCRIPTION
### Description

When `enable_ipv6: true` is set, APISIX generates dual-stack (IPv4 + IPv6) listen directives for `node_listen` and `ssl.listen`, but not for admin, control, status, or prometheus endpoints. This means deployers in IPv6 environments (e.g. Kubernetes) must work around this by manually setting listener IPs to `[::]` or injecting raw Nginx configuration snippets. This PR fixes that gap so `enable_ipv6: true` works consistently across all endpoints.

Note: proxy_protocol IPv6 support is handled separately in #12859.
The core change is ~54 lines across `ops.lua` and `ngx_tpl.lua`; the remaining ~288 lines are tests.

#### Which issue(s) this PR fixes:

Fixes #13112

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

## Changes

**`apisix/cli/ops.lua`**
- Extended `validate_and_get_listen_addr` to return the port and an IPv6 address alongside the existing `ip:port` string
- IPv6 address is `[::]` for wildcard-bound listeners (admin, default `0.0.0.0`) and `[::1]` for loopback-bound listeners (control, status, prometheus, default `127.0.0.1`)
- IPv6 is skipped when a user explicitly configures a non-default IP
- New variables (`*_server_port`, `*_server_ipv6`) passed to the template context

**`apisix/cli/ngx_tpl.lua`**
- Added IPv6 listen directives for admin (HTTP and HTTPS), control, status, and prometheus (stream and HTTP) — 6 template locations

**`t/cli/test_main.sh`**
- 11 new tests covering:
  - IPv6 generation for each endpoint (admin, control, status, prometheus)
  - No IPv6 when `enable_ipv6: false`
  - No IPv6 when an explicit IP is configured (admin, control, status, prometheus)
  - IPv6 with default config (no explicit IP)

---
*Note: AI was used to format this Pull Request.*