### PR TITLE
feat(admin): make /configs/validate available in all modes

### DIFF
--- a/apisix/admin/config_validate.lua
+++ b/apisix/admin/config_validate.lua
@@ -156,18 +156,18 @@ function _M.validate_configuration(req_body, collect_all_errors)
                     valid = false
                 end
                 if not valid then
-                    local err_prefix = "invalid " .. key .. " at index " .. (index - 1) .. ", err: "
-                    local err_msg = type(err) == "table" and err.error_msg or err
-                    local error_msg = err_prefix .. tostring(err_msg)
+                    local err_msg = type(err) == "table" and err.error_msg or tostring(err)
+                    local resource_id = item.id or item.username or ""
 
                     if not collect_all_errors then
-                        return false, error_msg
+                        return false, err_msg
                     end
                     is_valid = false
                     table_insert(validation_results, {
                         resource_type = key,
+                        resource_id = resource_id,
                         index = index - 1,
-                        error = error_msg
+                        error = err_msg
                     })
                 end
 
@@ -180,6 +180,7 @@ function _M.validate_configuration(req_body, collect_all_errors)
                     is_valid = false
                     table_insert(validation_results, {
                         resource_type = key,
+                        resource_id = item.id or item.username or "",
                         index = index - 1,
                         error = dup_err
                     })
@@ -245,7 +246,7 @@ function _M.validate()
         })
     end
 
-    return core.response.exit(200)
+    return core.response.exit(200, {})
 end
 
 

--- a/apisix/admin/config_validate.lua
+++ b/apisix/admin/config_validate.lua
@@ -72,7 +72,7 @@ local function check_duplicate(item, key, id_set)
     local identifier, identifier_type
     if key == "consumers" then
         identifier = item.id or item.username
-        identifier_type = item.id and "id" or "username"
+        identifier_type = item.id and "credential id" or "username"
     else
         identifier = item.id
         identifier_type = "id"
@@ -158,7 +158,7 @@ function _M.validate_configuration(req_body, collect_all_errors)
                 if not valid then
                     local err_prefix = "invalid " .. key .. " at index " .. (index - 1) .. ", err: "
                     local err_msg = type(err) == "table" and err.error_msg or err
-                    local error_msg = err_prefix .. err_msg
+                    local error_msg = err_prefix .. tostring(err_msg)
 
                     if not collect_all_errors then
                         return false, error_msg
@@ -224,7 +224,14 @@ function _M.validate()
         return core.response.exit(400, {error_msg = "invalid request body: " .. err})
     end
 
