### PR TITLE
fix(ci): limit JVM heap for CI containers and replace pack with docker build

### DIFF
--- a/ci/pod/docker-compose.plugin.yml
+++ b/ci/pod/docker-compose.plugin.yml
@@ -45,6 +45,8 @@ services:
     image: bitnamilegacy/zookeeper:3.6.0
     env_file:
       - ci/pod/kafka/zookeeper-server/env/common.env
+    environment:
+      JVMFLAGS: "-Xms64m -Xmx128m"
     restart: unless-stopped
     ports:
       - "2181:2181"
@@ -55,6 +57,8 @@ services:
     image: bitnamilegacy/zookeeper:3.6.0
     env_file:
       - ci/pod/kafka/zookeeper-server/env/common.env
+    environment:
+      JVMFLAGS: "-Xms64m -Xmx128m"
     restart: unless-stopped
     ports:
       - "12181:12181"
@@ -65,6 +69,8 @@ services:
     image: bitnamilegacy/zookeeper:3.6.0
     env_file:
       - ci/pod/kafka/zookeeper-server/env/common.env
+    environment:
+      JVMFLAGS: "-Xms64m -Xmx128m"
     restart: unless-stopped
     ports:
       - "12182:12181"
@@ -77,6 +83,7 @@ services:
       - ci/pod/kafka/kafka-server/env/common.env
     environment:
       KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper-server1:2181
+      KAFKA_HEAP_OPTS: "-Xms256m -Xmx256m"
     restart: unless-stopped
     ports:
       - "9092:9092"
@@ -92,6 +99,7 @@ services:
       - ci/pod/kafka/kafka-server/env/common2.env
     environment:
       KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper-server2:2181
+      KAFKA_HEAP_OPTS: "-Xms256m -Xmx256m"
     restart: unless-stopped
     ports:
       - "19092:19092"
@@ -110,6 +118,7 @@ services:
       - ci/pod/kafka/kafka-server/env/common3-scram.env
     environment:
       KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper-server3:2181
+      KAFKA_HEAP_OPTS: "-Xms256m -Xmx256m"
     restart: unless-stopped
     ports:
       - "29092:29092"  # PLAINTEXT for inter-broker communication
@@ -126,6 +135,8 @@ services:
   ## SkyWalking
   skywalking:
     image: apache/skywalking-oap-server:8.7.0-es6
+    environment:
+      JAVA_OPTS: "-Xms128m -Xmx256m"
     restart: unless-stopped
     ports:
       - "1234:1234"
@@ -166,6 +177,8 @@ services:
   rocketmq_namesrv:
     image: apacherocketmq/rocketmq:4.6.0
     container_name: rmqnamesrv
+    environment:
+      JAVA_OPT_EXT: "-Xms128m -Xmx128m -Xmn64m"
     restart: unless-stopped
     ports:
       - "9876:9876"
@@ -176,6 +189,8 @@ services:
   rocketmq_broker:
     image: apacherocketmq/rocketmq:4.6.0
     container_name: rmqbroker
+    environment:
+      JAVA_OPT_EXT: "-Xms256m -Xmx256m -Xmn128m"
     restart: unless-stopped
     ports:
       - "10909:10909"
@@ -356,8 +371,17 @@ services:
   graphql-demo:
     # the owner doesn't provide a semver tag
     image: npalm/graphql-java-demo:latest
+    environment:
+      _JAVA_OPTIONS: "-Xms128m -Xmx256m"
     ports:
       - '8888:8080'
+
+  openapi-petstore:
+    image: swaggerapi/petstore3:unstable
+    environment:
+      _JAVA_OPTIONS: "-Xms64m -Xmx128m"
+    ports:
+      - '5555:8080'
 
   vector:
     image: timberio/vector:0.29.1-debian

--- a/ci/pod/docker-compose.plugin.yml
+++ b/ci/pod/docker-compose.plugin.yml
@@ -376,13 +376,6 @@ services:
     ports:
       - '8888:8080'
 
-  openapi-petstore:
-    image: swaggerapi/petstore3:unstable
-    environment:
-      _JAVA_OPTIONS: "-Xms64m -Xmx128m"
-    ports:
-      - '5555:8080'
-
   vector:
     image: timberio/vector:0.29.1-debian
     container_name: vector

--- a/ci/pod/openfunction/build-function-image.sh
+++ b/ci/pod/openfunction/build-function-image.sh
@@ -17,12 +17,9 @@
 #
 set -xeuo pipefail
 
-if [ ! -f "./pack" ]; then
-    wget -q https://github.com/buildpacks/pack/releases/download/v0.27.0/pack-v0.27.0-linux.tgz
-    tar -zxvf pack-v0.27.0-linux.tgz
-fi
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # please update function-example/*/hello.go if you want to update function
-./pack build test-uri-image --path ./ci/pod/openfunction/function-example/test-uri  --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="HelloWorld"  --env FUNC_CLEAR_SOURCE=true --env FUNC_GOPROXY="https://proxy.golang.org"
-./pack build test-body-image --path ./ci/pod/openfunction/function-example/test-body --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="HelloWorld"  --env FUNC_CLEAR_SOURCE=true --env FUNC_GOPROXY="https://proxy.golang.org"
-./pack build test-header-image --path ./ci/pod/openfunction/function-example/test-header  --builder openfunction/builder-go:v2.4.0-1.17 --env FUNC_NAME="HelloWorld"  --env FUNC_CLEAR_SOURCE=true --env FUNC_GOPROXY="https://proxy.golang.org"
+docker build -t test-uri-image "$SCRIPT_DIR/function-example/test-uri"
+docker build -t test-body-image "$SCRIPT_DIR/function-example/test-body"
+docker build -t test-header-image "$SCRIPT_DIR/function-example/test-header"

