### PR TITLE
fix(nacos): restrict registry fetch to privileged agent only

### DIFF
--- a/apisix/discovery/nacos/init.lua
+++ b/apisix/discovery/nacos/init.lua
@@ -26,6 +26,7 @@ local error              = error
 local math_random        = math.random
 local ngx                = ngx
 local ngx_timer_at       = ngx.timer.at
+local process            = require("ngx.process")
 local log                = core.log
 
 local _M = {}
@@ -288,6 +289,10 @@ function _M.init_worker()
 
     local nacos_conf = local_conf.discovery and local_conf.discovery.nacos
     if not nacos_conf then
+        return
+    end
+
+    if process.type() ~= "privileged agent" then
         return
     end
 


### PR DESCRIPTION
### Description

All other discovery modules (tars, kubernetes, consul) restrict service data fetching to the privileged agent process only. The nacos module was missing this restriction, causing every worker process to independently start timers and fetch from nacos servers.

This results in:
- N worker processes × redundant nacos API requests
- N × unnecessary JSON encoding/decoding overhead
- Unnecessary load on nacos servers

This PR adds the same `process.type() ~= "privileged agent"` check used by other discovery modules, so only the privileged agent fetches from nacos while workers read from the shared dict populated by the agent.

**Reference**: This is a minimal fix extracted from the optimization discussed in #12867, adapted to the current codebase.

#### Which issue(s) this PR fixes:

Related to #12867

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
