### PR TITLE
docs: port request-validation plugin documentation

### DIFF
--- a/docs/en/latest/plugins/request-validation.md
+++ b/docs/en/latest/plugins/request-validation.md
@@ -30,6 +30,9 @@ description: The request-validation Plugin validates requests before forwarding 
   <link rel="canonical" href="https://docs.api7.ai/hub/request-validation" />
 </head>
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Description
 
 The `request-validation` Plugin validates requests before forwarding them to Upstream services. This Plugin uses [JSON Schema](https://github.com/api7/jsonschema) for validation and can validate headers and body of a request.
@@ -71,6 +74,17 @@ The following example demonstrates how to validate request headers against a def
 
 Create a Route with `request-validation` Plugin as follows:
 
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
+
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
@@ -103,6 +117,187 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
     }
   }'
 ```
+
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+services:
+  - name: request-validation-service
+    routes:
+      - name: request-validation-route
+        uris:
+          - /get
+        plugins:
+          request-validation:
+            header_schema:
+              type: object
+              required:
+                - User-Agent
+                - Host
+              properties:
+                User-Agent:
+                  type: string
+                  pattern: "^curl/"
+                Host:
+                  type: string
+                  enum:
+                    - httpbin.org
+                    - httpbin
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="request-validation-ic.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: request-validation-plugin-config
+spec:
+  plugins:
+    - name: request-validation
+      config:
+        header_schema:
+          type: object
+          required:
+            - User-Agent
+            - Host
+          properties:
+            User-Agent:
+              type: string
+              pattern: "^curl/"
+            Host:
+              type: string
+              enum:
+                - httpbin.org
+                - httpbin
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: request-validation-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /get
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: request-validation-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="request-validation-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: request-validation-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: request-validation-route
+      match:
+        paths:
+          - /get
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: request-validation
+        enable: true
+        config:
+          header_schema:
+            type: object
+            required:
+              - User-Agent
+              - Host
+            properties:
+              User-Agent:
+                type: string
+                pattern: "^curl/"
+              Host:
+                type: string
+                enum:
+                  - httpbin.org
+                  - httpbin
+```
+
+</TabItem>
+
+</Tabs>
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f request-validation-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
+❶ `required`: require requests to include the specified headers.
+
+❷ `properties`: require headers to conform to the specified requirements.
 
 #### Verify with Request Conforming to the Schema
 
@@ -161,6 +356,17 @@ The following example demonstrates how to customize response status and message 
 
 Configure the Route with `request-validation` as follows:
 
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
+
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
@@ -192,6 +398,181 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+services:
+  - name: request-validation-service
+    routes:
+      - name: request-validation-route
+        uris:
+          - /get
+        plugins:
+          request-validation:
+            header_schema:
+              type: object
+              required:
+                - Host
+              properties:
+                Host:
+                  type: string
+                  enum:
+                    - httpbin.org
+                    - httpbin
+            rejected_code: 403
+            rejected_msg: "Request header validation failed."
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="request-validation-ic.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: request-validation-plugin-config
+spec:
+  plugins:
+    - name: request-validation
+      config:
+        header_schema:
+          type: object
+          required:
+            - Host
+          properties:
+            Host:
+              type: string
+              enum:
+                - httpbin.org
+                - httpbin
+        rejected_code: 403
+        rejected_msg: "Request header validation failed."
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: request-validation-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /get
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: request-validation-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="request-validation-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: request-validation-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: request-validation-route
+      match:
+        paths:
+          - /get
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: request-validation
+        enable: true
+        config:
+          header_schema:
+            type: object
+            required:
+              - Host
+            properties:
+              Host:
+                type: string
+                enum:
+                  - httpbin.org
+                  - httpbin
+          rejected_code: 403
+          rejected_msg: "Request header validation failed."
+```
+
+</TabItem>
+
+</Tabs>
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f request-validation-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
+❶ `rejected_code`: customize rejection code.
+
+❷ `rejected_msg`: customize rejection message.
+
 Send a request with a misconfigured `Host` in the header:
 
 ```shell
