### PR TITLE
docs(ai-rate-limiting): re-port with Admin API, ADC, and Ingress Controller tabs

### DIFF
--- a/docs/en/latest/plugins/ai-rate-limiting.md
+++ b/docs/en/latest/plugins/ai-rate-limiting.md
@@ -85,9 +85,10 @@ Create a Route as such and update with your LLM providers, models, API keys, and
 <TabItem value="admin-api" label="Admin API">
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
+    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -295,9 +296,10 @@ Create a Route which applies a rate limiting quota of 100 total tokens in a 30-s
 <TabItem value="admin-api" label="Admin API">
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
+    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -562,9 +564,10 @@ Create a Route which applies a rate limiting quota of 100 total tokens for all i
 <TabItem value="admin-api" label="Admin API">
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
+    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -907,9 +910,10 @@ Create a Route as such to set rate limiting and a higher priority on `openai-ins
 <TabItem value="admin-api" label="Admin API">
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
+    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -1313,9 +1317,10 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers/janedoe/credentials" -X PUT \
 Create a Route as such and update with your LLM providers, models, API keys, and endpoints, if applicable:
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
+    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -1757,9 +1762,10 @@ Create a Route with the `ai-rate-limiting` Plugin that applies different rate li
 <TabItem value="admin-api" label="Admin API">
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
+    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {

--- a/docs/en/latest/plugins/ai-rate-limiting.md
+++ b/docs/en/latest/plugins/ai-rate-limiting.md
@@ -33,29 +33,33 @@ description: The ai-rate-limiting Plugin enforces token-based rate limiting for 
   <link rel="canonical" href="https://docs.api7.ai/hub/ai-rate-limiting" />
 </head>
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Description
 
-The `ai-rate-limiting` Plugin enforces token-based rate limiting for requests sent to LLM services. It helps manage API usage by controlling the number of tokens consumed within a specified time frame, ensuring fair resource allocation and preventing excessive load on the service. It is often used with [`ai-proxy`](./ai-proxy.md) or [`ai-proxy-multi`](./ai-proxy-multi.md) plugin.
+The `ai-rate-limiting` Plugin enforces token-based rate limiting for requests sent to LLM services. It helps manage API usage by controlling the number of tokens consumed within a specified time frame, ensuring fair resource allocation and preventing excessive load on the service. It is often used with [`ai-proxy`](./ai-proxy.md) or [`ai-proxy-multi`](./ai-proxy-multi.md) Plugin.
 
 ## Attributes
 
-| Name                         | Type            | Required | Default  | Valid values                                             | Description |
-|------------------------------|----------------|----------|----------|---------------------------------------------------------|-------------|
-| limit                        | integer        | False    |          | >0                             | The maximum number of tokens allowed within a given time interval. At least one of `limit` and `instances.limit` should be configured. Required if `rules` is not configured. |
-| time_window                  | integer        | False    |          | >0                             | The time interval corresponding to the rate limiting `limit` in seconds. At least one of `time_window` and `instances.time_window` should be configured. Required if `rules` is not configured. |
-| rules                        | array[object]  | False    |          |                                                         | A list of rate limiting rules. Each rule is an object containing `count`, `time_window`, and `key`. If configured, this takes precedence over `limit` and `time_window`. |
-| rules.count                  | integer or string | True  |          | >0 or variable expression                              | The maximum number of tokens allowed within a given time interval. Can be a static integer or a variable expression like `$http_custom_limit`. |
-| rules.time_window            | integer or string | True  |          | >0 or variable expression                              | The time interval corresponding to the rate limiting `count` in seconds. Can be a static integer or a variable expression. |
-| rules.key                    | string         | True     |          |                                                         | The key to count requests by. If the configured key does not exist, the rule will not be executed. The `key` is interpreted as a combination of variables, for example: `$http_custom_a $http_custom_b`. |
-| rules.header_prefix          | string         | False    |          |                                                         | Prefix for rate limit headers. If configured, the response will include `X-{header_prefix}-RateLimit-Limit`, `X-{header_prefix}-RateLimit-Remaining`, and `X-{header_prefix}-RateLimit-Reset` headers. If not configured, the index of the rule in the rules array is used as the prefix. For example, headers for the first rule will be `X-1-RateLimit-Limit`, `X-1-RateLimit-Remaining`, and `X-1-RateLimit-Reset`. |
-| show_limit_quota_header      | boolean        | False    | true     |                                                         | If true, includes `X-AI-RateLimit-Limit-*`, `X-AI-RateLimit-Remaining-*`, and `X-AI-RateLimit-Reset-*` headers in the response, where `*` is the instance name. |
-| limit_strategy               | string         | False    | total_tokens | [total_tokens, prompt_tokens, completion_tokens] | Type of token to apply rate limiting. `total_tokens` is the sum of `prompt_tokens` and `completion_tokens`. |
-| instances                    | array[object]  | False    |          |                                                         | LLM instance rate limiting configurations. |
-| instances.name               | string         | True     |          |                                                         | Name of the LLM service instance. |
-| instances.limit              | integer        | True     |          | >0                             | The maximum number of tokens allowed within a given time interval for an instance. |
-| instances.time_window        | integer        | True     |          | >0                             | The time interval corresponding to the rate limiting `limit` in seconds for an instance. |
-| rejected_code                | integer        | False    | 503      |  [200, 599]                           | The HTTP status code returned when a request exceeding the quota is rejected. |
-| rejected_msg                 | string         | False    |          |                                           | The response body returned when a request exceeding the quota is rejected. |
+| Name | Type | Required | Default | Valid values | Description |
+|------|------|----------|---------|-------------|-------------|
+| limit | integer | False | | >0 | The maximum number of tokens allowed within a given time interval. At least one of `limit` and `instances.limit` should be configured. Required if `rules` is not configured. |
+| time_window | integer | False | | >0 | The time interval corresponding to the rate limiting `limit` in seconds. At least one of `time_window` and `instances.time_window` should be configured. Required if `rules` is not configured. |
+| show_limit_quota_header | boolean | False | true | | If true, includes rate limiting response headers. When `rules` is not set, the headers are `X-AI-RateLimit-Limit-*`, `X-AI-RateLimit-Remaining-*`, and `X-AI-RateLimit-Reset-*`, where `*` is the instance name. When `rules` is set, see `rules.header_prefix` for details. |
+| limit_strategy | string | False | total_tokens | [`total_tokens`, `prompt_tokens`, `completion_tokens`, `expression`] | Type of token to apply rate limiting. `total_tokens` is the sum of `prompt_tokens` and `completion_tokens`. When set to `expression`, the `cost_expr` field is used to dynamically calculate token cost. |
+| cost_expr | string | False | | | Lua arithmetic expression for dynamic token cost calculation. Variables are injected from the LLM API raw usage response fields. Missing variables default to 0. Only valid when `limit_strategy` is `expression`. Example: `input_tokens + cache_creation_input_tokens + output_tokens`. |
+| instances | array[object] | False | | | LLM instance rate limiting configurations. |
+| instances.name | string | True | | | Name of the LLM service instance. |
+| instances.limit | integer | True | | >0 | The maximum number of tokens allowed within a given time interval for an instance. |
+| instances.time_window | integer | True | | >0 | The time interval corresponding to the rate limiting `limit` in seconds for an instance. |
+| rejected_code | integer | False | 503 | [200, 599] | The HTTP status code returned when a request exceeding the quota is rejected. |
+| rejected_msg | string | False | | | The response body returned when a request exceeding the quota is rejected. |
+| rules | array[object] | False | | | An array of rate-limiting rules that are applied sequentially. If configured, this takes precedence over `limit` and `time_window`. |
+| rules.count | integer or string | True | | >0 or variable expression | The maximum number of tokens allowed within a given time interval. Can be a static integer or a variable expression like `$http_custom_limit`. |
+| rules.time_window | integer or string | True | | >0 or variable expression | The time interval corresponding to the rate limiting `count` in seconds. Can be a static integer or a variable expression. |
+| rules.key | string | True | | | The key to count requests by. If the configured key does not exist, the rule will not be executed. The `key` is interpreted as a combination of variables. All variables should be prefixed by dollar signs (`$`). For example, `$http_custom_a $http_custom_b`. |
+| rules.header_prefix | string | False | | | Prefix for rate limiting response headers. When configured, the prefix is inserted after `X-AI-` in the header name. For example, with `header_prefix` set to `test`, the headers become `X-AI-Test-RateLimit-Limit`, `X-AI-Test-RateLimit-Remaining`, and `X-AI-Test-RateLimit-Reset`. When not configured, the index of the rule in the rules array is used as the prefix. For example, headers for the first rule will be `X-AI-1-RateLimit-Limit`, `X-AI-1-RateLimit-Remaining`, and `X-AI-1-RateLimit-Reset`. |
 
 ## Examples
 
@@ -65,7 +69,7 @@ The examples below demonstrate how you can configure `ai-rate-limiting` for diff
 
 You can fetch the `admin_key` from `config.yaml` and save to an environment variable with the following command:
 
-```bash
+```shell
 admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
 ```
 
@@ -77,11 +81,13 @@ The following example demonstrates how you can use `ai-proxy` to proxy LLM traff
 
 Create a Route as such and update with your LLM providers, models, API keys, and endpoints, if applicable:
 
+<Tabs groupId="api">
+<TabItem value="admin-api" label="Admin API">
+
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
-    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -106,6 +112,142 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
     }
   }'
 ```
+
+</TabItem>
+<TabItem value="adc" label="ADC">
+
+```yaml title="adc.yaml"
+services:
+  - name: ai-rate-limiting-service
+    routes:
+      - name: ai-rate-limiting-route
+        uris:
+          - /anything
+        methods:
+          - POST
+        plugins:
+          ai-proxy:
+            provider: openai
+            auth:
+              header:
+                Authorization: "Bearer ${OPENAI_API_KEY}"
+            options:
+              model: gpt-35-turbo-instruct
+              max_tokens: 512
+              temperature: 1.0
+          ai-rate-limiting:
+            limit: 300
+            time_window: 30
+            limit_strategy: prompt_tokens
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+<TabItem value="ingress" label="Ingress Controller">
+
+<Tabs groupId="k8s-api">
+<TabItem value="gateway-api" label="Gateway API">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-plugin-config
+spec:
+  plugins:
+    - name: ai-proxy
+      config:
+        provider: openai
+        auth:
+          header:
+            Authorization: "Bearer your-api-key"
+        options:
+          model: gpt-35-turbo-instruct
+          max_tokens: 512
+          temperature: 1.0
+    - name: ai-rate-limiting
+      config:
+        limit: 300
+        time_window: 30
+        limit_strategy: prompt_tokens
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+          method: POST
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: ai-rate-limiting-plugin-config
+```
+
+</TabItem>
+<TabItem value="ingress" label="APISIX Ingress Controller">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: ai-rate-limiting-route
+      match:
+        paths:
+          - /anything
+        methods:
+          - POST
+      plugins:
+        - name: ai-proxy
+          enable: true
+          config:
+            provider: openai
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: gpt-35-turbo-instruct
+              max_tokens: 512
+              temperature: 1.0
+        - name: ai-rate-limiting
+          enable: true
+          config:
+            limit: 300
+            time_window: 30
+            limit_strategy: prompt_tokens
+```
+
+</TabItem>
+</Tabs>
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f ai-rate-limiting-ic.yaml
+```
+
+</TabItem>
+</Tabs>
 
 Send a POST request to the Route with a system prompt and a sample user question in the request body:
 
@@ -147,13 +289,15 @@ If the rate limiting quota of 300 prompt tokens has been consumed in a 30-second
 
 The following example demonstrates how you can use `ai-proxy-multi` to configure two models for load balancing, forwarding 80% of the traffic to one instance and 20% to the other. Additionally, use `ai-rate-limiting` to configure token-based rate limiting on the instance that receives 80% of the traffic, such that when the configured quota is fully consumed, the additional traffic will be forwarded to the other instance.
 
-Create a Route which applies rate limiting quota of 100 total tokens in a 30-second window on the `deepseek-instance-1` instance, and update with your LLM providers, models, API keys, and endpoints, if applicable:
+Create a Route which applies a rate limiting quota of 100 total tokens in a 30-second window on the `deepseek-instance-1` instance, and update with your LLM providers, models, API keys, and endpoints, if applicable:
+
+<Tabs groupId="api">
+<TabItem value="admin-api" label="Admin API">
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
-    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -201,6 +345,175 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
+</TabItem>
+<TabItem value="adc" label="ADC">
+
+```yaml title="adc.yaml"
+services:
+  - name: ai-rate-limiting-service
+    routes:
+      - name: ai-rate-limiting-route
+        uris:
+          - /anything
+        methods:
+          - POST
+        plugins:
+          ai-proxy-multi:
+            instances:
+              - name: deepseek-instance-1
+                provider: deepseek
+                weight: 8
+                auth:
+                  header:
+                    Authorization: "Bearer ${DEEPSEEK_API_KEY}"
+                options:
+                  model: deepseek-chat
+              - name: deepseek-instance-2
+                provider: deepseek
+                weight: 2
+                auth:
+                  header:
+                    Authorization: "Bearer ${DEEPSEEK_API_KEY}"
+                options:
+                  model: deepseek-chat
+          ai-rate-limiting:
+            instances:
+              - name: deepseek-instance-1
+                limit_strategy: total_tokens
+                limit: 100
+                time_window: 30
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+<TabItem value="ingress" label="Ingress Controller">
+
+<Tabs groupId="k8s-api">
+<TabItem value="gateway-api" label="Gateway API">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-plugin-config
+spec:
+  plugins:
+    - name: ai-proxy-multi
+      config:
+        instances:
+          - name: deepseek-instance-1
+            provider: deepseek
+            weight: 8
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: deepseek-chat
+          - name: deepseek-instance-2
+            provider: deepseek
+            weight: 2
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: deepseek-chat
+    - name: ai-rate-limiting
+      config:
+        instances:
+          - name: deepseek-instance-1
+            limit_strategy: total_tokens
+            limit: 100
+            time_window: 30
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+          method: POST
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: ai-rate-limiting-plugin-config
+```
+
+</TabItem>
+<TabItem value="ingress" label="APISIX Ingress Controller">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: ai-rate-limiting-route
+      match:
+        paths:
+          - /anything
+        methods:
+          - POST
+      plugins:
+        - name: ai-proxy-multi
+          enable: true
+          config:
+            instances:
+              - name: deepseek-instance-1
+                provider: deepseek
+                weight: 8
+                auth:
+                  header:
+                    Authorization: "Bearer your-api-key"
+                options:
+                  model: deepseek-chat
+              - name: deepseek-instance-2
+                provider: deepseek
+                weight: 2
+                auth:
+                  header:
+                    Authorization: "Bearer your-api-key"
+                options:
+                  model: deepseek-chat
+        - name: ai-rate-limiting
+          enable: true
+          config:
+            instances:
+              - name: deepseek-instance-1
+                limit_strategy: total_tokens
+                limit: 100
+                time_window: 30
+```
+
+</TabItem>
+</Tabs>
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f ai-rate-limiting-ic.yaml
+```
+
+</TabItem>
+</Tabs>
+
 Send a POST request to the Route with a system prompt and a sample user question in the request body:
 
 ```shell
