### PR TITLE
fix(ci): replace mockbin.org with local httpbin in healthcheck test

### DIFF
--- a/ci/pod/docker-compose.common.yml
+++ b/ci/pod/docker-compose.common.yml
@@ -137,3 +137,4 @@ services:
     restart: unless-stopped
     ports:
       - "8280:80"
+      - "8281:80"

--- a/t/control/control-healthcheck-bug-fix.t
+++ b/t/control/control-healthcheck-bug-fix.t
@@ -38,7 +38,7 @@ __DATA__
                     "upstream": {
                         "nodes": {
                             "httpbin.local:8280": 1,
-                            "mockbin.org:80": 1
+                            "httpbin.local:8281": 1
                         },
                         "type": "roundrobin"
                     },


### PR DESCRIPTION
### Description

mockbin.org is a defunct external service that no longer resolves via DNS, causing CI failures in `t/control/control-healthcheck-bug-fix.t`. This is the same class of issue that previously affected httpbin.org (fixed in #12805).

The test requires two upstream nodes to activate APISIX's healthchecker, which is needed to reproduce the bug originally fixed in #11844. The second node (mockbin.org:80) is replaced with httpbin.local:8281 — the same kennethreitz/httpbin container already used in CI, exposed on an additional port — providing a genuinely distinct upstream node without introducing any new dependencies.

Changes:
  - Add port 8281:80 to the httpbin service in `ci/pod/docker-compose.common.yml`
  - Replace `mockbin.org:80` with `httpbin.local:8281` in `t/control/control-healthcheck-bug-fix.t`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