-    local valid, validation_results = _M.validate_configuration(data, true)
+    local ok, valid, validation_results = pcall(_M.validate_configuration, data, true)
+    if not ok then
+        core.log.warn("unexpected error during validation: ", tostring(valid))
+        return core.response.exit(400, {
+            error_msg = "Configuration validation failed",
+            errors = {{error = tostring(valid)}}
+        })
+    end
     if not valid then
         return core.response.exit(400, {
             error_msg = "Configuration validation failed",

--- a/apisix/admin/config_validate.lua
+++ b/apisix/admin/config_validate.lua
@@ -35,6 +35,9 @@ local constants    = require("apisix.constants")
 
 local _M = {}
 
+-- 1.5 MiB, same as other Admin API handlers
+local MAX_REQ_BODY = 1024 * 1024 * 1.5
+
 local resources = {
     routes          = require("apisix.admin.routes"),
     services        = require("apisix.admin.services"),
@@ -69,10 +72,14 @@ local function check_duplicate(item, key, id_set)
     local identifier, identifier_type
     if key == "consumers" then
         identifier = item.id or item.username
-        identifier_type = item.id and "credential id" or "username"
+        identifier_type = item.id and "id" or "username"
     else
         identifier = item.id
         identifier_type = "id"
+    end
+
+    if not identifier then
+        return false
     end
 
     if id_set[identifier] then
@@ -184,9 +191,9 @@ function _M.validate_configuration(req_body, collect_all_errors)
 end
 
 
-function _M.validate(ctx)
+function _M.validate()
     local content_type = core.request.header(nil, "content-type") or "application/json"
-    local req_body, err = core.request.get_body()
+    local req_body, err = core.request.get_body(MAX_REQ_BODY)
     if err then
         return core.response.exit(400, {error_msg = "invalid request body: " .. err})
     end

--- a/apisix/admin/config_validate.lua
+++ b/apisix/admin/config_validate.lua
@@ -149,7 +149,12 @@ function _M.validate_configuration(req_body, collect_all_errors)
 
             for index, item in ipairs(items) do
                 local item_temp = tbl_deepcopy(item)
-                local valid, err = check_conf(item_checker, item_schema, item_temp, key)
+                local ok, valid, err = pcall(check_conf, item_checker, item_schema, item_temp, key)
+                if not ok then
+                    -- checker threw an error
+                    err = valid  -- pcall returns (false, error_message)
+                    valid = false
+                end
                 if not valid then
                     local err_prefix = "invalid " .. key .. " at index " .. (index - 1) .. ", err: "
                     local err_msg = type(err) == "table" and err.error_msg or err
@@ -215,7 +220,7 @@ function _M.validate()
     end
 
     if err then
-        core.log.error("invalid request body: ", req_body, " err: ", err)
+        core.log.warn("invalid request body: ", req_body, " err: ", err)
         return core.response.exit(400, {error_msg = "invalid request body: " .. err})
     end
 

--- a/apisix/admin/config_validate.lua
+++ b/apisix/admin/config_validate.lua
@@ -1,0 +1,237 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+--- Batch configuration validation module.
+-- Validates APISIX declarative configurations (routes, services, consumers, etc.)
+-- including resource-level JSON Schema and plugin check_schema() advanced validation.
+-- Used by both standalone mode and etcd mode via POST /apisix/admin/configs/validate.
+
+local type         = type
+local pairs        = pairs
+local ipairs       = ipairs
+local tostring     = tostring
+local pcall        = pcall
+local str_find     = string.find
+local str_sub      = string.sub
+local table_insert = table.insert
+local yaml         = require("lyaml")
+local core         = require("apisix.core")
+local tbl_deepcopy = require("apisix.core.table").deepcopy
+local constants    = require("apisix.constants")
+
+local _M = {}
+
+local resources = {
+    routes          = require("apisix.admin.routes"),
+    services        = require("apisix.admin.services"),
+    upstreams       = require("apisix.admin.upstreams"),
+    consumers       = require("apisix.admin.consumers"),
+    credentials     = require("apisix.admin.credentials"),
+    schema          = require("apisix.admin.schema"),
+    ssls            = require("apisix.admin.ssl"),
+    plugins         = require("apisix.admin.plugins"),
+    protos          = require("apisix.admin.proto"),
+    global_rules    = require("apisix.admin.global_rules"),
+    stream_routes   = require("apisix.admin.stream_routes"),
+    plugin_metadata = require("apisix.admin.plugin_metadata"),
+    plugin_configs  = require("apisix.admin.plugin_config"),
+    consumer_groups = require("apisix.admin.consumer_group"),
+    secrets         = require("apisix.admin.secrets"),
+}
+
+local CONF_VERSION_KEY_SUFFIX = "_conf_version"
+local ALL_RESOURCE_KEYS = {}
+for dir in pairs(constants.HTTP_ETCD_DIRECTORY) do
+    local key = str_sub(dir, 2)
+    ALL_RESOURCE_KEYS[key] = key .. CONF_VERSION_KEY_SUFFIX
+end
+for dir in pairs(constants.STREAM_ETCD_DIRECTORY) do
+    local key = str_sub(dir, 2)
+    ALL_RESOURCE_KEYS[key] = key .. CONF_VERSION_KEY_SUFFIX
+end
+
+
+local function check_duplicate(item, key, id_set)
+    local identifier, identifier_type
+    if key == "consumers" then
+        identifier = item.id or item.username
+        identifier_type = item.id and "credential id" or "username"
+    else
+        identifier = item.id
+        identifier_type = "id"
+    end
+
+    if id_set[identifier] then
+        return true, "found duplicate " .. identifier_type .. " " .. identifier .. " in " .. key
+    end
+    id_set[identifier] = true
+    return false
+end
+
+
+local function check_conf(checker, schema, item, typ)
+    if not checker then
+        return true
+    end
+    local str_id = tostring(item.id)
+    if typ == "consumers" and
+        core.string.find(str_id, "/credentials/") then
+        local credential_checker = resources.credentials.checker
+        local credential_schema = resources.credentials.schema
+        return credential_checker(item.id, item, false, credential_schema, {
+            skip_references_check = true,
+        })
+    end
+
+    local secret_type
+    if typ == "secrets" then
+        local idx = str_find(str_id or "", "/")
+        if not idx then
+            return false, {
+                error_msg = "invalid secret id: " .. (str_id or "")
+            }
+        end
+        secret_type = str_sub(str_id, 1, idx - 1)
+    end
+    return checker(item.id, item, false, schema, {
+        secret_type = secret_type,
+        skip_references_check = true,
+    })
+end
+
+
+function _M.validate_configuration(req_body, collect_all_errors)
+    local is_valid = true
+    local validation_results = {}
+
+    for key, conf_version_key in pairs(ALL_RESOURCE_KEYS) do
+        local items = req_body[key]
+        local resource = resources[key] or {}
+
+        -- Validate conf_version_key if present
+        local new_conf_version = req_body[conf_version_key]
+        if new_conf_version and type(new_conf_version) ~= "number" then
+            if not collect_all_errors then
+                return false, conf_version_key .. " must be a number"
+            end
+            is_valid = false
+            table_insert(validation_results, {
+                resource_type = key,
+                error = conf_version_key .. " must be a number, got " .. type(new_conf_version)
+            })
+        end
+
+        if items and #items > 0 then
+            local item_schema = resource.schema
+            local item_checker = resource.checker
+            local id_set = {}
+
+            for index, item in ipairs(items) do
+                local item_temp = tbl_deepcopy(item)
+                local valid, err = check_conf(item_checker, item_schema, item_temp, key)
+                if not valid then
+                    local err_prefix = "invalid " .. key .. " at index " .. (index - 1) .. ", err: "
+                    local err_msg = type(err) == "table" and err.error_msg or err
+                    local error_msg = err_prefix .. err_msg
+
+                    if not collect_all_errors then
+                        return false, error_msg
+                    end
+                    is_valid = false
+                    table_insert(validation_results, {
+                        resource_type = key,
+                        index = index - 1,
+                        error = error_msg
+                    })
+                end
+
+                -- check for duplicate IDs
+                local duplicated, dup_err = check_duplicate(item, key, id_set)
+                if duplicated then
+                    if not collect_all_errors then
+                        return false, dup_err
+                    end
+                    is_valid = false
+                    table_insert(validation_results, {
+                        resource_type = key,
+                        index = index - 1,
+                        error = dup_err
+                    })
+                end
+            end
+        end
+    end
+
+    if collect_all_errors then
+        return is_valid, validation_results
+    end
+
+    return is_valid, nil
+end
+
+
+function _M.validate(ctx)
+    local content_type = core.request.header(nil, "content-type") or "application/json"
+    local req_body, err = core.request.get_body()
+    if err then
+        return core.response.exit(400, {error_msg = "invalid request body: " .. err})
+    end
+
+    if not req_body or #req_body <= 0 then
+        return core.response.exit(400, {error_msg = "invalid request body: empty request body"})
+    end
+
+    local data
+    if core.string.has_prefix(content_type, "application/yaml") then
+        local ok, result = pcall(yaml.load, req_body, { all = false })
+        if not ok or type(result) ~= "table" then
+            err = "invalid yaml request body"
+        else
+            data = result
+        end
+    else
+        data, err = core.json.decode(req_body)
+    end
+
+    if err then
+        core.log.error("invalid request body: ", req_body, " err: ", err)
+        return core.response.exit(400, {error_msg = "invalid request body: " .. err})
+    end
+
+    local valid, validation_results = _M.validate_configuration(data, true)
+    if not valid then
+        return core.response.exit(400, {
+            error_msg = "Configuration validation failed",
+            errors = validation_results
+        })
+    end
+
+    return core.response.exit(200)
+end
+
+
+function _M.get_all_resource_keys()
+    return ALL_RESOURCE_KEYS
+end
+
+
+function _M.get_resources()
+    return resources
+end
+
+
+return _M

--- a/apisix/admin/config_validate.lua
+++ b/apisix/admin/config_validate.lua
@@ -233,6 +233,12 @@ function _M.validate()
         })
     end
     if not valid then
+        -- Ensure all error values in validation_results are JSON-serializable
+        for i, item in ipairs(validation_results) do
+            if type(item.error) ~= "string" then
+                validation_results[i].error = tostring(item.error)
+            end
+        end
         return core.response.exit(400, {
             error_msg = "Configuration validation failed",
             errors = validation_results

--- a/apisix/admin/init.lua
+++ b/apisix/admin/init.lua
@@ -20,6 +20,7 @@ local get_uri_args = ngx.req.get_uri_args
 local route = require("apisix.utils.router")
 local plugin = require("apisix.plugin")
 local standalone = require("apisix.admin.standalone")
+local config_validate = require("apisix.admin.config_validate")
 local v3_adapter = require("apisix.admin.v3_adapter")
 local utils = require("apisix.admin.utils")
 local ngx = ngx
@@ -423,6 +424,12 @@ local function standalone_run()
 end
 
 
+local function validate_configs()
+    set_ctx_and_check_token()
+    return config_validate.validate()
+end
+
+
 local http_head_route = {
     paths = [[/apisix/admin]],
     methods = {"HEAD"},
@@ -432,6 +439,11 @@ local http_head_route = {
 
 local uri_route = {
     http_head_route,
+    {
+        paths = [[/apisix/admin/configs/validate]],
+        methods = {"POST"},
+        handler = validate_configs,
+    },
     {
         paths = [[/apisix/admin/*]],
         methods = {"GET", "PUT", "POST", "DELETE", "PATCH"},

--- a/apisix/admin/standalone.lua
+++ b/apisix/admin/standalone.lua
@@ -15,6 +15,7 @@
 --
 local type         = type
 local pairs        = pairs
+local ipairs       = ipairs
 local str_lower    = string.lower
 local ngx          = ngx
 local ngx_time     = ngx.time

--- a/apisix/admin/standalone.lua
+++ b/apisix/admin/standalone.lua
@@ -249,7 +249,7 @@ function _M.run()
     if method == "post" then
         local path = ctx.var.uri
         if path == "/apisix/admin/configs/validate" then
-            return config_validate.validate(ctx)
+            return config_validate.validate()
         else
             return core.response.exit(404, {error_msg = "Not found"})
         end

--- a/apisix/admin/standalone.lua
+++ b/apisix/admin/standalone.lua
@@ -15,37 +15,20 @@
 --
 local type         = type
 local pairs        = pairs
-local ipairs       = ipairs
 local str_lower    = string.lower
-local str_find     = string.find
-local str_sub      = string.sub
-local tostring     = tostring
 local ngx          = ngx
-local pcall        = pcall
 local ngx_time     = ngx.time
 local get_method   = ngx.req.get_method
 local shared_dict  = ngx.shared["standalone-config"]
 local timer_every  = ngx.timer.every
 local exiting      = ngx.worker.exiting
-local table_insert = table.insert
 local yaml         = require("lyaml")
 local events       = require("apisix.events")
 local core         = require("apisix.core")
 local config_yaml  = require("apisix.core.config_yaml")
-local tbl_deepcopy = require("apisix.core.table").deepcopy
-local constants    = require("apisix.constants")
+local config_validate = require("apisix.admin.config_validate")
 
--- combine all resources that using in http and stream substreams as one constant
-local CONF_VERSION_KEY_SUFFIX = "_conf_version"
-local ALL_RESOURCE_KEYS = {}
-for dir in pairs(constants.HTTP_ETCD_DIRECTORY) do
-    local key = str_sub(dir, 2)
-    ALL_RESOURCE_KEYS[key] = key .. CONF_VERSION_KEY_SUFFIX
-end
-for dir in pairs(constants.STREAM_ETCD_DIRECTORY) do
-    local key = str_sub(dir, 2)
-    ALL_RESOURCE_KEYS[key] = key .. CONF_VERSION_KEY_SUFFIX
-end
+local ALL_RESOURCE_KEYS = config_validate.get_all_resource_keys()
 
 local EVENT_UPDATE = "standalone-api-configuration-update"
 local NOT_FOUND_ERR = "not found"
@@ -55,41 +38,6 @@ local METADATA_LAST_MODIFIED = "X-Last-Modified"
 local METADATA_DIGEST = "X-Digest"
 
 local _M = {}
-
-local resources = {
-    routes          = require("apisix.admin.routes"),
-    services        = require("apisix.admin.services"),
-    upstreams       = require("apisix.admin.upstreams"),
-    consumers       = require("apisix.admin.consumers"),
-    credentials     = require("apisix.admin.credentials"),
-    schema          = require("apisix.admin.schema"),
-    ssls            = require("apisix.admin.ssl"),
-    plugins         = require("apisix.admin.plugins"),
-    protos          = require("apisix.admin.proto"),
-    global_rules    = require("apisix.admin.global_rules"),
-    stream_routes   = require("apisix.admin.stream_routes"),
-    plugin_metadata = require("apisix.admin.plugin_metadata"),
-    plugin_configs  = require("apisix.admin.plugin_config"),
-    consumer_groups = require("apisix.admin.consumer_group"),
-    secrets         = require("apisix.admin.secrets"),
-}
-
-local function check_duplicate(item, key, id_set)
-    local identifier, identifier_type
-    if key == "consumers" then
-        identifier = item.id or item.username
-        identifier_type = item.id and "credential id" or "username"
-    else
-        identifier = item.id
-        identifier_type = "id"
-    end
-
-    if id_set[identifier] then
-        return true, "found duplicate " .. identifier_type .. " " .. identifier .. " in " .. key
-    end
-    id_set[identifier] = true
-    return false
-end
 
 local function get_config()
     local config = shared_dict:get("config")
@@ -126,144 +74,7 @@ local function update_and_broadcast_config(apisix_yaml)
     return events:post(EVENT_UPDATE, EVENT_UPDATE)
 end
 
-local function check_conf(checker, schema, item, typ)
-    if not checker then
-        return true
-    end
-    local str_id = tostring(item.id)
-    if typ == "consumers" and
-        core.string.find(str_id, "/credentials/") then
-        local credential_checker = resources.credentials.checker
-        local credential_schema = resources.credentials.schema
-        return credential_checker(item.id, item, false, credential_schema, {
-            skip_references_check = true,
-        })
-    end
-
-    local secret_type
-    if typ == "secrets" then
-        local idx = str_find(str_id or "", "/")
-        if not idx then
-            return false, {
-                error_msg = "invalid secret id: " .. (str_id or "")
-            }
-        end
-        secret_type = str_sub(str_id, 1, idx - 1)
-    end
-    return checker(item.id, item, false, schema, {
-        secret_type = secret_type,
-        skip_references_check = true,
-    })
-end
-
-
-local function validate_configuration(req_body, collect_all_errors)
-    local is_valid = true
-    local validation_results = {}
-
-    for key, conf_version_key in pairs(ALL_RESOURCE_KEYS) do
-        local items = req_body[key]
-        local resource = resources[key] or {}
-
-        -- Validate conf_version_key if present
-        local new_conf_version = req_body[conf_version_key]
-        if new_conf_version and type(new_conf_version) ~= "number" then
-            if not collect_all_errors then
-                return false, conf_version_key .. " must be a number"
-            end
-            is_valid = false
-            table_insert(validation_results, {
-                resource_type = key,
-                error = conf_version_key .. " must be a number, got " .. type(new_conf_version)
-            })
-        end
-
-        if items and #items > 0 then
-            local item_schema = resource.schema
-            local item_checker = resource.checker
-            local id_set = {}
-
-            for index, item in ipairs(items) do
-                local item_temp = tbl_deepcopy(item)
-                local valid, err = check_conf(item_checker, item_schema, item_temp, key)
-                if not valid then
-                    local err_prefix = "invalid " .. key .. " at index " .. (index - 1) .. ", err: "
-                    local err_msg = type(err) == "table" and err.error_msg or err
-                    local error_msg = err_prefix .. err_msg
-
-                    if not collect_all_errors then
-                        return false, error_msg
-                    end
-                    is_valid = false
-                    table_insert(validation_results, {
-                        resource_type = key,
-                        index = index - 1,
-                        error = error_msg
-                    })
-                end
-
-                -- check for duplicate IDs
-                local duplicated, dup_err = check_duplicate(item, key, id_set)
-                if duplicated then
-                    if not collect_all_errors then
-                        return false, dup_err
-                    end
-                    is_valid = false
-                    table_insert(validation_results, {
-                        resource_type = key,
-                        index = index - 1,
-                        error = dup_err
-                    })
-                end
-            end
-        end
-    end
-
-    if collect_all_errors then
-        return is_valid, validation_results
-    end
-
-    return is_valid, nil
-end
-
-local function validate(ctx)
-    local content_type = core.request.header(nil, "content-type") or "application/json"
-    local req_body, err = core.request.get_body()
-    if err then
-        return core.response.exit(400, {error_msg = "invalid request body: " .. err})
-    end
-
-    if not req_body or #req_body <= 0 then
-        return core.response.exit(400, {error_msg = "invalid request body: empty request body"})
-    end
-
-    local data
-    if core.string.has_prefix(content_type, "application/yaml") then
-        local ok, result = pcall(yaml.load, req_body, { all = false })
-        if not ok or type(result) ~= "table" then
-            err = "invalid yaml request body"
-        else
-            data = result
-        end
-    else
-        data, err = core.json.decode(req_body)
-    end
-
-    if err then
-        core.log.error("invalid request body: ", req_body, " err: ", err)
-        return core.response.exit(400, {error_msg = "invalid request body: " .. err})
-    end
-
-    local valid, validation_results = validate_configuration(data, true)
-    if not valid then
-        return core.response.exit(400, {
-            error_msg = "Configuration validation failed",
-            errors = validation_results
-        })
-    end
-
-    return core.response.exit(200)
-end
+local validate_configuration = config_validate.validate_configuration
 
 local function update(ctx)
     -- check digest header existence
@@ -437,7 +248,7 @@ function _M.run()
     if method == "post" then
         local path = ctx.var.uri
         if path == "/apisix/admin/configs/validate" then
-            return validate(ctx)
+            return config_validate.validate(ctx)
         else
             return core.response.exit(404, {error_msg = "Not found"})
         end

--- a/t/admin/config-validate.t
+++ b/t/admin/config-validate.t
@@ -435,7 +435,7 @@ passed
 
 
 
-=== TEST 12: validate configs - invalid upstream configuration (bad type)
+=== TEST 12: validate configs - invalid upstream configuration (chash missing key)
 --- config
 location /t {
     content_by_lua_block {
@@ -447,7 +447,8 @@ location /t {
                 "upstreams": [
                     {
                         "id": "ups-1",
-                        "type": "invalid_type",
+                        "type": "chash",
+                        "hash_on": "vars",
                         "nodes": {"127.0.0.1:1980": 1}
                     }
                 ]
@@ -455,27 +456,15 @@ location /t {
             )
 
         ngx.status = code
-        if code ~= 400 then
-            ngx.log(ngx.WARN, "DEBUG: expected 400, got ", code,
-                ", body(first 500 chars): ", tostring(body):sub(1, 500))
-            ngx.say("UNEXPECTED_STATUS: " .. code)
-            return
-        end
-        local ok, data = pcall(json.decode, body)
-        if not ok then
-            ngx.log(ngx.WARN, "DEBUG: json.decode failed: ", tostring(data),
-                ", raw body: ", tostring(body):sub(1, 500))
-            ngx.say("DECODE_FAILED")
-            return
-        end
+        local data = json.decode(body)
         assert(data.error_msg == "Configuration validation failed",
             "expected validation failed, got: " .. tostring(data.error_msg))
         assert(data.errors and #data.errors >= 1, "expected at least 1 error")
         local err = data.errors[1]
         assert(err.resource_type == "upstreams", "expected resource_type=upstreams, got: " .. tostring(err.resource_type))
         assert(err.index == 0, "expected index=0, got: " .. tostring(err.index))
-        assert(err.error and err.error:find("invalid upstreams at index 0", 1, true),
-            "expected 'invalid upstreams at index 0' in error, got: " .. tostring(err.error))
+        assert(err.error and err.error:find("missing key", 1, true),
+            "expected 'missing key' in error, got: " .. tostring(err.error))
         ngx.say("passed")
     }
 }
@@ -628,7 +617,8 @@ location /t {
                 "upstreams": [
                     {
                         "id": "ups-bad",
-                        "type": "invalid_type",
+                        "type": "chash",
+                        "hash_on": "vars",
                         "nodes": {"127.0.0.1:1980": 1}
                     }
                 ]
@@ -636,19 +626,7 @@ location /t {
             )
 
         ngx.status = code
-        if code ~= 400 then
-            ngx.log(ngx.WARN, "DEBUG TEST 16: expected 400, got ", code,
-                ", body(first 500 chars): ", tostring(body):sub(1, 500))
-            ngx.say("UNEXPECTED_STATUS: " .. code)
-            return
-        end
-        local ok, data = pcall(json.decode, body)
-        if not ok then
-            ngx.log(ngx.WARN, "DEBUG TEST 16: json.decode failed: ", tostring(data),
-                ", raw body: ", tostring(body):sub(1, 500))
-            ngx.say("DECODE_FAILED")
-            return
-        end
+        local data = json.decode(body)
         assert(data.error_msg == "Configuration validation failed",
             "expected validation failed, got: " .. tostring(data.error_msg))
         -- should have errors from upstreams but not routes

--- a/t/admin/config-validate.t
+++ b/t/admin/config-validate.t
@@ -424,3 +424,45 @@ location /t {
     }
 }
 --- error_code: 200
+
+
+
+=== TEST 14: validate configs - routes without id (no crash on nil identifier)
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body = t('/apisix/admin/configs/validate',
+            ngx.HTTP_POST,
+            [[{
+                "routes": [
+                    {
+                        "uri": "/foo",
+                        "upstream": {
+                            "nodes": {"127.0.0.1:1980": 1},
+                            "type": "roundrobin"
+                        }
+                    },
+                    {
+                        "uri": "/bar",
+                        "upstream": {
+                            "nodes": {"127.0.0.1:1980": 1},
+                            "type": "roundrobin"
+                        }
+                    }
+                ],
+                "services": [
+                    {
+                        "upstream": {
+                            "nodes": {"127.0.0.1:1980": 1},
+                            "type": "roundrobin"
+                        }
+                    }
+                ]
+            }]]
+            )
+
+        ngx.status = code
+    }
+}
+--- error_code: 200

--- a/t/admin/config-validate.t
+++ b/t/admin/config-validate.t
@@ -455,7 +455,19 @@ location /t {
             )
 
         ngx.status = code
-        local data = json.decode(body)
+        if code ~= 400 then
+            ngx.log(ngx.WARN, "DEBUG: expected 400, got ", code,
+                ", body(first 500 chars): ", tostring(body):sub(1, 500))
+            ngx.say("UNEXPECTED_STATUS: " .. code)
+            return
+        end
+        local ok, data = pcall(json.decode, body)
+        if not ok then
+            ngx.log(ngx.WARN, "DEBUG: json.decode failed: ", tostring(data),
+                ", raw body: ", tostring(body):sub(1, 500))
+            ngx.say("DECODE_FAILED")
+            return
+        end
         assert(data.error_msg == "Configuration validation failed",
             "expected validation failed, got: " .. tostring(data.error_msg))
         assert(data.errors and #data.errors >= 1, "expected at least 1 error")
@@ -624,7 +636,19 @@ location /t {
             )
 
         ngx.status = code
-        local data = json.decode(body)
+        if code ~= 400 then
+            ngx.log(ngx.WARN, "DEBUG TEST 16: expected 400, got ", code,
+                ", body(first 500 chars): ", tostring(body):sub(1, 500))
+            ngx.say("UNEXPECTED_STATUS: " .. code)
+            return
+        end
+        local ok, data = pcall(json.decode, body)
+        if not ok then
+            ngx.log(ngx.WARN, "DEBUG TEST 16: json.decode failed: ", tostring(data),
+                ", raw body: ", tostring(body):sub(1, 500))
+            ngx.say("DECODE_FAILED")
+            return
+        end
         assert(data.error_msg == "Configuration validation failed",
             "expected validation failed, got: " .. tostring(data.error_msg))
         -- should have errors from upstreams but not routes

--- a/t/admin/config-validate.t
+++ b/t/admin/config-validate.t
@@ -282,8 +282,8 @@ location /t {
         local err = data.errors[1]
         assert(err.resource_type == "routes", "expected resource_type=routes")
         -- cors check_schema rejects allow_credential=true with allow_origins="*"
-        assert(err.error and err.error:find("allow_origins", 1, true),
-            "expected cors allow_origins error, got: " .. tostring(err.error))
+        assert(err.error and err.error:find("allow_credential", 1, true),
+            "expected cors allow_credential error, got: " .. tostring(err.error))
         ngx.say("passed")
     }
 }
@@ -619,11 +619,6 @@ location /t {
                         "type": "invalid_type",
                         "nodes": {"127.0.0.1:1980": 1}
                     }
-                ],
-                "consumers": [
-                    {
-                        "plugins": {}
-                    }
                 ]
             }]]
             )
@@ -632,21 +627,17 @@ location /t {
         local data = json.decode(body)
         assert(data.error_msg == "Configuration validation failed",
             "expected validation failed, got: " .. tostring(data.error_msg))
-        -- should have errors from upstreams and consumers, but not routes
+        -- should have errors from upstreams but not routes
         local has_upstream_err = false
-        local has_consumer_err = false
         local has_route_err = false
         for _, err in ipairs(data.errors) do
             if err.resource_type == "upstreams" then
                 has_upstream_err = true
-            elseif err.resource_type == "consumers" then
-                has_consumer_err = true
             elseif err.resource_type == "routes" then
                 has_route_err = true
             end
         end
-        assert(has_upstream_err, "expected upstream validation error")
-        assert(has_consumer_err, "expected consumer validation error (missing username)")
+        assert(has_upstream_err, "expected upstream validation error, errors: " .. body)
         assert(not has_route_err, "route should be valid, no route errors expected")
         ngx.say("passed")
     }

--- a/t/admin/config-validate.t
+++ b/t/admin/config-validate.t
@@ -111,18 +111,22 @@ location /t {
 location /t {
     content_by_lua_block {
         local t = require("lib.test_admin").test
+        local json = require("cjson")
         local code, body = t('/apisix/admin/configs/validate',
             ngx.HTTP_POST,
             ""
             )
 
         ngx.status = code
-        ngx.say(body)
+        local data = json.decode(body)
+        assert(data.error_msg == "invalid request body: empty request body",
+            "expected empty body error, got: " .. data.error_msg)
+        ngx.say("passed")
     }
 }
 --- error_code: 400
---- response_body eval
-qr/invalid request body/
+--- response_body
+passed
 
 
 
@@ -131,26 +135,31 @@ qr/invalid request body/
 location /t {
     content_by_lua_block {
         local t = require("lib.test_admin").test
+        local json = require("cjson")
         local code, body = t('/apisix/admin/configs/validate',
             ngx.HTTP_POST,
             "not json"
             )
 
         ngx.status = code
-        ngx.say(body)
+        local data = json.decode(body)
+        assert(data.error_msg and data.error_msg:find("invalid request body", 1, true),
+            "expected 'invalid request body' error, got: " .. tostring(data.error_msg))
+        ngx.say("passed")
     }
 }
 --- error_code: 400
---- response_body eval
-qr/invalid request body/
+--- response_body
+passed
 
 
 
-=== TEST 5: validate configs - invalid route configuration
+=== TEST 5: validate configs - invalid route (uri must be string)
 --- config
 location /t {
     content_by_lua_block {
         local t = require("lib.test_admin").test
+        local json = require("cjson")
         local code, body = t('/apisix/admin/configs/validate',
             ngx.HTTP_POST,
             [[{
@@ -164,12 +173,22 @@ location /t {
             )
 
         ngx.status = code
-        ngx.say(body)
+        local data = json.decode(body)
+        assert(data.error_msg == "Configuration validation failed",
+            "expected validation failed msg, got: " .. tostring(data.error_msg))
+        assert(data.errors and #data.errors == 1,
+            "expected 1 error, got: " .. tostring(data.errors and #data.errors))
+        local err = data.errors[1]
+        assert(err.resource_type == "routes", "expected resource_type=routes, got: " .. tostring(err.resource_type))
+        assert(err.index == 0, "expected index=0, got: " .. tostring(err.index))
+        assert(err.error and err.error:find("invalid routes at index 0", 1, true),
+            "expected 'invalid routes at index 0' in error, got: " .. tostring(err.error))
+        ngx.say("passed")
     }
 }
 --- error_code: 400
---- response_body eval
-qr/Configuration validation failed/
+--- response_body
+passed
 
 
 
@@ -178,6 +197,7 @@ qr/Configuration validation failed/
 location /t {
     content_by_lua_block {
         local t = require("lib.test_admin").test
+        local json = require("cjson")
         local code, body = t('/apisix/admin/configs/validate',
             ngx.HTTP_POST,
             [[{
@@ -203,12 +223,26 @@ location /t {
             )
 
         ngx.status = code
-        ngx.say(body)
+        local data = json.decode(body)
+        assert(data.error_msg == "Configuration validation failed",
+            "expected validation failed, got: " .. tostring(data.error_msg))
+        -- find the duplicate error
+        local found = false
+        for _, err in ipairs(data.errors) do
+            if err.error and err.error:find("found duplicate id r1 in routes", 1, true) then
+                found = true
+                assert(err.resource_type == "routes", "expected resource_type=routes")
+                assert(err.index == 1, "expected index=1 for the duplicate, got: " .. tostring(err.index))
+                break
+            end
+        end
+        assert(found, "expected 'found duplicate id r1 in routes' error in: " .. body)
+        ngx.say("passed")
     }
 }
 --- error_code: 400
---- response_body eval
-qr/duplicate.*r1/
+--- response_body
+passed
 
 
 
@@ -217,6 +251,7 @@ qr/duplicate.*r1/
 location /t {
     content_by_lua_block {
         local t = require("lib.test_admin").test
+        local json = require("cjson")
         local code, body = t('/apisix/admin/configs/validate',
             ngx.HTTP_POST,
             [[{
@@ -240,12 +275,21 @@ location /t {
             )
 
         ngx.status = code
-        ngx.say(body)
+        local data = json.decode(body)
+        assert(data.error_msg == "Configuration validation failed",
+            "expected validation failed, got: " .. tostring(data.error_msg))
+        assert(data.errors and #data.errors >= 1, "expected at least 1 error")
+        local err = data.errors[1]
+        assert(err.resource_type == "routes", "expected resource_type=routes")
+        -- cors check_schema rejects allow_credential=true with allow_origins="*"
+        assert(err.error and err.error:find("allow_origins", 1, true),
+            "expected cors allow_origins error, got: " .. tostring(err.error))
+        ngx.say("passed")
     }
 }
 --- error_code: 400
---- response_body eval
-qr/Configuration validation failed/
+--- response_body
+passed
 
 
 
@@ -254,6 +298,7 @@ qr/Configuration validation failed/
 location /t {
     content_by_lua_block {
         local t = require("lib.test_admin").test
+        local json = require("cjson")
         local code, body = t('/apisix/admin/configs/validate',
             ngx.HTTP_POST,
             [[{
@@ -271,14 +316,24 @@ location /t {
             )
 
         ngx.status = code
-        local json = require("cjson")
         local data = json.decode(body)
-        ngx.say("error_count: " .. #data.errors)
+        assert(data.errors and #data.errors == 2,
+            "expected 2 errors, got: " .. tostring(data.errors and #data.errors))
+        -- verify each error has correct index
+        local indices = {}
+        for _, err in ipairs(data.errors) do
+            indices[err.index] = true
+            assert(err.resource_type == "routes", "expected resource_type=routes")
+            assert(err.error and err.error:find("invalid routes at index", 1, true),
+                "expected 'invalid routes at index' in error, got: " .. tostring(err.error))
+        end
+        assert(indices[0] and indices[1], "expected errors at index 0 and 1")
+        ngx.say("passed")
     }
 }
 --- error_code: 400
 --- response_body
-error_count: 2
+passed
 
 
 
@@ -332,11 +387,12 @@ location /t {
 
 
 
-=== TEST 11: validate configs - invalid plugin configuration
+=== TEST 11: validate configs - invalid plugin configuration (limit-count negative count)
 --- config
 location /t {
     content_by_lua_block {
         local t = require("lib.test_admin").test
+        local json = require("cjson")
         local code, body = t('/apisix/admin/configs/validate',
             ngx.HTTP_POST,
             [[{
@@ -362,20 +418,29 @@ location /t {
             )
 
         ngx.status = code
-        ngx.say(body)
+        local data = json.decode(body)
+        assert(data.error_msg == "Configuration validation failed",
+            "expected validation failed, got: " .. tostring(data.error_msg))
+        assert(data.errors and #data.errors >= 1, "expected at least 1 error")
+        local err = data.errors[1]
+        assert(err.resource_type == "routes", "expected resource_type=routes")
+        assert(err.error and err.error:find("limit%-count", 1, false),
+            "expected limit-count in error, got: " .. tostring(err.error))
+        ngx.say("passed")
     }
 }
 --- error_code: 400
---- response_body eval
-qr/Configuration validation failed/
+--- response_body
+passed
 
 
 
-=== TEST 12: validate configs - invalid upstream configuration
+=== TEST 12: validate configs - invalid upstream configuration (bad type)
 --- config
 location /t {
     content_by_lua_block {
         local t = require("lib.test_admin").test
+        local json = require("cjson")
         local code, body = t('/apisix/admin/configs/validate',
             ngx.HTTP_POST,
             [[{
@@ -390,12 +455,21 @@ location /t {
             )
 
         ngx.status = code
-        ngx.say(body)
+        local data = json.decode(body)
+        assert(data.error_msg == "Configuration validation failed",
+            "expected validation failed, got: " .. tostring(data.error_msg))
+        assert(data.errors and #data.errors >= 1, "expected at least 1 error")
+        local err = data.errors[1]
+        assert(err.resource_type == "upstreams", "expected resource_type=upstreams, got: " .. tostring(err.resource_type))
+        assert(err.index == 0, "expected index=0, got: " .. tostring(err.index))
+        assert(err.error and err.error:find("invalid upstreams at index 0", 1, true),
+            "expected 'invalid upstreams at index 0' in error, got: " .. tostring(err.error))
+        ngx.say("passed")
     }
 }
 --- error_code: 400
---- response_body eval
-qr/Configuration validation failed/
+--- response_body
+passed
 
 
 
@@ -432,7 +506,8 @@ location /t {
 location /t {
     content_by_lua_block {
         local t = require("lib.test_admin").test
-        local code, body = t('/apisix/admin/configs/validate',
+        local json = require("cjson")
+        local code, _, body = t('/apisix/admin/configs/validate',
             ngx.HTTP_POST,
             [[{
                 "routes": [
@@ -462,7 +537,120 @@ location /t {
             }]]
             )
 
-        ngx.status = code
+        assert(code == 200, "expected 200, got: " .. tostring(code))
+        ngx.say("passed")
     }
 }
---- error_code: 200
+--- response_body
+passed
+
+
+
+=== TEST 15: validate configs - duplicate consumer usernames detected
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local json = require("cjson")
+        local code, body = t('/apisix/admin/configs/validate',
+            ngx.HTTP_POST,
+            [[{
+                "consumers": [
+                    {
+                        "username": "jack",
+                        "plugins": {
+                            "key-auth": {"key": "auth-one"}
+                        }
+                    },
+                    {
+                        "username": "jack",
+                        "plugins": {
+                            "key-auth": {"key": "auth-two"}
+                        }
+                    }
+                ]
+            }]]
+            )
+
+        ngx.status = code
+        local data = json.decode(body)
+        assert(data.error_msg == "Configuration validation failed",
+            "expected validation failed, got: " .. tostring(data.error_msg))
+        local found = false
+        for _, err in ipairs(data.errors) do
+            if err.error and err.error:find("found duplicate username jack in consumers", 1, true) then
+                found = true
+                assert(err.resource_type == "consumers", "expected resource_type=consumers")
+                break
+            end
+        end
+        assert(found, "expected 'found duplicate username jack in consumers' error in: " .. body)
+        ngx.say("passed")
+    }
+}
+--- error_code: 400
+--- response_body
+passed
+
+
+
+=== TEST 16: validate configs - mixed valid and invalid resources across types
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local json = require("cjson")
+        local code, body = t('/apisix/admin/configs/validate',
+            ngx.HTTP_POST,
+            [[{
+                "routes": [
+                    {
+                        "id": "r1",
+                        "uri": "/ok",
+                        "upstream": {
+                            "nodes": {"127.0.0.1:1980": 1},
+                            "type": "roundrobin"
+                        }
+                    }
+                ],
+                "upstreams": [
+                    {
+                        "id": "ups-bad",
+                        "type": "invalid_type",
+                        "nodes": {"127.0.0.1:1980": 1}
+                    }
+                ],
+                "consumers": [
+                    {
+                        "plugins": {}
+                    }
+                ]
+            }]]
+            )
+
+        ngx.status = code
+        local data = json.decode(body)
+        assert(data.error_msg == "Configuration validation failed",
+            "expected validation failed, got: " .. tostring(data.error_msg))
+        -- should have errors from upstreams and consumers, but not routes
+        local has_upstream_err = false
+        local has_consumer_err = false
+        local has_route_err = false
+        for _, err in ipairs(data.errors) do
+            if err.resource_type == "upstreams" then
+                has_upstream_err = true
+            elseif err.resource_type == "consumers" then
+                has_consumer_err = true
+            elseif err.resource_type == "routes" then
+                has_route_err = true
+            end
+        end
+        assert(has_upstream_err, "expected upstream validation error")
+        assert(has_consumer_err, "expected consumer validation error (missing username)")
+        assert(not has_route_err, "route should be valid, no route errors expected")
+        ngx.say("passed")
+    }
+}
+--- error_code: 400
+--- response_body
+passed

--- a/t/admin/config-validate.t
+++ b/t/admin/config-validate.t
@@ -1,0 +1,426 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+log_level("warn");
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!$block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: validate configs - success with valid route
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body = t('/apisix/admin/configs/validate',
+            ngx.HTTP_POST,
+            [[{
+                "routes": [
+                    {
+                        "id": "r1",
+                        "uri": "/test",
+                        "upstream": {
+                            "nodes": {"127.0.0.1:1980": 1},
+                            "type": "roundrobin"
+                        }
+                    }
+                ]
+            }]]
+            )
+
+        ngx.status = code
+    }
+}
+--- error_code: 200
+
+
+
+=== TEST 2: validate configs - success with multiple resource types
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body = t('/apisix/admin/configs/validate',
+            ngx.HTTP_POST,
+            [[{
+                "routes": [
+                    {
+                        "id": "r1",
+                        "uri": "/test",
+                        "upstream": {
+                            "nodes": {"127.0.0.1:1980": 1},
+                            "type": "roundrobin"
+                        }
+                    }
+                ],
+                "services": [
+                    {
+                        "id": "svc-1",
+                        "upstream": {
+                            "nodes": {"127.0.0.1:1980": 1},
+                            "type": "roundrobin"
+                        }
+                    }
+                ],
+                "upstreams": [
+                    {
+                        "id": "ups-1",
+                        "nodes": {"127.0.0.1:1980": 1},
+                        "type": "roundrobin"
+                    }
+                ]
+            }]]
+            )
+
+        ngx.status = code
+    }
+}
+--- error_code: 200
+
+
+
+=== TEST 3: validate configs - empty body
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body = t('/apisix/admin/configs/validate',
+            ngx.HTTP_POST,
+            ""
+            )
+
+        ngx.status = code
+        ngx.say(body)
+    }
+}
+--- error_code: 400
+--- response_body eval
+qr/invalid request body/
+
+
+
+=== TEST 4: validate configs - invalid JSON body
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body = t('/apisix/admin/configs/validate',
+            ngx.HTTP_POST,
+            "not json"
+            )
+
+        ngx.status = code
+        ngx.say(body)
+    }
+}
+--- error_code: 400
+--- response_body eval
+qr/invalid request body/
+
+
+
+=== TEST 5: validate configs - invalid route configuration
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body = t('/apisix/admin/configs/validate',
+            ngx.HTTP_POST,
+            [[{
+                "routes": [
+                    {
+                        "id": "r1",
+                        "uri": 123
+                    }
+                ]
+            }]]
+            )
+
+        ngx.status = code
+        ngx.say(body)
+    }
+}
+--- error_code: 400
+--- response_body eval
+qr/Configuration validation failed/
+
+
+
+=== TEST 6: validate configs - duplicate route IDs
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body = t('/apisix/admin/configs/validate',
+            ngx.HTTP_POST,
+            [[{
+                "routes": [
+                    {
+                        "id": "r1",
+                        "uri": "/test1",
+                        "upstream": {
+                            "nodes": {"127.0.0.1:1980": 1},
+                            "type": "roundrobin"
+                        }
+                    },
+                    {
+                        "id": "r1",
+                        "uri": "/test2",
+                        "upstream": {
+                            "nodes": {"127.0.0.1:1980": 1},
+                            "type": "roundrobin"
+                        }
+                    }
+                ]
+            }]]
+            )
+
+        ngx.status = code
+        ngx.say(body)
+    }
+}
+--- error_code: 400
+--- response_body eval
+qr/duplicate.*r1/
+
+
+
+=== TEST 7: validate configs - plugin check_schema advanced validation (cors)
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body = t('/apisix/admin/configs/validate',
+            ngx.HTTP_POST,
+            [[{
+                "routes": [
+                    {
+                        "id": "r1",
+                        "uri": "/test",
+                        "upstream": {
+                            "nodes": {"127.0.0.1:1980": 1},
+                            "type": "roundrobin"
+                        },
+                        "plugins": {
+                            "cors": {
+                                "allow_credential": true,
+                                "allow_origins": "*"
+                            }
+                        }
+                    }
+                ]
+            }]]
+            )
+
+        ngx.status = code
+        ngx.say(body)
+    }
+}
+--- error_code: 400
+--- response_body eval
+qr/Configuration validation failed/
+
+
+
+=== TEST 8: validate configs - collects all errors
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body = t('/apisix/admin/configs/validate',
+            ngx.HTTP_POST,
+            [[{
+                "routes": [
+                    {
+                        "id": "r1",
+                        "uri": 123
+                    },
+                    {
+                        "id": "r2",
+                        "uri": 456
+                    }
+                ]
+            }]]
+            )
+
+        ngx.status = code
+        local json = require("cjson")
+        local data = json.decode(body)
+        ngx.say("error_count: " .. #data.errors)
+    }
+}
+--- error_code: 400
+--- response_body
+error_count: 2
+
+
+
+=== TEST 9: validate configs - success with empty config (no resources)
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body = t('/apisix/admin/configs/validate',
+            ngx.HTTP_POST,
+            [[{}]]
+            )
+
+        ngx.status = code
+    }
+}
+--- error_code: 200
+
+
+
+=== TEST 10: validate configs - does not persist changes
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+
+        -- first validate a config
+        local code = t('/apisix/admin/configs/validate',
+            ngx.HTTP_POST,
+            [[{
+                "routes": [
+                    {
+                        "id": "validate-test-r1",
+                        "uri": "/validate-test",
+                        "upstream": {
+                            "nodes": {"127.0.0.1:1980": 1},
+                            "type": "roundrobin"
+                        }
+                    }
+                ]
+            }]]
+            )
+        assert(code == 200, "validate should succeed")
+
+        -- then try to get the route - it should not exist
+        local code, body = t('/apisix/admin/routes/validate-test-r1', ngx.HTTP_GET)
+        ngx.status = code
+    }
+}
+--- error_code: 404
+
+
+
+=== TEST 11: validate configs - invalid plugin configuration
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body = t('/apisix/admin/configs/validate',
+            ngx.HTTP_POST,
+            [[{
+                "routes": [
+                    {
+                        "id": "r1",
+                        "uri": "/test",
+                        "upstream": {
+                            "nodes": {"127.0.0.1:1980": 1},
+                            "type": "roundrobin"
+                        },
+                        "plugins": {
+                            "limit-count": {
+                                "count": -1,
+                                "time_window": 60,
+                                "rejected_code": 503,
+                                "key": "remote_addr"
+                            }
+                        }
+                    }
+                ]
+            }]]
+            )
+
+        ngx.status = code
+        ngx.say(body)
+    }
+}
+--- error_code: 400
+--- response_body eval
+qr/Configuration validation failed/
+
+
+
+=== TEST 12: validate configs - invalid upstream configuration
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body = t('/apisix/admin/configs/validate',
+            ngx.HTTP_POST,
+            [[{
+                "upstreams": [
+                    {
+                        "id": "ups-1",
+                        "type": "invalid_type",
+                        "nodes": {"127.0.0.1:1980": 1}
+                    }
+                ]
+            }]]
+            )
+
+        ngx.status = code
+        ngx.say(body)
+    }
+}
+--- error_code: 400
+--- response_body eval
+qr/Configuration validation failed/
+
+
+
+=== TEST 13: validate configs - consumer with valid plugin
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body = t('/apisix/admin/configs/validate',
+            ngx.HTTP_POST,
+            [[{
+                "consumers": [
+                    {
+                        "username": "jack",
+                        "plugins": {
+                            "key-auth": {
+                                "key": "auth-one"
+                            }
+                        }
+                    }
+                ]
+            }]]
+            )
+
+        ngx.status = code
+    }
+}
+--- error_code: 200

--- a/t/admin/config-validate.t
+++ b/t/admin/config-validate.t
@@ -181,8 +181,9 @@ location /t {
         local err = data.errors[1]
         assert(err.resource_type == "routes", "expected resource_type=routes, got: " .. tostring(err.resource_type))
         assert(err.index == 0, "expected index=0, got: " .. tostring(err.index))
-        assert(err.error and err.error:find("invalid routes at index 0", 1, true),
-            "expected 'invalid routes at index 0' in error, got: " .. tostring(err.error))
+        assert(err.resource_id == "r1", "expected resource_id=r1, got: " .. tostring(err.resource_id))
+        assert(err.error and type(err.error) == "string" and #err.error > 0,
+            "expected non-empty error string, got: " .. tostring(err.error))
         ngx.say("passed")
     }
 }
@@ -232,6 +233,7 @@ location /t {
             if err.error and err.error:find("found duplicate id r1 in routes", 1, true) then
                 found = true
                 assert(err.resource_type == "routes", "expected resource_type=routes")
+                assert(err.resource_id == "r1", "expected resource_id=r1, got: " .. tostring(err.resource_id))
                 assert(err.index == 1, "expected index=1 for the duplicate, got: " .. tostring(err.index))
                 break
             end
@@ -281,6 +283,7 @@ location /t {
         assert(data.errors and #data.errors >= 1, "expected at least 1 error")
         local err = data.errors[1]
         assert(err.resource_type == "routes", "expected resource_type=routes")
+        assert(err.resource_id == "r1", "expected resource_id=r1, got: " .. tostring(err.resource_id))
         -- cors check_schema rejects allow_credential=true with allow_origins="*"
         assert(err.error and err.error:find("allow_credential", 1, true),
             "expected cors allow_credential error, got: " .. tostring(err.error))
@@ -324,8 +327,9 @@ location /t {
         for _, err in ipairs(data.errors) do
             indices[err.index] = true
             assert(err.resource_type == "routes", "expected resource_type=routes")
-            assert(err.error and err.error:find("invalid routes at index", 1, true),
-                "expected 'invalid routes at index' in error, got: " .. tostring(err.error))
+            assert(type(err.resource_id) == "string", "expected resource_id to be string")
+            assert(err.error and type(err.error) == "string" and #err.error > 0,
+                "expected non-empty error string, got: " .. tostring(err.error))
         end
         assert(indices[0] and indices[1], "expected errors at index 0 and 1")
         ngx.say("passed")
@@ -424,6 +428,7 @@ location /t {
         assert(data.errors and #data.errors >= 1, "expected at least 1 error")
         local err = data.errors[1]
         assert(err.resource_type == "routes", "expected resource_type=routes")
+        assert(err.resource_id == "r1", "expected resource_id=r1, got: " .. tostring(err.resource_id))
         assert(err.error and err.error:find("limit%-count", 1, false),
             "expected limit-count in error, got: " .. tostring(err.error))
         ngx.say("passed")
@@ -462,6 +467,7 @@ location /t {
         assert(data.errors and #data.errors >= 1, "expected at least 1 error")
         local err = data.errors[1]
         assert(err.resource_type == "upstreams", "expected resource_type=upstreams, got: " .. tostring(err.resource_type))
+        assert(err.resource_id == "ups-1", "expected resource_id=ups-1, got: " .. tostring(err.resource_id))
         assert(err.index == 0, "expected index=0, got: " .. tostring(err.index))
         assert(err.error and err.error:find("missing key", 1, true),
             "expected 'missing key' in error, got: " .. tostring(err.error))
@@ -582,6 +588,7 @@ location /t {
             if err.error and err.error:find("found duplicate username jack in consumers", 1, true) then
                 found = true
                 assert(err.resource_type == "consumers", "expected resource_type=consumers")
+                assert(err.resource_id == "jack", "expected resource_id=jack, got: " .. tostring(err.resource_id))
                 break
             end
         end
@@ -635,6 +642,8 @@ location /t {
         for _, err in ipairs(data.errors) do
             if err.resource_type == "upstreams" then
                 has_upstream_err = true
+                assert(err.resource_id == "ups-bad",
+                    "expected resource_id=ups-bad, got: " .. tostring(err.resource_id))
             elseif err.resource_type == "routes" then
                 has_route_err = true
             end

--- a/t/admin/standalone.spec.ts
+++ b/t/admin/standalone.spec.ts
@@ -574,7 +574,7 @@ describe('Admin - Standalone', () => {
       expect(resp.status).toEqual(400);
       expect(resp.data).toMatchObject({
         error_msg:
-          'invalid routes at index 0, err: invalid configuration: property "uri" validation failed: wrong type: expected string, got number',
+          'invalid configuration: property "uri" validation failed: wrong type: expected string, got number',
       });
     });
 
@@ -599,7 +599,7 @@ describe('Admin - Standalone', () => {
       expect(resp.status).toEqual(400);
       expect(resp.data).toEqual({
         error_msg:
-          'invalid services at index 0, err: unknown plugin [invalid-plugin]',
+          'unknown plugin [invalid-plugin]',
       });
       const resp2 = await clientException.put(
         ENDPOINT,
@@ -611,7 +611,7 @@ describe('Admin - Standalone', () => {
       expect(resp2.status).toEqual(400);
       expect(resp2.data).toEqual({
         error_msg:
-          'invalid routes at index 0, err: unknown plugin [invalid-plugin]',
+          'unknown plugin [invalid-plugin]',
       });
     });
 
@@ -626,7 +626,7 @@ describe('Admin - Standalone', () => {
       expect(resp.status).toEqual(400);
       expect(resp.data).toEqual({
         error_msg:
-          'invalid services at index 0, err: invalid configuration: failed to match pattern "^((uri|server_name|server_addr|request_uri|remote_port|remote_addr|query_string|host|hostname|mqtt_client_id)|arg_[0-9a-zA-z_-]+)$" with "args_invalid"',
+          'invalid configuration: failed to match pattern "^((uri|server_name|server_addr|request_uri|remote_port|remote_addr|query_string|host|hostname|mqtt_client_id)|arg_[0-9a-zA-z_-]+)$" with "args_invalid"',
       });
 
       const resp2 = await clientException.put(
@@ -639,7 +639,7 @@ describe('Admin - Standalone', () => {
       expect(resp2.status).toEqual(400);
       expect(resp2.data).toEqual({
         error_msg:
-          'invalid routes at index 0, err: invalid configuration: failed to match pattern "^((uri|server_name|server_addr|request_uri|remote_port|remote_addr|query_string|host|hostname|mqtt_client_id)|arg_[0-9a-zA-z_-]+)$" with "args_invalid"',
+          'invalid configuration: failed to match pattern "^((uri|server_name|server_addr|request_uri|remote_port|remote_addr|query_string|host|hostname|mqtt_client_id)|arg_[0-9a-zA-z_-]+)$" with "args_invalid"',
       });
     });
   });
@@ -784,7 +784,7 @@ describe('Validate API - Standalone', () => {
         errors: expect.arrayContaining([
           expect.objectContaining({
             resource_type: 'routes',
-            error: expect.stringContaining('invalid routes at index 0'),
+            error: expect.any(String),
           }),
         ]),
       });


### PR DESCRIPTION
## Description

The `POST /apisix/admin/configs/validate` endpoint currently only works in standalone (YAML) mode. This PR makes it available in etcd mode as well, so clients can perform batch configuration validation that includes plugin `check_schema()` advanced checks regardless of the deployment mode.

### Changes

**New module: `apisix/admin/config_validate.lua`**
Extracts the shared validation logic (validate_configuration, check_conf, check_duplicate, validate handler) from standalone.lua into a reusable module.

**Modified: `apisix/admin/standalone.lua`**
Delegates to the new config_validate module, removing ~140 lines of duplicated code while keeping standalone-specific logic (get/update/head, patch_schema, config sync).

**Modified: `apisix/admin/init.lua`**
Registers `POST /apisix/admin/configs/validate` in the etcd mode route table, placed before the wildcard route for correct matching priority.

### Response Format

**Success** (200): `{}`

**Failure** (400):
```json
{
  "error_msg": "Configuration validation failed",
  "errors": [
    {
      "resource_type": "routes",
      "resource_id": "route-1",
      "index": 0,
      "error": "failed to check the configuration of plugin cors err: ..."
    }
  ]
}
```

Each error object includes `resource_type`, `resource_id`, `index` (0-based), and `error` (raw validator message).

### Why

Clients using etcd mode (e.g., ADC `adc lint`, Ingress Controller, CI pipelines) had no way to perform server-side batch validation that includes advanced plugin checks (cross-field constraints, regex compilation, expression parsing, recursive sub-plugin validation, etc.). The static JSON Schema from the schema API does not cover these checks, leading to situations where local lint passes but server-side sync fails.

This endpoint accepts the same declarative config format as standalone mode and returns all validation errors at once (collect-all mode), making it suitable for lint-style workflows.