@@ -245,11 +558,13 @@ For demonstration and easier differentiation, you will be configuring one OpenAI
 
 Create a Route which applies a rate limiting quota of 100 total tokens for all instances within a 60-second window, and update with your LLM providers, models, API keys, and endpoints, if applicable:
 
+<Tabs groupId="api">
+<TabItem value="admin-api" label="Admin API">
+
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
-    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -292,6 +607,172 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
     }
   }'
 ```
+
+</TabItem>
+<TabItem value="adc" label="ADC">
+
+```yaml title="adc.yaml"
+services:
+  - name: ai-rate-limiting-service
+    routes:
+      - name: ai-rate-limiting-route
+        uris:
+          - /anything
+        methods:
+          - POST
+        plugins:
+          ai-proxy-multi:
+            instances:
+              - name: openai-instance
+                provider: openai
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer ${OPENAI_API_KEY}"
+                options:
+                  model: gpt-4
+              - name: deepseek-instance
+                provider: deepseek
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer ${DEEPSEEK_API_KEY}"
+                options:
+                  model: deepseek-chat
+          ai-rate-limiting:
+            limit: 100
+            time_window: 60
+            rejected_code: 429
+            limit_strategy: total_tokens
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+<TabItem value="ingress" label="Ingress Controller">
+
+<Tabs groupId="k8s-api">
+<TabItem value="gateway-api" label="Gateway API">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-plugin-config
+spec:
+  plugins:
+    - name: ai-proxy-multi
+      config:
+        instances:
+          - name: openai-instance
+            provider: openai
+            weight: 0
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: gpt-4
+          - name: deepseek-instance
+            provider: deepseek
+            weight: 0
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: deepseek-chat
+    - name: ai-rate-limiting
+      config:
+        limit: 100
+        time_window: 60
+        rejected_code: 429
+        limit_strategy: total_tokens
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+          method: POST
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: ai-rate-limiting-plugin-config
+```
+
+</TabItem>
+<TabItem value="ingress" label="APISIX Ingress Controller">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: ai-rate-limiting-route
+      match:
+        paths:
+          - /anything
+        methods:
+          - POST
+      plugins:
+        - name: ai-proxy-multi
+          enable: true
+          config:
+            instances:
+              - name: openai-instance
+                provider: openai
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer your-api-key"
+                options:
+                  model: gpt-4
+              - name: deepseek-instance
+                provider: deepseek
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer your-api-key"
+                options:
+                  model: deepseek-chat
+        - name: ai-rate-limiting
+          enable: true
+          config:
+            limit: 100
+            time_window: 60
+            rejected_code: 429
+            limit_strategy: total_tokens
+```
+
+</TabItem>
+</Tabs>
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f ai-rate-limiting-ic.yaml
+```
+
+</TabItem>
+</Tabs>
 
 Send a POST request to the Route with a system prompt and a sample user question in the request body:
 
@@ -422,16 +903,18 @@ The following example demonstrates how you can configure two models with differe
 
 Create a Route as such to set rate limiting and a higher priority on `openai-instance` instance and set the `fallback_strategy` to `["rate_limiting"]`. Update with your LLM providers, models, API keys, and endpoints, if applicable:
 
+<Tabs groupId="api">
+<TabItem value="admin-api" label="Admin API">
+
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
-    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
       "ai-proxy-multi": {
-        "fallback_strategy: ["rate_limiting"],
+        "fallback_strategy": ["rate_limiting"],
         "instances": [
           {
             "name": "openai-instance",
@@ -476,6 +959,187 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
     }
   }'
 ```
+
+</TabItem>
+<TabItem value="adc" label="ADC">
+
+```yaml title="adc.yaml"
+services:
+  - name: ai-rate-limiting-service
+    routes:
+      - name: ai-rate-limiting-route
+        uris:
+          - /anything
+        methods:
+          - POST
+        plugins:
+          ai-proxy-multi:
+            fallback_strategy:
+              - rate_limiting
+            instances:
+              - name: openai-instance
+                provider: openai
+                priority: 1
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer ${OPENAI_API_KEY}"
+                options:
+                  model: gpt-4
+              - name: deepseek-instance
+                provider: deepseek
+                priority: 0
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer ${DEEPSEEK_API_KEY}"
+                options:
+                  model: deepseek-chat
+          ai-rate-limiting:
+            instances:
+              - name: openai-instance
+                limit: 10
+                time_window: 60
+            limit_strategy: total_tokens
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+<TabItem value="ingress" label="Ingress Controller">
+
+<Tabs groupId="k8s-api">
+<TabItem value="gateway-api" label="Gateway API">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-plugin-config
+spec:
+  plugins:
+    - name: ai-proxy-multi
+      config:
+        fallback_strategy:
+          - rate_limiting
+        instances:
+          - name: openai-instance
+            provider: openai
+            priority: 1
+            weight: 0
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: gpt-4
+          - name: deepseek-instance
+            provider: deepseek
+            priority: 0
+            weight: 0
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: deepseek-chat
+    - name: ai-rate-limiting
+      config:
+        instances:
+          - name: openai-instance
+            limit: 10
+            time_window: 60
+        limit_strategy: total_tokens
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+          method: POST
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: ai-rate-limiting-plugin-config
+```
+
+</TabItem>
+<TabItem value="ingress" label="APISIX Ingress Controller">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: ai-rate-limiting-route
+      match:
+        paths:
+          - /anything
+        methods:
+          - POST
+      plugins:
+        - name: ai-proxy-multi
+          enable: true
+          config:
+            fallback_strategy:
+              - rate_limiting
+            instances:
+              - name: openai-instance
+                provider: openai
+                priority: 1
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer your-api-key"
+                options:
+                  model: gpt-4
+              - name: deepseek-instance
+                provider: deepseek
+                priority: 0
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer your-api-key"
+                options:
+                  model: deepseek-chat
+        - name: ai-rate-limiting
+          enable: true
+          config:
+            instances:
+              - name: openai-instance
+                limit: 10
+                time_window: 60
+            limit_strategy: total_tokens
+```
+
+</TabItem>
+</Tabs>
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f ai-rate-limiting-ic.yaml
+```
+
+</TabItem>
+</Tabs>
 
 Send a POST request to the Route with a system prompt and a sample user question in the request body:
 
@@ -569,6 +1233,9 @@ The following example demonstrates how you can configure two models for load bal
 
 Create a Consumer `johndoe` and a rate limiting quota of 10 tokens in a 60-second window on `openai-instance` instance:
 
+<Tabs groupId="api">
+<TabItem value="admin-api" label="Admin API">
+
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
@@ -590,7 +1257,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   }'
 ```
 
-Configure `key-auth` credential for `johndoe`:
+Configure `key-auth` Credential for `johndoe`:
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/johndoe/credentials" -X PUT \
@@ -611,7 +1278,7 @@ Create another Consumer `janedoe` and a rate limiting quota of 10 tokens in a 60
 curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
-    "username": "johndoe",
+    "username": "janedoe",
     "plugins": {
       "ai-rate-limiting": {
         "instances": [
@@ -628,7 +1295,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   }'
 ```
 
