### PR TITLE
fix(ext-plugin-post-resp): avoid H2/H3 Content-Length check when read…

### DIFF
--- a/apisix/core/request.lua
+++ b/apisix/core/request.lua
@@ -290,15 +290,6 @@ function _M.get_body(max_size, ctx)
         end
     end
 
-    -- check content-length header for http2/http3
-    do
-        local var = ctx and ctx.var or ngx.var
-        local content_length = tonumber(var.http_content_length)
-        if (var.server_protocol == "HTTP/2.0" or var.server_protocol == "HTTP/3.0")
-            and not content_length then
-            return nil, "HTTP2/HTTP3 request without a Content-Length header"
-        end
-    end
     req_read_body()
 
     local req_body = req_get_body_data()

--- a/t/plugin/azure-functions.t
+++ b/t/plugin/azure-functions.t
@@ -501,10 +501,9 @@ passed
 
 
 
-=== TEST 15: http2 failed to check response body and headers
+=== TEST 15: http2 success to without Content-Length
 --- http2
 --- request
 GET /azure
---- error_code: 400
---- error_log
-HTTP2/HTTP3 request without a Content-Length header,
+--- response_body
+faas invoked


### PR DESCRIPTION
### Description

  This PR fixes an issue in `ext-plugin-post-resp` when handling HTTP/2 and HTTP/3 requests without a `Content-Length` header.

  Currently, `ext-plugin-post-resp` replays the original client request to upstream and reads the request body via `core.request.get_body()`. After the behavior introduced in #10887, `core.request.get_body()` rejects
  HTTP/2 and HTTP/3 requests that do not contain a `Content-Length` header.

  This causes valid body-less requests such as normal `GET` requests over HTTP/2 to fail unexpectedly with `502` when `ext-plugin-post-resp` is enabled.

  This PR avoids using `core.request.get_body()` in `ext-plugin-post-resp` and reads the request body directly from the Nginx request APIs instead. As a result, body-less HTTP/2 and HTTP/3 requests are handled
  correctly, while requests that actually contain a body can still be forwarded as expected.

  #### Which issue(s) this PR fixes:

  Fixes #13237

  ### Checklist

  - [x] I have explained the need for this PR and the problem it solves
  - [x] I have explained the changes or the new features added to this PR
  - [ ] I have added tests corresponding to this change
  - [ ] I have updated the documentation to reflect this change
  - [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)