@@ -216,6 +597,17 @@ The `request-validation` Plugin supports validation of two types of media types:
 #### Validate JSON Request Body
 
 Create a Route with `request-validation` Plugin as follows:
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
@@ -264,6 +656,222 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
     }
   }'
 ```
+
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+services:
+  - name: request-validation-service
+    routes:
+      - name: request-validation-route
+        uris:
+          - /post
+        plugins:
+          request-validation:
+            header_schema:
+              type: object
+              required:
+                - Content-Type
+              properties:
+                Content-Type:
+                  type: string
+                  pattern: "^application/json$"
+            body_schema:
+              type: object
+              required:
+                - required_payload
+              properties:
+                required_payload:
+                  type: string
+                boolean_payload:
+                  type: boolean
+                array_payload:
+                  type: array
+                  minItems: 1
+                  items:
+                    type: integer
+                    minimum: 200
+                    maximum: 599
+                  uniqueItems: true
+                  default:
+                    - 200
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="request-validation-ic.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: request-validation-plugin-config
+spec:
+  plugins:
+    - name: request-validation
+      config:
+        header_schema:
+          type: object
+          required:
+            - Content-Type
+          properties:
+            Content-Type:
+              type: string
+              pattern: "^application/json$"
+        body_schema:
+          type: object
+          required:
+            - required_payload
+          properties:
+            required_payload:
+              type: string
+            boolean_payload:
+              type: boolean
+            array_payload:
+              type: array
+              minItems: 1
+              items:
+                type: integer
+                minimum: 200
+                maximum: 599
+              uniqueItems: true
+              default:
+                - 200
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: request-validation-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /post
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: request-validation-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="request-validation-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: request-validation-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: request-validation-route
+      match:
+        paths:
+          - /post
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: request-validation
+        enable: true
+        config:
+          header_schema:
+            type: object
+            required:
+              - Content-Type
+            properties:
+              Content-Type:
+                type: string
+                pattern: "^application/json$"
+          body_schema:
+            type: object
+            required:
+              - required_payload
+            properties:
+              required_payload:
+                type: string
+              boolean_payload:
+                type: boolean
+              array_payload:
+                type: array
+                minItems: 1
+                items:
+                  type: integer
+                  minimum: 200
+                  maximum: 599
+                uniqueItems: true
+                default:
+                  - 200
+```
+
+</TabItem>
+
+</Tabs>
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f request-validation-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
 
 Send a request with JSON body that conforms to the schema to verify:
 
@@ -326,6 +934,17 @@ property "required_payload" is required
 
 Create a Route with `request-validation` Plugin as follows:
 
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
+
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
@@ -367,6 +986,207 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+services:
+  - name: request-validation-service
+    routes:
+      - name: request-validation-route
+        uris:
+          - /post
+        plugins:
+          request-validation:
+            header_schema:
+              type: object
+              required:
+                - Content-Type
+              properties:
+                Content-Type:
+                  type: string
+                  pattern: "^application/x-www-form-urlencoded$"
+            body_schema:
+              type: object
+              required:
+                - required_payload
+                - enum_payload
+              properties:
+                required_payload:
+                  type: string
+                enum_payload:
+                  type: string
+                  enum:
+                    - enum_string_1
+                    - enum_string_2
+                  default: enum_string_1
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="request-validation-ic.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: request-validation-plugin-config
+spec:
+  plugins:
+    - name: request-validation
+      config:
+        header_schema:
+          type: object
+          required:
+            - Content-Type
+          properties:
+            Content-Type:
+              type: string
+              pattern: "^application/x-www-form-urlencoded$"
+        body_schema:
+          type: object
+          required:
+            - required_payload
+            - enum_payload
+          properties:
+            required_payload:
+              type: string
+            enum_payload:
+              type: string
+              enum:
+                - enum_string_1
+                - enum_string_2
+              default: enum_string_1
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: request-validation-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /post
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: request-validation-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="request-validation-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: request-validation-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: request-validation-route
+      match:
+        paths:
+          - /post
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: request-validation
+        enable: true
+        config:
+          header_schema:
+            type: object
+            required:
+              - Content-Type
+            properties:
+              Content-Type:
+                type: string
+                pattern: "^application/x-www-form-urlencoded$"
+          body_schema:
+            type: object
+            required:
+              - required_payload
+              - enum_payload
+            properties:
+              required_payload:
+                type: string
+              enum_payload:
+                type: string
+                enum:
+                  - enum_string_1
+                  - enum_string_2
+                default: enum_string_1
+```
+
+</TabItem>
+
+</Tabs>
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f request-validation-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
 Send a request with URL-encoded form data to verify:
 
 ```shell