-Configure `key-auth` credential for `janedoe`:
+Configure `key-auth` Credential for `janedoe`:
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/janedoe/credentials" -X PUT \
@@ -646,16 +1313,15 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers/janedoe/credentials" -X PUT \
 Create a Route as such and update with your LLM providers, models, API keys, and endpoints, if applicable:
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
-    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
       "key-auth": {},
       "ai-proxy-multi": {
-        "fallback_strategy: ["rate_limiting"],
+        "fallback_strategy": ["rate_limiting"],
         "instances": [
           {
             "name": "openai-instance",
@@ -688,6 +1354,210 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
     }
   }'
 ```
+
+</TabItem>
+<TabItem value="adc" label="ADC">
+
+Create two Consumers and a Route that enables rate limiting by Consumers:
+
+```yaml title="adc.yaml"
+consumers:
+  - username: johndoe
+    plugins:
+      ai-rate-limiting:
+        instances:
+          - name: openai-instance
+            limit: 10
+            time_window: 60
+        rejected_code: 429
+        limit_strategy: total_tokens
+    credentials:
+      - name: key-auth
+        type: key-auth
+        config:
+          key: john-key
+  - username: janedoe
+    plugins:
+      ai-rate-limiting:
+        instances:
+          - name: deepseek-instance
+            limit: 10
+            time_window: 60
+        rejected_code: 429
+        limit_strategy: total_tokens
+    credentials:
+      - name: key-auth
+        type: key-auth
+        config:
+          key: jane-key
+services:
+  - name: ai-rate-limiting-service
+    routes:
+      - name: ai-rate-limiting-route
+        uris:
+          - /anything
+        methods:
+          - POST
+        plugins:
+          key-auth: {}
+          ai-proxy-multi:
+            fallback_strategy:
+              - rate_limiting
+            instances:
+              - name: openai-instance
+                provider: openai
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer ${OPENAI_API_KEY}"
+                options:
+                  model: gpt-4
+              - name: deepseek-instance
+                provider: deepseek
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer ${DEEPSEEK_API_KEY}"
+                options:
+                  model: deepseek-chat
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+<TabItem value="ingress" label="Ingress Controller">
+
+<Tabs groupId="k8s-api">
+<TabItem value="gateway-api" label="Gateway API">
+
+Create two Consumers and a Route that enables rate limiting by Consumers:
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: johndoe
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: primary-key
+      config:
+        key: john-key
+  plugins:
+    - name: ai-rate-limiting
+      config:
+        instances:
+          - name: openai-instance
+            limit: 10
+            time_window: 60
+        rejected_code: 429
+        limit_strategy: total_tokens
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: janedoe
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: primary-key
+      config:
+        key: jane-key
+  plugins:
+    - name: ai-rate-limiting
+      config:
+        instances:
+          - name: deepseek-instance
+            limit: 10
+            time_window: 60
+        rejected_code: 429
+        limit_strategy: total_tokens
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-plugin-config
+spec:
+  plugins:
+    - name: key-auth
+      config:
+        _meta:
+          disable: false
+    - name: ai-proxy-multi
+      config:
+        fallback_strategy:
+          - rate_limiting
+        instances:
+          - name: openai-instance
+            provider: openai
+            weight: 0
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: gpt-4
+          - name: deepseek-instance
+            provider: deepseek
+            weight: 0
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: deepseek-chat
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+          method: POST
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: ai-rate-limiting-plugin-config
+```
+
+</TabItem>
+<TabItem value="ingress" label="APISIX Ingress Controller">
+
+:::note
+
+The ApisixConsumer CRD currently does not support configuring plugins on Consumers, except for the authentication plugins allowed in `authParameter`. This example cannot be completed with APISIX CRDs.
+
+:::
+
+</TabItem>
+</Tabs>
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f ai-rate-limiting-ic.yaml
+```
+
+</TabItem>
+</Tabs>
 
 Send a POST request to the Route without any Consumer key:
 
@@ -876,3 +1746,354 @@ You should see a response similar to the following:
 ```
 
 This shows `ai-proxy-multi` load balance the traffic with respect to the rate limiting rules in `ai-rate-limiting` by Consumers.
+
+### Rate Limit by Rules
+
+The following example demonstrates how you can configure the Plugin to apply different rate-limiting rules based on request attributes. In this example, rate limits are applied based on HTTP header values that represent the caller's access tier. All rules are applied sequentially. If a configured key does not exist, the corresponding rule will be skipped.
+
+Create a Route with the `ai-rate-limiting` Plugin that applies different rate limits based on request headers, allowing requests to be rate limited per subscription (`X-Subscription-ID`) and enforcing a stricter limit for trial users (`X-Trial-ID`):
+
+<Tabs groupId="api">
+<TabItem value="admin-api" label="Admin API">
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "uri": "/anything",
+    "methods": ["POST"],
+    "plugins": {
+      "ai-proxy-multi": {
+        "fallback_strategy": ["rate_limiting"],
+        "instances": [
+          {
+            "name": "openai-instance",
+            "provider": "openai",
+            "priority": 1,
+            "weight": 0,
+            "auth": {
+              "header": {
+                "Authorization": "Bearer '"$OPENAI_API_KEY"'"
+              }
+            },
+            "options": {
+              "model": "gpt-4"
+            }
+          },
+          {
+            "name": "deepseek-instance",
+            "provider": "deepseek",
+            "priority": 0,
+            "weight": 0,
+            "auth": {
+              "header": {
+                "Authorization": "Bearer '"$DEEPSEEK_API_KEY"'"
+              }
+            },
+            "options": {
+              "model": "deepseek-chat"
+            }
+          }
+        ]
+      },
+      "ai-rate-limiting": {
+        "rejected_code": 429,
+        "rules": [
+          {
+            "key": "${http_x_subscription_id}",
+            "count": "${http_x_custom_count ?? 500}",
+            "time_window": 60
+          },
+          {
+            "key": "${http_x_trial_id}",
+            "count": 50,
+            "time_window": 60
+          }
+        ]
+      }
+    }
+  }'
+```
+
+</TabItem>
+<TabItem value="adc" label="ADC">
+
+```yaml title="adc.yaml"
+services:
+  - name: ai-rate-limiting-service
+    routes:
+      - name: ai-rate-limiting-route
+        uris:
+          - /anything
+        methods:
+          - POST
+        plugins:
+          ai-proxy-multi:
+            fallback_strategy:
+              - rate_limiting
+            instances:
+              - name: openai-instance
+                provider: openai
+                priority: 1
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer ${OPENAI_API_KEY}"
+                options:
+                  model: gpt-4
+              - name: deepseek-instance
+                provider: deepseek
+                priority: 0
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer ${DEEPSEEK_API_KEY}"
+                options:
+                  model: deepseek-chat
+          ai-rate-limiting:
+            rejected_code: 429
+            rules:
+              - key: "${http_x_subscription_id}"
+                count: "${http_x_custom_count ?? 500}"
+                time_window: 60
+              - key: "${http_x_trial_id}"
+                count: 50
+                time_window: 60
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+<TabItem value="ingress" label="Ingress Controller">
+
+<Tabs groupId="k8s-api">
+<TabItem value="gateway-api" label="Gateway API">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-plugin-config
+spec:
+  plugins:
+    - name: ai-proxy-multi
+      config:
+        fallback_strategy:
+          - rate_limiting
+        instances:
+          - name: openai-instance
+            provider: openai
+            priority: 1
+            weight: 0
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: gpt-4
+          - name: deepseek-instance
+            provider: deepseek
+            priority: 0
+            weight: 0
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: deepseek-chat
+    - name: ai-rate-limiting
+      config:
+        rejected_code: 429
+        rules:
+          - key: "${http_x_subscription_id}"
+            count: "${http_x_custom_count ?? 500}"
+            time_window: 60
+          - key: "${http_x_trial_id}"
+            count: 50
+            time_window: 60
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+          method: POST
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: ai-rate-limiting-plugin-config
+```
+
+</TabItem>
+<TabItem value="ingress" label="APISIX Ingress Controller">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: ai-rate-limiting-route
+      match:
+        paths:
+          - /anything
+        methods:
+          - POST
+      plugins:
+        - name: ai-proxy-multi
+          enable: true
+          config:
+            fallback_strategy:
+              - rate_limiting
+            instances:
+              - name: openai-instance
+                provider: openai
+                priority: 1
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer your-api-key"
+                options:
+                  model: gpt-4
+              - name: deepseek-instance
+                provider: deepseek
+                priority: 0
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer your-api-key"
+                options:
+                  model: deepseek-chat
+        - name: ai-rate-limiting
+          enable: true
+          config:
+            rejected_code: 429
+            rules:
+              - key: "${http_x_subscription_id}"
+                count: "${http_x_custom_count ?? 500}"
+                time_window: 60
+              - key: "${http_x_trial_id}"
+                count: 50
+                time_window: 60
+```
+
+</TabItem>
+</Tabs>
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f ai-rate-limiting-ic.yaml
+```
+
+</TabItem>
+</Tabs>
+
+The first rule uses the value of the `X-Subscription-ID` request header as the rate-limiting key and sets the request limit dynamically based on the `X-Custom-Count` header. If the header is not provided, a default count of 500 tokens is applied. The second rule uses the value of the `X-Trial-ID` request header as the rate-limiting key with a stricter limit of 50 tokens.
+
+To verify rate limiting, send several of the following requests to the Route with the same subscription ID:
+
+```shell
+curl "http://127.0.0.1:9080/anything" -i -X POST \
+  -H "X-Subscription-ID: sub-123456789" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      { "role": "system", "content": "You are a mathematician" },
+      { "role": "user", "content": "What is 1+1?" }
+    ]
+  }'
+```
+
+These requests should match the first rule with a default token count of 500. You should see that requests within the quota return `HTTP/1.1 200 OK`, while those exceeding it return `HTTP/1.1 429 Too Many Requests`:
+
+```text
+HTTP/1.1 200 OK
+...
+X-AI-1-RateLimit-Limit: 500
+X-AI-1-RateLimit-Remaining: 499
+X-AI-1-RateLimit-Reset: 60
+
+HTTP/1.1 429 Too Many Requests
+...
+X-AI-1-RateLimit-Limit: 500
+X-AI-1-RateLimit-Remaining: 0
+X-AI-1-RateLimit-Reset: 5.871000051498
+```
+
+Wait for the time window to reset. Send several of the following requests to the Route with the same subscription ID and set the `X-Custom-Count` header to 10:
+
+```shell
+curl "http://127.0.0.1:9080/anything" -i -X POST \
+  -H "X-Subscription-ID: sub-123456789" \
+  -H "X-Custom-Count: 10" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      { "role": "system", "content": "You are a mathematician" },
+      { "role": "user", "content": "What is 1+1?" }
+    ]
+  }'
+```
+
+These requests should match the first rule with a custom token count of 10. You should see that requests within the quota return `HTTP/1.1 200 OK`, while those exceeding it return `HTTP/1.1 429 Too Many Requests`:
+
+```text
+HTTP/1.1 200 OK
+...
+X-AI-1-RateLimit-Limit: 10
+X-AI-1-RateLimit-Remaining: 9
+X-AI-1-RateLimit-Reset: 60
+
+HTTP/1.1 429 Too Many Requests
+...
+X-AI-1-RateLimit-Limit: 10
+X-AI-1-RateLimit-Remaining: 0
+X-AI-1-RateLimit-Reset: 40.422000169754
+```
+
+Finally, send several of the following requests to the Route with a trial ID:
+
+```shell
+curl "http://127.0.0.1:9080/anything" -i -X POST \
+  -H "X-Trial-ID: trial-123456789" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      { "role": "system", "content": "You are a mathematician" },
+      { "role": "user", "content": "What is 1+1?" }
+    ]
+  }'
+```
+
+These requests should match the second rule with a token count of 50. You should see that requests within the quota return `HTTP/1.1 200 OK`, while those exceeding it return `HTTP/1.1 429 Too Many Requests`:
+
+```text
+HTTP/1.1 200 OK
+...
+X-AI-2-RateLimit-Limit: 50
+X-AI-2-RateLimit-Remaining: 49
+X-AI-2-RateLimit-Reset: 60
+
+HTTP/1.1 429 Too Many Requests
+...
+X-AI-2-RateLimit-Limit: 50
+X-AI-2-RateLimit-Remaining: 0
+X-AI-2-RateLimit-Reset: 44
+```

--- a/docs/en/latest/plugins/ai-rate-limiting.md
+++ b/docs/en/latest/plugins/ai-rate-limiting.md
@@ -332,10 +332,10 @@ curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
         ]
       },
       "ai-rate-limiting": {
+        "limit_strategy": "total_tokens",
         "instances": [
           {
             "name": "deepseek-instance-1",
-            "limit_strategy": "total_tokens",
             "limit": 100,
             "time_window": 30
           }
@@ -377,9 +377,9 @@ services:
                 options:
                   model: deepseek-chat
           ai-rate-limiting:
+            limit_strategy: total_tokens
             instances:
               - name: deepseek-instance-1
-                limit_strategy: total_tokens
                 limit: 100
                 time_window: 30
 ```
@@ -425,9 +425,9 @@ spec:
               model: deepseek-chat
     - name: ai-rate-limiting
       config:
+        limit_strategy: total_tokens
         instances:
           - name: deepseek-instance-1
-            limit_strategy: total_tokens
             limit: 100
             time_window: 30
 ---
@@ -495,9 +495,9 @@ spec:
         - name: ai-rate-limiting
           enable: true
           config:
+            limit_strategy: total_tokens
             instances:
               - name: deepseek-instance-1
-                limit_strategy: total_tokens
                 limit: 100
                 time_window: 30
 ```

--- a/docs/zh/latest/plugins/ai-rate-limiting.md
+++ b/docs/zh/latest/plugins/ai-rate-limiting.md
@@ -33,29 +33,33 @@ description: ai-rate-limiting 插件对发送到 LLM 服务的请求实施基于
   <link rel="canonical" href="https://docs.api7.ai/hub/ai-rate-limiting" />
 </head>
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## 描述
 
-`ai-rate-limiting` 插件对发送到 LLM 服务的请求实施基于令牌的速率限制。它通过控制在指定时间范围内消耗的令牌数量来帮助管理 API 使用，确保公平的资源分配并防止服务过载。它通常与 [`ai-proxy`](ai-proxy.md) 或 [`ai-proxy-multi`](ai-proxy-multi.md) 插件一起使用。
+`ai-rate-limiting` 插件对发送到 LLM 服务的请求实施基于令牌的速率限制。它通过控制在指定时间范围内消耗的令牌数量来帮助管理 API 使用，确保公平的资源分配并防止服务过载。它通常与 [`ai-proxy`](./ai-proxy.md) 或 [`ai-proxy-multi`](./ai-proxy-multi.md) 插件一起使用。
 
 ## 属性
 
-| 名称                         | 类型            | 必选项 | 默认值  | 有效值                                             | 描述 |
-|------------------------------|----------------|----------|----------|---------------------------------------------------------|-------------|
-| limit                        | integer        | 否    |          | >0                             | 在给定时间间隔内允许的最大令牌数。`limit` 和 `instances.limit` 中至少应配置一个。如果未配置 `rules`,则为必填项。 |
-| time_window                  | integer        | 否    |          | >0                             | 与速率限制 `limit` 对应的时间间隔（秒）。`time_window` 和 `instances.time_window` 中至少应配置一个。如果未配置 `rules`,则为必填项。 |
-| rules                        | array[object]  | 否    |          |                                                         | 速率限制规则列表。每个规则是一个包含 `count`、`time_window` 和 `key` 的对象。如果配置了此项，则优先于 `limit` 和 `time_window`。 |
-| rules.count                  | integer 或 string | 是  |          | >0 或变量表达式                              | 在给定时间间隔内允许的最大令牌数。可以是静态整数或变量表达式，如 `$http_custom_limit`。 |
-| rules.time_window            | integer 或 string | 是  |          | >0 或变量表达式                              | 与速率限制 `count` 对应的时间间隔（秒）。可以是静态整数或变量表达式。 |
-| rules.key                    | string         | 是     |          |                                                         | 用于计数请求的键。如果配置的键不存在，则不会执行该规则。`key` 被解释为变量组合，例如：`$http_custom_a $http_custom_b`。 |
-| rules.header_prefix          | string         | 否    |          |                                                         | 速率限制头部的前缀。如果配置了此项，响应将包含 `X-AI-{header_prefix}-RateLimit-Limit`、`X-AI-{header_prefix}-RateLimit-Remaining` 和 `X-AI-{header_prefix}-RateLimit-Reset` 头部。如果未配置，将使用规则索引 (从 1 开始) 作为前缀。|
-| show_limit_quota_header      | boolean        | 否    | true     |                                                         | 如果为 true，则在响应中包含 `X-AI-RateLimit-Limit-*`、`X-AI-RateLimit-Remaining-*` 和 `X-AI-RateLimit-Reset-*` 头部，其中 `*` 是实例名称。 |
-| limit_strategy               | string         | 否    | total_tokens | [total_tokens, prompt_tokens, completion_tokens] | 应用速率限制的令牌类型。`total_tokens` 是 `prompt_tokens` 和 `completion_tokens` 的总和。 |
-| instances                    | array[object]  | 否    |          |                                                         | LLM 实例速率限制配置。 |
-| instances.name               | string         | 是     |          |                                                         | LLM 服务实例的名称。 |
-| instances.limit              | integer        | 是     |          | >0                             | 实例在给定时间间隔内允许的最大令牌数。 |
-| instances.time_window        | integer        | 是     |          | >0                             | 实例速率限制 `limit` 对应的时间间隔（秒）。 |
-| rejected_code                | integer        | 否    | 503      |  [200, 599]                           | 当超出配额的请求被拒绝时返回的 HTTP 状态码。 |
-| rejected_msg                 | string         | 否    |          |                                           | 当超出配额的请求被拒绝时返回的响应体。 |
+| 名称 | 类型 | 必选项 | 默认值 | 有效值 | 描述 |
+|------|------|--------|--------|--------|------|
+| limit | integer | False | | >0 | 在给定时间间隔内允许的最大令牌数。`limit` 和 `instances.limit` 中至少应配置一个。如果未配置 `rules`，则为必填项。 |
+| time_window | integer | False | | >0 | 与速率限制 `limit` 对应的时间间隔（秒）。`time_window` 和 `instances.time_window` 中至少应配置一个。如果未配置 `rules`，则为必填项。 |
+| show_limit_quota_header | boolean | False | true | | 如果为 true，则在响应中包含速率限制头部。当未设置 `rules` 时，头部为 `X-AI-RateLimit-Limit-*`、`X-AI-RateLimit-Remaining-*` 和 `X-AI-RateLimit-Reset-*`，其中 `*` 是实例名称。当设置了 `rules` 时，详见 `rules.header_prefix`。 |
+| limit_strategy | string | False | total_tokens | [`total_tokens`, `prompt_tokens`, `completion_tokens`, `expression`] | 应用速率限制的令牌类型。`total_tokens` 是 `prompt_tokens` 和 `completion_tokens` 的总和。当设置为 `expression` 时，使用 `cost_expr` 字段动态计算令牌消耗。 |
+| cost_expr | string | False | | | 用于动态计算令牌消耗的 Lua 算术表达式。变量从 LLM API 原始使用量响应字段注入。缺失的变量默认为 0。仅在 `limit_strategy` 为 `expression` 时有效。示例：`input_tokens + cache_creation_input_tokens + output_tokens`。 |
+| instances | array[object] | False | | | LLM 实例速率限制配置。 |
+| instances.name | string | True | | | LLM 服务实例的名称。 |
+| instances.limit | integer | True | | >0 | 实例在给定时间间隔内允许的最大令牌数。 |
+| instances.time_window | integer | True | | >0 | 实例速率限制 `limit` 对应的时间间隔（秒）。 |
+| rejected_code | integer | False | 503 | [200, 599] | 当超出配额的请求被拒绝时返回的 HTTP 状态码。 |
+| rejected_msg | string | False | | | 当超出配额的请求被拒绝时返回的响应体。 |
+| rules | array[object] | False | | | 按顺序应用的速率限制规则数组。如果配置了此项，则优先于 `limit` 和 `time_window`。 |
+| rules.count | integer 或 string | True | | >0 或变量表达式 | 在给定时间间隔内允许的最大令牌数。可以是静态整数或变量表达式，如 `$http_custom_limit`。 |
+| rules.time_window | integer 或 string | True | | >0 或变量表达式 | 与速率限制 `count` 对应的时间间隔（秒）。可以是静态整数或变量表达式。 |
+| rules.key | string | True | | | 用于计数请求的键。如果配置的键不存在，则不会执行该规则。`key` 被解释为变量组合。所有变量应以美元符号（`$`）为前缀。例如：`$http_custom_a $http_custom_b`。 |
+| rules.header_prefix | string | False | | | 速率限制响应头部的前缀。配置后，前缀插入到头部名称中 `X-AI-` 之后。例如，将 `header_prefix` 设置为 `test` 时，头部变为 `X-AI-Test-RateLimit-Limit`、`X-AI-Test-RateLimit-Remaining` 和 `X-AI-Test-RateLimit-Reset`。未配置时，使用规则在数组中的索引作为前缀。例如，第一条规则的头部为 `X-AI-1-RateLimit-Limit`、`X-AI-1-RateLimit-Remaining` 和 `X-AI-1-RateLimit-Reset`。 |
 
 ## 示例
 
@@ -65,7 +69,7 @@ description: ai-rate-limiting 插件对发送到 LLM 服务的请求实施基于
 
 您可以使用以下命令从 `config.yaml` 获取 `admin_key` 并保存到环境变量中：
 
-```bash
+```shell
 admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
 ```
 
@@ -75,13 +79,15 @@ admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"/
 
 以下示例演示了如何使用 `ai-proxy` 代理 LLM 流量，并使用 `ai-rate-limiting` 在实例上配置基于令牌的速率限制。
 
-创建一个路由并更新您的 LLM 提供商、模型、API 密钥和端点（如适用）：
+创建一个 Route 并更新您的 LLM 提供商、模型、API 密钥和端点（如适用）：
+
+<Tabs groupId="api">
+<TabItem value="admin-api" label="Admin API">
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
-    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -107,7 +113,143 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
-向路由发送 POST 请求，在请求体中包含系统提示和示例用户问题：
+</TabItem>
+<TabItem value="adc" label="ADC">
+
+```yaml title="adc.yaml"
+services:
+  - name: ai-rate-limiting-service
+    routes:
+      - name: ai-rate-limiting-route
+        uris:
+          - /anything
+        methods:
+          - POST
+        plugins:
+          ai-proxy:
+            provider: openai
+            auth:
+              header:
+                Authorization: "Bearer ${OPENAI_API_KEY}"
+            options:
+              model: gpt-35-turbo-instruct
+              max_tokens: 512
+              temperature: 1.0
+          ai-rate-limiting:
+            limit: 300
+            time_window: 30
+            limit_strategy: prompt_tokens
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+<TabItem value="ingress" label="Ingress Controller">
+
+<Tabs groupId="k8s-api">
+<TabItem value="gateway-api" label="Gateway API">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-plugin-config
+spec:
+  plugins:
+    - name: ai-proxy
+      config:
+        provider: openai
+        auth:
+          header:
+            Authorization: "Bearer your-api-key"
+        options:
+          model: gpt-35-turbo-instruct
+          max_tokens: 512
+          temperature: 1.0
+    - name: ai-rate-limiting
+      config:
+        limit: 300
+        time_window: 30
+        limit_strategy: prompt_tokens
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+          method: POST
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: ai-rate-limiting-plugin-config
+```
+
+</TabItem>
+<TabItem value="ingress" label="APISIX Ingress Controller">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: ai-rate-limiting-route
+      match:
+        paths:
+          - /anything
+        methods:
+          - POST
+      plugins:
+        - name: ai-proxy
+          enable: true
+          config:
+            provider: openai
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: gpt-35-turbo-instruct
+              max_tokens: 512
+              temperature: 1.0
+        - name: ai-rate-limiting
+          enable: true
+          config:
+            limit: 300
+            time_window: 30
+            limit_strategy: prompt_tokens
+```
+
+</TabItem>
+</Tabs>
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f ai-rate-limiting-ic.yaml
+```
+
+</TabItem>
+</Tabs>
+
+向 Route 发送 POST 请求，在请求体中包含系统提示和示例用户问题：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -X POST \
@@ -147,13 +289,15 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 
 以下示例演示了如何使用 `ai-proxy-multi` 配置两个模型进行负载均衡，将 80% 的流量转发到一个实例，20% 转发到另一个实例。此外，使用 `ai-rate-limiting` 对接收 80% 流量的实例配置基于令牌的速率限制，这样当配置的配额完全消耗时，额外的流量将被转发到另一个实例。
 
-创建一个路由，对 `deepseek-instance-1` 实例应用 30 秒窗口内 100 个总令牌的速率限制配额，并更新您的 LLM 提供商、模型、API 密钥和端点（如适用）：
+创建一个 Route，对 `deepseek-instance-1` 实例应用 30 秒窗口内 100 个总令牌的速率限制配额，并更新您的 LLM 提供商、模型、API 密钥和端点（如适用）：
+
+<Tabs groupId="api">
+<TabItem value="admin-api" label="Admin API">
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
-    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -201,7 +345,176 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
-向路由发送 POST 请求，在请求体中包含系统提示和示例用户问题：
+</TabItem>
+<TabItem value="adc" label="ADC">
+
+```yaml title="adc.yaml"
+services:
+  - name: ai-rate-limiting-service
+    routes:
+      - name: ai-rate-limiting-route
+        uris:
+          - /anything
+        methods:
+          - POST
+        plugins:
+          ai-proxy-multi:
+            instances:
+              - name: deepseek-instance-1
+                provider: deepseek
+                weight: 8
+                auth:
+                  header:
+                    Authorization: "Bearer ${DEEPSEEK_API_KEY}"
+                options:
+                  model: deepseek-chat
+              - name: deepseek-instance-2
+                provider: deepseek
+                weight: 2
+                auth:
+                  header:
+                    Authorization: "Bearer ${DEEPSEEK_API_KEY}"
+                options:
+                  model: deepseek-chat
+          ai-rate-limiting:
+            instances:
+              - name: deepseek-instance-1
+                limit_strategy: total_tokens
+                limit: 100
+                time_window: 30
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+<TabItem value="ingress" label="Ingress Controller">
+
+<Tabs groupId="k8s-api">
+<TabItem value="gateway-api" label="Gateway API">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-plugin-config
+spec:
+  plugins:
+    - name: ai-proxy-multi
+      config:
+        instances:
+          - name: deepseek-instance-1
+            provider: deepseek
+            weight: 8
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: deepseek-chat
+          - name: deepseek-instance-2
+            provider: deepseek
+            weight: 2
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: deepseek-chat
+    - name: ai-rate-limiting
+      config:
+        instances:
+          - name: deepseek-instance-1
+            limit_strategy: total_tokens
+            limit: 100
+            time_window: 30
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+          method: POST
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: ai-rate-limiting-plugin-config
+```
+
+</TabItem>
+<TabItem value="ingress" label="APISIX Ingress Controller">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: ai-rate-limiting-route
+      match:
+        paths:
+          - /anything
+        methods:
+          - POST
+      plugins:
+        - name: ai-proxy-multi
+          enable: true
+          config:
+            instances:
+              - name: deepseek-instance-1
+                provider: deepseek
+                weight: 8
+                auth:
+                  header:
+                    Authorization: "Bearer your-api-key"
+                options:
+                  model: deepseek-chat
+              - name: deepseek-instance-2
+                provider: deepseek
+                weight: 2
+                auth:
+                  header:
+                    Authorization: "Bearer your-api-key"
+                options:
+                  model: deepseek-chat
+        - name: ai-rate-limiting
+          enable: true
+          config:
+            instances:
+              - name: deepseek-instance-1
+                limit_strategy: total_tokens
+                limit: 100
+                time_window: 30
+```
+
+</TabItem>
+</Tabs>
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f ai-rate-limiting-ic.yaml
+```
+
+</TabItem>
+</Tabs>
+
+向 Route 发送 POST 请求，在请求体中包含系统提示和示例用户问题：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -X POST \
@@ -235,7 +548,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 }
 ```
 
-如果 `deepseek-instance-1` 实例在 30 秒窗口内消耗了 100 个令牌的速率限制配额，额外的请求将全部转发到 `deepseek-instance-2`，该实例没有速率限制。
+如果 `deepseek-instance-1` 实例在 30 秒窗口内消耗了 100 个令牌的速率限制配额，额外的请求将全部转发到未设置速率限制的 `deepseek-instance-2`。
 
 ### 对所有实例应用相同配额
 
@@ -243,13 +556,15 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 
 为了演示和更容易区分，您将配置一个 OpenAI 实例和一个 DeepSeek 实例作为上游 LLM 服务。
 
-创建一个路由，对所有实例在 60 秒窗口内应用 100 个总令牌的速率限制配额，并更新您的 LLM 提供商、模型、API 密钥和端点（如适用）：
+创建一个 Route，对所有实例在 60 秒窗口内应用 100 个总令牌的速率限制配额，并更新您的 LLM 提供商、模型、API 密钥和端点（如适用）：
+
+<Tabs groupId="api">
+<TabItem value="admin-api" label="Admin API">
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
-    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -293,7 +608,173 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
-向路由发送 POST 请求，在请求体中包含系统提示和示例用户问题：
+</TabItem>
+<TabItem value="adc" label="ADC">
+
+```yaml title="adc.yaml"
+services:
+  - name: ai-rate-limiting-service
+    routes:
+      - name: ai-rate-limiting-route
+        uris:
+          - /anything
+        methods:
+          - POST
+        plugins:
+          ai-proxy-multi:
+            instances:
+              - name: openai-instance
+                provider: openai
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer ${OPENAI_API_KEY}"
+                options:
+                  model: gpt-4
+              - name: deepseek-instance
+                provider: deepseek
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer ${DEEPSEEK_API_KEY}"
+                options:
+                  model: deepseek-chat
+          ai-rate-limiting:
+            limit: 100
+            time_window: 60
+            rejected_code: 429
+            limit_strategy: total_tokens
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+<TabItem value="ingress" label="Ingress Controller">
+
+<Tabs groupId="k8s-api">
+<TabItem value="gateway-api" label="Gateway API">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-plugin-config
+spec:
+  plugins:
+    - name: ai-proxy-multi
+      config:
+        instances:
+          - name: openai-instance
+            provider: openai
+            weight: 0
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: gpt-4
+          - name: deepseek-instance
+            provider: deepseek
+            weight: 0
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: deepseek-chat
+    - name: ai-rate-limiting
+      config:
+        limit: 100
+        time_window: 60
+        rejected_code: 429
+        limit_strategy: total_tokens
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+          method: POST
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: ai-rate-limiting-plugin-config
+```
+
+</TabItem>
+<TabItem value="ingress" label="APISIX Ingress Controller">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: ai-rate-limiting-route
+      match:
+        paths:
+          - /anything
+        methods:
+          - POST
+      plugins:
+        - name: ai-proxy-multi
+          enable: true
+          config:
+            instances:
+              - name: openai-instance
+                provider: openai
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer your-api-key"
+                options:
+                  model: gpt-4
+              - name: deepseek-instance
+                provider: deepseek
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer your-api-key"
+                options:
+                  model: deepseek-chat
+        - name: ai-rate-limiting
+          enable: true
+          config:
+            limit: 100
+            time_window: 60
+            rejected_code: 429
+            limit_strategy: total_tokens
+```
+
+</TabItem>
+</Tabs>
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f ai-rate-limiting-ic.yaml
+```
+
+</TabItem>
+</Tabs>
+
+向 Route 发送 POST 请求，在请求体中包含系统提示和示例用户问题：
 
 ```shell
 curl -i "http://127.0.0.1:9080/anything" -X POST \
@@ -346,7 +827,7 @@ curl -i "http://127.0.0.1:9080/anything" -X POST \
 
 由于 `total_tokens` 值超过了配置的 `100` 配额，预期在 60 秒窗口内的下一个请求将被转发到另一个实例。
 
-在同一个 60 秒窗口内，向路由发送另一个 POST 请求：
+在同一个 60 秒窗口内，向 Route 发送另一个 POST 请求：
 
 ```shell
 curl -i "http://127.0.0.1:9080/anything" -X POST \
@@ -392,7 +873,7 @@ curl -i "http://127.0.0.1:9080/anything" -X POST \
 
 由于 `total_tokens` 值超过了配置的 `100` 配额，预期在 60 秒窗口内的下一个请求将被拒绝。
 
-在同一个 60 秒窗口内，向路由发送第三个 POST 请求：
+在同一个 60 秒窗口内，向 Route 发送第三个 POST 请求：
 
 ```shell
 curl -i "http://127.0.0.1:9080/anything" -X POST \
@@ -418,15 +899,17 @@ X-AI-RateLimit-Reset-deepseek-instance: 0
 
 ### 配置实例优先级和速率限制
 
-以下示例演示了如何配置两个具有不同优先级的模型，并对具有较高优先级的实例应用速率限制。在 `fallback_strategy` 设置为 `["rate_limiting"]` 的情况下，一旦高优先级实例的速率限制配额完全消耗，插件应继续将请求转发到低优先级实例。
+以下示例演示了如何配置两个具有不同优先级的模型，并对具有较高优先级的实例应用速率限制。在 `fallback_strategy` 设置为 `["rate_limiting"]` 的情况下，一旦高优先级实例的速率限制配额完全消耗，Plugin 应继续将请求转发到低优先级实例。
 
-创建一个路由，对 `openai-instance` 实例设置速率限制和更高的优先级，并将 `fallback_strategy` 设置为 `["rate_limiting"]`。更新您的 LLM 提供商、模型、API 密钥和端点（如适用）：
+创建一个 Route，对 `openai-instance` 实例设置速率限制和更高的优先级，并将 `fallback_strategy` 设置为 `["rate_limiting"]`。更新您的 LLM 提供商、模型、API 密钥和端点（如适用）：
+
+<Tabs groupId="api">
+<TabItem value="admin-api" label="Admin API">
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
-    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -477,7 +960,188 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
-向路由发送 POST 请求，在请求体中包含系统提示和示例用户问题：
+</TabItem>
+<TabItem value="adc" label="ADC">
+
+```yaml title="adc.yaml"
+services:
+  - name: ai-rate-limiting-service
+    routes:
+      - name: ai-rate-limiting-route
+        uris:
+          - /anything
+        methods:
+          - POST
+        plugins:
+          ai-proxy-multi:
+            fallback_strategy:
+              - rate_limiting
+            instances:
+              - name: openai-instance
+                provider: openai
+                priority: 1
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer ${OPENAI_API_KEY}"
+                options:
+                  model: gpt-4
+              - name: deepseek-instance
+                provider: deepseek
+                priority: 0
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer ${DEEPSEEK_API_KEY}"
+                options:
+                  model: deepseek-chat
+          ai-rate-limiting:
+            instances:
+              - name: openai-instance
+                limit: 10
+                time_window: 60
+            limit_strategy: total_tokens
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+<TabItem value="ingress" label="Ingress Controller">
+
+<Tabs groupId="k8s-api">
+<TabItem value="gateway-api" label="Gateway API">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-plugin-config
+spec:
+  plugins:
+    - name: ai-proxy-multi
+      config:
+        fallback_strategy:
+          - rate_limiting
+        instances:
+          - name: openai-instance
+            provider: openai
+            priority: 1
+            weight: 0
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: gpt-4
+          - name: deepseek-instance
+            provider: deepseek
+            priority: 0
+            weight: 0
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: deepseek-chat
+    - name: ai-rate-limiting
+      config:
+        instances:
+          - name: openai-instance
+            limit: 10
+            time_window: 60
+        limit_strategy: total_tokens
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+          method: POST
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: ai-rate-limiting-plugin-config
+```
+
+</TabItem>
+<TabItem value="ingress" label="APISIX Ingress Controller">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: ai-rate-limiting-route
+      match:
+        paths:
+          - /anything
+        methods:
+          - POST
+      plugins:
+        - name: ai-proxy-multi
+          enable: true
+          config:
+            fallback_strategy:
+              - rate_limiting
+            instances:
+              - name: openai-instance
+                provider: openai
+                priority: 1
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer your-api-key"
+                options:
+                  model: gpt-4
+              - name: deepseek-instance
+                provider: deepseek
+                priority: 0
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer your-api-key"
+                options:
+                  model: deepseek-chat
+        - name: ai-rate-limiting
+          enable: true
+          config:
+            instances:
+              - name: openai-instance
+                limit: 10
+                time_window: 60
+            limit_strategy: total_tokens
+```
+
+</TabItem>
+</Tabs>
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f ai-rate-limiting-ic.yaml
+```
+
+</TabItem>
+</Tabs>
+
+向 Route 发送 POST 请求，在请求体中包含系统提示和示例用户问题：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -X POST \
@@ -530,7 +1194,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 
 由于 `total_tokens` 值超过了配置的 `10` 配额，预期在 60 秒窗口内的下一个请求将被转发到另一个实例。
 
-在同一个 60 秒窗口内，向路由发送另一个 POST 请求：
+在同一个 60 秒窗口内，向 Route 发送另一个 POST 请求：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -X POST \
@@ -563,11 +1227,14 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 }
 ```
 
-### 按消费者进行负载均衡和速率限制
+### 按 Consumer 进行负载均衡和速率限制
 
-以下示例演示了如何配置两个模型进行负载均衡，并按消费者应用速率限制。
+以下示例演示了如何配置两个模型进行负载均衡，并按 Consumer 应用速率限制。
 
-创建消费者 `johndoe` 并对 `openai-instance` 实例设置 60 秒窗口内 10 个令牌的速率限制配额：
+创建 Consumer `johndoe` 并对 `openai-instance` 实例设置 60 秒窗口内 10 个令牌的速率限制配额：
+
+<Tabs groupId="api">
+<TabItem value="admin-api" label="Admin API">
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
@@ -590,7 +1257,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   }'
 ```
 
-为 `johndoe` 配置 `key-auth` 凭据：
+为 `johndoe` 配置 `key-auth` Credential：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/johndoe/credentials" -X PUT \
@@ -605,7 +1272,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers/johndoe/credentials" -X PUT \
   }'
 ```
 
-创建另一个消费者 `janedoe` 并对 `deepseek-instance` 实例设置 60 秒窗口内 10 个令牌的速率限制配额：
+创建另一个 Consumer `janedoe` 并对 `deepseek-instance` 实例设置 60 秒窗口内 10 个令牌的速率限制配额：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
@@ -628,7 +1295,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   }'
 ```
 
-为 `janedoe` 配置 `key-auth` 凭据：
+为 `janedoe` 配置 `key-auth` Credential：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/janedoe/credentials" -X PUT \
@@ -643,13 +1310,12 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers/janedoe/credentials" -X PUT \
   }'
 ```
 
