### PR TITLE
fix(env): fix os.getenv prefix collision bug in init_by_lua phase

### DIFF
--- a/apisix/core/env.lua
+++ b/apisix/core/env.lua
@@ -26,6 +26,7 @@ local upper       = string.upper
 local find        = string.find
 local sub         = string.sub
 local str         = ffi.string
+local os_getenv   = os.getenv
 
 local ENV_PREFIX = "$ENV://"
 
@@ -57,6 +58,19 @@ function _M.init()
         end
 
         i = i + 1
+    end
+
+    -- Override os.getenv to use exact lookup from apisix_env_vars, avoiding
+    -- the prefix collision bug in OpenResty's init_by_lua phase where
+    -- env NAME=VALUE directives with a common prefix cause os.getenv to
+    -- return the shorter-named variable's value for the longer-named one.
+    os.getenv = function(name)
+        local val = apisix_env_vars[name]
+        if val ~= nil then
+            return val
+        end
+        -- Fall back for vars set dynamically after startup (e.g., via core.os.setenv)
+        return os_getenv(name)
     end
 end
 

--- a/apisix/core/env.lua
+++ b/apisix/core/env.lua
@@ -64,7 +64,7 @@ function _M.init()
     -- the prefix collision bug in OpenResty's init_by_lua phase where
     -- env NAME=VALUE directives with a common prefix cause os.getenv to
     -- return the shorter-named variable's value for the longer-named one.
-    os.getenv = function(name)
+    os.getenv = function(name) -- luacheck: ignore
         local val = apisix_env_vars[name]
         if val ~= nil then
             return val

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -89,9 +89,9 @@ local _M = {version = 0.4}
 
 
 function _M.http_init(args)
+    core.env.init()
     core.resolver.init_resolver(args)
     core.id.init()
-    core.env.init()
 
     local process = require("ngx.process")
     local ok, err = process.enable_privileged_agent()

--- a/t/core/env.t
+++ b/t/core/env.t
@@ -179,3 +179,47 @@ env ngx_env=apisix-nice;
 GET /t
 --- response_body
 apisix-nice
+
+
+
+=== TEST 10: os.getenv prefix collision - shorter prefix first should not shadow longer name
+--- main_config
+env TEST_PREFIX=prefix-value;
+env TEST_PREFIX_LONGER=longer-value;
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say(os.getenv("TEST_PREFIX"))
+            ngx.say(os.getenv("TEST_PREFIX_LONGER"))
+        }
+    }
+--- request
+GET /t
+--- response_body
+prefix-value
+longer-value
+
+
+
+=== TEST 11: os.getenv prefix collision in init_by_lua - result preserved in request phase
+--- main_config
+env TEST_INIT_TOKEN=token-value;
+env TEST_INIT_TOKEN_FILE=/path/to/token;
+--- extra_init_by_lua
+package.loaded["test_init_env"] = {
+    token = os.getenv("TEST_INIT_TOKEN"),
+    token_file = os.getenv("TEST_INIT_TOKEN_FILE"),
+}
+--- config
+    location /t {
+        content_by_lua_block {
+            local result = package.loaded["test_init_env"]
+            ngx.say(result.token)
+            ngx.say(result.token_file)
+        }
+    }
+--- request
+GET /t
+--- response_body
+token-value
+/path/to/token


### PR DESCRIPTION
## Problem

In OpenResty's `init_by_lua` phase, `os.getenv()` uses nginx's internal environment mechanism which performs prefix-based matching when `env NAME=VALUE` directives share a common prefix. This causes `os.getenv()` to return the shorter-named variable's value when the longer-named one is requested.

Example: with both `KUBERNETES_CLIENT_TOKEN` and `KUBERNETES_CLIENT_TOKEN_FILE` defined as `env NAME=VALUE;` directives, calling `os.getenv("KUBERNETES_CLIENT_TOKEN_FILE")` returns `KUBERNETES_CLIENT_TOKEN`'s value when the shorter name appears first in the config.

Fixes #13055

## Root cause

OpenResty's `os.getenv` in `init_by_lua` does not perform exact-match lookup when `env NAME=VALUE;` directives have a common prefix — the shorter name is matched first. In contrast, reading `ffi.C.environ` directly with Lua string operations (as `_M.init()` already does) produces a correctly keyed table.

## Fix

1. **`apisix/core/env.lua`**: After `_M.init()` populates `apisix_env_vars` from `ffi.C.environ`, override `os.getenv` with a wrapper that does exact table lookup. Falls back to the original `os.getenv` for variables set dynamically after startup (e.g., via `core.os.setenv`).

2. **`apisix/init.lua`**: Move `core.env.init()` to be the **first** call in `http_init()`, ensuring the override is applied before any other code in `init_by_lua` can call `os.getenv`.

## Tests

- **TEST 10**: Verifies `os.getenv` returns correct values when shorter-prefix variable is declared first in nginx config.
- **TEST 11**: Verifies `os.getenv` called inside `init_by_lua` (via `extra_init_by_lua`) returns correct values for prefix-colliding variables.

## Risk / Compatibility

- `os.getenv` is monkey-patched globally after `_M.init()`. Existing callers continue to work — the semantics are identical for non-colliding variable names.
- Variables set dynamically via `core.os.setenv` fall back to the original `os.getenv`, so those are unaffected.
- The ordering change in `http_init` is safe: `core.env.init()` has no dependencies on `resolver` or `id` initialization.