@@ -375,7 +1195,7 @@ curl -i "http://127.0.0.1:9080/post" -X POST \
   -d "required_payload=hello&enum_payload=enum_string_1"
 ```
 
-You should receive an `HTTP/1.1 400 Bad Request` response similar to the following:
+You should receive an `HTTP/1.1 200 OK` response similar to the following:
 
 ```json
 {

--- a/docs/zh/latest/plugins/request-validation.md
+++ b/docs/zh/latest/plugins/request-validation.md
@@ -30,6 +30,9 @@ description: request-validation 插件会在将请求转发到上游服务之前
   <link rel="canonical" href="https://docs.api7.ai/hub/request-validation" />
 </head>
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## 描述
 
 `request-validation` 插件会在将请求转发到上游服务之前对其进行验证。此插件使用 [JSON Schema](https://github.com/api7/jsonschema) 进行验证，并且可以验证请求的标头和正文。
@@ -71,6 +74,17 @@ admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"/
 
 使用 `request-validation` 插件创建路由，如下所示：
 
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
+
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
@@ -103,6 +117,187 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
     }
   }'
 ```
+
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+services:
+  - name: request-validation-service
+    routes:
+      - name: request-validation-route
+        uris:
+          - /get
+        plugins:
+          request-validation:
+            header_schema:
+              type: object
+              required:
+                - User-Agent
+                - Host
+              properties:
+                User-Agent:
+                  type: string
+                  pattern: "^curl/"
+                Host:
+                  type: string
+                  enum:
+                    - httpbin.org
+                    - httpbin
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="request-validation-ic.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: request-validation-plugin-config
+spec:
+  plugins:
+    - name: request-validation
+      config:
+        header_schema:
+          type: object
+          required:
+            - User-Agent
+            - Host
+          properties:
+            User-Agent:
+              type: string
+              pattern: "^curl/"
+            Host:
+              type: string
+              enum:
+                - httpbin.org
+                - httpbin
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: request-validation-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /get
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: request-validation-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="request-validation-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: request-validation-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: request-validation-route
+      match:
+        paths:
+          - /get
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: request-validation
+        enable: true
+        config:
+          header_schema:
+            type: object
+            required:
+              - User-Agent
+              - Host
+            properties:
+              User-Agent:
+                type: string
+                pattern: "^curl/"
+              Host:
+                type: string
+                enum:
+                  - httpbin.org
+                  - httpbin
+```
+
+</TabItem>
+
+</Tabs>
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f request-validation-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
+❶ `required`：要求请求包含指定的标头。
+
+❷ `properties`：要求标头符合指定的要求。
 
 #### 使用符合架构的请求进行验证
 
@@ -161,6 +356,17 @@ property "User-Agent" validation failed: failed to match pattern "^curl/" with "
 
 使用 `request-validation` 配置路由，如下所示：
 
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
+
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
@@ -192,6 +398,181 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+services:
+  - name: request-validation-service
+    routes:
+      - name: request-validation-route
+        uris:
+          - /get
+        plugins:
+          request-validation:
+            header_schema:
+              type: object
+              required:
+                - Host
+              properties:
+                Host:
+                  type: string
+                  enum:
+                    - httpbin.org
+                    - httpbin
+            rejected_code: 403
+            rejected_msg: "Request header validation failed."
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="request-validation-ic.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: request-validation-plugin-config
+spec:
+  plugins:
+    - name: request-validation
+      config:
+        header_schema:
+          type: object
+          required:
+            - Host
+          properties:
+            Host:
+              type: string
+              enum:
+                - httpbin.org
+                - httpbin
+        rejected_code: 403
+        rejected_msg: "Request header validation failed."
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: request-validation-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /get
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: request-validation-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="request-validation-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: request-validation-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: request-validation-route
+      match:
+        paths:
+          - /get
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: request-validation
+        enable: true
+        config:
+          header_schema:
+            type: object
+            required:
+              - Host
+            properties:
+              Host:
+                type: string
+                enum:
+                  - httpbin.org
+                  - httpbin
+          rejected_code: 403
+          rejected_msg: "Request header validation failed."
+```
+
+</TabItem>
+
+</Tabs>
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f request-validation-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
+❶ `rejected_code`：自定义拒绝状态码。
+
+❷ `rejected_msg`：自定义拒绝消息。
+
 发送一个在标头中配置错误的 `Host` 的请求：
 
 ```shell