-创建一个路由并更新您的 LLM 提供商、模型、API 密钥和端点（如适用）：
+创建一个 Route 并更新您的 LLM 提供商、模型、API 密钥和端点（如适用）：
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
-    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -689,7 +1355,211 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
-向路由发送不带任何消费者密钥的 POST 请求：
+</TabItem>
+<TabItem value="adc" label="ADC">
+
+创建两个 Consumer 和一个启用按 Consumer 速率限制的 Route：
+
+```yaml title="adc.yaml"
+consumers:
+  - username: johndoe
+    plugins:
+      ai-rate-limiting:
+        instances:
+          - name: openai-instance
+            limit: 10
+            time_window: 60
+        rejected_code: 429
+        limit_strategy: total_tokens
+    credentials:
+      - name: key-auth
+        type: key-auth
+        config:
+          key: john-key
+  - username: janedoe
+    plugins:
+      ai-rate-limiting:
+        instances:
+          - name: deepseek-instance
+            limit: 10
+            time_window: 60
+        rejected_code: 429
+        limit_strategy: total_tokens
+    credentials:
+      - name: key-auth
+        type: key-auth
+        config:
+          key: jane-key
+services:
+  - name: ai-rate-limiting-service
+    routes:
+      - name: ai-rate-limiting-route
+        uris:
+          - /anything
+        methods:
+          - POST
+        plugins:
+          key-auth: {}
+          ai-proxy-multi:
+            fallback_strategy:
+              - rate_limiting
+            instances:
+              - name: openai-instance
+                provider: openai
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer ${OPENAI_API_KEY}"
+                options:
+                  model: gpt-4
+              - name: deepseek-instance
+                provider: deepseek
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer ${DEEPSEEK_API_KEY}"
+                options:
+                  model: deepseek-chat
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+<TabItem value="ingress" label="Ingress Controller">
+
+<Tabs groupId="k8s-api">
+<TabItem value="gateway-api" label="Gateway API">
+
+创建两个 Consumer 和一个启用按 Consumer 速率限制的 Route：
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: johndoe
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: primary-key
+      config:
+        key: john-key
+  plugins:
+    - name: ai-rate-limiting
+      config:
+        instances:
+          - name: openai-instance
+            limit: 10
+            time_window: 60
+        rejected_code: 429
+        limit_strategy: total_tokens
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: janedoe
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: primary-key
+      config:
+        key: jane-key
+  plugins:
+    - name: ai-rate-limiting
+      config:
+        instances:
+          - name: deepseek-instance
+            limit: 10
+            time_window: 60
+        rejected_code: 429
+        limit_strategy: total_tokens
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-plugin-config
+spec:
+  plugins:
+    - name: key-auth
+      config:
+        _meta:
+          disable: false
+    - name: ai-proxy-multi
+      config:
+        fallback_strategy:
+          - rate_limiting
+        instances:
+          - name: openai-instance
+            provider: openai
+            weight: 0
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: gpt-4
+          - name: deepseek-instance
+            provider: deepseek
+            weight: 0
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: deepseek-chat
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+          method: POST
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: ai-rate-limiting-plugin-config
+```
+
+</TabItem>
+<TabItem value="ingress" label="APISIX Ingress Controller">
+
+:::note
+
+ApisixConsumer CRD 目前不支持在 Consumer 上配置除 `authParameter` 中允许的认证插件之外的其他插件。此示例无法使用 APISIX CRD 完成。
+
+:::
+
+</TabItem>
+</Tabs>
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f ai-rate-limiting-ic.yaml
+```
+
+</TabItem>
+</Tabs>
+
+向 Route 发送不带任何 Consumer 密钥的 POST 请求：
 
 ```shell
 curl -i "http://127.0.0.1:9080/anything" -X POST \
