### PR TITLE
docs: port workflow plugin documentation

### DIFF
--- a/docs/en/latest/plugins/workflow.md
+++ b/docs/en/latest/plugins/workflow.md
@@ -6,7 +6,7 @@ keywords:
   - Plugin
   - workflow
   - traffic control
-description: The workflow Plugin supports the conditional execution of user-defined actions to client traffic based a given set of rules. This provides a granular approach to implement complex traffic management.
+description: The workflow Plugin supports the conditional execution of user-defined actions to client traffic based on a given set of rules. This provides a granular approach to traffic management.
 ---
 
 <!--
@@ -32,21 +32,24 @@ description: The workflow Plugin supports the conditional execution of user-defi
   <link rel="canonical" href="https://docs.api7.ai/hub/workflow" />
 </head>
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Description
 
-The `workflow` Plugin supports the conditional execution of user-defined actions to client traffic based a given set of rules, defined using [lua-resty-expr](https://github.com/api7/lua-resty-expr#operator-list). This provides a granular approach to traffic management.
+The `workflow` Plugin supports the conditional execution of user-defined actions to client traffic based on a given set of rules, defined using [lua-resty-expr](https://github.com/api7/lua-resty-expr#operator-list). This provides a granular approach to traffic management.
 
 ## Attributes
 
-| Name                         | Type          | Required | Default | Valid values | Description                                                  |
-| ---------------------------- | ------------- | -------- | ------- | ------------ | ------------------------------------------------------------ |
-| rules                   | array[object]  | True     |         |              |  An array of one or more pairs of matching conditions and actions to be executed. |
-| rules.case                   | array[array]  | False     |         |              | An array of one or more matching conditions in the form of [lua-resty-expr](https://github.com/api7/lua-resty-expr#operator-list). For example, `{"arg_name", "==", "json"}`.  |
-| rules.actions                | array[object] | True     |         |              | An array of actions to be executed when a condition is successfully matched. Currently, the array only supports one action, and it should be either `return`, or `limit-count` or `limit-conn`. When the action is configured to be `return`, you can configure an HTTP status code to return to the client when the condition is matched. When the action is configured to be `limit-count`, you can configure all options of the [`limit-count`](./limit-count.md) plugin, except for `group`. When the action is configured to be `limit-conn`, you can configure all options of the [`limit-conn`](./limit-conn.md) plugin. |
+| Name | Type | Required | Default | Valid values | Description |
+|------|------|----------|---------|--------------|-------------|
+| rules | array[object] | True | | | An array of one or more pairs of matching conditions and actions to be executed. |
+| rules.case | array[array] | False | | | An array of one or more matching conditions in the form of [lua-resty-expr](https://github.com/api7/lua-resty-expr#operator-list). For example, `{"arg_name", "==", "json"}`. |
+| rules.actions | array[array] | True | | | An array of actions to be executed when a condition is successfully matched. Currently, the array only supports one action, and it should be either `return`, `limit-count`, or `limit-conn`. When the action is set to `return`, you can configure an HTTP status code to return to the client when the condition is matched. When the action is set to `limit-count`, you can configure all options of the [`limit-count`](./limit-count.md) plugin, except for `group`. When the action is configured to be `limit-conn`, you can configure all options of the [`limit-conn`](./limit-conn.md) plugin. |
 
 ## Examples
 
-The examples below demonstrates how you can use the `workflow` Plugin for different scenarios.
+The examples below demonstrate how you can use the `workflow` Plugin for different scenarios.
 
 :::note
 
@@ -62,7 +65,18 @@ admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"/
 
 The following example demonstrates a simple rule with one matching condition and one associated action to return HTTP status code conditionally.
 
-Create a Route with the `workflow` Plugin to return HTTP status code 403 when the request's URI path is `/anything/rejected`:
+Create a Route with the `workflow` Plugin as such:
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
@@ -96,6 +110,159 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+services:
+  - name: httpbin
+    routes:
+      - uris:
+          - /anything/*
+        name: workflow-route
+        plugins:
+          workflow:
+            rules:
+              - case:
+                  - ["uri", "==", "/anything/rejected"]
+                actions:
+                  - - return
+                    - code: 403
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="workflow-ic.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: workflow-plugin-config
+spec:
+  plugins:
+    - name: workflow
+      config:
+        rules:
+          - case:
+              - ["uri", "==", "/anything/rejected"]
+            actions:
+              - - return
+                - code: 403
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: workflow-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /anything/
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: workflow-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="workflow-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: workflow-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: workflow-route
+      match:
+        paths:
+          - /anything/*
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: workflow
+        enable: true
+        config:
+          rules:
+            - case:
+                - ["uri", "==", "/anything/rejected"]
+              actions:
+                - - return
+                  - code: 403
+```
+
+</TabItem>
+
+</Tabs>
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f workflow-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
 Send a request that matches none of the rules:
 
 ```shell
@@ -120,7 +287,18 @@ You should receive an `HTTP/1.1 403 Forbidden` response of following:
 
 The following example demonstrates a rule with two matching conditions and one associated action to rate limit requests conditionally.
 
-Create a Route with the `workflow` Plugin to apply rate limiting when the URI path is `/anything/rate-limit` and the query parameter `env` value is `v1`:
+Create a Route with the `workflow` Plugin as such:
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
@@ -159,7 +337,169 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
-Generate two consecutive requests that matches the second rule:
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+services:
+  - name: httpbin
+    routes:
+      - uris:
+          - /anything/*
+        name: workflow-route
+        plugins:
+          workflow:
+            rules:
+              - case:
+                  - ["uri", "==", "/anything/rate-limit"]
+                  - ["arg_env", "==", "v1"]
+                actions:
+                  - - limit-count
+                    - count: 1
+                      time_window: 60
+                      rejected_code: 429
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="workflow-ic.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: workflow-plugin-config
+spec:
+  plugins:
+    - name: workflow
+      config:
+        rules:
+          - case:
+              - ["uri", "==", "/anything/rate-limit"]
+              - ["arg_env", "==", "v1"]
+            actions:
+              - - limit-count
+                - count: 1
+                  time_window: 60
+                  rejected_code: 429
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: workflow-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /anything/
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: workflow-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="workflow-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: workflow-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: workflow-route
+      match:
+        paths:
+          - /anything/*
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: workflow
+        enable: true
+        config:
+          rules:
+            - case:
+                - ["uri", "==", "/anything/rate-limit"]
+                - ["arg_env", "==", "v1"]
+              actions:
+                - - limit-count
+                  - count: 1
+                    time_window: 60
+                    rejected_code: 429
+```
+
+</TabItem>
+
+</Tabs>
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f workflow-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
+Generate two consecutive requests that match the rule:
 
 ```shell
 curl -i "http://127.0.0.1:9080/anything/rate-limit?env=v1"
@@ -181,9 +521,20 @@ The following example demonstrates how to configure the Plugin to perform rate l
 
 * Consumer `john` should have a quota of 5 requests within a 30-second window
 * Consumer `jane` should have a quota of 3 requests within a 30-second window
-* All other consumers should have a quota of 2 requests within a 30-second window
+* All other Consumers should have a quota of 2 requests within a 30-second window
 
 While this example will be using [`key-auth`](./key-auth.md), you can easily replace it with other authentication Plugins.
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
 
 Create a Consumer `john`:
 
@@ -195,7 +546,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   }'
 ```
 
-Create `key-auth` credential for the consumer:
+Create `key-auth` Credential for the Consumer:
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/john/credentials" -X PUT \
@@ -220,7 +571,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   }'
 ```
 
-Create `key-auth` credential for the consumer:
+Create `key-auth` Credential for the Consumer:
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/jane/credentials" -X PUT \
@@ -245,7 +596,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   }'
 ```
 
-Create `key-auth` credential for the consumer:
+Create `key-auth` Credential for the Consumer:
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/jimmy/credentials" -X PUT \
@@ -281,7 +632,8 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
                   "key": "consumer_john",
                   "key_type": "constant",
                   "rejected_code": 429,
-                  "time_window": 30
+                  "time_window": 30,
+                  "policy": "local"
                 }
               ]
             ],
@@ -302,7 +654,8 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
                   "key": "consumer_jane",
                   "key_type": "constant",
                   "rejected_code": 429,
-                  "time_window": 30
+                  "time_window": 30,
+                  "policy": "local"
                 }
               ]
             ],
@@ -323,7 +676,8 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
                   "key": "$consumer_name",
                   "key_type": "var",
                   "rejected_code": 429,
-                  "time_window": 30
+                  "time_window": 30,
+                  "policy": "local"
                 }
               ]
             ]
@@ -339,6 +693,336 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
     }
   }'
 ```
+
+</TabItem>
+
+<TabItem value="adc">
+
+Create three Consumers and a Route that enables per-Consumer rate limiting:
+
+```yaml title="adc.yaml"
+consumers:
+  - username: john
+    credentials:
+      - name: key-auth
+        type: key-auth
+        config:
+          key: john-key
+  - username: jane
+    credentials:
+      - name: key-auth
+        type: key-auth
+        config:
+          key: jane-key
+  - username: jimmy
+    credentials:
+      - name: key-auth
+        type: key-auth
+        config:
+          key: jimmy-key
+services:
+  - name: httpbin
+    routes:
+      - uris:
+          - /anything
+        name: workflow-route
+        plugins:
+          key-auth: {}
+          workflow:
+            rules:
+              - case:
+                  - ["consumer_name", "==", "john"]
+                actions:
+                  - - limit-count
+                    - count: 5
+                      key: consumer_john
+                      key_type: constant
+                      rejected_code: 429
+                      time_window: 30
+                      policy: local
+              - case:
+                  - ["consumer_name", "==", "jane"]
+                actions:
+                  - - limit-count
+                    - count: 3
+                      key: consumer_jane
+                      key_type: constant
+                      rejected_code: 429
+                      time_window: 30
+                      policy: local
+              - actions:
+                  - - limit-count
+                    - count: 2
+                      key: "$consumer_name"
+                      key_type: var
+                      rejected_code: 429
+                      time_window: 30
+                      policy: local
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+Create three Consumers and a Route that enables per-Consumer rate limiting. When Consumers are configured using the Ingress Controller, the Consumer name is generated in the format `namespace_consumername`. As a result, the `consumer_name` logic in the `workflow` Plugin should match the Consumer name in this format.
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="workflow-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: john
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: primary-key
+      config:
+        key: john-key
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: jane
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: primary-key
+      config:
+        key: jane-key
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: jimmy
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: primary-key
+      config:
+        key: jimmy-key
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: workflow-plugin-config
+spec:
+  plugins:
+    - name: key-auth
+      config:
+        _meta:
+          disable: false
+    - name: workflow
+      config:
+        rules:
+          - case:
+              - ["consumer_name", "==", "aic_john"]
+            actions:
+              - - limit-count
+                - count: 5
+                  key: consumer_john
+                  key_type: constant
+                  rejected_code: 429
+                  time_window: 30
+                  policy: local
+          - case:
+              - ["consumer_name", "==", "aic_jane"]
+            actions:
+              - - limit-count
+                - count: 3
+                  key: consumer_jane
+                  key_type: constant
+                  rejected_code: 429
+                  time_window: 30
+                  policy: local
+          - actions:
+              - - limit-count
+                - count: 2
+                  key: "$consumer_name"
+                  key_type: var
+                  rejected_code: 429
+                  time_window: 30
+                  policy: local
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: workflow-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: workflow-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="workflow-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: john
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: john-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jane
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: jane-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jimmy
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: jimmy-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: workflow-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: workflow-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: key-auth
+        enable: true
+      - name: workflow
+        enable: true
+        config:
+          rules:
+            - case:
+                - ["consumer_name", "==", "aic_john"]
+              actions:
+                - - limit-count
+                  - count: 5
+                    key: consumer_john
+                    key_type: constant
+                    rejected_code: 429
+                    time_window: 30
+                    policy: local
+            - case:
+                - ["consumer_name", "==", "aic_jane"]
+              actions:
+                - - limit-count
+                  - count: 3
+                    key: consumer_jane
+                    key_type: constant
+                    rejected_code: 429
+                    time_window: 30
+                    policy: local
+            - actions:
+                - - limit-count
+                  - count: 2
+                    key: "$consumer_name"
+                    key_type: var
+                    rejected_code: 429
+                    time_window: 30
+                    policy: local
+```
+
+</TabItem>
+
+</Tabs>
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f workflow-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
 
 To verify, send 6 consecutive requests with `john`'s key:
 

--- a/docs/zh/latest/plugins/workflow.md
+++ b/docs/zh/latest/plugins/workflow.md
@@ -32,17 +32,20 @@ description: workflow 插件支持根据给定的一组规则有条件地执行�
   <link rel="canonical" href="https://docs.api7.ai/hub/workflow" />
 </head>
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## 描述
 
 `workflow` 插件支持根据给定的规则集有条件地执行对客户端流量的用户定义操作，这些规则集使用 [lua-resty-expr](https://github.com/api7/lua-resty-expr#operator-list) 定义。这为流量管理提供了一种细粒度的方法。
 
 ## 属性
 
-| 名称          | 类型   | 必选项  | 默认值                    | 有效值                                                                                                                                            | 描述 |
-| ------------- | ------ | ------ | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| 名称 | 类型 | 必选项 | 默认值 | 有效值 | 描述 |
+|------|------|--------|--------|--------|------|
 | rules | array[object] | 是 | | | 一对或多对匹配条件和要执行的操作组成的数组。 |
 | rules.case | array[array] | 否 | | | 一个或多个匹配条件的数组，形式为 [lua-resty-expr](https://github.com/api7/lua-resty-expr#operator-list)，例如 `{"arg_name", "==", "json"}`。 |
-| rules.actions | array[object] | 是 | | | 条件匹配成功后要执行的操作的数组。目前数组只支持一个操作，必须是 `return` 或者 `limit-count`。当操作配置为 `return` 时，可以配置条件匹配成功时返回给客户端的 HTTP 状态码。当操作配置为 `limit-count` 时，可以配置 [`limit-count`](./limit-count.md) 插件除 `group` 之外的所有选项。当操作配置为 `limit-conn` 时，可以配置 [`limit-conn`](./limit-conn.md)。 |
+| rules.actions | array[array] | 是 | | | 条件匹配成功后要执行的操作的数组。目前数组只支持一个操作，必须是 `return`、`limit-count` 或 `limit-conn`。当操作配置为 `return` 时，可以配置条件匹配成功时返回给客户端的 HTTP 状态码。当操作配置为 `limit-count` 时，可以配置 [`limit-count`](./limit-count.md) 插件除 `group` 之外的所有选项。当操作配置为 `limit-conn` 时，可以配置 [`limit-conn`](./limit-conn.md) 插件的所有选项。 |
 
 ## 示例
 
@@ -58,11 +61,22 @@ admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"/
 
 :::
 
-### 有条件地返回响应 HTTP 状态代码
+### 有条件地返回响应 HTTP 状态码
 
-以下示例演示了一个简单的规则，其中包含一个匹配条件和一个关联操作，用于有条件地返回 HTTP 状态代码。
+以下示例演示了一个简单的规则，其中包含一个匹配条件和一个关联操作，用于有条件地返回 HTTP 状态码。
 
-使用 `workflow` 插件创建一个路由，当请求的 URI 路径为 `/anything/rejected` 时返回 HTTP 状态代码 403：
+使用 `workflow` 插件创建路由：
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
@@ -96,6 +110,159 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+services:
+  - name: httpbin
+    routes:
+      - uris:
+          - /anything/*
+        name: workflow-route
+        plugins:
+          workflow:
+            rules:
+              - case:
+                  - ["uri", "==", "/anything/rejected"]
+                actions:
+                  - - return
+                    - code: 403
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="workflow-ic.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: workflow-plugin-config
+spec:
+  plugins:
+    - name: workflow
+      config:
+        rules:
+          - case:
+              - ["uri", "==", "/anything/rejected"]
+            actions:
+              - - return
+                - code: 403
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: workflow-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /anything/
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: workflow-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="workflow-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: workflow-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: workflow-route
+      match:
+        paths:
+          - /anything/*
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: workflow
+        enable: true
+        config:
+          rules:
+            - case:
+                - ["uri", "==", "/anything/rejected"]
+              actions:
+                - - return
+                  - code: 403
+```
+
+</TabItem>
+
+</Tabs>
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f workflow-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
 发送与任何规则都不匹配的请求：
 
 ```shell
@@ -120,7 +287,18 @@ curl -i "http://127.0.0.1:9080/anything/rejected"
 
 以下示例演示了一条具有两个匹配条件和一个关联操作的规则，用于有条件地限制请求速率。
 
-使用 `workflow` 插件创建路由，以在 URI 路径为 `/anything/rate-limit` 且查询参数 `env` 值为 `v1` 时应用速率限制：
+使用 `workflow` 插件创建路由：
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
@@ -159,7 +337,169 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
-生成两个符合第二条规则的连续请求：
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+services:
+  - name: httpbin
+    routes:
+      - uris:
+          - /anything/*
+        name: workflow-route
+        plugins:
+          workflow:
+            rules:
+              - case:
+                  - ["uri", "==", "/anything/rate-limit"]
+                  - ["arg_env", "==", "v1"]
+                actions:
+                  - - limit-count
+                    - count: 1
+                      time_window: 60
+                      rejected_code: 429
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="workflow-ic.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: workflow-plugin-config
+spec:
+  plugins:
+    - name: workflow
+      config:
+        rules:
+          - case:
+              - ["uri", "==", "/anything/rate-limit"]
+              - ["arg_env", "==", "v1"]
+            actions:
+              - - limit-count
+                - count: 1
+                  time_window: 60
+                  rejected_code: 429
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: workflow-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /anything/
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: workflow-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="workflow-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: workflow-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: workflow-route
+      match:
+        paths:
+          - /anything/*
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: workflow
+        enable: true
+        config:
+          rules:
+            - case:
+                - ["uri", "==", "/anything/rate-limit"]
+                - ["arg_env", "==", "v1"]
+              actions:
+                - - limit-count
+                  - count: 1
+                    time_window: 60
+                    rejected_code: 429
+```
+
+</TabItem>
+
+</Tabs>
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f workflow-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
+生成两个符合规则的连续请求：
 
 ```shell
 curl -i "http://127.0.0.1:9080/anything/rate-limit?env=v1"
@@ -175,7 +515,7 @@ curl -i "http://127.0.0.1:9080/anything/anything?env=v1"
 
 您应该收到所有请求的 `HTTP/1.1 200 OK` 响应，因为它们不受速率限制。
 
-### 消费者有条件地应用速率限制
+### 按消费者有条件地应用速率限制
 
 以下示例演示了如何配置插件以根据以下规范执行速率限制：
 
@@ -184,6 +524,17 @@ curl -i "http://127.0.0.1:9080/anything/anything?env=v1"
 * 所有其他消费者在 30 秒内应有 2 个请求的配额
 
 虽然此示例将使用 [`key-auth`](./key-auth.md)，但您可以轻松地将其替换为其他身份验证插件。
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
 
 创建消费者 `john`：
 
@@ -195,7 +546,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   }'
 ```
 
-Create `key-auth` credential for the consumer:
+为消费者创建 `key-auth` 凭证：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/john/credentials" -X PUT \
@@ -281,7 +632,8 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
                   "key": "consumer_john",
                   "key_type": "constant",
                   "rejected_code": 429,
-                  "time_window": 30
+                  "time_window": 30,
+                  "policy": "local"
                 }
               ]
             ],
@@ -302,7 +654,8 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
                   "key": "consumer_jane",
                   "key_type": "constant",
                   "rejected_code": 429,
-                  "time_window": 30
+                  "time_window": 30,
+                  "policy": "local"
                 }
               ]
             ],
@@ -323,7 +676,8 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
                   "key": "$consumer_name",
                   "key_type": "var",
                   "rejected_code": 429,
-                  "time_window": 30
+                  "time_window": 30,
+                  "policy": "local"
                 }
               ]
             ]
@@ -340,7 +694,337 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
-为了验证，请使用 `john` 的密钥发送 6 个连续的请求：
+</TabItem>
+
+<TabItem value="adc">
+
+创建三个消费者以及启用按消费者速率限制的路由：
+
+```yaml title="adc.yaml"
+consumers:
+  - username: john
+    credentials:
+      - name: key-auth
+        type: key-auth
+        config:
+          key: john-key
+  - username: jane
+    credentials:
+      - name: key-auth
+        type: key-auth
+        config:
+          key: jane-key
+  - username: jimmy
+    credentials:
+      - name: key-auth
+        type: key-auth
+        config:
+          key: jimmy-key
+services:
+  - name: httpbin
+    routes:
+      - uris:
+          - /anything
+        name: workflow-route
+        plugins:
+          key-auth: {}
+          workflow:
+            rules:
+              - case:
+                  - ["consumer_name", "==", "john"]
+                actions:
+                  - - limit-count
+                    - count: 5
+                      key: consumer_john
+                      key_type: constant
+                      rejected_code: 429
+                      time_window: 30
+                      policy: local
+              - case:
+                  - ["consumer_name", "==", "jane"]
+                actions:
+                  - - limit-count
+                    - count: 3
+                      key: consumer_jane
+                      key_type: constant
+                      rejected_code: 429
+                      time_window: 30
+                      policy: local
+              - actions:
+                  - - limit-count
+                    - count: 2
+                      key: "$consumer_name"
+                      key_type: var
+                      rejected_code: 429
+                      time_window: 30
+                      policy: local
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+创建三个消费者以及启用按消费者速率限制的路由。当使用 Ingress Controller 配置消费者时，消费者名称以 `namespace_consumername` 格式生成。因此，`workflow` 插件中的 `consumer_name` 逻辑应以此格式匹配消费者名称。
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="workflow-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: john
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: primary-key
+      config:
+        key: john-key
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: jane
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: primary-key
+      config:
+        key: jane-key
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: jimmy
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: primary-key
+      config:
+        key: jimmy-key
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: workflow-plugin-config
+spec:
+  plugins:
+    - name: key-auth
+      config:
+        _meta:
+          disable: false
+    - name: workflow
+      config:
+        rules:
+          - case:
+              - ["consumer_name", "==", "aic_john"]
+            actions:
+              - - limit-count
+                - count: 5
+                  key: consumer_john
+                  key_type: constant
+                  rejected_code: 429
+                  time_window: 30
+                  policy: local
+          - case:
+              - ["consumer_name", "==", "aic_jane"]
+            actions:
+              - - limit-count
+                - count: 3
+                  key: consumer_jane
+                  key_type: constant
+                  rejected_code: 429
+                  time_window: 30
+                  policy: local
+          - actions:
+              - - limit-count
+                - count: 2
+                  key: "$consumer_name"
+                  key_type: var
+                  rejected_code: 429
+                  time_window: 30
+                  policy: local
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: workflow-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: workflow-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="workflow-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: john
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: john-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jane
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: jane-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jimmy
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: jimmy-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: workflow-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: workflow-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: key-auth
+        enable: true
+      - name: workflow
+        enable: true
+        config:
+          rules:
+            - case:
+                - ["consumer_name", "==", "aic_john"]
+              actions:
+                - - limit-count
+                  - count: 5
+                    key: consumer_john
+                    key_type: constant
+                    rejected_code: 429
+                    time_window: 30
+                    policy: local
+            - case:
+                - ["consumer_name", "==", "aic_jane"]
+              actions:
+                - - limit-count
+                  - count: 3
+                    key: consumer_jane
+                    key_type: constant
+                    rejected_code: 429
+                    time_window: 30
+                    policy: local
+            - actions:
+                - - limit-count
+                  - count: 2
+                    key: "$consumer_name"
+                    key_type: var
+                    rejected_code: 429
+                    time_window: 30
+                    policy: local
+```
+
+</TabItem>
+
+</Tabs>
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f workflow-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
+为了验证，请使用 `john` 的密钥发送 6 个连续请求：
 
 ```shell
 resp=$(seq 6 | xargs -I{} curl "http://127.0.0.1:9080/anything" -H 'apikey: john-key' -o /dev/null -s -w "%{http_code}\n") && \
@@ -349,13 +1033,13 @@ resp=$(seq 6 | xargs -I{} curl "http://127.0.0.1:9080/anything" -H 'apikey: john
   echo "200": $count_200, "429": $count_429
 ```
 
-您应该看到以下响应，显示在 6 个请求中，5 个请求成功（状态代码 200），而其他请求被拒绝（状态代码 429）。
+您应该看到以下响应，显示在 6 个请求中，5 个请求成功（状态码 200），而其他请求被拒绝（状态码 429）。
 
 ```text
-200： 5，429： 1
+200:    5, 429:    1
 ```
 
-使用 `jane` 的密钥连续发送 6 个请求：
+使用 `jane` 的密钥发送 6 个连续请求：
 
 ```shell
 resp=$(seq 6 | xargs -I{} curl "http://127.0.0.1:9080/anything" -H 'apikey: jane-key' -o /dev/null -s -w "%{http_code}\n") && \
@@ -364,10 +1048,10 @@ resp=$(seq 6 | xargs -I{} curl "http://127.0.0.1:9080/anything" -H 'apikey: jane
   echo "200": $count_200, "429": $count_429
 ```
 
-您应该看到以下响应，显示在 6 个请求中，3 个请求成功（状态代码 200），而其他请求被拒绝（状态代码 429）。
+您应该看到以下响应，显示在 6 个请求中，3 个请求成功（状态码 200），而其他请求被拒绝（状态码 429）。
 
 ```text
-200： 3，429： 3
+200:    3, 429:    3
 ```
 
 使用 `jimmy` 的密钥发送 3 个连续请求：
@@ -379,8 +1063,8 @@ resp=$(seq 3 | xargs -I{} curl "http://127.0.0.1:9080/anything" -H 'apikey: jimm
   echo "200": $count_200, "429": $count_429
 ```
 
-您应该看到以下响应，显示在 3 个请求中，2 个请求成功（状态代码 200），而其他请求被拒绝（状态代码 429）。
+您应该看到以下响应，显示在 3 个请求中，2 个请求成功（状态码 200），而其他请求被拒绝（状态码 429）。
 
 ```text
-200： 2，429： 1
+200:    2, 429:    1
 ```


### PR DESCRIPTION
## Summary

- Port `workflow` plugin documentation from API7 docs to APISIX
- Include all three tabs: Admin API, ADC, and Ingress Controller (Gateway API / APISIX CRD)
- Add both EN and ZH translations
- Remove enterprise-only `limit-count-advanced` section
- 3 example sections: conditional HTTP status return, rate limiting by URI/query, rate limiting by consumers