### PR TITLE
refactor: extract reusable building blocks from Consul discovery

### DIFF
--- a/apisix/discovery/consul/client.lua
+++ b/apisix/discovery/consul/client.lua
@@ -274,8 +274,11 @@ end
 -- ─── service fetching ─────────────────────────────────────────────────
 
 --- Fetch all services from a single consul server.
---- Returns: up_services (table of service_name -> nodes), catalog_index, health_index
----          On failure: nil, err_string
+--- Returns: up_services, err, catalog_index, health_index
+---   up_services: table of key -> nodes (nil on failure)
+---   err: error string (nil on success)
+---   catalog_index: latest catalog index from consul
+---   health_index: latest health index from consul
 ---
 --- options:
 ---   default_weight     (number)    default node weight

--- a/apisix/discovery/consul/client.lua
+++ b/apisix/discovery/consul/client.lua
@@ -453,9 +453,8 @@ local function iter_and_add_service(services, values)
             goto CONTINUE
         end
 
-        local svc_name = up.service_name
-        if not services[svc_name] then
-            services[svc_name] = true
+        if not services[up.service_name] then
+            services[up.service_name] = true
         end
         ::CONTINUE::
     end

--- a/apisix/discovery/consul/client.lua
+++ b/apisix/discovery/consul/client.lua
@@ -1,0 +1,479 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+--- Reusable HTTP client primitives for Consul service discovery.
+--- Extracted from init.lua so that both static-config mode and
+--- dynamic-config mode can share the same core logic.
+
+local require            = require
+local core               = require("apisix.core")
+local core_sleep         = require("apisix.core.utils").sleep
+local resty_consul       = require('resty.consul')
+local http               = require('resty.http')
+local ipairs             = ipairs
+local pairs              = pairs
+local unpack             = unpack
+local tonumber           = tonumber
+local type               = type
+local next               = next
+local ngx                = ngx
+local math_random        = math.random
+local log                = core.log
+local json_delay_encode  = core.json.delay_encode
+local pcall              = pcall
+local null               = ngx.null
+
+local _M = {}
+
+local default_random_range = 5
+local default_catalog_error_index = -1
+local default_health_error_index = -2
+local watch_type_catalog = 1
+local watch_type_health = 2
+local max_retry_time = 256
+
+
+-- ─── helpers ──────────────────────────────────────────────────────────
+
+function _M.get_retry_delay(retry_delay)
+    if not retry_delay or retry_delay >= max_retry_time then
+        retry_delay = 1
+    else
+        retry_delay = retry_delay * 4
+    end
+
+    return retry_delay
+end
+
+
+local function is_not_empty(value)
+    if value == nil or value == null
+            or (type(value) == "table" and not next(value))
+            or (type(value) == "string" and value == "")
+    then
+        return false
+    end
+
+    return true
+end
+
+
+-- ─── sort comparators ─────────────────────────────────────────────────
+
+local function combine_sort_nodes_cmp(left, right)
+    if left.host ~= right.host then
+        return left.host < right.host
+    end
+
+    return left.port < right.port
+end
+
+
+local function port_sort_nodes_cmp(left, right)
+    return left.port < right.port
+end
+
+
+local function host_sort_nodes_cmp(left, right)
+    return left.host < right.host
+end
+
+
+function _M.sort_nodes(nodes, sort_type)
+    if not nodes or not sort_type or sort_type == "origin" then
+        return
+    end
+
+    if sort_type == "port_sort" then
+        core.table.sort(nodes, port_sort_nodes_cmp)
+    elseif sort_type == "host_sort" then
+        core.table.sort(nodes, host_sort_nodes_cmp)
+    elseif sort_type == "combine_sort" then
+        core.table.sort(nodes, combine_sort_nodes_cmp)
+    end
+end
+
+
+-- ─── resty.consul options ─────────────────────────────────────────────
+
+local function get_opts(consul_server, is_catalog)
+    local opts = {
+        host = consul_server.host,
+        port = consul_server.port,
+        connect_timeout = consul_server.connect_timeout,
+        read_timeout = consul_server.read_timeout,
+        default_args = {
+            token = consul_server.token,
+        }
+    }
+    if not consul_server.keepalive then
+        return opts
+    end
+
+    opts.default_args.wait = consul_server.wait_timeout
+
+    if is_catalog then
+        opts.default_args.index = consul_server.catalog_index
+    else
+        opts.default_args.index = consul_server.health_index
+    end
+
+    return opts
+end
+
+
+-- ─── blocking query watchers ──────────────────────────────────────────
+
+function _M.watch_catalog(consul_server)
+    local client = resty_consul:new(get_opts(consul_server, true))
+
+    ::RETRY::
+    local watch_result, watch_err = client:get(consul_server.consul_watch_catalog_url)
+    local watch_error_info = (watch_err ~= nil and watch_err)
+                             or ((watch_result ~= nil and watch_result.status ~= 200)
+                             and watch_result.status)
+    if watch_error_info then
+        log.error("connect consul: ", consul_server.consul_server_url,
+            " by sub url: ", consul_server.consul_watch_catalog_url,
+            ", got watch result: ", json_delay_encode(watch_result),
+            ", with error: ", watch_error_info)
+
+        return watch_type_catalog, default_catalog_error_index
+    end
+
+    if consul_server.catalog_index > 0
+            and consul_server.catalog_index == tonumber(watch_result.headers['X-Consul-Index']) then
+        local random_delay = math_random(default_random_range)
+        log.info("watch catalog has no change, re-watch consul after ", random_delay, " seconds")
+        core_sleep(random_delay)
+        goto RETRY
+    end
+
+    return watch_type_catalog, watch_result.headers['X-Consul-Index']
+end
+
+
+function _M.watch_health(consul_server)
+    local client = resty_consul:new(get_opts(consul_server, false))
+
+    ::RETRY::
+    local watch_result, watch_err = client:get(consul_server.consul_watch_health_url)
+    local watch_error_info = (watch_err ~= nil and watch_err)
+            or ((watch_result ~= nil and watch_result.status ~= 200)
+            and watch_result.status)
+    if watch_error_info then
+        log.error("connect consul: ", consul_server.consul_server_url,
+            " by sub url: ", consul_server.consul_watch_health_url,
+            ", got watch result: ", json_delay_encode(watch_result),
+            ", with error: ", watch_error_info)
+
+        return watch_type_health, default_health_error_index
+    end
+
+    if consul_server.health_index > 0
+            and consul_server.health_index == tonumber(watch_result.headers['X-Consul-Index']) then
+        local random_delay = math_random(default_random_range)
+        log.info("watch health has no change, re-watch consul after ", random_delay, " seconds")
+        core_sleep(random_delay)
+        goto RETRY
+    end
+
+    return watch_type_health, watch_result.headers['X-Consul-Index']
+end
+
+
+function _M.watch_result_is_valid(watch_type, index, catalog_index, health_index)
+    if index <= 0 then
+        return false
+    end
+
+    if watch_type == watch_type_catalog then
+        if index == catalog_index then
+            return false
+        end
+    else
+        if index == health_index then
+            return false
+        end
+    end
+
+    return true
+end
+
+
+function _M.update_index(consul_server, catalog_index, health_index)
+    local c_index = 0
+    local h_index = 0
+    if catalog_index ~= nil then
+        c_index = tonumber(catalog_index)
+    end
+
+    if health_index ~= nil then
+        h_index = tonumber(health_index)
+    end
+
+    if c_index > 0 then
+        consul_server.catalog_index = c_index
+    end
+
+    if h_index > 0 then
+        consul_server.health_index = h_index
+    end
+end
+
+
+-- ─── URL parsing ──────────────────────────────────────────────────────
+
+function _M.format_consul_params(consul_conf)
+    local servers = consul_conf.servers
+    local consul_server_list = core.table.new(0, #servers)
+
+    for _, v in pairs(servers) do
+        local scheme, host, port, path = unpack(http.parse_uri(nil, v))
+        if scheme ~= "http" then
+            return nil, "only support consul http schema address, eg: http://address:port"
+        elseif path ~= "/" or core.string.has_suffix(v, '/') then
+            return nil, "invalid consul server address, the valid format: http://address:port"
+        end
+        core.table.insert(consul_server_list, {
+            host = host,
+            port = port,
+            token = consul_conf.token,
+            connect_timeout = consul_conf.timeout.connect,
+            read_timeout = consul_conf.timeout.read,
+            wait_timeout = consul_conf.timeout.wait,
+            consul_watch_catalog_url = "/catalog/services",
+            consul_sub_url = "/health/service",
+            consul_watch_health_url = "/health/state/any",
+            consul_server_url = v .. "/v1",
+            weight = consul_conf.weight,
+            keepalive = consul_conf.keepalive,
+            health_index = 0,
+            catalog_index = 0,
+            fetch_interval = consul_conf.fetch_interval,
+        })
+    end
+    return consul_server_list, nil
+end
+
+
+-- ─── service fetching ─────────────────────────────────────────────────
+
+--- Fetch all services from a single consul server.
+--- Returns: up_services (table of service_name -> nodes), catalog_index, health_index
+---          On failure: nil, err_string
+---
+--- options:
+---   default_weight     (number)    default node weight
+---   sort_type          (string)    "origin"/"host_sort"/"port_sort"/"combine_sort"
+---   skip_service_map   (table)     set of service names to skip
+---   preserve_metadata  (bool)      include Service.Meta in returned nodes
+---   key_builder        (function)  key_builder(service_name) -> string for the result key
+function _M.fetch_services_from_server(consul_server, options)
+    options = options or {}
+    local default_weight = options.default_weight or 1
+    local sort_type = options.sort_type
+    local skip_service_map = options.skip_service_map or {}
+    local preserve_metadata = options.preserve_metadata or false
+    local key_builder = options.key_builder
+
+    local consul_client = resty_consul:new({
+        host = consul_server.host,
+        port = consul_server.port,
+        connect_timeout = consul_server.connect_timeout,
+        read_timeout = consul_server.read_timeout,
+        default_args = {
+            token = consul_server.token
+        }
+    })
+
+    -- fetch catalog
+    local catalog_success, catalog_res, catalog_err = pcall(function()
+        return consul_client:get(consul_server.consul_watch_catalog_url)
+    end)
+    if not catalog_success then
+        log.error("connect consul: ", consul_server.consul_server_url,
+            " by sub url: ", consul_server.consul_watch_catalog_url,
+            ", got catalog result: ", json_delay_encode(catalog_res))
+        return nil, "catalog fetch failed"
+    end
+    local catalog_error_info = (catalog_err ~= nil and catalog_err)
+            or ((catalog_res ~= nil and catalog_res.status ~= 200)
+            and catalog_res.status)
+    if catalog_error_info then
+        log.error("connect consul: ", consul_server.consul_server_url,
+            " by sub url: ", consul_server.consul_watch_catalog_url,
+            ", got catalog result: ", json_delay_encode(catalog_res),
+            ", with error: ", catalog_error_info)
+        return nil, "catalog error: " .. tostring(catalog_error_info)
+    end
+
+    -- fetch health index
+    local success, health_res, health_err = pcall(function()
+        return consul_client:get(consul_server.consul_watch_health_url)
+    end)
+    if not success then
+        log.error("connect consul: ", consul_server.consul_server_url,
+            " by sub url: ", consul_server.consul_watch_health_url,
+            ", got health result: ", json_delay_encode(health_res))
+        return nil, "health fetch failed"
+    end
+    local health_error_info = (health_err ~= nil and health_err)
+            or ((health_res ~= nil and health_res.status ~= 200)
+            and health_res.status)
+    if health_error_info then
+        log.error("connect consul: ", consul_server.consul_server_url,
+            " by sub url: ", consul_server.consul_watch_health_url,
+            ", got health result: ", json_delay_encode(health_res),
+            ", with error: ", health_error_info)
+        return nil, "health error: " .. tostring(health_error_info)
+    end
+
+    log.info("connect consul: ", consul_server.consul_server_url,
+        ", catalog_result status: ", catalog_res.status,
+        ", catalog_result.headers.index: ", catalog_res.headers['X-Consul-Index'],
+        ", consul_server.index: ", consul_server.index,
+        ", consul_server: ", json_delay_encode(consul_server))
+
+    -- check if index changed
+    if consul_server.catalog_index == tonumber(catalog_res.headers['X-Consul-Index'])
+            and consul_server.health_index == tonumber(health_res.headers['X-Consul-Index']) then
+        return {}, nil, catalog_res.headers['X-Consul-Index'],
+                        health_res.headers['X-Consul-Index']
+    end
+
+    -- build service nodes
+    local up_services = core.table.new(0, #catalog_res.body)
+    for service_name, _ in pairs(catalog_res.body) do
+        if skip_service_map[service_name] then
+            goto CONTINUE
+        end
+
+        local svc_url = consul_server.consul_sub_url .. "/" .. service_name
+        local svc_success, result, get_err = pcall(function()
+            return consul_client:get(svc_url, {passing = true})
+        end)
+        local error_info = (get_err ~= nil and get_err) or
+                ((result ~= nil and result.status ~= 200) and result.status)
+        if not svc_success or error_info then
+            log.error("connect consul: ", consul_server.consul_server_url,
+                ", by service url: ", svc_url, ", with error: ", error_info)
+            goto CONTINUE
+        end
+
+        if is_not_empty(result.body) then
+            local key = service_name
+            if key_builder then
+                key = key_builder(service_name)
+            end
+
+            local nodes = up_services[key]
+            local nodes_uniq = {}
+            for _, node in ipairs(result.body) do
+                if not node.Service then
+                    goto CONTINUE
+                end
+
+                local svc_address, svc_port = node.Service.Address, node.Service.Port
+                if not svc_port or svc_port == 0 then
+                    svc_port = 80
+                end
+                if not nodes then
+                    nodes = core.table.new(1, 0)
+                    up_services[key] = nodes
+                end
+                local service_id = svc_address .. ":" .. svc_port
+                if not nodes_uniq[service_id] then
+                    local n = {
+                        host = svc_address,
+                        port = tonumber(svc_port),
+                        weight = default_weight,
+                    }
+                    if preserve_metadata and node.Service.Meta
+                            and next(node.Service.Meta) then
+                        n.metadata = node.Service.Meta
+                    end
+                    core.table.insert(nodes, n)
+                    nodes_uniq[service_id] = true
+                end
+            end
+
+            if nodes then
+                _M.sort_nodes(nodes, sort_type)
+            end
+            up_services[key] = nodes
+        end
+        :: CONTINUE ::
+    end
+
+    return up_services, nil, catalog_res.headers['X-Consul-Index'],
+                              health_res.headers['X-Consul-Index']
+end
+
+
+-- ─── service scanning ─────────────────────────────────────────────────
+
+local function iter_and_add_service(services, values)
+    if not values then
+        return
+    end
+
+    for _, value in core.config_util.iterate_values(values) do
+        local conf = value.value
+        if not conf then
+            goto CONTINUE
+        end
+
+        local up
+        if conf.upstream then
+            up = conf.upstream
+        else
+            up = conf
+        end
+
+        if up.discovery_type ~= 'consul' then
+            goto CONTINUE
+        end
+
+        local svc_name = up.service_name
+        if not services[svc_name] then
+            services[svc_name] = true
+        end
+        ::CONTINUE::
+    end
+end
+
+
+--- Scan APISIX routes/services/upstreams for consul discovery references.
+function _M.get_consul_services()
+    local services = {}
+
+    local get_upstreams = require('apisix.upstream').upstreams
+    local get_routes = require('apisix.router').http_routes
+    local get_stream_routes = require('apisix.router').stream_routes
+    local get_services = require('apisix.http.service').services
+
+    iter_and_add_service(services, get_upstreams())
+    iter_and_add_service(services, get_routes())
+    iter_and_add_service(services, get_services())
+    iter_and_add_service(services, get_stream_routes())
+
+    return services
+end
+
+
+return _M

--- a/apisix/discovery/consul/client.lua
+++ b/apisix/discovery/consul/client.lua
@@ -40,6 +40,11 @@ local null               = ngx.null
 
 local _M = {}
 
+-- Registry id for the implicit single-instance namespace. When service_name
+-- is written without a "/" prefix, it is treated as belonging to this registry.
+local DEFAULT_REGISTRY_ID = "default"
+_M.DEFAULT_REGISTRY_ID = DEFAULT_REGISTRY_ID
+
 local default_random_range = 5
 local default_catalog_error_index = -1
 local default_health_error_index = -2
@@ -431,7 +436,7 @@ end
 
 -- ─── service scanning ─────────────────────────────────────────────────
 
-local function iter_and_add_service(services, values)
+local function iter_and_add_service(services, values, id)
     if not values then
         return
     end
@@ -453,8 +458,23 @@ local function iter_and_add_service(services, values)
             goto CONTINUE
         end
 
-        if not services[up.service_name] then
-            services[up.service_name] = true
+        local svc_name = up.service_name
+        local m = ngx.re.match(svc_name, "^(.*?)/(.*)$", "jo")
+        if m then
+            -- explicit "{registry_id}/{name}" — filter by prefix and strip
+            if m[1] ~= id then
+                goto CONTINUE
+            end
+            svc_name = m[2]
+        else
+            -- no prefix — implicit default namespace
+            if id ~= DEFAULT_REGISTRY_ID then
+                goto CONTINUE
+            end
+        end
+
+        if not services[svc_name] then
+            services[svc_name] = true
         end
         ::CONTINUE::
     end
@@ -462,7 +482,11 @@ end
 
 
 --- Scan APISIX routes/services/upstreams for consul discovery references.
-function _M.get_consul_services()
+--- id: registry id to filter by. Service names written as "{id}/{name}" match
+---     by strict prefix and are returned stripped. Service names without "/"
+---     are treated as belonging to the implicit default registry and match
+---     only when id == DEFAULT_REGISTRY_ID.
+function _M.get_consul_services(id)
     local services = {}
 
     local get_upstreams = require('apisix.upstream').upstreams
@@ -470,10 +494,10 @@ function _M.get_consul_services()
     local get_stream_routes = require('apisix.router').stream_routes
     local get_services = require('apisix.http.service').services
 
-    iter_and_add_service(services, get_upstreams())
-    iter_and_add_service(services, get_routes())
-    iter_and_add_service(services, get_services())
-    iter_and_add_service(services, get_stream_routes())
+    iter_and_add_service(services, get_upstreams(), id)
+    iter_and_add_service(services, get_routes(), id)
+    iter_and_add_service(services, get_services(), id)
+    iter_and_add_service(services, get_stream_routes(), id)
 
     return services
 end

--- a/apisix/discovery/consul/client.lua
+++ b/apisix/discovery/consul/client.lua
@@ -30,6 +30,7 @@ local unpack             = unpack
 local tonumber           = tonumber
 local type               = type
 local next               = next
+local tostring           = tostring
 local ngx                = ngx
 local math_random        = math.random
 local log                = core.log

--- a/apisix/discovery/consul/init.lua
+++ b/apisix/discovery/consul/init.lua
@@ -22,7 +22,6 @@ local consul_client      = require("apisix.discovery.consul.client")
 local util               = require("apisix.cli.util")
 local ipairs             = ipairs
 local pairs              = pairs
-local next               = next
 local error              = error
 local ngx                = ngx
 local tonumber           = tonumber

--- a/apisix/discovery/consul/init.lua
+++ b/apisix/discovery/consul/init.lua
@@ -331,12 +331,17 @@ function _M.connect(premature, reg, consul_server, retry_delay)
         return
     end
 
-    -- Always call update_all_services to clean up stale keys even when
-    -- up_services is empty (e.g., all Consul services deleted).
-    update_all_services(reg, consul_server.consul_server_url, up_services)
+    -- fetch_services_from_server returns {} when indexes are unchanged (no-change).
+    -- Only update services when at least one index actually changed, so we don't
+    -- accidentally clear stale keys on no-change polling timeouts.
+    local index_changed = (new_catalog_index ~= consul_server.catalog_index)
+                       or (new_health_index ~= consul_server.health_index)
+    if index_changed then
+        update_all_services(reg, consul_server.consul_server_url, up_services)
 
-    if reg.dump_params then
-        ngx_timer_at(0, write_dump_services, reg)
+        if reg.dump_params then
+            ngx_timer_at(0, write_dump_services, reg)
+        end
     end
 
     consul_client.update_index(consul_server, new_catalog_index, new_health_index)

--- a/apisix/discovery/consul/init.lua
+++ b/apisix/discovery/consul/init.lua
@@ -112,7 +112,7 @@ local function update_all_services(reg, consul_server_url, up_services)
     end
 
     reg.consul_services[consul_server_url] = up_services
-    log.info("update all services to shared dict")
+    log.info("consul registry updated, id: ", reg.id, ", services: ", i)
 end
 
 

--- a/apisix/discovery/consul/init.lua
+++ b/apisix/discovery/consul/init.lua
@@ -18,15 +18,13 @@ local require            = require
 local local_conf         = require("apisix.core.config_local").local_conf()
 local core               = require("apisix.core")
 local core_sleep         = require("apisix.core.utils").sleep
-local resty_consul       = require('resty.consul')
-local http               = require('resty.http')
+local consul_client      = require("apisix.discovery.consul.client")
 local util               = require("apisix.cli.util")
 local ipairs             = ipairs
+local pairs              = pairs
 local error              = error
 local ngx                = ngx
-local unpack             = unpack
 local tonumber           = tonumber
-local pairs              = pairs
 local ngx_timer_at       = ngx.timer.at
 local ngx_timer_every    = ngx.timer.every
 local log                = core.log
@@ -38,26 +36,17 @@ local thread_spawn       = ngx.thread.spawn
 local thread_wait        = ngx.thread.wait
 local thread_kill        = ngx.thread.kill
 local math_random        = math.random
-local pcall              = pcall
-local null               = ngx.null
-local type               = type
-local next               = next
+local is_http            = ngx.config.subsystem == "http"
 
-local consul_dict = ngx.shared.consul
-if not consul_dict then
-    error("lua_shared_dict \"consul\" not configured")
-end
+local _M = {
+    version = 0.3,
+}
 
-local default_service
-local default_weight
-local sort_type
-local skip_service_map = core.table.new(0, 1)
-local dump_params
+local registries = {}
+local consul_dict
+local dict_name = is_http and "consul" or "consul-stream"
 
-local consul_services
 -- Per-worker LRU cache: avoids shared dict access on every request.
--- neg_ttl caches unknown services. invalid_stale ensures expired
--- entries are refreshed from the shared dict instead of re-cached.
 local nodes_cache = core.lrucache.new({
     ttl = 1,
     count = 1024,
@@ -68,77 +57,36 @@ local nodes_cache = core.lrucache.new({
 
 local default_skip_services = {"consul"}
 local default_random_range = 5
-local default_catalog_error_index = -1
-local default_health_error_index = -2
-local watch_type_catalog = 1
-local watch_type_health = 2
-local max_retry_time = 256
-
-local _M = {
-    version = 0.3,
-}
 
 
-local function fetch_node_from_shdict(service_name)
-    local value = consul_dict:get(service_name)
-    if not value then
-        return nil, "consul service not found: " .. service_name
+local function get_dict()
+    if not consul_dict then
+        consul_dict = ngx.shared[dict_name]
     end
-
-    local nodes, err = core.json.decode(value)
-    if not nodes then
-        return nil, "failed to decode nodes for service: "
-                    .. service_name .. ", error: " .. (err or "")
-    end
-
-    return nodes
+    return consul_dict
 end
 
 
-function _M.all_nodes()
-    local keys = consul_dict:get_keys(0)
-    local services = core.table.new(0, #keys)
-    for i, key in ipairs(keys) do
-        local value = consul_dict:get(key)
-        if value then
-            local nodes, err = core.json.decode(value)
-            if nodes then
-                services[key] = nodes
-            else
-                log.error("failed to decode nodes for service: ", key, ", error: ", err)
-            end
-        end
-
-        if i % 100 == 0 then
-            ngx.sleep(0)
-        end
+local function default_key_builder(id)
+    return function(service_name)
+        return id .. "/" .. service_name
     end
-    return services
 end
 
 
-function _M.nodes(service_name)
-    local nodes, err = nodes_cache(service_name, nil,
-                                   fetch_node_from_shdict, service_name)
-    if not nodes then
-        log.error("fetch nodes failed by ", service_name, ", error: ", err)
-        return default_service and {default_service}
+-- ─── shared dict operations ───────────────────────────────────────────
+
+local function update_all_services(reg, consul_server_url, up_services)
+    local dict = get_dict()
+    if not dict then
+        return
     end
 
-    log.info("process id: ", ngx_worker_id(), ", [", service_name, "] = ",
-        json_delay_encode(nodes, true))
-
-    return nodes
-end
-
-
-local function update_all_services(consul_server_url, up_services)
-    -- write new/updated values first so readers never see a missing service
     local i = 0
     for k, v in pairs(up_services) do
         local content, err = core.json.encode(v)
         if content then
-            local ok, set_err, forcible = consul_dict:set(k, content)
+            local ok, set_err, forcible = dict:set(k, content)
             if not ok then
                 log.error("failed to set nodes for service: ", k, ", error: ", set_err,
                           ", please consider increasing lua_shared_dict consul size")
@@ -156,22 +104,26 @@ local function update_all_services(consul_server_url, up_services)
         end
     end
 
-    -- then delete keys that are no longer present
-    local old_services = consul_services[consul_server_url] or {}
+    local old_services = reg.consul_services[consul_server_url] or {}
     for k, _ in pairs(old_services) do
         if not up_services[k] then
-            consul_dict:delete(k)
+            dict:delete(k)
         end
     end
 
-    consul_services[consul_server_url] = up_services
-
+    reg.consul_services[consul_server_url] = up_services
     log.info("update all services to shared dict")
 end
 
 
-local function read_dump_services()
-    local data, err = util.read_file(dump_params.path)
+-- ─── dump file operations ─────────────────────────────────────────────
+
+local function read_dump_services(reg)
+    if not reg.dump_params then
+        return
+    end
+
+    local data, err = util.read_file(reg.dump_params.path)
     if not data then
         log.error("read dump file get error: ", err)
         return
@@ -197,16 +149,22 @@ local function read_dump_services()
 
     local now_time = ngx.time()
     log.info("dump file last_update: ", entity.last_update, ", dump_params.expire: ",
-        dump_params.expire, ", now_time: ", now_time)
-    if dump_params.expire ~= 0 and (entity.last_update + dump_params.expire) < now_time then
-        log.warn("dump file: ", dump_params.path, " had expired, ignored it")
+        reg.dump_params.expire, ", now_time: ", now_time)
+    if reg.dump_params.expire ~= 0
+            and (entity.last_update + reg.dump_params.expire) < now_time then
+        log.warn("dump file: ", reg.dump_params.path, " had expired, ignored it")
+        return
+    end
+
+    local dict = get_dict()
+    if not dict then
         return
     end
 
     for k, v in pairs(entity.services) do
         local content, json_err = core.json.encode(v)
         if content then
-            consul_dict:set(k, content)
+            dict:set(reg.key_builder(k), content)
         else
             log.error("failed to encode dump service: ", k, ", error: ", json_err)
         end
@@ -215,35 +173,48 @@ local function read_dump_services()
 end
 
 
-local function write_dump_services()
-    -- build services from the privileged agent's in-memory tracking table
-    -- to avoid a full shared dict scan + JSON decode via _M.all_nodes()
+local function write_dump_services(premature, reg)
+    if premature then
+        return
+    end
+
+    if not reg.dump_params then
+        return
+    end
+
+    -- build services from the tracking table using bare service names for dump
     local services = core.table.new(0, 8)
-    for _, svcs in pairs(consul_services) do
+    local prefix = reg.id .. "/"
+    for _, svcs in pairs(reg.consul_services) do
         for k, v in pairs(svcs) do
-            services[k] = v
+            -- strip prefix for dump file compatibility
+            local bare_key = k
+            if core.string.has_prefix(k, prefix) then
+                bare_key = k:sub(#prefix + 1)
+            end
+            services[bare_key] = v
         end
     end
 
     local entity = {
         services = services,
         last_update = ngx.time(),
-        expire = dump_params.expire, -- later need handle it
+        expire = reg.dump_params.expire,
     }
     local data = core.json.encode(entity)
-    local succ, err = util.write_file(dump_params.path, data)
+    local succ, err = util.write_file(reg.dump_params.path, data)
     if not succ then
         log.error("write dump into file got error: ", err)
     end
 end
 
 
-local function show_dump_file()
-    if not dump_params then
+local function show_dump_file(reg)
+    if not reg or not reg.dump_params then
         return 503, "dump params is nil"
     end
 
-    local data, err = util.read_file(dump_params.path)
+    local data, err = util.read_file(reg.dump_params.path)
     if not data then
         return 503, err
     end
@@ -252,104 +223,15 @@ local function show_dump_file()
 end
 
 
-local function get_retry_delay(retry_delay)
-    if not retry_delay or retry_delay >= max_retry_time then
-        retry_delay = 1
-    else
-        retry_delay = retry_delay * 4
+-- ─── polling loop ─────────────────────────────────────────────────────
+
+local function check_keepalive(reg, consul_server, retry_delay)
+    if reg.stop_flag then
+        return
     end
 
-    return retry_delay
-end
-
-
-local function get_opts(consul_server, is_catalog)
-    local opts = {
-        host = consul_server.host,
-        port = consul_server.port,
-        connect_timeout = consul_server.connect_timeout,
-        read_timeout = consul_server.read_timeout,
-        default_args = {
-            token = consul_server.token,
-        }
-    }
-    if not consul_server.keepalive then
-        return opts
-    end
-
-    opts.default_args.wait = consul_server.wait_timeout --blocked wait!=0; unblocked by wait=0
-
-    if is_catalog then
-        opts.default_args.index = consul_server.catalog_index
-    else
-        opts.default_args.index = consul_server.health_index
-    end
-
-    return opts
-end
-
-
-local function watch_catalog(consul_server)
-    local client = resty_consul:new(get_opts(consul_server, true))
-
-    ::RETRY::
-    local watch_result, watch_err = client:get(consul_server.consul_watch_catalog_url)
-    local watch_error_info = (watch_err ~= nil and watch_err)
-                             or ((watch_result ~= nil and watch_result.status ~= 200)
-                             and watch_result.status)
-    if watch_error_info then
-        log.error("connect consul: ", consul_server.consul_server_url,
-            " by sub url: ", consul_server.consul_watch_catalog_url,
-            ", got watch result: ", json_delay_encode(watch_result),
-            ", with error: ", watch_error_info)
-
-        return watch_type_catalog, default_catalog_error_index
-    end
-
-    if consul_server.catalog_index > 0
-            and consul_server.catalog_index == tonumber(watch_result.headers['X-Consul-Index']) then
-        local random_delay = math_random(default_random_range)
-        log.info("watch catalog has no change, re-watch consul after ", random_delay, " seconds")
-        core_sleep(random_delay)
-        goto RETRY
-    end
-
-    return watch_type_catalog, watch_result.headers['X-Consul-Index']
-end
-
-
-local function watch_health(consul_server)
-    local client = resty_consul:new(get_opts(consul_server, false))
-
-    ::RETRY::
-    local watch_result, watch_err = client:get(consul_server.consul_watch_health_url)
-    local watch_error_info = (watch_err ~= nil and watch_err)
-            or ((watch_result ~= nil and watch_result.status ~= 200)
-            and watch_result.status)
-    if watch_error_info then
-        log.error("connect consul: ", consul_server.consul_server_url,
-            " by sub url: ", consul_server.consul_watch_health_url,
-            ", got watch result: ", json_delay_encode(watch_result),
-            ", with error: ", watch_error_info)
-
-        return watch_type_health, default_health_error_index
-    end
-
-    if consul_server.health_index > 0
-            and consul_server.health_index == tonumber(watch_result.headers['X-Consul-Index']) then
-        local random_delay = math_random(default_random_range)
-        log.info("watch health has no change, re-watch consul after ", random_delay, " seconds")
-        core_sleep(random_delay)
-        goto RETRY
-    end
-
-    return watch_type_health, watch_result.headers['X-Consul-Index']
-end
-
-
-local function check_keepalive(consul_server, retry_delay)
     if consul_server.keepalive and not exiting() then
-        local ok, err = ngx_timer_at(0, _M.connect, consul_server, retry_delay)
+        local ok, err = ngx_timer_at(0, _M.connect, reg, consul_server, retry_delay)
         if not ok then
             log.error("create ngx_timer_at got error: ", err)
             return
@@ -358,102 +240,32 @@ local function check_keepalive(consul_server, retry_delay)
 end
 
 
-local function update_index(consul_server, catalog_index, health_index)
-    local c_index = 0
-    local h_index = 0
-    if catalog_index ~= nil then
-        c_index = tonumber(catalog_index)
-    end
-
-    if health_index ~= nil then
-        h_index = tonumber(health_index)
-    end
-
-    if c_index > 0 then
-        consul_server.catalog_index = c_index
-    end
-
-    if h_index > 0 then
-        consul_server.health_index = h_index
-    end
-end
-
-
-local function is_not_empty(value)
-    if value == nil or value == null
-            or (type(value) == "table" and not next(value))
-            or (type(value) == "string" and value == "")
-    then
-        return false
-    end
-
-    return true
-end
-
-
-local function watch_result_is_valid(watch_type, index, catalog_index, health_index)
-    if index <= 0 then
-        return false
-    end
-
-    if watch_type == watch_type_catalog then
-        if index == catalog_index then
-            return false
-        end
-    else
-        if index == health_index then
-            return false
-        end
-    end
-
-    return true
-end
-
-
-local function combine_sort_nodes_cmp(left, right)
-    if left.host ~= right.host then
-        return left.host < right.host
-    end
-
-    return left.port < right.port
-end
-
-
-local function port_sort_nodes_cmp(left, right)
-    return left.port < right.port
-end
-
-
-local function host_sort_nodes_cmp(left, right)
-    return left.host < right.host
-end
-
-
-function _M.connect(premature, consul_server, retry_delay)
-    if premature then
+function _M.connect(premature, reg, consul_server, retry_delay)
+    if premature or reg.stop_flag then
         return
     end
 
-    local catalog_thread, spawn_catalog_err = thread_spawn(watch_catalog, consul_server)
+    local catalog_thread, spawn_catalog_err = thread_spawn(consul_client.watch_catalog,
+                                                           consul_server)
     if not catalog_thread then
         local random_delay = math_random(default_random_range)
         log.error("failed to spawn thread watch catalog: ", spawn_catalog_err,
             ", retry connecting consul after ", random_delay, " seconds")
         core_sleep(random_delay)
 
-        check_keepalive(consul_server, retry_delay)
+        check_keepalive(reg, consul_server, retry_delay)
         return
     end
 
-    local health_thread, err = thread_spawn(watch_health, consul_server)
+    local health_thread, err = thread_spawn(consul_client.watch_health, consul_server)
     if not health_thread then
         thread_kill(catalog_thread)
         local random_delay = math_random(default_random_range)
-        log.error("failed to spawn thread watch health: ", err, ", retry connecting consul after ",
-            random_delay, " seconds")
+        log.error("failed to spawn thread watch health: ", err,
+            ", retry connecting consul after ", random_delay, " seconds")
         core_sleep(random_delay)
 
-        check_keepalive(consul_server, retry_delay)
+        check_keepalive(reg, consul_server, retry_delay)
         return
     end
 
@@ -466,282 +278,355 @@ function _M.connect(premature, consul_server, retry_delay)
                 random_delay, " seconds")
         core_sleep(random_delay)
 
-        check_keepalive(consul_server, retry_delay)
+        check_keepalive(reg, consul_server, retry_delay)
         return
     end
 
-    -- double check index has changed
-    if not watch_result_is_valid(tonumber(watch_type),
+    if not consul_client.watch_result_is_valid(tonumber(watch_type),
             tonumber(index), consul_server.catalog_index, consul_server.health_index) then
-        retry_delay = get_retry_delay(retry_delay)
+        retry_delay = consul_client.get_retry_delay(retry_delay)
         log.warn("get all svcs got err, retry connecting consul after ", retry_delay, " seconds")
         core_sleep(retry_delay)
 
-        check_keepalive(consul_server, retry_delay)
+        check_keepalive(reg, consul_server, retry_delay)
         return
     end
 
-    local consul_client = resty_consul:new({
-        host = consul_server.host,
-        port = consul_server.port,
-        connect_timeout = consul_server.connect_timeout,
-        read_timeout = consul_server.read_timeout,
-        default_args = {
-            token = consul_server.token
-        }
-    })
-    local catalog_success, catalog_res, catalog_err = pcall(function()
-        return consul_client:get(consul_server.consul_watch_catalog_url)
-    end)
-    if not catalog_success then
-        log.error("connect consul: ", consul_server.consul_server_url,
-            " by sub url: ", consul_server.consul_watch_catalog_url,
-            ", got catalog result: ", json_delay_encode(catalog_res))
-        check_keepalive(consul_server, retry_delay)
-        return
-    end
-    local catalog_error_info = (catalog_err ~= nil and catalog_err)
-            or ((catalog_res ~= nil and catalog_res.status ~= 200)
-            and catalog_res.status)
-    if catalog_error_info then
-        log.error("connect consul: ", consul_server.consul_server_url,
-            " by sub url: ", consul_server.consul_watch_catalog_url,
-            ", got catalog result: ", json_delay_encode(catalog_res),
-            ", with error: ", catalog_error_info)
-
-        retry_delay = get_retry_delay(retry_delay)
-        log.warn("get all svcs got err, retry connecting consul after ", retry_delay, " seconds")
-        core_sleep(retry_delay)
-
-        check_keepalive(consul_server, retry_delay)
+    if reg.stop_flag then
         return
     end
 
-    -- get health index
-    local success, health_res, health_err = pcall(function()
-        return consul_client:get(consul_server.consul_watch_health_url)
-    end)
-    if not success then
-        log.error("connect consul: ", consul_server.consul_server_url,
-            " by sub url: ", consul_server.consul_watch_health_url,
-            ", got health result: ", json_delay_encode(health_res))
-        check_keepalive(consul_server, retry_delay)
-        return
-    end
-    local health_error_info = (health_err ~= nil and health_err)
-            or ((health_res ~= nil and health_res.status ~= 200)
-            and health_res.status)
-    if health_error_info then
-        log.error("connect consul: ", consul_server.consul_server_url,
-            " by sub url: ", consul_server.consul_watch_health_url,
-            ", got health result: ", json_delay_encode(health_res),
-            ", with error: ", health_error_info)
-
-        retry_delay = get_retry_delay(retry_delay)
-        log.warn("get all svcs got err, retry connecting consul after ", retry_delay, " seconds")
-        core_sleep(retry_delay)
-
-        check_keepalive(consul_server, retry_delay)
-        return
-    end
-
-    log.info("connect consul: ", consul_server.consul_server_url,
-        ", catalog_result status: ", catalog_res.status,
-        ", catalog_result.headers.index: ", catalog_res.headers['X-Consul-Index'],
-        ", consul_server.index: ", consul_server.index,
-        ", consul_server: ", json_delay_encode(consul_server))
-
-    -- if the current index is different from the last index, then update the service
-    if (consul_server.catalog_index ~= tonumber(catalog_res.headers['X-Consul-Index']))
-            or (consul_server.health_index ~= tonumber(health_res.headers['X-Consul-Index'])) then
-        local up_services = core.table.new(0, #catalog_res.body)
-        for service_name, _ in pairs(catalog_res.body) do
-            -- check if the service_name is 'skip service'
-            if skip_service_map[service_name] then
-                goto CONTINUE
-            end
-
-            -- get node from service
-            local svc_url = consul_server.consul_sub_url .. "/" .. service_name
-            local svc_success, result, get_err = pcall(function()
-                return consul_client:get(svc_url, {passing = true})
-            end)
-            local error_info = (get_err ~= nil and get_err) or
-                    ((result ~= nil and result.status ~= 200) and result.status)
-            if not svc_success or error_info then
-                log.error("connect consul: ", consul_server.consul_server_url,
-                    ", by service url: ", svc_url, ", with error: ", error_info)
-                goto CONTINUE
-            end
-
-            -- decode body, decode json, update service, error handling
-            -- check result body is not nil and not empty
-            if is_not_empty(result.body) then
-                -- add services to table
-                local nodes = up_services[service_name]
-                local nodes_uniq = {}
-                for _, node in ipairs(result.body) do
-                    if not node.Service then
-                        goto CONTINUE
-                    end
-
-                    local svc_address, svc_port = node.Service.Address, node.Service.Port
-                    -- Handle nil or 0 port case - default to 80 for HTTP services
-                    if not svc_port or svc_port == 0 then
-                        svc_port = 80
-                    end
-                    -- if nodes is nil, new nodes table and set to up_services
-                    if not nodes then
-                        nodes = core.table.new(1, 0)
-                        up_services[service_name] = nodes
-                    end
-                    -- not store duplicate service IDs.
-                    local service_id = svc_address .. ":" .. svc_port
-                    if not nodes_uniq[service_id] then
-                        -- add node to nodes table
-                        core.table.insert(nodes, {
-                            host = svc_address,
-                            port = tonumber(svc_port),
-                            weight = default_weight,
-                        })
-                        nodes_uniq[service_id] = true
-                    end
-                end
-                if nodes then
-                    if sort_type == "port_sort" then
-                        core.table.sort(nodes, port_sort_nodes_cmp)
-
-                    elseif sort_type == "host_sort" then
-                        core.table.sort(nodes, host_sort_nodes_cmp)
-
-                    elseif sort_type == "combine_sort" then
-                        core.table.sort(nodes, combine_sort_nodes_cmp)
-
-                    end
-                end
-                up_services[service_name] = nodes
-            end
-            :: CONTINUE ::
-        end
-
-        update_all_services(consul_server.consul_server_url, up_services)
-
-        if dump_params then
-            ngx_timer_at(0, write_dump_services)
-        end
-
-        update_index(consul_server,
-                catalog_res.headers['X-Consul-Index'],
-                health_res.headers['X-Consul-Index'])
-    end
-
-    check_keepalive(consul_server, retry_delay)
-end
-
-
-local function format_consul_params(consul_conf)
-    local consul_server_list = core.table.new(0, #consul_conf.servers)
-
-    for _, v in pairs(consul_conf.servers) do
-        local scheme, host, port, path = unpack(http.parse_uri(nil, v))
-        if scheme ~= "http" then
-            return nil, "only support consul http schema address, eg: http://address:port"
-        elseif path ~= "/" or core.string.has_suffix(v, '/') then
-            return nil, "invalid consul server address, the valid format: http://address:port"
-        end
-        core.table.insert(consul_server_list, {
-            host = host,
-            port = port,
-            token = consul_conf.token,
-            connect_timeout = consul_conf.timeout.connect,
-            read_timeout = consul_conf.timeout.read,
-            wait_timeout = consul_conf.timeout.wait,
-            consul_watch_catalog_url = "/catalog/services",
-            consul_sub_url = "/health/service",
-            consul_watch_health_url = "/health/state/any",
-            consul_server_url = v .. "/v1",
-            weight = consul_conf.weight,
-            keepalive = consul_conf.keepalive,
-            health_index = 0,
-            catalog_index = 0,
-            fetch_interval = consul_conf.fetch_interval -- fetch interval to next connect consul
+    local up_services, fetch_err, new_catalog_index, new_health_index =
+        consul_client.fetch_services_from_server(consul_server, {
+            default_weight    = reg.conf.weight,
+            sort_type         = reg.conf.sort_type,
+            skip_service_map  = reg.skip_service_map,
+            preserve_metadata = reg.preserve_metadata,
+            key_builder       = reg.key_builder,
         })
-    end
-    return consul_server_list, nil
-end
 
+    if fetch_err then
+        retry_delay = consul_client.get_retry_delay(retry_delay)
+        log.warn("get all svcs got err: ", fetch_err,
+                 ", retry connecting consul after ", retry_delay, " seconds")
+        core_sleep(retry_delay)
 
-function _M.init_worker()
-    local consul_conf = local_conf.discovery.consul
-    dump_params = consul_conf.dump
-
-    default_weight = consul_conf.weight
-    sort_type = consul_conf.sort_type
-    -- set default service, used when the server node cannot be found
-    if consul_conf.default_service then
-        default_service = consul_conf.default_service
-        default_service.weight = default_weight
-    end
-
-    if process.type() ~= "privileged agent" then
+        check_keepalive(reg, consul_server, retry_delay)
         return
     end
 
-    -- flush stale data that may persist across reloads,
-    -- since consul_services is re-initialized empty
-    consul_dict:flush_all()
+    if reg.stop_flag then
+        return
+    end
 
-    if consul_conf.dump then
-        if consul_conf.dump.load_on_init then
-            read_dump_services()
+    -- only update if there are actual services (empty table means no index change)
+    if next(up_services) then
+        update_all_services(reg, consul_server.consul_server_url, up_services)
+
+        if reg.dump_params then
+            ngx_timer_at(0, write_dump_services, reg)
         end
     end
 
-    log.notice("consul_conf: ", json_delay_encode(consul_conf, true))
+    consul_client.update_index(consul_server, new_catalog_index, new_health_index)
+    check_keepalive(reg, consul_server, retry_delay)
+end
 
-    if consul_conf.skip_services then
-        skip_service_map = core.table.new(0, #consul_conf.skip_services)
-        for _, v in ipairs(consul_conf.skip_services) do
-            skip_service_map[v] = true
+
+-- ─── Registry management API ──────────────────────────────────────────
+
+--- Create a consul registry instance.
+---
+--- conf fields: id, servers (array of URLs), token, timeout, weight,
+---              keepalive, fetch_interval, sort_type, skip_services,
+---              dump, default_service, shared_size
+---
+--- options: service_scanner (function), preserve_metadata (bool),
+---          key_builder (function(service_name) -> string)
+function _M.create_registry(conf, options)
+    options = options or {}
+    local id = conf.id
+    if not id or id == "" then
+        return nil, "registry id is required"
+    end
+
+    if registries[id] then
+        _M.stop_registry(id)
+    end
+
+    -- build skip service map
+    local skip_map = core.table.new(0, 1)
+    if conf.skip_services then
+        for _, v in ipairs(conf.skip_services) do
+            skip_map[v] = true
         end
     end
-    -- set up default skip service
     for _, v in ipairs(default_skip_services) do
-        skip_service_map[v] = true
+        skip_map[v] = true
     end
 
-    local consul_servers_list, err = format_consul_params(consul_conf)
+    -- build default_service
+    local default_svc
+    if conf.default_service then
+        default_svc = conf.default_service
+        default_svc.weight = conf.weight
+    end
+
+    local reg = {
+        id                = id,
+        conf              = conf,
+        stop_flag         = false,
+        preserve_metadata = options.preserve_metadata or false,
+        key_builder       = options.key_builder or default_key_builder(id),
+        service_scanner   = options.service_scanner or consul_client.get_consul_services,
+        skip_service_map  = skip_map,
+        default_service   = default_svc,
+        dump_params       = conf.dump,
+        consul_services   = core.table.new(0, 1),
+    }
+
+    registries[id] = reg
+    return reg
+end
+
+
+function _M.start_registry(reg)
+    local dict = get_dict()
+    if not dict then
+        error('lua_shared_dict "' .. dict_name .. '" not configured')
+    end
+
+    -- flush stale data for this registry
+    local prefix = reg.id .. "/"
+    local all_keys = dict:get_keys(0)
+    for _, key in ipairs(all_keys) do
+        if core.string.has_prefix(key, prefix) then
+            dict:delete(key)
+        end
+    end
+
+    -- load dump file if configured
+    if reg.dump_params and reg.dump_params.load_on_init then
+        read_dump_services(reg)
+    end
+
+    local consul_servers_list, err = consul_client.format_consul_params(reg.conf)
     if err then
         error("format consul config got error: " .. err)
     end
     log.info("consul_server_list: ", json_delay_encode(consul_servers_list, true))
 
-    consul_services = core.table.new(0, 1)
-    -- success or failure
     for _, server in ipairs(consul_servers_list) do
-        local ok, err = ngx_timer_at(0, _M.connect, server)
+        local ok, timer_err = ngx_timer_at(0, _M.connect, reg, server)
         if not ok then
-            error("create consul got error: " .. err)
+            error("create consul got error: " .. timer_err)
         end
 
         if server.keepalive == false then
-            ngx_timer_every(server.fetch_interval, _M.connect, server)
+            ngx_timer_every(server.fetch_interval, _M.connect, reg, server)
         end
     end
 end
 
 
+function _M.stop_registry(id)
+    local reg = registries[id]
+    if not reg then
+        return
+    end
+
+    reg.stop_flag = true
+    registries[id] = nil
+
+    local dict = get_dict()
+    if dict then
+        local prefix = id .. "/"
+        local all_keys = dict:get_keys(0)
+        for _, key in ipairs(all_keys) do
+            if core.string.has_prefix(key, prefix) then
+                dict:delete(key)
+            end
+        end
+    end
+end
+
+
+function _M.get_registry(id)
+    return registries[id]
+end
+
+
+-- ─── Shared helpers ──────────────────────────────────────────────────
+
+local function match_metadata(node_metadata, upstream_metadata)
+    if upstream_metadata == nil then
+        return true
+    end
+
+    if not node_metadata then
+        node_metadata = {}
+    end
+
+    for k, v in pairs(upstream_metadata) do
+        if not node_metadata[k] or node_metadata[k] ~= v then
+            return false
+        end
+    end
+
+    return true
+end
+
+
+function _M.get_nodes(key, metadata)
+    local dict = get_dict()
+    if not dict then
+        return nil
+    end
+
+    local value = dict:get(key)
+    if not value then
+        return nil
+    end
+
+    local nodes = core.json.decode(value)
+    if not metadata then
+        return nodes
+    end
+
+    local res = {}
+    for _, node in ipairs(nodes) do
+        if match_metadata(node.metadata, metadata) then
+            core.table.insert(res, node)
+        end
+    end
+    return res
+end
+
+
+-- ─── Standard discovery interface ─────────────────────────────────────
+
+local function fetch_node_from_shdict(service_name)
+    local dict = get_dict()
+    if not dict then
+        return nil, "consul shared dict not available"
+    end
+
+    -- look up with the default registry prefix
+    local value = dict:get("default/" .. service_name)
+    if not value then
+        return nil, "consul service not found: " .. service_name
+    end
+
+    local nodes, err = core.json.decode(value)
+    if not nodes then
+        return nil, "failed to decode nodes for service: "
+                    .. service_name .. ", error: " .. (err or "")
+    end
+
+    return nodes
+end
+
+
+function _M.nodes(service_name)
+    local default_reg = registries["default"]
+    local default_svc = default_reg and default_reg.default_service
+
+    local nodes, err = nodes_cache(service_name, nil,
+                                   fetch_node_from_shdict, service_name)
+    if not nodes then
+        log.error("fetch nodes failed by ", service_name, ", error: ", err)
+        return default_svc and {default_svc}
+    end
+
+    log.info("process id: ", ngx_worker_id(), ", [", service_name, "] = ",
+        json_delay_encode(nodes, true))
+
+    return nodes
+end
+
+
+function _M.all_nodes()
+    local dict = get_dict()
+    if not dict then
+        return {}
+    end
+
+    local keys = dict:get_keys(0)
+    local services = core.table.new(0, #keys)
+    local prefix = "default/"
+    for i, key in ipairs(keys) do
+        -- only return default registry nodes, strip prefix for BC
+        if core.string.has_prefix(key, prefix) then
+            local value = dict:get(key)
+            if value then
+                local nodes, err = core.json.decode(value)
+                if nodes then
+                    local bare_key = key:sub(#prefix + 1)
+                    services[bare_key] = nodes
+                else
+                    log.error("failed to decode nodes for service: ", key, ", error: ", err)
+                end
+            end
+        end
+
+        if i % 100 == 0 then
+            ngx.sleep(0)
+        end
+    end
+    return services
+end
+
+
+-- ─── Initialization ───────────────────────────────────────────────────
+
+function _M.init_worker()
+    local consul_conf = local_conf.discovery and local_conf.discovery.consul
+    if not consul_conf then
+        return
+    end
+
+    local dict = ngx.shared[dict_name]
+    if not dict then
+        error('lua_shared_dict "' .. dict_name .. '" not configured')
+    end
+    consul_dict = dict
+
+    if process.type() ~= "privileged agent" then
+        return
+    end
+
+    -- flush stale data that may persist across reloads
+    dict:flush_all()
+
+    log.notice("consul_conf: ", json_delay_encode(consul_conf, true))
+
+    -- shallow copy to avoid mutating cached config
+    local conf = {}
+    for k, v in pairs(consul_conf) do
+        conf[k] = v
+    end
+    conf.id = "default"
+
+    local reg = _M.create_registry(conf)
+    _M.start_registry(reg)
+end
+
+
 function _M.dump_data()
-    return {config = local_conf.discovery.consul, services = _M.all_nodes()}
+    return {config = local_conf.discovery and local_conf.discovery.consul,
+            services = _M.all_nodes()}
 end
 
 
 function _M.control_api()
+    local default_reg = registries["default"]
     return {
         {
             methods = {"GET"},
             uris = {"/show_dump_file"},
-            handler = show_dump_file,
+            handler = function()
+                return show_dump_file(default_reg)
+            end,
         }
     }
 end

--- a/apisix/discovery/consul/init.lua
+++ b/apisix/discovery/consul/init.lua
@@ -26,7 +26,6 @@ local error              = error
 local ngx                = ngx
 local tonumber           = tonumber
 local ngx_timer_at       = ngx.timer.at
-local ngx_timer_every    = ngx.timer.every
 local log                = core.log
 local json_delay_encode  = core.json.delay_encode
 local process            = require("ngx.process")
@@ -230,8 +229,21 @@ local function check_keepalive(reg, consul_server, retry_delay)
         return
     end
 
-    if consul_server.keepalive and not exiting() then
+    if exiting() then
+        return
+    end
+
+    if consul_server.keepalive then
         local ok, err = ngx_timer_at(0, _M.connect, reg, consul_server, retry_delay)
+        if not ok then
+            log.error("create ngx_timer_at got error: ", err)
+            return
+        end
+    else
+        -- self-rescheduling poll: use timer.at instead of timer.every
+        -- so stop_flag can actually halt future wakeups
+        local ok, err = ngx_timer_at(consul_server.fetch_interval,
+                                     _M.connect, reg, consul_server, retry_delay)
         if not ok then
             log.error("create ngx_timer_at got error: ", err)
             return
@@ -365,10 +377,13 @@ function _M.create_registry(conf, options)
         skip_map[v] = true
     end
 
-    -- build default_service
+    -- clone default_service to avoid mutating the caller's table
     local default_svc
     if conf.default_service then
-        default_svc = conf.default_service
+        default_svc = {}
+        for k, v in pairs(conf.default_service) do
+            default_svc[k] = v
+        end
         default_svc.weight = conf.weight
     end
 
@@ -420,10 +435,6 @@ function _M.start_registry(reg)
         local ok, timer_err = ngx_timer_at(0, _M.connect, reg, server)
         if not ok then
             error("create consul got error: " .. timer_err)
-        end
-
-        if server.keepalive == false then
-            ngx_timer_every(server.fetch_interval, _M.connect, reg, server)
         end
     end
 end
@@ -591,13 +602,6 @@ function _M.init_worker()
     end
     consul_dict = dict
 
-    if process.type() ~= "privileged agent" then
-        return
-    end
-
-    -- flush stale data that may persist across reloads
-    dict:flush_all()
-
     log.notice("consul_conf: ", json_delay_encode(consul_conf, true))
 
     -- shallow copy to avoid mutating cached config
@@ -607,7 +611,23 @@ function _M.init_worker()
     end
     conf.id = "default"
 
+    -- create default registry on all workers so nodes()/control_api() work
     local reg = _M.create_registry(conf)
+
+    -- only the privileged agent runs timers / writes to shared dict
+    if process.type() ~= "privileged agent" then
+        return
+    end
+
+    -- flush stale data for the default registry that may persist across reloads
+    local prefix = "default/"
+    local all_keys = dict:get_keys(0)
+    for _, key in ipairs(all_keys) do
+        if core.string.has_prefix(key, prefix) then
+            dict:delete(key)
+        end
+    end
+
     _M.start_registry(reg)
 end
 
@@ -619,12 +639,12 @@ end
 
 
 function _M.control_api()
-    local default_reg = registries["default"]
     return {
         {
             methods = {"GET"},
             uris = {"/show_dump_file"},
             handler = function()
+                local default_reg = registries["default"]
                 return show_dump_file(default_reg)
             end,
         }

--- a/apisix/discovery/consul/init.lua
+++ b/apisix/discovery/consul/init.lua
@@ -332,13 +332,12 @@ function _M.connect(premature, reg, consul_server, retry_delay)
         return
     end
 
-    -- only update if there are actual services (empty table means no index change)
-    if next(up_services) then
-        update_all_services(reg, consul_server.consul_server_url, up_services)
+    -- Always call update_all_services to clean up stale keys even when
+    -- up_services is empty (e.g., all Consul services deleted).
+    update_all_services(reg, consul_server.consul_server_url, up_services)
 
-        if reg.dump_params then
-            ngx_timer_at(0, write_dump_services, reg)
-        end
+    if reg.dump_params then
+        ngx_timer_at(0, write_dump_services, reg)
     end
 
     consul_client.update_index(consul_server, new_catalog_index, new_health_index)
@@ -489,20 +488,31 @@ local function match_metadata(node_metadata, upstream_metadata)
 end
 
 
-function _M.get_nodes(key, metadata)
+local function fetch_nodes_from_shdict(key)
     local dict = get_dict()
     if not dict then
-        return nil
+        return nil, "consul shared dict not available"
     end
 
     local value = dict:get(key)
     if not value then
-        return nil
+        return nil, "consul service not found: " .. key
     end
 
-    local nodes, decode_err = core.json.decode(value)
+    local nodes, err = core.json.decode(value)
     if not nodes then
-        log.error("failed to decode nodes for key: ", key, ", error: ", decode_err)
+        return nil, "failed to decode nodes for key: " .. key
+                    .. ", error: " .. (err or "")
+    end
+
+    return nodes
+end
+
+
+function _M.get_nodes(key, metadata)
+    local nodes, err = nodes_cache(key, nil, fetch_nodes_from_shdict, key)
+    if not nodes then
+        log.error("fetch nodes failed for key: ", key, ", error: ", err)
         return nil
     end
 
@@ -522,34 +532,14 @@ end
 
 -- ─── Standard discovery interface ─────────────────────────────────────
 
-local function fetch_node_from_shdict(service_name)
-    local dict = get_dict()
-    if not dict then
-        return nil, "consul shared dict not available"
-    end
-
-    -- look up with the default registry prefix
-    local value = dict:get("default/" .. service_name)
-    if not value then
-        return nil, "consul service not found: " .. service_name
-    end
-
-    local nodes, err = core.json.decode(value)
-    if not nodes then
-        return nil, "failed to decode nodes for service: "
-                    .. service_name .. ", error: " .. (err or "")
-    end
-
-    return nodes
-end
-
-
 function _M.nodes(service_name)
     local default_reg = registries["default"]
     local default_svc = default_reg and default_reg.default_service
 
-    local nodes, err = nodes_cache(service_name, nil,
-                                   fetch_node_from_shdict, service_name)
+    -- reuse the cached fetch with "default/" prefix for BC
+    local nodes, err = nodes_cache("default/" .. service_name, nil,
+                                   fetch_nodes_from_shdict,
+                                   "default/" .. service_name)
     if not nodes then
         log.error("fetch nodes failed by ", service_name, ", error: ", err)
         return default_svc and {default_svc}
@@ -562,6 +552,7 @@ function _M.nodes(service_name)
 end
 
 
+-- Used only by dump_data() for diagnostic purposes; not a hot path.
 function _M.all_nodes()
     local dict = get_dict()
     if not dict then

--- a/apisix/discovery/consul/init.lua
+++ b/apisix/discovery/consul/init.lua
@@ -22,6 +22,7 @@ local consul_client      = require("apisix.discovery.consul.client")
 local util               = require("apisix.cli.util")
 local ipairs             = ipairs
 local pairs              = pairs
+local next               = next
 local error              = error
 local ngx                = ngx
 local tonumber           = tonumber

--- a/apisix/discovery/consul/init.lua
+++ b/apisix/discovery/consul/init.lua
@@ -397,7 +397,8 @@ function _M.create_registry(conf, options)
         stop_flag         = false,
         preserve_metadata = options.preserve_metadata or false,
         key_builder       = options.key_builder or default_key_builder(id),
-        service_scanner   = options.service_scanner or consul_client.get_consul_services,
+        service_scanner   = options.service_scanner
+                            or function() return consul_client.get_consul_services(id) end,
         skip_service_map  = skip_map,
         default_service   = default_svc,
         dump_params       = conf.dump,

--- a/apisix/discovery/consul/init.lua
+++ b/apisix/discovery/consul/init.lua
@@ -500,7 +500,12 @@ function _M.get_nodes(key, metadata)
         return nil
     end
 
-    local nodes = core.json.decode(value)
+    local nodes, decode_err = core.json.decode(value)
+    if not nodes then
+        log.error("failed to decode nodes for key: ", key, ", error: ", decode_err)
+        return nil
+    end
+
     if not metadata then
         return nodes
     end

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -424,6 +424,7 @@ _EOC_
     lua_shared_dict kubernetes-first-stream 1m;
     lua_shared_dict kubernetes-second-stream 1m;
     lua_shared_dict nacos-stream 10m;
+    lua_shared_dict consul-stream 10m;
     lua_shared_dict tars-stream 1m;
 
     upstream apisix_backend {

--- a/t/discovery/consul.t
+++ b/t/discovery/consul.t
@@ -807,6 +807,9 @@ discovery:
     weight: 1
     fetch_interval: 1
     keepalive: true
+--- apisix_yaml
+routes: []
+#END
 --- config
     location /t {
         content_by_lua_block {

--- a/t/discovery/consul.t
+++ b/t/discovery/consul.t
@@ -781,3 +781,87 @@ location /sleep {
     qr//
 ]
 --- ignore_error_log
+
+
+
+=== TEST 16: test get_nodes metadata filtering via shared dict
+--- yaml_config
+apisix:
+  node_listen: 1984
+  enable_control: true
+  control:
+    ip: 127.0.0.1
+    port: 9090
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+discovery:
+  consul:
+    servers:
+      - "http://127.0.0.1:8500"
+    timeout:
+      connect: 1000
+      read: 1000
+      wait: 60
+    weight: 1
+    fetch_interval: 1
+    keepalive: true
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local core = require("apisix.core")
+            local consul = require("apisix.discovery.consul")
+
+            -- write test nodes with metadata directly to shared dict
+            local dict = ngx.shared["consul"]
+            local nodes = {
+                {host = "127.0.0.1", port = 30511, weight = 1, metadata = {env = "prod", version = "v1"}},
+                {host = "127.0.0.1", port = 30512, weight = 1, metadata = {env = "staging", version = "v1"}},
+                {host = "127.0.0.1", port = 30513, weight = 1},
+            }
+            dict:set("test_reg/test_svc", core.json.encode(nodes))
+
+            -- no metadata filter: returns all 3
+            local all = consul.get_nodes("test_reg/test_svc")
+            ngx.say("all nodes: ", all and #all or "nil")
+
+            -- filter by env=prod: returns 1
+            local prod = consul.get_nodes("test_reg/test_svc", {env = "prod"})
+            ngx.say("prod nodes: ", prod and #prod or "nil")
+            if prod and #prod > 0 then
+                ngx.say("prod port: ", prod[1].port)
+            end
+
+            -- filter by env=staging: returns 1
+            local staging = consul.get_nodes("test_reg/test_svc", {env = "staging"})
+            ngx.say("staging nodes: ", staging and #staging or "nil")
+            if staging and #staging > 0 then
+                ngx.say("staging port: ", staging[1].port)
+            end
+
+            -- filter by version=v1: returns 2 (node without metadata is excluded)
+            local v1 = consul.get_nodes("test_reg/test_svc", {version = "v1"})
+            ngx.say("v1 nodes: ", v1 and #v1 or "nil")
+
+            -- filter by non-existent key: returns 0
+            local none = consul.get_nodes("test_reg/test_svc", {env = "dev"})
+            ngx.say("dev nodes: ", none and #none or "nil")
+
+            -- cleanup
+            dict:delete("test_reg/test_svc")
+        }
+    }
+--- request
+GET /t
+--- response_body
+all nodes: 3
+prod nodes: 1
+prod port: 30511
+staging nodes: 1
+staging port: 30512
+v1 nodes: 2
+dev nodes: 0
+--- no_error_log
+[error]


### PR DESCRIPTION
Following the pattern established by #13201 (Nacos + K8s refactor), this PR refactors the Consul discovery module to support a multi-instance registry API while preserving all existing behavior.

The goal is to let the Consul module be driven by an external caller so that multiple Consul registries can coexist, each with their own configuration.

**What changed:**

- New `client.lua`: HTTP/protocol primitives extracted from `init.lua` — blocking query watchers, service fetching, URL parsing, sort helpers, and service scanner
- Refactored `init.lua`: `create_registry()` / `start_registry()` / `stop_registry()` / `get_registry()` / `get_nodes()` multi-instance API, following the same pattern as nacos
- Mutable module state moved into per-registry object (skip_service_map, dump_params, consul_services, default_service)
- Shared dict keys use registry ID prefix (`default/service_name`) for multi-instance isolation
- `all_nodes()` / `dump_data()` / `show_dump_file()` strip the prefix for backward compatibility
- Optional metadata filtering via `get_nodes(key, metadata)`
- Privileged-agent-only gating preserved for write operations
- No schema changes — all existing tests should pass as-is