@@ -704,7 +1574,7 @@ curl -i "http://127.0.0.1:9080/anything" -X POST \
 
 您应该收到 `HTTP/1.1 401 Unauthorized` 响应。
 
-使用 `johndoe` 的密钥向路由发送 POST 请求：
+使用 `johndoe` 的密钥向 Route 发送 POST 请求：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -X POST \
@@ -758,7 +1628,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 
 由于 `total_tokens` 值超过了 `johndoe` 的 `openai` 实例配置配额，预期在 60 秒窗口内来自 `johndoe` 的下一个请求将被转发到 `deepseek` 实例。
 
-在同一个 60 秒窗口内，使用 `johndoe` 的密钥向路由发送另一个 POST 请求：
+在同一个 60 秒窗口内，使用 `johndoe` 的密钥向 Route 发送另一个 POST 请求：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -X POST \
@@ -792,7 +1662,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 }
 ```
 
-使用 `janedoe` 的密钥向路由发送 POST 请求：
+使用 `janedoe` 的密钥向 Route 发送 POST 请求：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -X POST \
@@ -839,7 +1709,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 
 由于 `total_tokens` 值超过了 `janedoe` 的 `deepseek` 实例配置配额，预期在 60 秒窗口内来自 `janedoe` 的下一个请求将被转发到 `openai` 实例。
 
-在同一个 60 秒窗口内，使用 `janedoe` 的密钥向路由发送另一个 POST 请求：
+在同一个 60 秒窗口内，使用 `janedoe` 的密钥向 Route 发送另一个 POST 请求：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -X POST \
@@ -864,7 +1734,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
       "index": 0,
       "message": {
         "role": "assistant",
-        "content": "Sure, here are Newton's three laws of motion:\n\n1) Newton's First Law, also known as the Law of Inertia, states that an object at rest will stay at rest, and an object in motion will stay in motion, unless acted on by an external force. In simple words, this law suggests th",
+        "content": "Sure, here are Newton's three laws of motion:\n\n1) Newton's First Law, also known as the Law of Inertia, states that an object at rest will stay at rest, and an object in motion will stay in motion, unless acted on by an external force. In simple words, this law suggests that an object will keep doing whatever it is doing until something causes it to do otherwise. \n\n2) Newton's Second Law states that the force acting on an object is equal to the mass of that object times its acceleration (F=ma). This means that force is directly proportional to mass and acceleration. The heavier the object and the faster it accelerates, the greater the force.\n\n3) Newton's Third Law, also known as the law of action and reaction, states that for every action, there is an equal and opposite reaction. Essentially, any force exerted onto a body will create a force of equal magnitude but in the opposite direction on the object that exerted the first force.\n\nRemember, these laws become less accurate when considering speeds near the speed of light (where Einstein's theory of relativity becomes more appropriate) or objects very small or very large. However, for everyday situations, they provide a good model of how things move.",
         "refusal": null
       },
       "logprobs": null,
@@ -875,4 +1745,355 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 }
 ```
 
