### PR TITLE
fix: consumer/credential/stream_route compatible with older versions schema

### DIFF
--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -728,6 +728,7 @@ _M.consumer = {
     type = "object",
     properties = {
         -- metadata
+        id = id_schema,
         username = {
             type = "string", minLength = 1, maxLength = rule_name_def.maxLength,
             pattern = [[^[a-zA-Z0-9_\-]+$]]
@@ -749,7 +750,17 @@ _M.credential = {
     type = "object",
     properties = {
         -- metadata
-        id = id_schema,
+        id = {
+            oneOf = {
+                id_schema,
+                {
+                    type = "string",
+                    minLength = 15,
+                    maxLength = 128,
+                    pattern = [[^[a-zA-Z0-9-_]+/credentials/[a-zA-Z0-9-_.]+$]],
+                }
+            }
+        },
         name = rule_name_def,
         desc = desc_def,
         labels = labels_def,

--- a/t/config-center-yaml/credentials.t
+++ b/t/config-center-yaml/credentials.t
@@ -1,0 +1,117 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+log_level('info');
+no_root_location();
+no_shuffle();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    my $yaml_config = $block->yaml_config // <<_EOC_;
+apisix:
+    node_listen: 1984
+deployment:
+    role: data_plane
+    role_data_plane:
+        config_provider: yaml
+_EOC_
+
+    $block->set_value("yaml_config", $yaml_config);
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: test with username in id field - invalid key
+--- apisix_yaml
+routes:
+  -
+    uri: /hello
+    plugins:
+      key-auth:
+    upstream:
+      nodes:
+        "127.0.0.1:1980": 1
+      type: roundrobin
+consumers:
+  - id: rose/credentials/542f7414-87f6-4793-a68e-99983dde9913
+    name: rose
+    plugins:
+      key-auth:
+        key: csdt8UPw76/SG+WlHBoFeg==
+
+  - id: rose
+    username: rose
+    plugins:
+      limit-count:
+        time_window: 3
+        count: 100000000
+        key_type: var
+        allow_degradation: false
+        key: remote_addr
+        rejected_code: 429
+        show_limit_quota_header: true
+        policy: local
+#END
+--- more_headers
+apikey: user-key
+--- error_code: 401
+--- request
+POST /hello
+
+
+
+=== TEST 2: test with username in id field - valid key
+--- apisix_yaml
+routes:
+  -
+    uri: /hello
+    plugins:
+      key-auth:
+    upstream:
+      nodes:
+        "127.0.0.1:1980": 1
+      type: roundrobin
+consumers:
+  - id: rose/credentials/542f7414-87f6-4793-a68e-99983dde9913
+    name: rose
+    plugins:
+      key-auth:
+        key: csdt8UPw76/SG+WlHBoFeg==
+
+  - id: rose
+    username: rose
+    plugins:
+      limit-count:
+        time_window: 3
+        count: 100000000
+        key_type: var
+        allow_degradation: false
+        key: remote_addr
+        rejected_code: 429
+        show_limit_quota_header: true
+        policy: local
+#END
+--- more_headers
+apikey: csdt8UPw76/SG+WlHBoFeg==
+--- error_code: 200
+--- request
+POST /hello


### PR DESCRIPTION
## Summary
- Adds `id` field to consumer schema for backward compatibility with older config formats
- Extends credential `id` schema to accept `consumer/credentials/uuid` path format via `oneOf`
- Adds `name` and `labels` fields to stream_route schema for compatibility

## Test plan
- [x] Credential with `consumer/credentials/uuid` id format is accepted
- [x] Consumer with explicit `id` field works in YAML config mode
- [x] Invalid API key returns 401
- [x] Valid credential key returns 200