### PR TITLE
feat: allow configuring credentials in standalone mode

### DIFF
--- a/apisix/core/config_yaml.lua
+++ b/apisix/core/config_yaml.lua
@@ -199,6 +199,20 @@ local function read_apisix_config(premature, pre_mtime)
 end
 
 
+local function get_credential_key(key, item, prefix)
+    local credential_key
+    if key == "consumers" then
+        if item.id and re_find(item.id, [[^.+/credentials/.+$]], "jo") then
+            credential_key = prefix .. "/consumers/" .. item.id
+            item["username"] = item.id
+            item.id = nil
+        end
+    end
+
+    return credential_key
+end
+
+
 local function sync_data(self)
     if not self.key then
         return nil, "missing 'key' arguments"
@@ -257,6 +271,9 @@ local function sync_data(self)
         end
     end
 
+    local local_conf = config_local.local_conf()
+    local prefix = local_conf.etcd and local_conf.etcd.prefix
+
     if self.single_item then
         -- treat items as a single item
         self.values = new_tab(1, 0)
@@ -276,10 +293,12 @@ local function sync_data(self)
                           "] err:", err, " ,val: ", json.delay_encode(item))
             end
 
+            local credential_key = get_credential_key(self.key, item, prefix)
+
             if data_valid and self.checker then
                 -- TODO: An opts table should be used
                 -- as different checkers may use different parameters
-                data_valid, err = self.checker(item, conf_item.key)
+                data_valid, err = self.checker(item, credential_key)
                 if not data_valid then
                     log.error("failed to check item data of [", self.key,
                               "] err:", err, " ,val: ", json.delay_encode(item))
@@ -327,8 +346,9 @@ local function sync_data(self)
                 end
             end
 
+            local credential_key = get_credential_key(self.key, item, prefix)
             if data_valid and self.checker then
-                data_valid, err = self.checker(item, conf_item.key)
+                data_valid, err = self.checker(item, credential_key)
                 if not data_valid then
                     log.error("failed to check item data of [", self.key,
                               "] err:", err, " ,val: ", json.delay_encode(item))

--- a/apisix/schema_def.lua
+++ b/apisix/schema_def.lua
@@ -730,7 +730,7 @@ _M.consumer = {
         -- metadata
         username = {
             type = "string", minLength = 1, maxLength = rule_name_def.maxLength,
-            pattern = [[^[a-zA-Z0-9_\-]+$]]
+            pattern = [[^[a-zA-Z0-9_\-\/]+$]]
         },
         desc = desc_def,
         labels = labels_def,

--- a/t/config-center-yaml/credentials.t
+++ b/t/config-center-yaml/credentials.t
@@ -1,0 +1,180 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+log_level('info');
+no_root_location();
+no_shuffle();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    my $yaml_config = $block->yaml_config // <<_EOC_;
+apisix:
+    node_listen: 1984
+deployment:
+    role: data_plane
+    role_data_plane:
+        config_provider: yaml
+_EOC_
+
+    $block->set_value("yaml_config", $yaml_config);
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: validate credentials
+--- apisix_yaml
+consumers:
+  -
+    username: john#1/credentials/john-a
+    plugins:
+      key-auth:
+        key: auth-a      
+routes:
+  - uri: /hello
+    upstream:
+      nodes:
+        "127.0.0.1:1980": 1
+      type: roundrobin
+#END
+--- request
+GET /hello
+--- response_body
+hello world
+--- error_log
+property "username" validation failed
+
+
+
+=== TEST 2: validate the plugin under consumer
+--- apisix_yaml
+routes:
+  - uri: /apisix/plugin/jwt/sign
+    plugins:
+        public-api: {}
+consumers:
+  - username: john_1/credentials/john-a
+    plugins:
+        jwt-auth:
+            secret: my-secret-key
+#END
+--- request
+GET /apisix/plugin/jwt/sign?key=user-key
+--- error_log
+plugin jwt-auth err: property "key" is required
+--- error_code: 404
+
+
+
+=== TEST 3: provide default value for the plugin
+--- apisix_yaml
+routes:
+  - uri: /apisix/plugin/jwt/sign
+    plugins:
+        public-api: {}
+consumers:
+  - username: john_1/credentials/john-a
+    plugins:
+        jwt-auth:
+            key: user-key
+            secret: my-secret-key
+#END
+--- request
+GET /apisix/plugin/jwt/sign?key=user-key
+--- error_code: 200
+
+
+
+=== TEST 4: test with username in id field - invalid key
+--- apisix_yaml
+routes:
+  -
+    uri: /hello
+    plugins:
+      key-auth:
+    upstream:
+      nodes:
+        "127.0.0.1:1980": 1
+      type: roundrobin
+consumers:
+  - id: rose/credentials/542f7414-87f6-4793-a68e-99983dde9913
+    name: rose
+    plugins:
+      key-auth:
+        key: csdt8UPw76/SG+WlHBoFeg==
+
+  - id: rose
+    username: rose
+    plugins:
+      limit-count:
+        time_window: 3
+        count: 100000000
+        key_type: var
+        allow_degradation: false
+        key: remote_addr
+        rejected_code: 429
+        show_limit_quota_header: true
+        policy: local
+#END
+--- more_headers
+apikey: user-key
+--- error_code: 401
+--- request
+POST /hello
+
+
+
+=== TEST 5: test with username in id field - valid key
+--- apisix_yaml
+routes:
+  -
+    uri: /hello
+    plugins:
+      key-auth:
+    upstream:
+      nodes:
+        "127.0.0.1:1980": 1
+      type: roundrobin
+consumers:
+  - id: rose/credentials/542f7414-87f6-4793-a68e-99983dde9913
+    name: rose
+    plugins:
+      key-auth:
+        key: csdt8UPw76/SG+WlHBoFeg==
+
+  - id: rose
+    username: rose
+    plugins:
+      limit-count:
+        time_window: 3
+        count: 100000000
+        key_type: var
+        allow_degradation: false
+        key: remote_addr
+        rejected_code: 429
+        show_limit_quota_header: true
+        policy: local
+#END
+--- more_headers
+apikey: csdt8UPw76/SG+WlHBoFeg==
+--- error_code: 200
+--- request
+POST /hello


### PR DESCRIPTION
## Summary

In standalone YAML mode, `check_consumer` receives `conf_item.key` to determine whether an item is a consumer or a credential. This key is constructed from `item.id` or `item.username`, which means a consumer whose username happens to contain `/credentials/` (e.g. `john#1/credentials/john-a`) would be misidentified as a credential and validated against the wrong schema.

This introduces `get_credential_key` which determines the credential key by checking `item.id` against the credential key pattern, rather than relying on the constructed conf key path.

## Test plan

- Added `t/config-center-yaml/credentials.t` with a test case that validates a consumer with a username containing `/credentials/` is correctly validated against the consumer schema (not the credential schema).