-这显示了 `ai-proxy-multi` 根据消费者在 `ai-rate-limiting` 中的速率限制规则对流量进行负载均衡。
+这显示了 `ai-proxy-multi` 根据 Consumer 在 `ai-rate-limiting` 中的速率限制规则对流量进行负载均衡。
+
+### 按规则进行速率限制
+
+以下示例演示了如何配置 Plugin 根据请求属性应用不同的速率限制规则。在此示例中，速率限制基于表示调用者访问层级的 HTTP 头部值进行应用。所有规则按顺序执行。如果配置的键不存在，则跳过相应的规则。
+
+创建一个带有 `ai-rate-limiting` Plugin 的 Route，根据请求头部应用不同的速率限制，允许按订阅（`X-Subscription-ID`）进行速率限制，并对试用用户（`X-Trial-ID`）实施更严格的限制：
+
+<Tabs groupId="api">
+<TabItem value="admin-api" label="Admin API">
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "uri": "/anything",
+    "methods": ["POST"],
+    "plugins": {
+      "ai-proxy-multi": {
+        "fallback_strategy": ["rate_limiting"],
+        "instances": [
+          {
+            "name": "openai-instance",
+            "provider": "openai",
+            "priority": 1,
+            "weight": 0,
+            "auth": {
+              "header": {
+                "Authorization": "Bearer '"$OPENAI_API_KEY"'"
+              }
+            },
+            "options": {
+              "model": "gpt-4"
+            }
+          },
+          {
+            "name": "deepseek-instance",
+            "provider": "deepseek",
+            "priority": 0,
+            "weight": 0,
+            "auth": {
+              "header": {
+                "Authorization": "Bearer '"$DEEPSEEK_API_KEY"'"
+              }
+            },
+            "options": {
+              "model": "deepseek-chat"
+            }
+          }
+        ]
+      },
+      "ai-rate-limiting": {
+        "rejected_code": 429,
+        "rules": [
+          {
+            "key": "${http_x_subscription_id}",
+            "count": "${http_x_custom_count ?? 500}",
+            "time_window": 60
+          },
+          {
+            "key": "${http_x_trial_id}",
+            "count": 50,
+            "time_window": 60
+          }
+        ]
+      }
+    }
+  }'
+```
+
+</TabItem>
+<TabItem value="adc" label="ADC">
+
+```yaml title="adc.yaml"
+services:
+  - name: ai-rate-limiting-service
+    routes:
+      - name: ai-rate-limiting-route
+        uris:
+          - /anything
+        methods:
+          - POST
+        plugins:
+          ai-proxy-multi:
+            fallback_strategy:
+              - rate_limiting
+            instances:
+              - name: openai-instance
+                provider: openai
+                priority: 1
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer ${OPENAI_API_KEY}"
+                options:
+                  model: gpt-4
+              - name: deepseek-instance
+                provider: deepseek
+                priority: 0
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer ${DEEPSEEK_API_KEY}"
+                options:
+                  model: deepseek-chat
+          ai-rate-limiting:
+            rejected_code: 429
+            rules:
+              - key: "${http_x_subscription_id}"
+                count: "${http_x_custom_count ?? 500}"
+                time_window: 60
+              - key: "${http_x_trial_id}"
+                count: 50
+                time_window: 60
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+<TabItem value="ingress" label="Ingress Controller">
+
+<Tabs groupId="k8s-api">
+<TabItem value="gateway-api" label="Gateway API">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-plugin-config
+spec:
+  plugins:
+    - name: ai-proxy-multi
+      config:
+        fallback_strategy:
+          - rate_limiting
+        instances:
+          - name: openai-instance
+            provider: openai
+            priority: 1
+            weight: 0
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: gpt-4
+          - name: deepseek-instance
+            provider: deepseek
+            priority: 0
+            weight: 0
+            auth:
+              header:
+                Authorization: "Bearer your-api-key"
+            options:
+              model: deepseek-chat
+    - name: ai-rate-limiting
+      config:
+        rejected_code: 429
+        rules:
+          - key: "${http_x_subscription_id}"
+            count: "${http_x_custom_count ?? 500}"
+            time_window: 60
+          - key: "${http_x_trial_id}"
+            count: 50
+            time_window: 60
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+          method: POST
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: ai-rate-limiting-plugin-config
+```
+
+</TabItem>
+<TabItem value="ingress" label="APISIX Ingress Controller">
+
+```yaml title="ai-rate-limiting-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: ai-rate-limiting-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: ai-rate-limiting-route
+      match:
+        paths:
+          - /anything
+        methods:
+          - POST
+      plugins:
+        - name: ai-proxy-multi
+          enable: true
+          config:
+            fallback_strategy:
+              - rate_limiting
+            instances:
+              - name: openai-instance
+                provider: openai
+                priority: 1
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer your-api-key"
+                options:
+                  model: gpt-4
+              - name: deepseek-instance
+                provider: deepseek
+                priority: 0
+                weight: 0
+                auth:
+                  header:
+                    Authorization: "Bearer your-api-key"
+                options:
+                  model: deepseek-chat
+        - name: ai-rate-limiting
+          enable: true
+          config:
+            rejected_code: 429
+            rules:
+              - key: "${http_x_subscription_id}"
+                count: "${http_x_custom_count ?? 500}"
+                time_window: 60
+              - key: "${http_x_trial_id}"
+                count: 50
+                time_window: 60
+```
+
+</TabItem>
+</Tabs>
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f ai-rate-limiting-ic.yaml
+```
+
+</TabItem>
+</Tabs>
+
+第一条规则使用 `X-Subscription-ID` 请求头部的值作为速率限制键，并根据 `X-Custom-Count` 头部动态设置请求限制。如果未提供该头部，则应用默认的 500 个令牌计数。第二条规则使用 `X-Trial-ID` 请求头部的值作为速率限制键，设置更严格的 50 个令牌限制。
+
+要验证速率限制，使用相同的订阅 ID 向 Route 发送多个以下请求：
+
+```shell
+curl "http://127.0.0.1:9080/anything" -i -X POST \
+  -H "X-Subscription-ID: sub-123456789" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      { "role": "system", "content": "You are a mathematician" },
+      { "role": "user", "content": "What is 1+1?" }
+    ]
+  }'
+```
+
+这些请求应匹配第一条规则，默认令牌计数为 500。您应该看到配额内的请求返回 `HTTP/1.1 200 OK`，而超出配额的请求返回 `HTTP/1.1 429 Too Many Requests`：
+
+```text
+HTTP/1.1 200 OK
+...
+X-AI-1-RateLimit-Limit: 500
+X-AI-1-RateLimit-Remaining: 499
+X-AI-1-RateLimit-Reset: 60
+
+HTTP/1.1 429 Too Many Requests
+...
+X-AI-1-RateLimit-Limit: 500
+X-AI-1-RateLimit-Remaining: 0
+X-AI-1-RateLimit-Reset: 5.871000051498
+```
+
+等待时间窗口重置。使用相同的订阅 ID 向 Route 发送多个以下请求，并将 `X-Custom-Count` 头部设置为 10：
+
+```shell
+curl "http://127.0.0.1:9080/anything" -i -X POST \
+  -H "X-Subscription-ID: sub-123456789" \
+  -H "X-Custom-Count: 10" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      { "role": "system", "content": "You are a mathematician" },
+      { "role": "user", "content": "What is 1+1?" }
+    ]
+  }'
+```
+
+这些请求应匹配第一条规则，自定义令牌计数为 10。您应该看到配额内的请求返回 `HTTP/1.1 200 OK`，而超出配额的请求返回 `HTTP/1.1 429 Too Many Requests`：
+
+```text
+HTTP/1.1 200 OK
+...
+X-AI-1-RateLimit-Limit: 10
+X-AI-1-RateLimit-Remaining: 9
+X-AI-1-RateLimit-Reset: 60
+
+HTTP/1.1 429 Too Many Requests
+...
+X-AI-1-RateLimit-Limit: 10
+X-AI-1-RateLimit-Remaining: 0
+X-AI-1-RateLimit-Reset: 40.422000169754
+```
+
+最后，使用试用 ID 向 Route 发送多个以下请求：
+
+```shell
+curl "http://127.0.0.1:9080/anything" -i -X POST \
+  -H "X-Trial-ID: trial-123456789" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      { "role": "system", "content": "You are a mathematician" },
+      { "role": "user", "content": "What is 1+1?" }
+    ]
+  }'
+```
+
+这些请求应匹配第二条规则，令牌计数为 50。您应该看到配额内的请求返回 `HTTP/1.1 200 OK`，而超出配额的请求返回 `HTTP/1.1 429 Too Many Requests`：
+
+```text
+HTTP/1.1 200 OK
+...
+X-AI-2-RateLimit-Limit: 50
+X-AI-2-RateLimit-Remaining: 49
+X-AI-2-RateLimit-Reset: 60
+
+HTTP/1.1 429 Too Many Requests
+...
+X-AI-2-RateLimit-Limit: 50
+X-AI-2-RateLimit-Remaining: 0
+X-AI-2-RateLimit-Reset: 44
+```

