### PR TITLE
fix: remove credential-leaking log statements in sls-logger, hmac-auth, tcp-logger, udp-logger

### DIFF
--- a/apisix/plugins/hmac-auth.lua
+++ b/apisix/plugins/hmac-auth.lua
@@ -153,16 +153,10 @@ local function generate_signature(ctx, secret_key, params)
               if h == "@request-target" then
                 local request_target = request_method .. " " .. uri
                 core.table.insert(signing_string_items, request_target)
-                core.log.info("canonical_header name:", core.json.delay_encode(h))
-                core.log.info("canonical_header value: ",
-                              core.json.delay_encode(request_target))
               end
             else
               core.table.insert(signing_string_items,
                                 h .. ": " .. canonical_header)
-              core.log.info("canonical_header name:", core.json.delay_encode(h))
-              core.log.info("canonical_header value: ",
-                            core.json.delay_encode(canonical_header))
             end
         end
     end

--- a/apisix/plugins/sls-logger.lua
+++ b/apisix/plugins/sls-logger.lua
@@ -142,7 +142,6 @@ local function combine_syslog(entries)
     local items = {}
     for _, entry in ipairs(entries) do
         table.insert(items, entry.data)
-        core.log.info("buffered logs:", entry.data)
     end
 
     return table.concat(items)
@@ -185,7 +184,6 @@ function _M.log(conf, ctx)
     }
     local rf5424_data = rf5424.encode("SYSLOG", "INFO", ctx.var.host, "apisix",
                                       ctx.var.pid, json_str, structured_data)
-    core.log.info("collect_data:" .. rf5424_data)
     local process_context = {
         data = rf5424_data,
         route_conf = conf

--- a/apisix/plugins/tcp-logger.lua
+++ b/apisix/plugins/tcp-logger.lua
@@ -101,7 +101,6 @@ local function send_tcp_data(conf, log_message)
     sock:settimeout(conf.timeout)
 
     core.log.info("sending a batch logs to ", conf.host, ":", conf.port)
-    core.log.info("sending log_message: ", log_message)
 
     local ok, err = sock:connect(conf.host, conf.port)
     if not ok then

--- a/apisix/plugins/udp-logger.lua
+++ b/apisix/plugins/udp-logger.lua
@@ -93,7 +93,6 @@ local function send_udp_data(conf, log_message)
     sock:settimeout(conf.timeout * 1000)
 
     core.log.info("sending a batch logs to ", conf.host, ":", conf.port)
-    core.log.info("sending log_message: ", log_message)
 
     local ok, err = sock:setpeername(conf.host, conf.port)
 

--- a/t/plugin/sls-logger.t
+++ b/t/plugin/sls-logger.t
@@ -27,6 +27,19 @@ add_block_preprocessor(sub {
         $block->set_value("request", "GET /t");
     }
 
+        my $extra_init_by_lua = <<_EOC_;
+    local bp_manager = require("apisix.utils.batch-processor-manager")
+    local core = require("apisix.core")
+    local old_f = bp_manager.add_entry_to_new_processor
+    bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
+        ngx.log(ngx.INFO, "batch_entry: ", entry.data or core.json.encode(entry))
+        return old_f(self, conf, entry, ctx, func, max_pending_entries)
+    end
+_EOC_
+
+    if (!defined $block->extra_init_by_lua) {
+         $block->set_value("extra_init_by_lua", $extra_init_by_lua);
+    }
 });
 
 run_tests();

--- a/t/plugin/tcp-logger.t
+++ b/t/plugin/tcp-logger.t
@@ -19,6 +19,29 @@ use t::APISIX 'no_plan';
 repeat_each(1);
 no_long_string();
 no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+        my $extra_init_by_lua = <<_EOC_;
+    local bp_manager = require("apisix.utils.batch-processor-manager")
+    local core = require("apisix.core")
+    local old_f = bp_manager.add_entry_to_new_processor
+    bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
+        ngx.log(ngx.INFO, "batch_entry: ", core.json.encode(entry))
+        return old_f(self, conf, entry, ctx, func, max_pending_entries)
+    end
+_EOC_
+
+    if (!defined $block->extra_init_by_lua) {
+         $block->set_value("extra_init_by_lua", $extra_init_by_lua);
+    }
+});
+
 run_tests;
 
 __DATA__

--- a/t/plugin/udp-logger.t
+++ b/t/plugin/udp-logger.t
@@ -19,6 +19,29 @@ use t::APISIX 'no_plan';
 repeat_each(1);
 no_long_string();
 no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+        my $extra_init_by_lua = <<_EOC_;
+    local bp_manager = require("apisix.utils.batch-processor-manager")
+    local core = require("apisix.core")
+    local old_f = bp_manager.add_entry_to_new_processor
+    bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
+        ngx.log(ngx.INFO, "batch_entry: ", core.json.encode(entry))
+        return old_f(self, conf, entry, ctx, func, max_pending_entries)
+    end
+_EOC_
+
+    if (!defined $block->extra_init_by_lua) {
+         $block->set_value("extra_init_by_lua", $extra_init_by_lua);
+    }
+});
+
 run_tests;
 
 __DATA__


### PR DESCRIPTION
## Summary

Remove debug `core.log.info` statements that exposed sensitive credentials in nginx error logs at info level.

### Vulnerabilities Fixed

- **`sls-logger.lua`**: The `rf5424_data` string (containing `access-key-secret`) was logged in `combine_syslog()` and `_M.log()` on each log flush.
- **`hmac-auth.lua`**: Canonical header names and values (which may include `Authorization` and `Cookie` headers) were logged during HMAC signature generation.
- **`tcp-logger.lua`** / **`udp-logger.lua`**: The full serialized `log_message` payload (containing all request headers and body) was logged before each send.

### Changes

**Plugin fixes** (`apisix/plugins/`):
- Remove 8 `core.log.info` lines across 4 plugin files (`sls-logger.lua`, `hmac-auth.lua`, `tcp-logger.lua`, `udp-logger.lua`).

**Regression tests** (`t/plugin/`):
- `sls-logger.t`: Add `extra_init_by_lua` hook on `batch_processor_manager.add_entry_to_new_processor` to print `entry.data` (the raw RFC5424-encoded string) to the error log. Existing TEST 14 and TEST 15 `--- error_log` assertions continue to verify that request/response body is captured and forwarded correctly.
- `tcp-logger.t` / `udp-logger.t`: Same hook pattern using `core.json.encode(entry)`. Existing TEST 16/17 and TEST 13/14 `--- error_log` assertions continue to verify body collection works end-to-end.