### PR TITLE
feat(request-id): add UUID v7 support via algorithm uuidv7

### DIFF
--- a/apisix/core/utils.lua
+++ b/apisix/core/utils.lua
@@ -47,6 +47,12 @@ local get_string_buf = base.get_string_buf
 local exiting        = ngx.worker.exiting
 local ngx_sleep      = ngx.sleep
 local ipairs         = ipairs
+local str_format     = string.format
+local ngx_now        = ngx.now
+local ngx_update_time = ngx.update_time
+local math_random    = math.random
+local math_floor     = math.floor
+local bit            = require("bit")
 
 local hostname
 local dns_resolvers
@@ -469,6 +475,63 @@ function _M.check_tls_bool(fields, conf, plugin_name)
                      plugin_name, " configuration is a security risk")
         end
     end
+end
+
+
+-- worker-local monotonic state for UUID v7 (no shared dict needed)
+-- Each nginx worker has its own copy; no locking required.
+local _v7_last_ms = 0
+local _v7_seq     = 0
+local _v7_rand_b  = { 0, 0, 0, 0, 0, 0, 0 }  -- 7 bytes = 56 random bits
+
+
+local function _v7_reset(ms)
+    _v7_last_ms = ms
+    _v7_seq = 0
+    for i = 1, 7 do
+        _v7_rand_b[i] = math_random(0, 255)
+    end
+end
+
+
+function _M.generate_uuid_v7()
+    local ms = math_floor(ngx_now() * 1000)
+
+    if ms > _v7_last_ms then
+        _v7_reset(ms)
+    else
+        if ms < _v7_last_ms then
+            ms = _v7_last_ms
+        end
+
+        _v7_seq = _v7_seq + 1
+        if _v7_seq > 0x3ffff then
+            repeat
+                ngx_update_time()
+                ms = math_floor(ngx_now() * 1000)
+            until ms > _v7_last_ms
+            _v7_reset(ms)
+        end
+    end
+
+    local ts_hi = math_floor(ms / 0x100000000)
+    local ts_lo = ms % 0x100000000
+
+    local seq_hi = bit.rshift(_v7_seq, 6)
+    local seq_lo = bit.band(_v7_seq, 0x3F)
+
+    local r = _v7_rand_b
+    return str_format(
+        "%02x%02x%04x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+        bit.rshift(ts_hi, 8),
+        bit.band(ts_hi, 0xFF),
+        bit.rshift(ts_lo, 16),
+        bit.band(ts_lo, 0xFFFF),
+        bit.bor(0x7000, seq_hi),
+        bit.bor(0x80, seq_lo),
+        r[1],
+        r[2], r[3], r[4], r[5], r[6], r[7]
+    )
 end
 
 