--- a/docs/zh/latest/plugins/ai-rate-limiting.md
+++ b/docs/zh/latest/plugins/ai-rate-limiting.md
@@ -67,7 +67,7 @@ import TabItem from '@theme/TabItem';
 
 :::note
 
-您可以使用以下命令从 `config.yaml` 获取 `admin_key` 并保存到环境变量中：
+你可以使用以下命令从 `config.yaml` 获取 `admin_key` 并保存到环境变量中：
 
 ```shell
 admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
@@ -79,7 +79,7 @@ admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"/
 
 以下示例演示了如何使用 `ai-proxy` 代理 LLM 流量，并使用 `ai-rate-limiting` 在实例上配置基于令牌的速率限制。
 
-创建一个 Route 并更新您的 LLM 提供商、模型、API 密钥和端点（如适用）：
+创建一个路由并更新你的 LLM 提供商、模型、API 密钥和端点（如适用）：
 
 <Tabs groupId="api">
 <TabItem value="admin-api" label="Admin API">
@@ -250,7 +250,7 @@ kubectl apply -f ai-rate-limiting-ic.yaml
 </TabItem>
 </Tabs>
 
-向 Route 发送 POST 请求，在请求体中包含系统提示和示例用户问题：
+向路由发送 POST 请求，在请求体中包含系统提示和示例用户问题：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -X POST \
@@ -263,7 +263,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
   }'
 ```
 
-您应该收到类似以下的响应：
+你应该收到类似以下的响应：
 
 ```json
 {
@@ -290,7 +290,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 
 以下示例演示了如何使用 `ai-proxy-multi` 配置两个模型进行负载均衡，将 80% 的流量转发到一个实例，20% 转发到另一个实例。此外，使用 `ai-rate-limiting` 对接收 80% 流量的实例配置基于令牌的速率限制，这样当配置的配额完全消耗时，额外的流量将被转发到另一个实例。
 
-创建一个 Route，对 `deepseek-instance-1` 实例应用 30 秒窗口内 100 个总令牌的速率限制配额，并更新您的 LLM 提供商、模型、API 密钥和端点（如适用）：
+创建一个路由，对 `deepseek-instance-1` 实例应用 30 秒窗口内 100 个总令牌的速率限制配额，并更新你的 LLM 提供商、模型、API 密钥和端点（如适用）：
 
 <Tabs groupId="api">
 <TabItem value="admin-api" label="Admin API">
@@ -516,7 +516,7 @@ kubectl apply -f ai-rate-limiting-ic.yaml
 </TabItem>
 </Tabs>
 
-向 Route 发送 POST 请求，在请求体中包含系统提示和示例用户问题：
+向路由发送 POST 请求，在请求体中包含系统提示和示例用户问题：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -X POST \
@@ -529,7 +529,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
   }'
 ```
 
-您应该收到类似以下的响应：
+你应该收到类似以下的响应：
 
 ```json
 {
@@ -556,9 +556,9 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 
 以下示例演示了如何对 `ai-rate-limiting` 中的所有 LLM 上游实例应用相同的速率限制配额。
 
-为了演示和更容易区分，您将配置一个 OpenAI 实例和一个 DeepSeek 实例作为上游 LLM 服务。
+为了演示和更容易区分，你将配置一个 OpenAI 实例和一个 DeepSeek 实例作为上游 LLM 服务。
 
-创建一个 Route，对所有实例在 60 秒窗口内应用 100 个总令牌的速率限制配额，并更新您的 LLM 提供商、模型、API 密钥和端点（如适用）：
+创建一个路由，对所有实例在 60 秒窗口内应用 100 个总令牌的速率限制配额，并更新你的 LLM 提供商、模型、API 密钥和端点（如适用）：
 
 <Tabs groupId="api">
 <TabItem value="admin-api" label="Admin API">
@@ -777,7 +777,7 @@ kubectl apply -f ai-rate-limiting-ic.yaml
 </TabItem>
 </Tabs>
 
-向 Route 发送 POST 请求，在请求体中包含系统提示和示例用户问题：
+向路由发送 POST 请求，在请求体中包含系统提示和示例用户问题：
 
 ```shell
 curl -i "http://127.0.0.1:9080/anything" -X POST \
@@ -790,7 +790,7 @@ curl -i "http://127.0.0.1:9080/anything" -X POST \
   }'
 ```
 
-您应该收到来自任一 LLM 实例的响应，类似以下内容：
+你应该收到来自任一 LLM 实例的响应，类似以下内容：
 
 ```json
 {
@@ -830,7 +830,7 @@ curl -i "http://127.0.0.1:9080/anything" -X POST \
 
 由于 `total_tokens` 值超过了配置的 `100` 配额，预期在 60 秒窗口内的下一个请求将被转发到另一个实例。
 
-在同一个 60 秒窗口内，向 Route 发送另一个 POST 请求：
+在同一个 60 秒窗口内，向路由发送另一个 POST 请求：
 
 ```shell
 curl -i "http://127.0.0.1:9080/anything" -X POST \
@@ -843,7 +843,7 @@ curl -i "http://127.0.0.1:9080/anything" -X POST \
   }'
 ```
 
-您应该收到来自另一个 LLM 实例的响应，类似以下内容：
+你应该收到来自另一个 LLM 实例的响应，类似以下内容：
 
 ```json
 {
@@ -876,7 +876,7 @@ curl -i "http://127.0.0.1:9080/anything" -X POST \
 
 由于 `total_tokens` 值超过了配置的 `100` 配额，预期在 60 秒窗口内的下一个请求将被拒绝。
 
-在同一个 60 秒窗口内，向 Route 发送第三个 POST 请求：
+在同一个 60 秒窗口内，向路由发送第三个 POST 请求：
 
 ```shell
 curl -i "http://127.0.0.1:9080/anything" -X POST \
@@ -889,7 +889,7 @@ curl -i "http://127.0.0.1:9080/anything" -X POST \
   }'
 ```
 
-您应该收到 `HTTP 429 Too Many Requests` 响应并观察到以下头部：
+你应该收到 `HTTP 429 Too Many Requests` 响应并观察到以下头部：
 
 ```text
 X-AI-RateLimit-Limit-openai-instance: 100
@@ -902,9 +902,9 @@ X-AI-RateLimit-Reset-deepseek-instance: 0
 
 ### 配置实例优先级和速率限制
 
-以下示例演示了如何配置两个具有不同优先级的模型，并对具有较高优先级的实例应用速率限制。在 `fallback_strategy` 设置为 `["rate_limiting"]` 的情况下，一旦高优先级实例的速率限制配额完全消耗，Plugin 应继续将请求转发到低优先级实例。
+以下示例演示了如何配置两个具有不同优先级的模型，并对具有较高优先级的实例应用速率限制。在 `fallback_strategy` 设置为 `["rate_limiting"]` 的情况下，一旦高优先级实例的速率限制配额完全消耗，插件应继续将请求转发到低优先级实例。
 
-创建一个 Route，对 `openai-instance` 实例设置速率限制和更高的优先级，并将 `fallback_strategy` 设置为 `["rate_limiting"]`。更新您的 LLM 提供商、模型、API 密钥和端点（如适用）：
+创建一个路由，对 `openai-instance` 实例设置速率限制和更高的优先级，并将 `fallback_strategy` 设置为 `["rate_limiting"]`。更新你的 LLM 提供商、模型、API 密钥和端点（如适用）：
 
 <Tabs groupId="api">
 <TabItem value="admin-api" label="Admin API">
@@ -1145,7 +1145,7 @@ kubectl apply -f ai-rate-limiting-ic.yaml
 </TabItem>
 </Tabs>
 
-向 Route 发送 POST 请求，在请求体中包含系统提示和示例用户问题：
+向路由发送 POST 请求，在请求体中包含系统提示和示例用户问题：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -X POST \
@@ -1158,7 +1158,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
   }'
 ```
 
-您应该收到类似以下的响应：
+你应该收到类似以下的响应：
 
 ```json
 {
@@ -1198,7 +1198,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 
 由于 `total_tokens` 值超过了配置的 `10` 配额，预期在 60 秒窗口内的下一个请求将被转发到另一个实例。
 
-在同一个 60 秒窗口内，向 Route 发送另一个 POST 请求：
+在同一个 60 秒窗口内，向路由发送另一个 POST 请求：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -X POST \
@@ -1211,7 +1211,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
   }'
 ```
 
-您应该看到类似以下的响应：
+你应该看到类似以下的响应：
 
 ```json
 {
@@ -1231,11 +1231,11 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 }
 ```
 
-### 按 Consumer 进行负载均衡和速率限制
+### 按消费者进行负载均衡和速率限制
 
-以下示例演示了如何配置两个模型进行负载均衡，并按 Consumer 应用速率限制。
+以下示例演示了如何配置两个模型进行负载均衡，并按消费者应用速率限制。
 
-创建 Consumer `johndoe` 并对 `openai-instance` 实例设置 60 秒窗口内 10 个令牌的速率限制配额：
+创建消费者 `johndoe` 并对 `openai-instance` 实例设置 60 秒窗口内 10 个令牌的速率限制配额：
 
 <Tabs groupId="api">
 <TabItem value="admin-api" label="Admin API">
@@ -1276,7 +1276,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers/johndoe/credentials" -X PUT \
   }'
 ```
 
