### PR TITLE
fix(tencent-cloud-cls): add ssl_verify option and fix shared state in cls-sdk

### DIFF
--- a/apisix/plugins/tencent-cloud-cls.lua
+++ b/apisix/plugins/tencent-cloud-cls.lua
@@ -14,6 +14,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 --
+
 local core = require("apisix.core")
 local plugin = require("apisix.plugin")
 local log_util = require("apisix.utils.log-util")
@@ -22,6 +23,7 @@ local cls_sdk = require("apisix.plugins.tencent-cloud-cls.cls-sdk")
 local math = math
 local pairs = pairs
 
+
 local plugin_name = "tencent-cloud-cls"
 local batch_processor_manager = bp_manager_mod.new(plugin_name)
 local schema = {
@@ -29,7 +31,8 @@ local schema = {
     properties = {
         cls_host = { type = "string" },
         cls_topic = { type = "string" },
-        scheme = { type = "string", default = "https"},
+        scheme = { type = "string", enum = {"http", "https"}, default = "https" },
+        ssl_verify = { type = "boolean", default = true },
         secret_id = { type = "string" },
         secret_key = { type = "string" },
         sample_ratio = {
@@ -147,7 +150,7 @@ function _M.log(conf, ctx)
         local sdk, err = cls_sdk.new(
                             conf.scheme, conf.cls_host,
                             conf.cls_topic, conf.secret_id,
-                            conf.secret_key)
+                            conf.secret_key, conf.ssl_verify)
         if err then
             core.log.error("init sdk failed err:", err)
             return false, err

--- a/apisix/plugins/tencent-cloud-cls/cls-sdk.lua
+++ b/apisix/plugins/tencent-cloud-cls/cls-sdk.lua
@@ -53,12 +53,6 @@ local cls_conn_timeout = 1000
 local cls_read_timeout = 10000
 local cls_send_timeout = 10000
 
-local headers_cache = {}
-local params_cache = {
-    ssl_verify = false,
-    headers = headers_cache,
-}
-
 
 local function get_ip(hostname)
     local _, resolved = socket.dns.toip(hostname)
@@ -202,7 +196,7 @@ message LogGroupList
 end
 
 
-function _M.new(scheme, host, topic, secret_id, secret_key)
+function _M.new(scheme, host, topic, secret_id, secret_key, ssl_verify)
     if not pb_state then
         local err = init_pb_state()
         if err then
@@ -215,6 +209,7 @@ function _M.new(scheme, host, topic, secret_id, secret_key)
         topic = topic,
         secret_id = secret_id,
         secret_key = secret_key,
+        ssl_verify = ssl_verify,
     }
     return setmetatable(self, mt)
 end
@@ -239,19 +234,24 @@ function _M.send_cls_request(self, pb_obj)
         return false, pb_data
     end
 
-    clear_tab(headers_cache)
-    headers_cache["Host"] = self.host
-    headers_cache["Content-Type"] = "application/x-protobuf"
-    headers_cache["Authorization"] = sign(self.secret_id, self.secret_key, cls_api_path)
+    local headers = {
+        ["Host"] = self.host,
+        ["Content-Type"] = "application/x-protobuf",
+        ["Authorization"] = sign(self.secret_id, self.secret_key, cls_api_path),
+    }
 
     -- TODO: support lz4/zstd compress
-    params_cache.method = "POST"
-    params_cache.body = pb_data
+    local params = {
+        method = "POST",
+        body = pb_data,
+        headers = headers,
+        ssl_verify = self.ssl_verify,
+    }
 
     local cls_url = self.scheme .. "://" .. self.host .. cls_api_path .. "?topic_id=" .. self.topic
     core.log.debug("CLS request URL: ", cls_url)
 
-    local res, err = do_request_uri(cls_url, params_cache)
+    local res, err = do_request_uri(cls_url, params)
     if not res then
         return false, err
     end

--- a/t/plugin/tencent-cloud-cls.t
+++ b/t/plugin/tencent-cloud-cls.t
@@ -729,7 +729,7 @@ qr/resolve ip failed, hostname: .*, error: address can't be resolved/
                         "plugins": {
                             "tencent-cloud-cls": {
                                 "scheme": "https",
-                                "cls_host": "127.0.0.1:10422",
+                                "cls_host": "test.com:10422",
                                 "cls_topic": "143b5d70-139b-4aec-b54e-bb97756916de",
                                 "secret_id": "secret_id",
                                 "secret_key": "secret_key",


### PR DESCRIPTION
## Summary

- Replace module-level shared `headers_cache` and `params_cache` tables in cls-sdk with per-request local tables to prevent data leaking between concurrent requests.
- Add `ssl_verify` plugin configuration option (default: `true`) so TLS certificate verification is no longer unconditionally disabled.
- Add enum validation for `scheme` to restrict it to `http` and `https`.

## Test plan

- [ ] Existing `t/plugin/tencent-cloud-cls.t` tests pass
- [ ] Verify `ssl_verify` defaults to `true` and is correctly passed through to the HTTP client