@@ -216,6 +597,17 @@ Request header validation failed.
 #### 验证 JSON 请求主体
 
 使用 `request-validation` 插件创建路由，如下所示：
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
@@ -264,6 +656,222 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
     }
   }'
 ```
+
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+services:
+  - name: request-validation-service
+    routes:
+      - name: request-validation-route
+        uris:
+          - /post
+        plugins:
+          request-validation:
+            header_schema:
+              type: object
+              required:
+                - Content-Type
+              properties:
+                Content-Type:
+                  type: string
+                  pattern: "^application/json$"
+            body_schema:
+              type: object
+              required:
+                - required_payload
+              properties:
+                required_payload:
+                  type: string
+                boolean_payload:
+                  type: boolean
+                array_payload:
+                  type: array
+                  minItems: 1
+                  items:
+                    type: integer
+                    minimum: 200
+                    maximum: 599
+                  uniqueItems: true
+                  default:
+                    - 200
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="request-validation-ic.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: request-validation-plugin-config
+spec:
+  plugins:
+    - name: request-validation
+      config:
+        header_schema:
+          type: object
+          required:
+            - Content-Type
+          properties:
+            Content-Type:
+              type: string
+              pattern: "^application/json$"
+        body_schema:
+          type: object
+          required:
+            - required_payload
+          properties:
+            required_payload:
+              type: string
+            boolean_payload:
+              type: boolean
+            array_payload:
+              type: array
+              minItems: 1
+              items:
+                type: integer
+                minimum: 200
+                maximum: 599
+              uniqueItems: true
+              default:
+                - 200
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: request-validation-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /post
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: request-validation-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="request-validation-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: request-validation-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: request-validation-route
+      match:
+        paths:
+          - /post
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: request-validation
+        enable: true
+        config:
+          header_schema:
+            type: object
+            required:
+              - Content-Type
+            properties:
+              Content-Type:
+                type: string
+                pattern: "^application/json$"
+          body_schema:
+            type: object
+            required:
+              - required_payload
+            properties:
+              required_payload:
+                type: string
+              boolean_payload:
+                type: boolean
+              array_payload:
+                type: array
+                minItems: 1
+                items:
+                  type: integer
+                  minimum: 200
+                  maximum: 599
+                uniqueItems: true
+                default:
+                  - 200
+```
+
+</TabItem>
+
+</Tabs>
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f request-validation-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
 
 发送符合架构的 JSON Schema 的请求以验证：
 
@@ -326,6 +934,17 @@ property "required_payload" is required
 
 使用 `request-validation` 插件创建路由，如下所示：
 
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
+
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
@@ -366,6 +985,207 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
     }
   }'
 ```
+
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+services:
+  - name: request-validation-service
+    routes:
+      - name: request-validation-route
+        uris:
+          - /post
+        plugins:
+          request-validation:
+            header_schema:
+              type: object
+              required:
+                - Content-Type
+              properties:
+                Content-Type:
+                  type: string
+                  pattern: "^application/x-www-form-urlencoded$"
+            body_schema:
+              type: object
+              required:
+                - required_payload
+                - enum_payload
+              properties:
+                required_payload:
+                  type: string
+                enum_payload:
+                  type: string
+                  enum:
+                    - enum_string_1
+                    - enum_string_2
+                  default: enum_string_1
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="request-validation-ic.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: request-validation-plugin-config
+spec:
+  plugins:
+    - name: request-validation
+      config:
+        header_schema:
+          type: object
+          required:
+            - Content-Type
+          properties:
+            Content-Type:
+              type: string
+              pattern: "^application/x-www-form-urlencoded$"
+        body_schema:
+          type: object
+          required:
+            - required_payload
+            - enum_payload
+          properties:
+            required_payload:
+              type: string
+            enum_payload:
+              type: string
+              enum:
+                - enum_string_1
+                - enum_string_2
+              default: enum_string_1
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: request-validation-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /post
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: request-validation-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="request-validation-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: request-validation-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: request-validation-route
+      match:
+        paths:
+          - /post
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: request-validation
+        enable: true
+        config:
+          header_schema:
+            type: object
+            required:
+              - Content-Type
+            properties:
+              Content-Type:
+                type: string
+                pattern: "^application/x-www-form-urlencoded$"
+          body_schema:
+            type: object
+            required:
+              - required_payload
+              - enum_payload
+            properties:
+              required_payload:
+                type: string
+              enum_payload:
+                type: string
+                enum:
+                  - enum_string_1
+                  - enum_string_2
+                default: enum_string_1
+```
+
+</TabItem>
+
+</Tabs>
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f request-validation-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
 
 发送带有 URL 编码的表单数据的请求来验证：
 


### PR DESCRIPTION
## Summary

- Port `request-validation` plugin documentation from API7 docs to APISIX
- Include all three tabs: Admin API, ADC, and Ingress Controller (Gateway API / APISIX CRD)
- Add both EN and ZH translations
- Fix original bug: URL-encoded form success response incorrectly said "400 Bad Request" instead of "200 OK"