-创建另一个 Consumer `janedoe` 并对 `deepseek-instance` 实例设置 60 秒窗口内 10 个令牌的速率限制配额：
+创建另一个消费者 `janedoe` 并对 `deepseek-instance` 实例设置 60 秒窗口内 10 个令牌的速率限制配额：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
@@ -1314,7 +1314,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers/janedoe/credentials" -X PUT \
   }'
 ```
 
-创建一个 Route 并更新您的 LLM 提供商、模型、API 密钥和端点（如适用）：
+创建一个路由并更新你的 LLM 提供商、模型、API 密钥和端点（如适用）：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
@@ -1363,7 +1363,7 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
 </TabItem>
 <TabItem value="adc" label="ADC">
 
-创建两个 Consumer 和一个启用按 Consumer 速率限制的 Route：
+创建两个消费者和一个启用按消费者速率限制的路由：
 
 ```yaml title="adc.yaml"
 consumers:
@@ -1439,7 +1439,7 @@ adc sync -f adc.yaml
 <Tabs groupId="k8s-api">
 <TabItem value="gateway-api" label="Gateway API">
 
-创建两个 Consumer 和一个启用按 Consumer 速率限制的 Route：
+创建两个消费者和一个启用按消费者速率限制的路由：
 
 ```yaml title="ai-rate-limiting-ic.yaml"
 apiVersion: apisix.apache.org/v1alpha1
@@ -1548,7 +1548,7 @@ spec:
 
 :::note
 
-ApisixConsumer CRD 目前不支持在 Consumer 上配置除 `authParameter` 中允许的认证插件之外的其他插件。此示例无法使用 APISIX CRD 完成。
+ApisixConsumer CRD 目前不支持在消费者上配置除 `authParameter` 中允许的认证插件之外的其他插件。此示例无法使用 APISIX CRD 完成。
 
 :::
 
@@ -1564,7 +1564,7 @@ kubectl apply -f ai-rate-limiting-ic.yaml
 </TabItem>
 </Tabs>
 
-向 Route 发送不带任何 Consumer 密钥的 POST 请求：
+向路由发送不带任何消费者密钥的 POST 请求：
 
 ```shell
 curl -i "http://127.0.0.1:9080/anything" -X POST \
@@ -1577,9 +1577,9 @@ curl -i "http://127.0.0.1:9080/anything" -X POST \
   }'
 ```
 
-您应该收到 `HTTP/1.1 401 Unauthorized` 响应。
+你应该收到 `HTTP/1.1 401 Unauthorized` 响应。
 
-使用 `johndoe` 的密钥向 Route 发送 POST 请求：
+使用 `johndoe` 的密钥向路由发送 POST 请求：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -X POST \
@@ -1593,7 +1593,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
   }'
 ```
 
-您应该收到类似以下的响应：
+你应该收到类似以下的响应：
 
 ```json
 {
@@ -1633,7 +1633,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 
 由于 `total_tokens` 值超过了 `johndoe` 的 `openai` 实例配置配额，预期在 60 秒窗口内来自 `johndoe` 的下一个请求将被转发到 `deepseek` 实例。
 
-在同一个 60 秒窗口内，使用 `johndoe` 的密钥向 Route 发送另一个 POST 请求：
+在同一个 60 秒窗口内，使用 `johndoe` 的密钥向路由发送另一个 POST 请求：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -X POST \
@@ -1647,7 +1647,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
   }'
 ```
 
-您应该看到类似以下的响应：
+你应该看到类似以下的响应：
 
 ```json
 {
@@ -1667,7 +1667,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 }
 ```
 
-使用 `janedoe` 的密钥向 Route 发送 POST 请求：
+使用 `janedoe` 的密钥向路由发送 POST 请求：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -X POST \
@@ -1681,7 +1681,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
   }'
 ```
 
-您应该收到类似以下的响应：
+你应该收到类似以下的响应：
 
 ```json
 {
@@ -1714,7 +1714,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 
 由于 `total_tokens` 值超过了 `janedoe` 的 `deepseek` 实例配置配额，预期在 60 秒窗口内来自 `janedoe` 的下一个请求将被转发到 `openai` 实例。
 
-在同一个 60 秒窗口内，使用 `janedoe` 的密钥向 Route 发送另一个 POST 请求：
+在同一个 60 秒窗口内，使用 `janedoe` 的密钥向路由发送另一个 POST 请求：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -X POST \
@@ -1728,7 +1728,7 @@ curl "http://127.0.0.1:9080/anything" -X POST \
   }'
 ```
 
-您应该看到类似以下的响应：
+你应该看到类似以下的响应：
 
 ```json
 {
@@ -1750,13 +1750,13 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 }
 ```
 
-这显示了 `ai-proxy-multi` 根据 Consumer 在 `ai-rate-limiting` 中的速率限制规则对流量进行负载均衡。
+这显示了 `ai-proxy-multi` 根据消费者在 `ai-rate-limiting` 中的速率限制规则对流量进行负载均衡。
 
 ### 按规则进行速率限制
 
-以下示例演示了如何配置 Plugin 根据请求属性应用不同的速率限制规则。在此示例中，速率限制基于表示调用者访问层级的 HTTP 头部值进行应用。所有规则按顺序执行。如果配置的键不存在，则跳过相应的规则。
+以下示例演示了如何配置插件根据请求属性应用不同的速率限制规则。在此示例中，速率限制基于表示调用者访问层级的 HTTP 头部值进行应用。所有规则按顺序执行。如果配置的键不存在，则跳过相应的规则。
 
-创建一个带有 `ai-rate-limiting` Plugin 的 Route，根据请求头部应用不同的速率限制，允许按订阅（`X-Subscription-ID`）进行速率限制，并对试用用户（`X-Trial-ID`）实施更严格的限制：
+创建一个带有 `ai-rate-limiting` 插件的路由，根据请求头部应用不同的速率限制，允许按订阅（`X-Subscription-ID`）进行速率限制，并对试用用户（`X-Trial-ID`）实施更严格的限制：
 
 <Tabs groupId="api">
 <TabItem value="admin-api" label="Admin API">
@@ -2013,7 +2013,7 @@ kubectl apply -f ai-rate-limiting-ic.yaml
 
 第一条规则使用 `X-Subscription-ID` 请求头部的值作为速率限制键，并根据 `X-Custom-Count` 头部动态设置请求限制。如果未提供该头部，则应用默认的 500 个令牌计数。第二条规则使用 `X-Trial-ID` 请求头部的值作为速率限制键，设置更严格的 50 个令牌限制。
 
-要验证速率限制，使用相同的订阅 ID 向 Route 发送多个以下请求：
+要验证速率限制，使用相同的订阅 ID 向路由发送多个以下请求：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -i -X POST \
@@ -2027,7 +2027,7 @@ curl "http://127.0.0.1:9080/anything" -i -X POST \
   }'
 ```
 
-这些请求应匹配第一条规则，默认令牌计数为 500。您应该看到配额内的请求返回 `HTTP/1.1 200 OK`，而超出配额的请求返回 `HTTP/1.1 429 Too Many Requests`：
+这些请求应匹配第一条规则，默认令牌计数为 500。你应该看到配额内的请求返回 `HTTP/1.1 200 OK`，而超出配额的请求返回 `HTTP/1.1 429 Too Many Requests`：
 
 ```text
 HTTP/1.1 200 OK
@@ -2043,7 +2043,7 @@ X-AI-1-RateLimit-Remaining: 0
 X-AI-1-RateLimit-Reset: 5.871000051498
 ```
 
-等待时间窗口重置。使用相同的订阅 ID 向 Route 发送多个以下请求，并将 `X-Custom-Count` 头部设置为 10：
+等待时间窗口重置。使用相同的订阅 ID 向路由发送多个以下请求，并将 `X-Custom-Count` 头部设置为 10：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -i -X POST \
@@ -2058,7 +2058,7 @@ curl "http://127.0.0.1:9080/anything" -i -X POST \
   }'
 ```
 
-这些请求应匹配第一条规则，自定义令牌计数为 10。您应该看到配额内的请求返回 `HTTP/1.1 200 OK`，而超出配额的请求返回 `HTTP/1.1 429 Too Many Requests`：
+这些请求应匹配第一条规则，自定义令牌计数为 10。你应该看到配额内的请求返回 `HTTP/1.1 200 OK`，而超出配额的请求返回 `HTTP/1.1 429 Too Many Requests`：
 
 ```text
 HTTP/1.1 200 OK
@@ -2074,7 +2074,7 @@ X-AI-1-RateLimit-Remaining: 0
 X-AI-1-RateLimit-Reset: 40.422000169754
 ```
 
-最后，使用试用 ID 向 Route 发送多个以下请求：
+最后，使用试用 ID 向路由发送多个以下请求：
 
 ```shell
 curl "http://127.0.0.1:9080/anything" -i -X POST \
@@ -2088,7 +2088,7 @@ curl "http://127.0.0.1:9080/anything" -i -X POST \
   }'
 ```
 
-这些请求应匹配第二条规则，令牌计数为 50。您应该看到配额内的请求返回 `HTTP/1.1 200 OK`，而超出配额的请求返回 `HTTP/1.1 429 Too Many Requests`：
+这些请求应匹配第二条规则，令牌计数为 50。你应该看到配额内的请求返回 `HTTP/1.1 200 OK`，而超出配额的请求返回 `HTTP/1.1 429 Too Many Requests`：
 
 ```text
 HTTP/1.1 200 OK

--- a/docs/zh/latest/plugins/ai-rate-limiting.md
+++ b/docs/zh/latest/plugins/ai-rate-limiting.md
@@ -332,10 +332,10 @@ curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
         ]
       },
       "ai-rate-limiting": {
+        "limit_strategy": "total_tokens",
         "instances": [
           {
             "name": "deepseek-instance-1",
-            "limit_strategy": "total_tokens",
             "limit": 100,
             "time_window": 30
           }
@@ -377,9 +377,9 @@ services:
                 options:
                   model: deepseek-chat
           ai-rate-limiting:
+            limit_strategy: total_tokens
             instances:
               - name: deepseek-instance-1
-                limit_strategy: total_tokens
                 limit: 100
                 time_window: 30
 ```
@@ -425,9 +425,9 @@ spec:
               model: deepseek-chat
     - name: ai-rate-limiting
       config:
+        limit_strategy: total_tokens
         instances:
           - name: deepseek-instance-1
-            limit_strategy: total_tokens
             limit: 100
             time_window: 30
 ---
@@ -495,9 +495,9 @@ spec:
         - name: ai-rate-limiting
           enable: true
           config:
+            limit_strategy: total_tokens
             instances:
               - name: deepseek-instance-1
-                limit_strategy: total_tokens
                 limit: 100
                 time_window: 30
 ```

--- a/docs/zh/latest/plugins/ai-rate-limiting.md
+++ b/docs/zh/latest/plugins/ai-rate-limiting.md
@@ -85,9 +85,10 @@ admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"/
 <TabItem value="admin-api" label="Admin API">
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
+    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -295,9 +296,10 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 <TabItem value="admin-api" label="Admin API">
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
+    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -562,9 +564,10 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 <TabItem value="admin-api" label="Admin API">
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
+    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -907,9 +910,10 @@ X-AI-RateLimit-Reset-deepseek-instance: 0
 <TabItem value="admin-api" label="Admin API">
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
+    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -1313,9 +1317,10 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers/janedoe/credentials" -X PUT \
 创建一个 Route 并更新您的 LLM 提供商、模型、API 密钥和端点（如适用）：
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
+    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {
@@ -1757,9 +1762,10 @@ curl "http://127.0.0.1:9080/anything" -X POST \
 <TabItem value="admin-api" label="Admin API">
 
 ```shell
-curl "http://127.0.0.1:9180/apisix/admin/routes/1" -X PUT \
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
+    "id": "ai-rate-limiting-route",
     "uri": "/anything",
     "methods": ["POST"],
     "plugins": {


### PR DESCRIPTION
## Summary

- Re-port `ai-rate-limiting` plugin documentation from API7 docs with all three configuration tabs (Admin API, ADC, Ingress Controller)
- Include nested Gateway API / APISIX Ingress Controller sub-tabs within the Ingress Controller tab
- 6 example sections covering single instance, multi-instance, shared quota, instance priority, consumer-level, and rule-based rate limiting
- Update both English and Chinese documentation