--- a/apisix/plugins/request-id.lua
+++ b/apisix/plugins/request-id.lua
@@ -33,7 +33,7 @@ local schema = {
         include_in_response = {type = "boolean", default = true},
         algorithm = {
             type = "string",
-            enum = {"uuid", "nanoid", "range_id", "ksuid"},
+            enum = {"uuid", "nanoid", "range_id", "ksuid", "uuidv7"},
             default = "uuid"
         },
         range_id = {
@@ -82,6 +82,9 @@ end
 local function get_request_id(conf)
     if conf.algorithm == "uuid" then
         return uuid()
+    end
+    if conf.algorithm == "uuidv7" then
+        return core.utils.generate_uuid_v7()
     end
     if conf.algorithm == "nanoid" then
         return nanoid.safe_simple()

--- a/t/plugin/request-id.t
+++ b/t/plugin/request-id.t
@@ -533,3 +533,483 @@ true
     }
 --- response_body
 request header present and is not empty
+
+
+
+=== TEST 17: sanity check - algorithm uuidv7 schema valid
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.request-id")
+            local ok, err = plugin.check_schema({
+                algorithm = "uuidv7"
+            })
+            if not ok then
+                ngx.say(err)
+                return
+            end
+            ngx.say("done")
+        }
+    }
+--- response_body
+done
+
+
+
+=== TEST 18: sanity check - algorithm invalid value rejected
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.request-id")
+            local ok, err = plugin.check_schema({
+                algorithm = "uuidv5"
+            })
+            if not ok then
+                ngx.say(err)
+                return
+            end
+            ngx.say("done")
+        }
+    }
+--- response_body_like
+property "algorithm" validation failed: matches none of the enum values
+
+
+
+=== TEST 19: add plugin with algorithm uuidv7
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "request-id": {
+                                "algorithm": "uuidv7"
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1982": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/opentracing"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 20: uuid v7 has correct format (version=7, variant=8-b)
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/opentracing"
+            local res, err = httpc:request_uri(uri, {method = "GET"})
+            if not res then
+                ngx.say("failed to request: ", err)
+                return
+            end
+
+            local id = res.headers["X-Request-Id"]
+            if not id then
+                ngx.say("header not found")
+                return
+            end
+
+            if not string.match(id, "^%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x$") then
+                ngx.say("format invalid: ", id)
+                return
+            end
+
+            if string.sub(id, 15, 15) ~= "7" then
+                ngx.say("version wrong, expected 7, got: ", string.sub(id, 15, 15), " in: ", id)
+                return
+            end
+
+            local variant = string.sub(id, 20, 20)
+            if variant ~= "8" and variant ~= "9" and variant ~= "a" and variant ~= "b" then
+                ngx.say("variant wrong, got: ", variant, " in: ", id)
+                return
+            end
+
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+
+
+
+=== TEST 21: uuid v7 uniqueness (180 concurrent requests)
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local t = {}
+            local ids = {}
+            local found_dup = false
+            for i = 1, 180 do
+                local th = assert(ngx.thread.spawn(function()
+                    local httpc = http.new()
+                    local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/opentracing"
+                    local res, err = httpc:request_uri(uri, {method = "GET"})
+                    if not res then
+                        ngx.log(ngx.ERR, err)
+                        return
+                    end
+                    local id = res.headers["X-Request-Id"]
+                    if not id then return end
+                    if ids[id] then
+                        found_dup = true
+                        return
+                    end
+                    ids[id] = true
+                end, i))
+                table.insert(t, th)
+            end
+            for _, th in ipairs(t) do
+                ngx.thread.wait(th)
+            end
+            if found_dup then
+                ngx.say("duplicate found")
+            else
+                ngx.say("true")
+            end
+        }
+    }
+--- wait: 5
+--- response_body
+true
+
+
+
+=== TEST 22: uuid v7 time ordering (sequential UUIDs are lexicographically monotone)
+--- config
+    location /t {
+        content_by_lua_block {
+            local utils = require("apisix.core.utils")
+            local prev = utils.generate_uuid_v7()
+            local ok = true
+            for i = 1, 20 do
+                local cur = utils.generate_uuid_v7()
+                if cur <= prev then
+                    ok = false
+                    ngx.say("not monotone: prev=", prev, " cur=", cur)
+                    return
+                end
+                prev = cur
+            end
+            if ok then
+                ngx.say("ok")
+            end
+        }
+    }
+--- response_body
+ok
+
+
+
+=== TEST 23: algorithm uuid (default) generates uuid v4
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local http = require "resty.http"
+
+            t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "request-id": {
+                                "algorithm": "uuid"
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1982": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/opentracing"
+                }]]
+            )
+
+            local httpc = http.new()
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/opentracing"
+            local res, err = httpc:request_uri(uri, {method = "GET"})
+            if not res then
+                ngx.say("failed: ", err)
+                return
+            end
+
+            local id = res.headers["X-Request-Id"]
+            if not id then
+                ngx.say("header not found")
+                return
+            end
+
+            local ver = string.sub(id, 15, 15)
+            if ver ~= "4" then
+                ngx.say("expected v4, got version: ", ver)
+                return
+            end
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+
+
+
+=== TEST 24: uuid v7 timestamp prefix is non-zero (48-bit ts encoded correctly)
+--- config
+    location /t {
+        content_by_lua_block {
+            local utils = require("apisix.core.utils")
+            local id = utils.generate_uuid_v7()
+            local seg1 = string.sub(id, 1, 8)
+            if string.sub(seg1, 1, 4) == "0000" then
+                ngx.say("ts truncation detected (first 4 hex are 0000): ", id)
+                return
+            end
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+
+
+
+=== TEST 25: algorithm uuidv7 with custom header name
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local http = require "resty.http"
+
+            t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "request-id": {
+                                "algorithm": "uuidv7",
+                                "header_name": "X-Trace-Id"
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1982": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/opentracing"
+                }]]
+            )
+
+            local httpc = http.new()
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/opentracing"
+            local res, err = httpc:request_uri(uri, {method = "GET"})
+            if not res then
+                ngx.say("failed: ", err)
+                return
+            end
+
+            local id = res.headers["X-Trace-Id"]
+            if not id then
+                ngx.say("X-Trace-Id header not found")
+                return
+            end
+
+            if string.sub(id, 15, 15) ~= "7" then
+                ngx.say("version wrong: ", id)
+                return
+            end
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+
+
+
+=== TEST 26: uuid v7 overflow loop refreshes cached ngx.now time
+--- config
+    location /t {
+        content_by_lua_block {
+            local debug = require("debug")
+            local utils = require("apisix.core.utils")
+
+            local function set_upvalue(func, name, value)
+                for i = 1, 32 do
+                    local upname = debug.getupvalue(func, i)
+                    if not upname then
+                        break
+                    end
+
+                    if upname == name then
+                        debug.setupvalue(func, i, value)
+                        return true
+                    end
+                end
+
+                return false
+            end
+
+            local function get_upvalue(func, name)
+                for i = 1, 32 do
+                    local upname, upvalue = debug.getupvalue(func, i)
+                    if not upname then
+                        break
+                    end
+
+                    if upname == name then
+                        return upvalue
+                    end
+                end
+            end
+
+            local gen = utils.generate_uuid_v7
+            local old_last_ms = get_upvalue(gen, "_v7_last_ms")
+            local old_seq = get_upvalue(gen, "_v7_seq")
+            local old_rand_b = get_upvalue(gen, "_v7_rand_b")
+            local old_ngx_now = get_upvalue(gen, "ngx_now")
+            local old_ngx_update_time = get_upvalue(gen, "ngx_update_time")
+
+            local fake_now = 1000.100
+            local update_calls = 0
+            local now_calls = 0
+
+            assert(set_upvalue(gen, "_v7_last_ms", 1000100))
+            assert(set_upvalue(gen, "_v7_seq", 0x3ffff))
+            assert(set_upvalue(gen, "_v7_rand_b", {1, 2, 3, 4, 5, 6, 7}))
+            assert(set_upvalue(gen, "ngx_now", function()
+                now_calls = now_calls + 1
+                if now_calls > 5 and update_calls == 0 then
+                    error("stale cached time")
+                end
+                return fake_now
+            end))
+            assert(set_upvalue(gen, "ngx_update_time", function()
+                update_calls = update_calls + 1
+                fake_now = 1000.101
+            end))
+
+            local ok, id = pcall(gen)
+
+            assert(set_upvalue(gen, "_v7_last_ms", old_last_ms))
+            assert(set_upvalue(gen, "_v7_seq", old_seq))
+            assert(set_upvalue(gen, "_v7_rand_b", old_rand_b))
+            assert(set_upvalue(gen, "ngx_now", old_ngx_now))
+            assert(set_upvalue(gen, "ngx_update_time", old_ngx_update_time))
+
+            if not ok then
+                ngx.say(id)
+                return
+            end
+
+            if update_calls < 1 then
+                ngx.say("ngx.update_time not called")
+                return
+            end
+
+            if string.sub(id, 15, 15) ~= "7" then
+                ngx.say("not uuidv7: ", id)
+                return
+            end
+
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+
+
+
+=== TEST 27: uuid v7 stays monotone when clock moves backwards
+--- config
+    location /t {
+        content_by_lua_block {
+            local debug = require("debug")
+            local utils = require("apisix.core.utils")
+
+            local function set_upvalue(func, name, value)
+                for i = 1, 32 do
+                    local upname = debug.getupvalue(func, i)
+                    if not upname then
+                        break
+                    end
+
+                    if upname == name then
+                        debug.setupvalue(func, i, value)
+                        return true
+                    end
+                end
+
+                return false
+            end
+
+            local function get_upvalue(func, name)
+                for i = 1, 32 do
+                    local upname, upvalue = debug.getupvalue(func, i)
+                    if not upname then
+                        break
+                    end
+
+                    if upname == name then
+                        return upvalue
+                    end
+                end
+            end
+
+            local gen = utils.generate_uuid_v7
+            local old_last_ms = get_upvalue(gen, "_v7_last_ms")
+            local old_seq = get_upvalue(gen, "_v7_seq")
+            local old_rand_b = get_upvalue(gen, "_v7_rand_b")
+            local old_ngx_now = get_upvalue(gen, "ngx_now")
+            local old_ngx_update_time = get_upvalue(gen, "ngx_update_time")
+
+            local fixed_rand = {1, 2, 3, 4, 5, 6, 7}
+            local fixed_last_ms = 1000100
+
+            assert(set_upvalue(gen, "_v7_last_ms", fixed_last_ms))
+            assert(set_upvalue(gen, "_v7_seq", 4))
+            assert(set_upvalue(gen, "_v7_rand_b", fixed_rand))
+            assert(set_upvalue(gen, "ngx_now", function() return 1000.100 end))
+            assert(set_upvalue(gen, "ngx_update_time", function() end))
+            local expected = gen()
+
+            assert(set_upvalue(gen, "_v7_last_ms", fixed_last_ms))
+            assert(set_upvalue(gen, "_v7_seq", 4))
+            assert(set_upvalue(gen, "_v7_rand_b", fixed_rand))
+            assert(set_upvalue(gen, "ngx_now", function() return 1000.099 end))
+            local actual = gen()
+
+            assert(set_upvalue(gen, "_v7_last_ms", old_last_ms))
+            assert(set_upvalue(gen, "_v7_seq", old_seq))
+            assert(set_upvalue(gen, "_v7_rand_b", old_rand_b))
+            assert(set_upvalue(gen, "ngx_now", old_ngx_now))
+            assert(set_upvalue(gen, "ngx_update_time", old_ngx_update_time))
+
+            if actual ~= expected then
+                ngx.say("rollback changed encoded timestamp: expected=", expected, " actual=", actual)
+                return
+            end
+
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok


### PR DESCRIPTION
## Summary
- Adds UUID v7 (RFC 9562) generation support to the `request-id` plugin via `algorithm: "uuidv7"`
- UUID v7 provides time-ordered, lexicographically sortable IDs with millisecond precision
- Includes worker-local monotonic sequence to guarantee uniqueness and ordering within a single millisecond

## Test plan
- [x] Schema validation tests (valid/invalid algorithm values)
- [x] Format validation (version nibble = 7, variant = 8-b)
- [x] Uniqueness test (180 concurrent requests)
- [x] Monotonicity test (sequential UUIDs are lexicographically ordered)
- [x] Timestamp encoding test (48-bit ts non-zero, no LuaJIT truncation)
- [x] Custom header name support
- [x] Sequence overflow handling
- [x] Clock rollback resilience