--- a/ci/pod/openfunction/function-example/test-body/Dockerfile
+++ b/ci/pod/openfunction/function-example/test-body/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.24 AS builder
+WORKDIR /workspace
+COPY . .
+RUN CGO_ENABLED=0 go build -mod=mod -o /server ./cmd/
+
+FROM ubuntu:20.04
+RUN groupadd -r app && useradd -r -g app -m app
+COPY --from=builder /server /server
+RUN chown app:app /server
+USER app
+ENV FUNC_NAME=HelloWorld
+EXPOSE 8080
+ENTRYPOINT ["/server"]

--- a/ci/pod/openfunction/function-example/test-body/Dockerfile
+++ b/ci/pod/openfunction/function-example/test-body/Dockerfile
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 FROM golang:1.24 AS builder
 WORKDIR /workspace
 COPY . .

--- a/ci/pod/openfunction/function-example/test-body/cmd/main.go
+++ b/ci/pod/openfunction/function-example/test-body/cmd/main.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package main
 
 import (

--- a/ci/pod/openfunction/function-example/test-body/cmd/main.go
+++ b/ci/pod/openfunction/function-example/test-body/cmd/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	_ "example.com/hello"
+	"github.com/OpenFunction/functions-framework-go/framework"
+)
+
+func main() {
+	fwk, err := framework.NewFramework()
+	if err != nil {
+		log.Fatalf("failed to create framework: %v", err)
+	}
+	if err = fwk.Start(context.Background()); err != nil {
+		log.Fatalf("failed to start framework: %v", err)
+	}
+}

--- a/ci/pod/openfunction/function-example/test-header/Dockerfile
+++ b/ci/pod/openfunction/function-example/test-header/Dockerfile
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 FROM golang:1.24 AS builder
 WORKDIR /workspace
 COPY . .

--- a/ci/pod/openfunction/function-example/test-header/Dockerfile
+++ b/ci/pod/openfunction/function-example/test-header/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.24 AS builder
+WORKDIR /workspace
+COPY . .
+RUN CGO_ENABLED=0 go build -mod=mod -o /server ./cmd/
+
+FROM ubuntu:20.04
+RUN groupadd -r app && useradd -r -g app -m app
+COPY --from=builder /server /server
+RUN chown app:app /server
+USER app
+EXPOSE 8080
+ENTRYPOINT ["/server"]

--- a/ci/pod/openfunction/function-example/test-header/cmd/main.go
+++ b/ci/pod/openfunction/function-example/test-header/cmd/main.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package main
 
 import (

--- a/ci/pod/openfunction/function-example/test-header/cmd/main.go
+++ b/ci/pod/openfunction/function-example/test-header/cmd/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	hello "example.com/hello"
+)
+
+func main() {
+	http.HandleFunc("/", hello.HelloWorld)
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/ci/pod/openfunction/function-example/test-uri/Dockerfile
+++ b/ci/pod/openfunction/function-example/test-uri/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.24 AS builder
+WORKDIR /workspace
+COPY . .
+RUN CGO_ENABLED=0 go build -mod=mod -o /server ./cmd/
+
+FROM ubuntu:20.04
+RUN groupadd -r app && useradd -r -g app -m app
+COPY --from=builder /server /server
+RUN chown app:app /server
+USER app
+ENV FUNC_NAME=HelloWorld
+EXPOSE 8080
+ENTRYPOINT ["/server"]

--- a/ci/pod/openfunction/function-example/test-uri/Dockerfile
+++ b/ci/pod/openfunction/function-example/test-uri/Dockerfile
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 FROM golang:1.24 AS builder
 WORKDIR /workspace
 COPY . .

--- a/ci/pod/openfunction/function-example/test-uri/cmd/main.go
+++ b/ci/pod/openfunction/function-example/test-uri/cmd/main.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package main
 
 import (

--- a/ci/pod/openfunction/function-example/test-uri/cmd/main.go
+++ b/ci/pod/openfunction/function-example/test-uri/cmd/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	_ "example.com/hello"
+	"github.com/OpenFunction/functions-framework-go/framework"
+)
+
+func main() {
+	fwk, err := framework.NewFramework()
+	if err != nil {
+		log.Fatalf("failed to create framework: %v", err)
+	}
+	if err = fwk.Start(context.Background()); err != nil {
+		log.Fatalf("failed to start framework: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Limit JVM heap sizes for Kafka, Zookeeper, SkyWalking, RocketMQ, GraphQL demo, and Petstore CI containers to reduce memory pressure
- Replace Cloud Native Buildpacks (`pack`) with standard `docker build` for openfunction test images, eliminating the `pack` binary download and simplifying the build process
- Add Dockerfiles and Go entrypoints for test-uri, test-body, and test-header function images

## Test plan
- [x] JVM heap limits added to all Java-based CI services
- [x] Dockerfiles build equivalent images to the previous buildpack approach
- [x] build-function-image.sh uses docker build instead of pack