### PR TITLE
docs(jwt-auth): re-port with Admin API, ADC, and Ingress Controller tabs

### DIFF
--- a/docs/en/latest/plugins/jwt-auth.md
+++ b/docs/en/latest/plugins/jwt-auth.md
@@ -56,7 +56,6 @@ The following attributes are available for configurations on Consumers or Creden
 | exp | integer | False | 86400 | >=1 | Expiry time of the token in seconds. If you are not using APISIX to sign the JWT, this parameter is ignored and you should specify the expiration in the payload when signing the JWT. |
 | base64_secret | boolean | False | false | | Set to true if the secret is base64 encoded. |
 | lifetime_grace_period | integer | False | 0 | >=0 | Grace period in seconds. Used to account for clock skew between the server generating the JWT and the server validating the JWT. |
-| key_claim_name | string | False | key | | The claim in the JWT payload that identifies the associated secret, such as `iss`. |
 
 NOTE: `encrypt_fields = {"secret"}` is also defined in the schema, which means that the field will be stored encrypted in etcd. See [encrypted storage fields](../plugin-develop.md#encrypted-storage-fields).
 
@@ -72,6 +71,7 @@ The following attributes are available for configurations on Routes or Services.
 | claims_to_verify | array[string] | False | ["exp", "nbf"] | combination of `exp` and `nbf` | Specify the JWT claim(s) to verify, to ensure that the token is used within its allowed timeframe. Note that this is not the claims required to be presented in the payload, but the claims to verify, if presented. |
 | store_in_ctx | boolean | False | false | | If true, store JWT payload in the request context variable `ctx.jwt_auth_payload`. This allows plugins executed after `jwt-auth` on the same request to retrieve and use the payload information. |
 | realm | string | False | jwt | | The realm to include in the `WWW-Authenticate` header when authentication fails. |
+| key_claim_name | string | False | key | | The claim in the JWT payload that identifies the associated secret, such as `iss`. |
 
 You can implement `jwt-auth` with [HashiCorp Vault](https://www.vaultproject.io/) to store and fetch secrets and RSA key pairs from its [encrypted KV engine](https://developer.hashicorp.com/vault/docs/secrets/kv) using the [APISIX Secret](../terminology/secret.md) resource.
 
@@ -81,10 +81,10 @@ The examples below demonstrate how you can work with the `jwt-auth` Plugin for d
 
 :::note
 
-You can fetch the `admin_key` from `config.yaml` and save to an environment variable with the following command:
+You can fetch the `admin_key` from `/conf/config.yaml` and save to an environment variable with the following command:
 
 ```bash
-admin_key=$(yq '.deployment.admin.admin_key[0].key' /usr/local/apisix/conf/config.yaml | sed 's/"//g')
+admin_key=$(yq '.deployment.admin.admin_key[0].key' /conf/config.yaml | sed 's/"//g')
 ```
 
 :::

--- a/docs/en/latest/plugins/jwt-auth.md
+++ b/docs/en/latest/plugins/jwt-auth.md
@@ -51,7 +51,7 @@ The following attributes are available for configurations on Consumers or Creden
 |------|------|----------|---------|--------------|-------------|
 | key | string | True | | non-empty | A unique key that identifies the credential for a Consumer. |
 | secret | string | False | | non-empty | Shared key used to sign and verify the JWT when the algorithm is symmetric. Required when using `HS256`, `HS384`, or `HS512` as the algorithm. This field supports saving the value in Secret Manager using the [APISIX Secret](../terminology/secret.md) resource. |
-| public_key | string | False | | | RSA or ECDSA public key. Required if the `algorithm` is `RS256`, `ES256`, `RS384`, `RS512`, `ES384`, `ES512`, `PS256`, `PS384`, `PS512`, or `EdDSA`. This field supports saving the value in Secret Manager using the [APISIX Secret](../terminology/secret.md) resource. |
+| public_key | string | False | | | Public key in PEM format required by the configured asymmetric algorithm. Required if the `algorithm` is `RS256`, `ES256`, `RS384`, `RS512`, `ES384`, `ES512`, `PS256`, `PS384`, `PS512`, or `EdDSA`. This field supports saving the value in Secret Manager using the [APISIX Secret](../terminology/secret.md) resource. |
 | algorithm | string | False | HS256 | `HS256`, `HS384`, `HS512`, `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`, `PS256`, `PS384`, `PS512`, `EdDSA` | Encryption algorithm. |
 | exp | integer | False | 86400 | >=1 | Expiry time of the token in seconds. If you are not using APISIX to sign the JWT, this parameter is ignored and you should specify the expiration in the payload when signing the JWT. |
 | base64_secret | boolean | False | false | | Set to true if the secret is base64 encoded. |

--- a/docs/en/latest/plugins/jwt-auth.md
+++ b/docs/en/latest/plugins/jwt-auth.md
@@ -32,46 +32,48 @@ description: The jwt-auth Plugin supports the use of JSON Web Token (JWT) as a m
   <link rel="canonical" href="https://docs.api7.ai/hub/jwt-auth" />
 </head>
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Description
 
 The `jwt-auth` Plugin supports the use of [JSON Web Token (JWT)](https://jwt.io/) as a mechanism for clients to authenticate themselves before accessing Upstream resources.
 
 Once enabled, the Plugin exposes an endpoint to create JWT credentials by [Consumers](../terminology/consumer.md). The process generates a token that client requests should carry to identify themselves to APISIX. The token can be included in the request URL query string, request header, or cookie. APISIX will then verify the token to determine if a request should be allowed or denied to access Upstream resources.
 
-When a Consumer is successfully authenticated, APISIX adds additional headers, such as `X-Consumer-Username`, `X-Credential-Indentifier`, and other Consumer custom headers if configured, to the request, before proxying it to the Upstream service. The Upstream service will be able to differentiate between consumers and implement additional logics as needed. If any of these values is not available, the corresponding header will not be added.
+When a Consumer is successfully authenticated, APISIX adds additional headers, such as `X-Consumer-Username`, `X-Credential-Identifier`, and other Consumer custom headers if configured, to the request, before proxying it to the Upstream service. The Upstream service will be able to differentiate between consumers and implement additional logics as needed. If any of these values is not available, the corresponding header will not be added.
 
 ## Attributes
 
-For Consumer/Credential:
+The following attributes are available for configurations on Consumers or Credentials.
 
-| Name          | Type    | Required                                              | Default | Valid values                | Description                                                                                                                                                                                 |
-|---------------|---------|-------------------------------------------------------|---------|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| key           | string  | True                                                  |         |     non-empty       | Unique key for a Consumer.                                                                                                                                                                  |
-| secret        | string  | False                                                 |         |        non-empty        | Shared key used to sign and verify the JWT when the algorithm is symmetric. Required when using `HS256` or `HS512` as the algorithm. This field supports saving the value in Secret Manager using the [APISIX Secret](../terminology/secret.md) resource.       |
-| public_key    | string  | True if `RS256` or `ES256` is set for the `algorithm` attribute. |         |                             | RSA or ECDSA public key. This field supports saving the value in Secret Manager using the [APISIX Secret](../terminology/secret.md) resource.                      |
-| algorithm     | string  | False                                                 | HS256 | ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512", "EdDSA"] | Encryption algorithm.                                                                                                                                                                       |
-| exp           | integer | False                                                 | 86400   | [1,...]                     | Expiry time of the token in seconds.                                                                                                                                                        |
-| base64_secret | boolean | False                                                 | false   |                             | Set to true if the secret is base64 encoded.                                                                                                                                                |
-| lifetime_grace_period | integer | False                                         | 0       | [0,...]                     | Grace period in seconds. Used to account for clock skew between the server generating the JWT and the server validating the JWT.  |
-| key_claim_name | string | False                                                 | key     |                             | The claim in the JWT payload that identifies the associated secret, such as `iss`. |
+| Name | Type | Required | Default | Valid values | Description |
+|------|------|----------|---------|--------------|-------------|
+| key | string | True | | non-empty | A unique key that identifies the credential for a Consumer. |
+| secret | string | False | | non-empty | Shared key used to sign and verify the JWT when the algorithm is symmetric. Required when using `HS256`, `HS384`, or `HS512` as the algorithm. This field supports saving the value in Secret Manager using the [APISIX Secret](../terminology/secret.md) resource. |
+| public_key | string | False | | | RSA or ECDSA public key. Required if the `algorithm` is `RS256`, `ES256`, `RS384`, `RS512`, `ES384`, `ES512`, `PS256`, `PS384`, `PS512`, or `EdDSA`. This field supports saving the value in Secret Manager using the [APISIX Secret](../terminology/secret.md) resource. |
+| algorithm | string | False | HS256 | `HS256`, `HS384`, `HS512`, `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`, `PS256`, `PS384`, `PS512`, `EdDSA` | Encryption algorithm. |
+| exp | integer | False | 86400 | >=1 | Expiry time of the token in seconds. If you are not using APISIX to sign the JWT, this parameter is ignored and you should specify the expiration in the payload when signing the JWT. |
+| base64_secret | boolean | False | false | | Set to true if the secret is base64 encoded. |
+| lifetime_grace_period | integer | False | 0 | >=0 | Grace period in seconds. Used to account for clock skew between the server generating the JWT and the server validating the JWT. |
+| key_claim_name | string | False | key | | The claim in the JWT payload that identifies the associated secret, such as `iss`. |
 
 NOTE: `encrypt_fields = {"secret"}` is also defined in the schema, which means that the field will be stored encrypted in etcd. See [encrypted storage fields](../plugin-develop.md#encrypted-storage-fields).
 
-For Routes or Services:
+The following attributes are available for configurations on Routes or Services.
 
-| Name   | Type   | Required | Default       | Description                                                         |
-|--------|--------|----------|---------------|---------------------------------------------------------------------|
-| header | string | False    | authorization | The header to get the token from.                                   |
-| query  | string | False    | jwt           | The query string to get the token from. Lower priority than header. |
-| cookie | string | False    | jwt           | The cookie to get the token from. Lower priority than query.        |
-| hide_credentials| boolean | False    | false  | If true, do not pass the header, query, or cookie with JWT to Upstream services.  |
-| key_claim_name  | string  | False    | key     | The name of the JWT claim that contains the user key (corresponds to Consumer's key attribute). |
-| anonymous_consumer | string | False  | false  | Anonymous Consumer name. If configured, allow anonymous users to bypass the authentication.   |
-| store_in_ctx     | boolean | False    | false   | Set to true will store the JWT payload in the request context (`ctx.jwt_auth_payload`). This allows lower-priority plugins that run afterwards on the same request to retrieve and use the JWT token. |
-| realm            | string  | False    | jwt     | The realm to include in the `WWW-Authenticate` header when authentication fails. |
-| claims_to_verify | array[string] | False | ["exp", "nbf"] | ["exp", "nbf"] | The claims that need to be verified in the JWT payload. |
+| Name | Type | Required | Default | Valid values | Description |
+|------|------|----------|---------|--------------|-------------|
+| header | string | False | authorization | | The header to get the token from. |
+| query | string | False | jwt | | The query string to get the token from. Lower priority than header. |
+| cookie | string | False | jwt | | The cookie to get the token from. Lower priority than query. |
+| hide_credentials | boolean | False | false | | If true, do not pass the header, query, or cookie with JWT to Upstream services. |
+| anonymous_consumer | string | False | | | Anonymous Consumer name. If configured, allow anonymous users to bypass the authentication. |
+| claims_to_verify | array[string] | False | ["exp", "nbf"] | combination of `exp` and `nbf` | Specify the JWT claim(s) to verify, to ensure that the token is used within its allowed timeframe. Note that this is not the claims required to be presented in the payload, but the claims to verify, if presented. |
+| store_in_ctx | boolean | False | false | | If true, store JWT payload in the request context variable `ctx.jwt_auth_payload`. This allows plugins executed after `jwt-auth` on the same request to retrieve and use the payload information. |
+| realm | string | False | jwt | | The realm to include in the `WWW-Authenticate` header when authentication fails. |
 
-You can implement `jwt-auth` with [HashiCorp Vault](https://www.vaultproject.io/) to store and fetch secrets and RSA keys pairs from its [encrypted KV engine](https://developer.hashicorp.com/vault/docs/secrets/kv) using the [APISIX Secret](../terminology/secret.md) resource.
+You can implement `jwt-auth` with [HashiCorp Vault](https://www.vaultproject.io/) to store and fetch secrets and RSA key pairs from its [encrypted KV engine](https://developer.hashicorp.com/vault/docs/secrets/kv) using the [APISIX Secret](../terminology/secret.md) resource.
 
 ## Examples
 
@@ -82,7 +84,7 @@ The examples below demonstrate how you can work with the `jwt-auth` Plugin for d
 You can fetch the `admin_key` from `config.yaml` and save to an environment variable with the following command:
 
 ```bash
-admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
+admin_key=$(yq '.deployment.admin.admin_key[0].key' /usr/local/apisix/conf/config.yaml | sed 's/"//g')
 ```
 
 :::
@@ -90,6 +92,17 @@ admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"/
 ### Use JWT for Consumer Authentication
 
 The following example demonstrates how to implement JWT for Consumer key authentication.
+
+<Tabs
+groupId="api"
+defaultValue="dashboard"
+values={[
+{label: 'Admin API', value: 'dashboard'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'ingress'}
+]}>
+
+<TabItem value="dashboard">
 
 Create a Consumer `jack`:
 
@@ -101,7 +114,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   }'
 ```
 
-Create `jwt-auth` Credential for the consumer:
+Create `jwt-auth` Credential for the Consumer:
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
@@ -137,20 +150,154 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
+</TabItem>
+
+<TabItem value="adc">
+
+Create a Consumer with `jwt-auth` Credential and a Route with `jwt-auth` Plugin configured as such:
+
+```yaml title="adc.yaml"
+consumers:
+  - username: jack
+    credentials:
+      - name: jwt-auth
+        type: jwt-auth
+        config:
+          key: jack-key
+          secret: jack-hs256-secret-that-is-very-long
+services:
+  - name: jwt-auth-service
+    routes:
+      - name: jwt-route
+        uris:
+          - /headers
+        plugins:
+          jwt-auth: {}
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="ingress">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX Ingress Controller', value: 'apisix-ingress-controller'}
+]}>
+
+<TabItem value="gateway-api">
+
+Create a Consumer with `jwt-auth` Credential and a Route with `jwt-auth` Plugin configured as such:
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: jwt-auth
+      name: primary-cred
+      config:
+        key: jack-key
+        secret: jack-hs256-secret-that-is-very-long
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: jwt-auth-plugin-config
+spec:
+  plugins:
+    - name: jwt-auth
+      config:
+        _meta:
+          disable: false
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: jwt-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /headers
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: jwt-auth-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-ingress-controller">
+
+The ApisixConsumer CRD has a known issue where `private_key` is incorrectly required during the configuration. This issue will be addressed in a future release. At the moment, the example cannot be completed with APISIX CRDs.
+
+</TabItem>
+
+</Tabs>
+
+</TabItem>
+
+</Tabs>
+
 To issue a JWT for `jack`, you could use [JWT.io's JWT encoder](https://jwt.io) or other utilities. If you are using [JWT.io's JWT encoder](https://jwt.io), do the following:
 
 * Fill in `HS256` as the algorithm.
 * Update the secret in the __Valid secret__ section to be `jack-hs256-secret-that-is-very-long`.
 * Update payload with Consumer key `jack-key`; and add `exp` or `nbf` in UNIX timestamp.
 
-  Your payload should look similar to the following:
+Your payload should look similar to the following:
 
-  ```json
-  {
-    "key": "jack-key",
-    "nbf": 1729132271
-  }
-  ```
+```json
+{
+  "key": "jack-key",
+  "nbf": 1729132271
+}
+```
 
 Copy the generated JWT and save to a variable:
 
@@ -197,6 +344,17 @@ You should receive an `HTTP/1.1 401 Unauthorized` response similar to the follow
 
 The following example demonstrates how to accept JWT in specified header, query string, and cookie.
 
+<Tabs
+groupId="api"
+defaultValue="dashboard"
+values={[
+{label: 'Admin API', value: 'dashboard'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'ingress'}
+]}>
+
+<TabItem value="dashboard">
+
 Create a Consumer `jack`:
 
 ```shell
@@ -223,7 +381,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
   }'
 ```
 
-Create a Route with `jwt-auth` plugin, and specify the request parameters carrying the token:
+Create a Route with `jwt-auth` Plugin, and specify the request parameters carrying the token:
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
@@ -247,20 +405,160 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
+</TabItem>
+
+<TabItem value="adc">
+
+Create a Consumer with `jwt-auth` Credential and a Route with `jwt-auth` Plugin configured as such:
+
+```yaml title="adc.yaml"
+consumers:
+  - username: jack
+    credentials:
+      - name: jwt-auth
+        type: jwt-auth
+        config:
+          key: jack-key
+          secret: jack-hs256-secret-that-is-very-long
+services:
+  - name: jwt-auth-service
+    routes:
+      - name: jwt-route
+        uris:
+          - /get
+        plugins:
+          jwt-auth:
+            header: jwt-auth-header
+            query: jwt-query
+            cookie: jwt-cookie
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="ingress">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX Ingress Controller', value: 'apisix-ingress-controller'}
+]}>
+
+<TabItem value="gateway-api">
+
+Create a Consumer with `jwt-auth` Credential and a Route with `jwt-auth` Plugin configured as such:
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: jwt-auth
+      name: primary-cred
+      config:
+        key: jack-key
+        secret: jack-hs256-secret-that-is-very-long
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: jwt-auth-plugin-config
+spec:
+  plugins:
+    - name: jwt-auth
+      config:
+        _meta:
+          disable: false
+        header: jwt-auth-header
+        query: jwt-query
+        cookie: jwt-cookie
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: jwt-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /get
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: jwt-auth-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-ingress-controller">
+
+The ApisixConsumer CRD has a known issue where `private_key` is incorrectly required during the configuration. This issue will be addressed in a future release. At the moment, the example cannot be completed with APISIX CRDs.
+
+</TabItem>
+
+</Tabs>
+
+</TabItem>
+
+</Tabs>
+
 To issue a JWT for `jack`, you could use [JWT.io's JWT encoder](https://jwt.io) or other utilities. If you are using [JWT.io's JWT encoder](https://jwt.io), do the following:
 
 * Fill in `HS256` as the algorithm.
 * Update the secret in the __Valid secret__ section to be `jack-hs256-secret-that-is-very-long`.
 * Update payload with Consumer key `jack-key`; and add `exp` or `nbf` in UNIX timestamp.
 
-  Your payload should look similar to the following:
+Your payload should look similar to the following:
 
-  ```json
-  {
-    "key": "jack-key",
-    "nbf": 1729132271
-  }
-  ```
+```json
+{
+  "key": "jack-key",
+  "nbf": 1729132271
+}
+```
 
 Copy the generated JWT and save to a variable:
 
@@ -343,17 +641,21 @@ The following example demonstrates how to save `jwt-auth` Consumer key to an env
 
 APISIX supports referencing system and user environment variables configured through the [NGINX `env` directive](https://nginx.org/en/docs/ngx_core_module.html#env).
 
-Save the key to an environment variable:
+Save the key to an environment variable. If you are running APISIX in Docker, you should set the environment variable using the `-e` flag when starting the container.
 
 ```shell
 export JACK_JWT_SECRET=jack-hs256-secret-that-is-very-long
 ```
 
-:::tip
+<Tabs
+groupId="api"
+defaultValue="dashboard"
+values={[
+{label: 'Admin API', value: 'dashboard'},
+{label: 'ADC', value: 'adc'}
+]}>
 
-If you are running APISIX in Docker, you should set the environment variable using the `-e` flag when starting the container.
-
-:::
+<TabItem value="dashboard">
 
 Create a Consumer `jack`:
 
@@ -401,20 +703,61 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
+</TabItem>
+
+<TabItem value="adc">
+
+Create a Consumer with `jwt-auth` Credential referencing an environment variable and a Route with `jwt-auth` Plugin enabled as such:
+
+```yaml title="adc.yaml"
+consumers:
+  - username: jack
+    credentials:
+      - name: jwt-auth
+        type: jwt-auth
+        config:
+          key: jack-key
+          secret: $env://JACK_JWT_SECRET
+services:
+  - name: jwt-auth-service
+    routes:
+      - name: jwt-route
+        uris:
+          - /get
+        plugins:
+          jwt-auth: {}
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
 To issue a JWT for `jack`, you could use [JWT.io's JWT encoder](https://jwt.io) or other utilities. If you are using [JWT.io's JWT encoder](https://jwt.io), do the following:
 
 * Fill in `HS256` as the algorithm.
 * Update the secret in the __Valid secret__ section to be `jack-hs256-secret-that-is-very-long`.
 * Update payload with Consumer key `jack-key`; and add `exp` or `nbf` in UNIX timestamp.
 
-  Your payload should look similar to the following:
+Your payload should look similar to the following:
 
-  ```json
-  {
-    "key": "jack-key",
-    "nbf": 1729132271
-  }
-  ```
+```json
+{
+  "key": "jack-key",
+  "nbf": 1729132271
+}
+```
 
 Copy the generated JWT and save to a variable:
 
@@ -432,7 +775,7 @@ You should receive an `HTTP/1.1 200 OK` response.
 
 ### Manage Secrets in Secret Manager
 
-The following example demonstrates how to manage `jwt-auth` consumer key in [HashiCorp Vault](https://www.vaultproject.io) and reference it in plugin configuration.
+The following example demonstrates how to manage `jwt-auth` Consumer key in [HashiCorp Vault](https://www.vaultproject.io) and reference it in Plugin configuration.
 
 Start a Vault development server in Docker:
 
@@ -459,13 +802,23 @@ You should see a response similar to the following:
 Success! Enabled the kv secrets engine at: kv/
 ```
 
-Create a Secret and configure the Vault address and other connection information. Update the Vault address accordingly:
+<Tabs
+groupId="api"
+defaultValue="dashboard"
+values={[
+{label: 'Admin API', value: 'dashboard'},
+{label: 'ADC', value: 'adc'}
+]}>
+
+<TabItem value="dashboard">
+
+Create a [Secret](../terminology/secret.md) and configure the Vault address and other connection information. Adjust the Vault address accordingly:
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/secrets/vault/jwt" -X PUT \
-  -H "X-API-KEY: ${ADMIN_API_KEY}" \
+  -H "X-API-KEY: ${admin_key}" \
   -d '{
-    "uri": "https://127.0.0.1:8200",
+    "uri": "http://127.0.0.1:8200",
     "prefix": "kv/apisix",
     "token": "root"
   }'
@@ -475,7 +828,7 @@ Create a Consumer `jack`:
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
-  -H "X-API-KEY: ${ADMIN_API_KEY}" \
+  -H "X-API-KEY: ${admin_key}" \
   -d '{
     "username": "jack"
   }'
@@ -485,7 +838,7 @@ Create `jwt-auth` Credential for the Consumer and reference the Secret:
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
-  -H "X-API-KEY: ${ADMIN_API_KEY}" \
+  -H "X-API-KEY: ${admin_key}" \
   -d '{
     "id": "cred-jack-jwt-auth",
     "plugins": {
@@ -501,7 +854,7 @@ Create a Route with `jwt-auth` enabled:
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
-  -H "X-API-KEY: ${ADMIN_API_KEY}" \
+  -H "X-API-KEY: ${admin_key}" \
   -d '{
     "id": "jwt-route",
     "uri": "/get",
@@ -516,6 +869,53 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
     }
   }'
 ```
+
+</TabItem>
+
+<TabItem value="adc">
+
+Create a Secret and configure the Vault address. Adjust the Vault address accordingly:
+
+```yaml title="adc.yaml"
+secrets:
+  - name: vault-jwt
+    vault:
+      url: http://127.0.0.1:8200
+      prefix: kv/apisix
+      token: root
+consumers:
+  - username: jack
+    credentials:
+      - name: jwt-auth
+        type: jwt-auth
+        config:
+          key: jwt-vault-key
+          secret: $secret://vault-jwt/jack/jwt-secret
+services:
+  - name: jwt-auth-service
+    routes:
+      - name: jwt-route
+        uris:
+          - /get
+        plugins:
+          jwt-auth: {}
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+</Tabs>
 
 Set `jwt-auth` key value to be `vault-hs256-secret-that-is-very-long` in Vault:
 
@@ -533,16 +933,16 @@ To issue a JWT, you could use [JWT.io's JWT encoder](https://jwt.io) or other ut
 
 * Fill in `HS256` as the algorithm.
 * Update the secret in the __Valid secret__ section to be `vault-hs256-secret-that-is-very-long`.
-* Update payload with consumer key `jwt-vault-key`; and add `exp` or `nbf` in UNIX timestamp.
+* Update payload with Consumer key `jwt-vault-key`; and add `exp` or `nbf` in UNIX timestamp.
 
-  Your payload should look similar to the following:
+Your payload should look similar to the following:
 
-  ```json
-  {
-    "key": "jwt-vault-key",
-    "nbf": 1729132271
-  }
-  ```
+```json
+{
+  "key": "jwt-vault-key",
+  "nbf": 1729132271
+}
+```
 
 Copy the generated JWT and save to a variable:
 
@@ -577,20 +977,31 @@ Visit [JWT.io's JWT encoder](https://jwt.io) and do the following:
 * Copy and paste the private key content into the __SIGN JWT: PRIVATE KEY__ section.
 * Update payload with Consumer key `jack-key`; and add `exp` or `nbf` in UNIX timestamp.
 
-  Your payload should look similar to the following:
+Your payload should look similar to the following:
 
-  ```json
-  {
-    "key": "jack-key",
-    "nbf": 1729132271
-  }
-  ```
+```json
+{
+  "key": "jack-key",
+  "nbf": 1729132271
+}
+```
 
 Copy the generated JWT and save to a variable:
 
 ```shell
 export jwt_token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJqYWNrLWtleSIsIm5iZiI6MTcyOTEzMjI3MX0.K-I13em84kAcyH1jfIJl7ls_4jlwg1GzEzo5_xrDu-3wt3Xa3irS6naUsWpxX-a-hmcZZxRa9zqunqQjUP4kvn5e3xg2f_KyCR-_ZbwqYEPk3bXeFV1l4iypv6z5L7W1Niharun-dpMU03b1Tz64vhFx6UwxNL5UIZ7bunDAo_BXZ7Xe8rFhNHvIHyBFsDEXIBgx8lNYMq8QJk3iKxZhZZ5Om7lgYjOOKRgew4WkhBAY0v1AkO77nTlvSK0OEeeiwhkROyntggyx-S-U222ykMQ6mBLxkP4Cq5qHwXD8AUcLk5mhEij-3QhboYnt7yhKeZ3wDSpcjDvvL2aasC25ng
 ```
+
+<Tabs
+groupId="api"
+defaultValue="dashboard"
+values={[
+{label: 'Admin API', value: 'dashboard'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'ingress'}
+]}>
+
+<TabItem value="dashboard">
 
 Create a Consumer `jack`:
 
@@ -602,7 +1013,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   }'
 ```
 
-Create `jwt-auth` Credential for the Consumer and configure the RSA keys:
+Create `jwt-auth` Credential for the Consumer and configure the RSA keys. You should add a newline character after the opening line and before the closing line of the public key, for example `-----BEGIN PUBLIC KEY-----\n......\n-----END PUBLIC KEY-----`. The key content can be directly concatenated.
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
@@ -618,14 +1029,6 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
     }
   }'
 ```
-
-:::tip
-
-You should add a newline character after the opening line and before the closing line, for example `-----BEGIN PUBLIC KEY-----\n......\n-----END PUBLIC KEY-----`.
-
-The key content can be directly concatenated.
-
-:::
 
 Create a Route with the `jwt-auth` Plugin:
 
@@ -647,6 +1050,160 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
+</TabItem>
+
+<TabItem value="adc">
+
+Create a Consumer with `jwt-auth` Credential using RS256 algorithm and a Route with `jwt-auth` Plugin enabled as such:
+
+```yaml title="adc.yaml"
+consumers:
+  - username: jack
+    credentials:
+      - name: jwt-auth
+        type: jwt-auth
+        config:
+          key: jack-key
+          algorithm: RS256
+          public_key: |
+            -----BEGIN PUBLIC KEY-----
+            MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoTxe7ZPycrEP0SK4OBA2
+            0OUQsDN9gSFSHVvx/t++nZNrFxzZnV6q6/TRsihNXUIgwaOu5icFlIcxPL9Mf9UJ
+            a5/XCQExp1TxpuSmjkhIFAJ/x5zXrC8SGTztP3SjkhYnQO9PKVXI6ljwgakVCfpl
+            umuTYqI+ev7e45NdK8gJoJxPp8bPMdf8/nHfLXZuqhO/btrDg1x+j7frDNrEw+6B
+            CK2SsuypmYN+LwHfaH4Of7MQFk3LNIxyBz0mdbsKJBzp360rbWnQeauWtDymZxLT
+            ATRNBVyl3nCNsURRTkc7eyknLaDt2N5xTIoUGHTUFYSdE68QWmukYMVGcEHEEPkp
+            aQIDAQAB
+            -----END PUBLIC KEY-----
+services:
+  - name: jwt-auth-service
+    routes:
+      - name: jwt-route
+        uris:
+          - /headers
+        plugins:
+          jwt-auth: {}
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="ingress">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX Ingress Controller', value: 'apisix-ingress-controller'}
+]}>
+
+<TabItem value="gateway-api">
+
+Create a Consumer with `jwt-auth` Credential using RS256 algorithm and a Route with `jwt-auth` Plugin enabled as such:
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: jwt-auth
+      name: primary-cred
+      config:
+        key: jack-key
+        algorithm: RS256
+        public_key: |
+          -----BEGIN PUBLIC KEY-----
+          MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoTxe7ZPycrEP0SK4OBA2
+          0OUQsDN9gSFSHVvx/t++nZNrFxzZnV6q6/TRsihNXUIgwaOu5icFlIcxPL9Mf9UJ
+          a5/XCQExp1TxpuSmjkhIFAJ/x5zXrC8SGTztP3SjkhYnQO9PKVXI6ljwgakVCfpl
+          umuTYqI+ev7e45NdK8gJoJxPp8bPMdf8/nHfLXZuqhO/btrDg1x+j7frDNrEw+6B
+          CK2SsuypmYN+LwHfaH4Of7MQFk3LNIxyBz0mdbsKJBzp360rbWnQeauWtDymZxLT
+          ATRNBVyl3nCNsURRTkc7eyknLaDt2N5xTIoUGHTUFYSdE68QWmukYMVGcEHEEPkp
+          aQIDAQAB
+          -----END PUBLIC KEY-----
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: jwt-auth-plugin-config
+spec:
+  plugins:
+    - name: jwt-auth
+      config:
+        _meta:
+          disable: false
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: jwt-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /headers
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: jwt-auth-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-ingress-controller">
+
+The ApisixConsumer CRD has a known issue where `private_key` is incorrectly required during the configuration. This issue will be addressed in a future release. At the moment, the example cannot be completed with APISIX CRDs.
+
+</TabItem>
+
+</Tabs>
+
+</TabItem>
+
+</Tabs>
+
 To verify, send a request to the Route with the JWT in the `Authorization` header:
 
 ```shell
@@ -658,6 +1215,17 @@ You should receive an `HTTP/1.1 200 OK` response.
 ### Add Consumer Custom ID to Header
 
 The following example demonstrates how you can attach a Consumer custom ID to authenticated request in the `Consumer-Custom-Id` header, which can be used to implement additional logics as needed.
+
+<Tabs
+groupId="api"
+defaultValue="dashboard"
+values={[
+{label: 'Admin API', value: 'dashboard'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'ingress'}
+]}>
+
+<TabItem value="dashboard">
 
 Create a Consumer `jack` with a custom ID label:
 
@@ -708,20 +1276,69 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
+</TabItem>
+
+<TabItem value="adc">
+
+Create a Consumer with `jwt-auth` Credential and a Route with `jwt-auth` Plugin enabled as such:
+
+```yaml title="adc.yaml"
+consumers:
+  - username: jack
+    labels:
+      custom_id: "495aec6a"
+    credentials:
+      - name: jwt-auth
+        type: jwt-auth
+        config:
+          key: jack-key
+          secret: jack-hs256-secret-that-is-very-long
+services:
+  - name: jwt-auth-service
+    routes:
+      - name: jwt-auth-route
+        uris:
+          - /anything
+        plugins:
+          jwt-auth: {}
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="ingress">
+
+Consumer custom labels are currently not supported when configuring resources through the Ingress Controller, and the `X-Consumer-Custom-Id` header is not included in requests. At the moment, this example cannot be completed with the Ingress Controller.
+
+</TabItem>
+
+</Tabs>
+
 To issue a JWT for `jack`, you could use [JWT.io's JWT encoder](https://jwt.io) or other utilities. If you are using [JWT.io's JWT encoder](https://jwt.io), do the following:
 
 * Fill in `HS256` as the algorithm.
 * Update the secret in the __Valid secret__ section to be `jack-hs256-secret-that-is-very-long`.
 * Update payload with Consumer key `jack-key`; and add `exp` or `nbf` in UNIX timestamp.
 
-  Your payload should look similar to the following:
+Your payload should look similar to the following:
 
-  ```json
-  {
-    "key": "jack-key",
-    "nbf": 1729132271
-  }
-  ```
+```json
+{
+  "key": "jack-key",
+  "nbf": 1729132271
+}
+```
 
 Copy the generated JWT and save to a variable:
 
@@ -756,6 +1373,17 @@ You should see an `HTTP/1.1 200 OK` response similar to the following:
 ### Rate Limit with Anonymous Consumer
 
 The following example demonstrates how you can configure different rate limiting policies by regular and anonymous consumers, where the anonymous Consumer does not need to authenticate and has less quotas.
+
+<Tabs
+groupId="api"
+defaultValue="dashboard"
+values={[
+{label: 'Admin API', value: 'dashboard'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'ingress'}
+]}>
+
+<TabItem value="dashboard">
 
 Create a regular Consumer `jack` and configure the `limit-count` Plugin to allow for a quota of 3 within a 30-second window:
 
@@ -829,20 +1457,190 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
+</TabItem>
+
+<TabItem value="adc">
+
+Configure Consumers with different rate limits and a Route that accepts anonymous users:
+
+```yaml title="adc.yaml"
+consumers:
+  - username: jack
+    plugins:
+      limit-count:
+        count: 3
+        time_window: 30
+        rejected_code: 429
+        policy: local
+    credentials:
+      - name: jwt-auth
+        type: jwt-auth
+        config:
+          key: jack-key
+          secret: jack-hs256-secret-that-is-very-long
+  - username: anonymous
+    plugins:
+      limit-count:
+        count: 1
+        time_window: 30
+        rejected_code: 429
+        policy: local
+services:
+  - name: anonymous-rate-limit-service
+    routes:
+      - name: jwt-auth-route
+        uris:
+          - /anything
+        plugins:
+          jwt-auth:
+            anonymous_consumer: anonymous
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="ingress">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX Ingress Controller', value: 'apisix-ingress-controller'}
+]}>
+
+<TabItem value="gateway-api">
+
+Configure Consumers with different rate limits and a Route that accepts anonymous users:
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: jwt-auth
+      name: primary-key
+      config:
+        key: jack-key
+        secret: jack-hs256-secret-that-is-very-long
+  plugins:
+    - name: limit-count
+      config:
+        count: 3
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: anonymous
+spec:
+  gatewayRef:
+    name: apisix
+  plugins:
+    - name: limit-count
+      config:
+        count: 1
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: jwt-auth-plugin-config
+spec:
+  plugins:
+    - name: jwt-auth
+      config:
+        anonymous_consumer: aic_anonymous  # namespace_consumername
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: jwt-auth-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: jwt-auth-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-ingress-controller">
+
+The ApisixConsumer CRD currently does not support configuring plugins on Consumers, except for the authentication plugins allowed in `authParameter`. This example cannot be completed with APISIX CRDs.
+
+</TabItem>
+
+</Tabs>
+
+</TabItem>
+
+</Tabs>
+
 To issue a JWT for `jack`, you could use [JWT.io's JWT encoder](https://jwt.io) or other utilities. If you are using [JWT.io's JWT encoder](https://jwt.io), do the following:
 
 * Fill in `HS256` as the algorithm.
 * Update the secret in the __Valid secret__ section to be `jack-hs256-secret-that-is-very-long`.
 * Update payload with Consumer key `jack-key`; and add `exp` or `nbf` in UNIX timestamp.
 
-  Your payload should look similar to the following:
+Your payload should look similar to the following:
 
-  ```json
-  {
-    "key": "jack-key",
-    "nbf": 1729132271
-  }
-  ```
+```json
+{
+  "key": "jack-key",
+  "nbf": 1729132271
+}
+```
 
 Copy the generated JWT and save to a variable:
 

--- a/docs/en/latest/plugins/jwt-auth.md
+++ b/docs/en/latest/plugins/jwt-auth.md
@@ -1214,7 +1214,7 @@ You should receive an `HTTP/1.1 200 OK` response.
 
 ### Add Consumer Custom ID to Header
 
-The following example demonstrates how you can attach a Consumer custom ID to authenticated request in the `Consumer-Custom-Id` header, which can be used to implement additional logics as needed.
+The following example demonstrates how you can attach a Consumer custom ID to authenticated request in the `X-Consumer-Custom-ID` header, which can be used to implement additional logics as needed.
 
 <Tabs
 groupId="api"

--- a/docs/en/latest/plugins/jwt-auth.md
+++ b/docs/en/latest/plugins/jwt-auth.md
@@ -81,10 +81,10 @@ The examples below demonstrate how you can work with the `jwt-auth` Plugin for d
 
 :::note
 
-You can fetch the `admin_key` from `/conf/config.yaml` and save to an environment variable with the following command:
+You can fetch the `admin_key` from `conf/config.yaml` and save to an environment variable with the following command:
 
 ```bash
-admin_key=$(yq '.deployment.admin.admin_key[0].key' /conf/config.yaml | sed 's/"//g')
+admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
 ```
 
 :::

--- a/docs/zh/latest/plugins/jwt-auth.md
+++ b/docs/zh/latest/plugins/jwt-auth.md
@@ -1214,7 +1214,7 @@ curl -i "http://127.0.0.1:9080/headers" -H "Authorization: ${jwt_token}"
 
 ### 在请求头中添加消费者自定义 ID
 
-以下示例演示如何在已验证请求的 `Consumer-Custom-Id` 请求头中附加消费者自定义 ID，以便根据需要实现额外逻辑。
+以下示例演示如何在已验证请求的 `X-Consumer-Custom-ID` 请求头中附加消费者自定义 ID，以便根据需要实现额外逻辑。
 
 <Tabs
 groupId="api"

--- a/docs/zh/latest/plugins/jwt-auth.md
+++ b/docs/zh/latest/plugins/jwt-auth.md
@@ -56,7 +56,6 @@ import TabItem from '@theme/TabItem';
 | exp | integer | 否 | 86400 | >=1 | 令牌的过期时间，单位为秒。若不使用 APISIX 签发 JWT，则该参数会被忽略，签发时应在 payload 中指定过期时间。 |
 | base64_secret | boolean | 否 | false | | 若密钥经过 base64 编码，则设为 true。 |
 | lifetime_grace_period | integer | 否 | 0 | >=0 | 宽限期，单位为秒。用于处理生成 JWT 的服务器与验证 JWT 的服务器之间的时钟偏差。 |
-| key_claim_name | string | 否 | key | | JWT payload 中用于标识关联密钥的声明，例如 `iss`。 |
 
 注意：Schema 中同时定义了 `encrypt_fields = {"secret"}`，这意味着该字段将在 etcd 中加密存储。详见[加密存储字段](../plugin-develop.md#encrypted-storage-fields)。
 
@@ -72,8 +71,9 @@ import TabItem from '@theme/TabItem';
 | claims_to_verify | array[string] | 否 | ["exp", "nbf"] | `exp` 和 `nbf` 的组合 | 指定需要验证的 JWT 声明，以确保令牌在其允许的时间范围内使用。注意，这不是要求 payload 中必须存在的声明，而是在声明存在时进行验证。 |
 | store_in_ctx | boolean | 否 | false | | 若为 true，则将 JWT payload 存储在请求上下文变量 `ctx.jwt_auth_payload` 中，以便在同一请求中在 `jwt-auth` 之后执行的插件获取和使用 payload 信息。 |
 | realm | string | 否 | jwt | | 身份验证失败时，在 `WWW-Authenticate` 响应头中包含的 realm 值。 |
+| key_claim_name | string | 否 | key | | JWT payload 中用于标识关联密钥的声明，例如 `iss`。 |
 
-您可以将 `jwt-auth` 与 [HashiCorp Vault](https://www.vaultproject.io/) 结合使用，通过 [APISIX Secret](../terminology/secret.md) 资源从其[加密 KV 引擎](https://developer.hashicorp.com/vault/docs/secrets/kv)中存储和获取密钥及 RSA 密钥对。
+你可以将 `jwt-auth` 与 [HashiCorp Vault](https://www.vaultproject.io/) 结合使用，通过 [APISIX Secret](../terminology/secret.md) 资源从其[加密 KV 引擎](https://developer.hashicorp.com/vault/docs/secrets/kv)中存储和获取密钥及 RSA 密钥对。
 
 ## 示例
 
@@ -81,10 +81,10 @@ import TabItem from '@theme/TabItem';
 
 :::note
 
-您可以通过以下命令从 `config.yaml` 中获取 `admin_key` 并保存到环境变量：
+你可以通过以下命令从 `conf/config.yaml` 中获取 `admin_key` 并保存到环境变量：
 
 ```bash
-admin_key=$(yq '.deployment.admin.admin_key[0].key' /usr/local/apisix/conf/config.yaml | sed 's/"//g')
+admin_key=$(yq '.deployment.admin.admin_key[0].key' /conf/config.yaml | sed 's/"//g')
 ```
 
 :::
@@ -311,7 +311,7 @@ export jwt_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJqYWNrLWtleSIsIm
 curl -i "http://127.0.0.1:9080/headers" -H "Authorization: ${jwt_token}"
 ```
 
-您应收到类似如下的 `HTTP/1.1 200 OK` 响应：
+你应收到类似如下的 `HTTP/1.1 200 OK` 响应：
 
 ```json
 {
@@ -334,7 +334,7 @@ curl -i "http://127.0.0.1:9080/headers" -H "Authorization: ${jwt_token}"
 curl -i "http://127.0.0.1:9080/headers" -H "Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE3MjY2NDk2NDAsImtleSI6ImphY2sta2V5In0.kdhumNWrZFxjU_random_random"
 ```
 
-您应收到类似如下的 `HTTP/1.1 401 Unauthorized` 响应：
+你应收到类似如下的 `HTTP/1.1 401 Unauthorized` 响应：
 
 ```text
 {"message":"failed to verify jwt"}
@@ -574,7 +574,7 @@ export jwt_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJqYWNrLWtleSIsIm
 curl -i "http://127.0.0.1:9080/get" -H "jwt-auth-header: ${jwt_token}"
 ```
 
-您应收到类似如下的 `HTTP/1.1 200 OK` 响应：
+你应收到类似如下的 `HTTP/1.1 200 OK` 响应：
 
 ```json
 {
@@ -597,7 +597,7 @@ curl -i "http://127.0.0.1:9080/get" -H "jwt-auth-header: ${jwt_token}"
 curl -i "http://127.0.0.1:9080/get?jwt-query=${jwt_token}"
 ```
 
-您应收到类似如下的 `HTTP/1.1 200 OK` 响应：
+你应收到类似如下的 `HTTP/1.1 200 OK` 响应：
 
 ```json
 {
@@ -621,7 +621,7 @@ curl -i "http://127.0.0.1:9080/get?jwt-query=${jwt_token}"
 curl -i "http://127.0.0.1:9080/get" --cookie jwt-cookie=${jwt_token}
 ```
 
-您应收到类似如下的 `HTTP/1.1 200 OK` 响应：
+你应收到类似如下的 `HTTP/1.1 200 OK` 响应：
 
 ```json
 {
@@ -771,7 +771,7 @@ export jwt_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJqYWNrLWtleSIsIm
 curl -i "http://127.0.0.1:9080/get" -H "Authorization: ${jwt_token}"
 ```
 
-您应收到 `HTTP/1.1 200 OK` 响应。
+你应收到 `HTTP/1.1 200 OK` 响应。
 
 ### 在 Secret Manager 中管理密钥
 
@@ -796,7 +796,7 @@ APISIX 目前支持 [Vault KV 引擎第 1 版](https://developer.hashicorp.com/v
 docker exec -i vault sh -c "VAULT_TOKEN='root' VAULT_ADDR='http://0.0.0.0:8200' vault secrets enable -path=kv -version=1 kv"
 ```
 
-您应收到类似如下的响应：
+你应收到类似如下的响应：
 
 ```text
 Success! Enabled the kv secrets engine at: kv/
@@ -923,7 +923,7 @@ adc sync -f adc.yaml
 docker exec -i vault sh -c "VAULT_TOKEN='root' VAULT_ADDR='http://0.0.0.0:8200' vault kv put kv/apisix/jack jwt-secret=vault-hs256-secret-that-is-very-long"
 ```
 
-您应收到类似如下的响应：
+你应收到类似如下的响应：
 
 ```text
 Success! Data written to: kv/apisix/jack
@@ -956,11 +956,11 @@ export jwt_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJqd3QtdmF1bHQta2
 curl -i "http://127.0.0.1:9080/get" -H "Authorization: ${jwt_token}"
 ```
 
-您应收到 `HTTP/1.1 200 OK` 响应。
+你应收到 `HTTP/1.1 200 OK` 响应。
 
 ### 使用 RS256 算法签名 JWT
 
-以下示例演示如何使用 RS256 等非对称算法对 JWT 进行签名和验证。您将使用 [openssl](https://openssl-library.org/source/) 生成 RSA 密钥对，并使用 [JWT.io](https://jwt.io) 生成 JWT，以便更好地理解 JWT 的组成。
+以下示例演示如何使用 RS256 等非对称算法对 JWT 进行签名和验证。你将使用 [openssl](https://openssl-library.org/source/) 生成 RSA 密钥对，并使用 [JWT.io](https://jwt.io) 生成 JWT，以便更好地理解 JWT 的组成。
 
 生成 2048 位 RSA 私钥并提取对应的 PEM 格式公钥：
 
@@ -969,7 +969,7 @@ openssl genrsa -out jwt-rsa256-private.pem 2048
 openssl rsa -in jwt-rsa256-private.pem -pubout -out jwt-rsa256-public.pem
 ```
 
-您应在当前工作目录中看到生成的 `jwt-rsa256-private.pem` 和 `jwt-rsa256-public.pem` 文件。
+你应在当前工作目录中看到生成的 `jwt-rsa256-private.pem` 和 `jwt-rsa256-public.pem` 文件。
 
 访问 [JWT.io 的 JWT 编码器](https://jwt.io)并执行以下步骤：
 
@@ -1210,7 +1210,7 @@ ApisixConsumer CRD 存在一个已知问题，配置时会错误地要求提供 
 curl -i "http://127.0.0.1:9080/headers" -H "Authorization: ${jwt_token}"
 ```
 
-您应收到 `HTTP/1.1 200 OK` 响应。
+你应收到 `HTTP/1.1 200 OK` 响应。
 
 ### 在请求头中添加消费者自定义 ID
 
@@ -1352,7 +1352,7 @@ export jwt_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJqYWNrLWtleSIsIm
 curl -i "http://127.0.0.1:9080/headers" -H "Authorization: ${jwt_token}"
 ```
 
-您应看到类似如下的 `HTTP/1.1 200 OK` 响应：
+你应看到类似如下的 `HTTP/1.1 200 OK` 响应：
 
 ```json
 {
@@ -1657,7 +1657,7 @@ resp=$(seq 5 | xargs -I{} curl "http://127.0.0.1:9080/anything" -H "Authorizatio
   echo "200": $count_200, "429": $count_429
 ```
 
-您应看到如下响应，说明 5 次请求中有 3 次成功（状态码 200），其余被拒绝（状态码 429）：
+你应看到如下响应，说明 5 次请求中有 3 次成功（状态码 200），其余被拒绝（状态码 429）：
 
 ```text
 200:    3, 429:    2
@@ -1672,7 +1672,7 @@ resp=$(seq 5 | xargs -I{} curl "http://127.0.0.1:9080/anything" -o /dev/null -s 
   echo "200": $count_200, "429": $count_429
 ```
 
-您应看到如下响应，说明只有 1 次请求成功：
+你应看到如下响应，说明只有 1 次请求成功：
 
 ```text
 200:    1, 429:    4

--- a/docs/zh/latest/plugins/jwt-auth.md
+++ b/docs/zh/latest/plugins/jwt-auth.md
@@ -58,7 +58,7 @@ import TabItem from '@theme/TabItem';
 | lifetime_grace_period | integer | 否 | 0 | >=0 | 宽限期，单位为秒。用于处理生成 JWT 的服务器与验证 JWT 的服务器之间的时钟偏差。 |
 | key_claim_name | string | 否 | key | | JWT payload 中用于标识关联密钥的声明，例如 `iss`。 |
 
-注意：Schema 中同时定义了 `encrypt_fields = {"secret"}`，这意味着该字段将在 etcd 中加密存储。详见[加密存储字段](../plugin-develop.md#encrypted-storage-fields)。
+注意：Schema 中同时定义了 `encrypt_fields = {"secret"}`，这意味着该字段将在 etcd 中加密存储。详见[加密存储字段](../plugin-develop.md#加密存储字段)。
 
 以下属性可用于路由或服务上的配置。
 

--- a/docs/zh/latest/plugins/jwt-auth.md
+++ b/docs/zh/latest/plugins/jwt-auth.md
@@ -51,7 +51,7 @@ import TabItem from '@theme/TabItem';
 |------|------|--------|--------|--------|------|
 | key | string | 是 | | 非空 | 用于标识消费者凭据的唯一键。 |
 | secret | string | 否 | | 非空 | 算法为对称算法时，用于签名和验证 JWT 的共享密钥。使用 `HS256`、`HS384` 或 `HS512` 算法时必填。该字段支持使用 [APISIX Secret](../terminology/secret.md) 资源将值保存在 Secret Manager 中。 |
-| public_key | string | 否 | | | RSA 或 ECDSA 公钥。当 `algorithm` 为 `RS256`、`ES256`、`RS384`、`RS512`、`ES384`、`ES512`、`PS256`、`PS384`、`PS512` 或 `EdDSA` 时必填。该字段支持使用 [APISIX Secret](../terminology/secret.md) 资源将值保存在 Secret Manager 中。 |
+| public_key | string | 否 | | | 由所配置非对称算法使用的公钥（PEM 格式）。当 `algorithm` 为 `RS256`、`ES256`、`RS384`、`RS512`、`ES384`、`ES512`、`PS256`、`PS384`、`PS512` 或 `EdDSA` 时必填。该字段支持使用 [APISIX Secret](../terminology/secret.md) 资源将值保存在 Secret Manager 中。 |
 | algorithm | string | 否 | HS256 | `HS256`、`HS384`、`HS512`、`RS256`、`RS384`、`RS512`、`ES256`、`ES384`、`ES512`、`PS256`、`PS384`、`PS512`、`EdDSA` | 加密算法。 |
 | exp | integer | 否 | 86400 | >=1 | 令牌的过期时间，单位为秒。若不使用 APISIX 签发 JWT，则该参数会被忽略，签发时应在 payload 中指定过期时间。 |
 | base64_secret | boolean | 否 | false | | 若密钥经过 base64 编码，则设为 true。 |

--- a/docs/zh/latest/plugins/jwt-auth.md
+++ b/docs/zh/latest/plugins/jwt-auth.md
@@ -84,7 +84,7 @@ import TabItem from '@theme/TabItem';
 你可以通过以下命令从 `conf/config.yaml` 中获取 `admin_key` 并保存到环境变量：
 
 ```bash
-admin_key=$(yq '.deployment.admin.admin_key[0].key' /conf/config.yaml | sed 's/"//g')
+admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
 ```
 
 :::

--- a/docs/zh/latest/plugins/jwt-auth.md
+++ b/docs/zh/latest/plugins/jwt-auth.md
@@ -6,7 +6,7 @@ keywords:
   - Plugin
   - JWT Auth
   - jwt-auth
-description: jwt-auth 插件支持使用 JSON Web Token (JWT) 作为客户端在访问上游资源之前进行身份验证的机制。
+description: jwt-auth 插件支持使用 JSON Web Token（JWT）作为客户端在访问上游资源之前进行身份验证的机制。
 ---
 
 <!--
@@ -28,64 +28,81 @@ description: jwt-auth 插件支持使用 JSON Web Token (JWT) 作为客户端在
 #
 -->
 
+<head>
+  <link rel="canonical" href="https://docs.api7.ai/hub/jwt-auth" />
+</head>
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## 描述
 
-`jwt-auth` 插件支持使用 [JSON Web Token (JWT)](https://jwt.io/) 作为客户端在访问上游资源之前进行身份验证的机制。
+`jwt-auth` 插件支持使用 [JSON Web Token（JWT）](https://jwt.io/) 作为客户端在访问上游资源之前进行身份验证的机制。
 
-启用后，该插件会公开一个端点，供 [消费者](../terminology/consumer.md) 创建 JWT 凭据。该过程会生成一个令牌，客户端请求应携带该令牌以向 APISIX 标识自己。该令牌可以包含在请求 URL 查询字符串、请求标头或 cookie 中。然后，APISIX 将验证该令牌以确定是否应允许或拒绝请求访问上游资源。
+启用后，该插件会暴露一个端点，供 [消费者](../terminology/consumer.md) 创建 JWT 凭据。该过程会生成一个令牌，客户端请求应携带该令牌以向 APISIX 标识自身。令牌可以包含在请求 URL 查询字符串、请求头或 Cookie 中。APISIX 随后会验证该令牌，以判断是否允许或拒绝请求访问上游资源。
 
-当消费者成功通过身份验证后，APISIX 会在将请求代理到上游服务之前向请求添加其他标头，例如 `X-Consumer-Username`、`X-Credential-Indentifier` 和其他消费者自定义标头（如已配置）。上游服务将能够区分消费者并根据需要实施其他逻辑。如果任何一个值不可用，则不会添加相应的标题。
+当消费者成功通过身份验证后，APISIX 会在将请求代理到上游服务之前，向请求添加额外的请求头，例如 `X-Consumer-Username`、`X-Credential-Identifier` 以及其他已配置的消费者自定义请求头。上游服务可据此区分消费者并根据需要实现额外逻辑。若某个值不可用，则不会添加对应的请求头。
 
 ## 属性
 
-Consumer/Credential 端：
+以下属性可用于消费者或凭据上的配置。
 
-| 名称          | 类型     | 必选项 | 默认值  | 有效值                      | 描述                                                                                                          |
-| ------------- | ------- | ----- | ------- | --------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| key           | string  | 是    |         |                             | 消费者的唯一密钥。  |
-| secret        | string  | 否    |         |                             | 当使用对称算法时，用于对 JWT 进行签名和验证的共享密钥。使用 `HS256` 或 `HS512` 作为算法时必填。该字段支持使用 [APISIX Secret](../terminology/secret.md) 资源，将值保存在 Secret Manager 中。   |
-| public_key    | string  | 否    |         |                             | RSA 或 ECDSA 公钥， `algorithm` 属性选择 `RS256` 或 `ES256` 算法时必选。该字段支持使用 [APISIX Secret](../terminology/secret.md) 资源，将值保存在 Secret Manager 中。       |
-| algorithm     | string  | 否    | "HS256" | ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512", "EdDSA"] | 加密算法。                                                                                                      |
-| exp           | integer | 否    | 86400   | [1,...]                     | token 的超时时间。                                                                                              |
-| base64_secret | boolean | 否    | false   |                             | 当设置为 `true` 时，密钥为 base64 编码。                                                                                         |
-| lifetime_grace_period | integer | 否    | 0  | [0,...]                  | 宽限期（以秒为单位）。用于解决生成 JWT 的服务器与验证 JWT 的服务器之间的时钟偏差。 |
-| key_claim_name | string | 否                                                 | key     |                             | JWT payload 中的声明用于标识相关的秘密，例如 `iss`。 |
+| 名称 | 类型 | 必选项 | 默认值 | 有效值 | 描述 |
+|------|------|--------|--------|--------|------|
+| key | string | 是 | | 非空 | 用于标识消费者凭据的唯一键。 |
+| secret | string | 否 | | 非空 | 算法为对称算法时，用于签名和验证 JWT 的共享密钥。使用 `HS256`、`HS384` 或 `HS512` 算法时必填。该字段支持使用 [APISIX Secret](../terminology/secret.md) 资源将值保存在 Secret Manager 中。 |
+| public_key | string | 否 | | | RSA 或 ECDSA 公钥。当 `algorithm` 为 `RS256`、`ES256`、`RS384`、`RS512`、`ES384`、`ES512`、`PS256`、`PS384`、`PS512` 或 `EdDSA` 时必填。该字段支持使用 [APISIX Secret](../terminology/secret.md) 资源将值保存在 Secret Manager 中。 |
+| algorithm | string | 否 | HS256 | `HS256`、`HS384`、`HS512`、`RS256`、`RS384`、`RS512`、`ES256`、`ES384`、`ES512`、`PS256`、`PS384`、`PS512`、`EdDSA` | 加密算法。 |
+| exp | integer | 否 | 86400 | >=1 | 令牌的过期时间，单位为秒。若不使用 APISIX 签发 JWT，则该参数会被忽略，签发时应在 payload 中指定过期时间。 |
+| base64_secret | boolean | 否 | false | | 若密钥经过 base64 编码，则设为 true。 |
+| lifetime_grace_period | integer | 否 | 0 | >=0 | 宽限期，单位为秒。用于处理生成 JWT 的服务器与验证 JWT 的服务器之间的时钟偏差。 |
+| key_claim_name | string | 否 | key | | JWT payload 中用于标识关联密钥的声明，例如 `iss`。 |
 
-注意：schema 中还定义了 `encrypt_fields = {"secret"}`，这意味着该字段将会被加密存储在 etcd 中。具体参考 [加密存储字段](../plugin-develop.md#加密存储字段)。
+注意：Schema 中同时定义了 `encrypt_fields = {"secret"}`，这意味着该字段将在 etcd 中加密存储。详见[加密存储字段](../plugin-develop.md#encrypted-storage-fields)。
 
-Route 端：
+以下属性可用于路由或服务上的配置。
 
-| 名称   | 类型    | 必选项 | 默认值         | 描述                                                    |
-| ------ | ------ | ------ | ------------- |---------------------------------------------------------|
-| header | string | 否     | authorization | 设置我们从哪个 header 获取 token。                         |
-| query  | string | 否     | jwt           | 设置我们从哪个 query string 获取 token，优先级低于 header。  |
-| cookie | string | 否     | jwt           | 设置我们从哪个 cookie 获取 token，优先级低于 query。        |
-| hide_credentials | boolean | 否     | false  | 如果为 true，则不要将 header、query 或带有 JWT 的 cookie 传递给上游服务。 |
-| key_claim_name | string  | 否     | key           | 包含用户密钥（对应消费者的密钥属性）的 JWT 声明的名称。|
-| anonymous_consumer | string | 否     | false  | 匿名消费者名称。如果已配置，则允许匿名用户绕过身份验证。  |
-| store_in_ctx | boolean | 否     | false  | 设置为 `true` 将会将 JWT 负载存储在请求上下文 (`ctx.jwt_auth_payload`) 中。这允许在同一请求上随后运行的低优先级插件检索和使用 JWT 令牌。 |
-| realm | string | 否 | jwt |在身份验证失败时，应包含在 `WWW-Authenticate` 标头中的域。|
-| claims_to_verify | array[string] | 否 | ["exp", "nbf"] | ["exp", "nbf"] | 需要在 JWT 负载中验证的声明。 |
+| 名称 | 类型 | 必选项 | 默认值 | 有效值 | 描述 |
+|------|------|--------|--------|--------|------|
+| header | string | 否 | authorization | | 用于获取令牌的请求头。 |
+| query | string | 否 | jwt | | 用于获取令牌的查询字符串。优先级低于 header。 |
+| cookie | string | 否 | jwt | | 用于获取令牌的 Cookie。优先级低于 query。 |
+| hide_credentials | boolean | 否 | false | | 若为 true，则不将携带 JWT 的 header、query 或 cookie 传递给上游服务。 |
+| anonymous_consumer | string | 否 | | | 匿名消费者名称。配置后，允许匿名用户绕过身份验证。 |
+| claims_to_verify | array[string] | 否 | ["exp", "nbf"] | `exp` 和 `nbf` 的组合 | 指定需要验证的 JWT 声明，以确保令牌在其允许的时间范围内使用。注意，这不是要求 payload 中必须存在的声明，而是在声明存在时进行验证。 |
+| store_in_ctx | boolean | 否 | false | | 若为 true，则将 JWT payload 存储在请求上下文变量 `ctx.jwt_auth_payload` 中，以便在同一请求中在 `jwt-auth` 之后执行的插件获取和使用 payload 信息。 |
+| realm | string | 否 | jwt | | 身份验证失败时，在 `WWW-Authenticate` 响应头中包含的 realm 值。 |
 
-您可以使用 [HashiCorp Vault](https://www.vaultproject.io/) 实施 `jwt-auth`，以从其[加密的 KV 引擎](https://developer.hashicorp.com/vault/docs/secrets/kv) 使用 [APISIX Secret](../terminology/secret.md) 资源。
+您可以将 `jwt-auth` 与 [HashiCorp Vault](https://www.vaultproject.io/) 结合使用，通过 [APISIX Secret](../terminology/secret.md) 资源从其[加密 KV 引擎](https://developer.hashicorp.com/vault/docs/secrets/kv)中存储和获取密钥及 RSA 密钥对。
 
 ## 示例
 
-以下示例演示了如何在不同场景中使用 `jwt-auth` 插件。
+以下示例展示了如何针对不同场景使用 `jwt-auth` 插件。
 
 :::note
 
-您可以这样从 `config.yaml` 中获取 `admin_key` 并存入环境变量：
+您可以通过以下命令从 `config.yaml` 中获取 `admin_key` 并保存到环境变量：
 
 ```bash
-admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
+admin_key=$(yq '.deployment.admin.admin_key[0].key' /usr/local/apisix/conf/config.yaml | sed 's/"//g')
 ```
 
 :::
 
 ### 使用 JWT 进行消费者身份验证
 
-以下示例演示了如何使用 JWT 进行消费者密钥身份验证。
+以下示例演示如何为消费者实现 JWT 密钥身份验证。
+
+<Tabs
+groupId="api"
+defaultValue="dashboard"
+values={[
+{label: 'Admin API', value: 'dashboard'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'ingress'}
+]}>
+
+<TabItem value="dashboard">
 
 创建消费者 `jack`：
 
@@ -97,7 +114,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   }'
 ```
 
-为消费者创建 `jwt-auth` 凭证：
+为消费者创建 `jwt-auth` 凭据：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
@@ -113,7 +130,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
   }'
 ```
 
-使用 `jwt-auth` 插件创建路由：
+创建带有 `jwt-auth` 插件的路由：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
@@ -133,34 +150,168 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
-要为 `jack` 颁发 JWT，您可以使用 [JWT.io 的 JWT 编码器](https://jwt.io) 或其他实用程序。如果您使用 [JWT.io 的 JWT 编码器](https://jwt.io)，请执行以下操作：
+</TabItem>
 
-* 填写 `HS256` 作为算法。
-* 将 __Valid secret__ 部分中的密钥更新为 `jack-hs256-secret-that-is-very-long`。
-* 使用消费者密钥 `jack-key` 更新有效 payload；并添加 `exp` 或 `nbf` UNIX 时间戳。
+<TabItem value="adc">
 
-  您的 payload 应类似于以下内容：
+创建带有 `jwt-auth` 凭据的消费者和配置了 `jwt-auth` 插件的路由：
 
-  ```json
-  {
-    "key": "jack-key",
-    "nbf": 1729132271
-  }
-  ```
+```yaml title="adc.yaml"
+consumers:
+  - username: jack
+    credentials:
+      - name: jwt-auth
+        type: jwt-auth
+        config:
+          key: jack-key
+          secret: jack-hs256-secret-that-is-very-long
+services:
+  - name: jwt-auth-service
+    routes:
+      - name: jwt-route
+        uris:
+          - /headers
+        plugins:
+          jwt-auth: {}
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
 
-将生成的 JWT 保存到变量中：
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="ingress">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX Ingress Controller', value: 'apisix-ingress-controller'}
+]}>
+
+<TabItem value="gateway-api">
+
+创建带有 `jwt-auth` 凭据的消费者和配置了 `jwt-auth` 插件的路由：
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: jwt-auth
+      name: primary-cred
+      config:
+        key: jack-key
+        secret: jack-hs256-secret-that-is-very-long
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: jwt-auth-plugin-config
+spec:
+  plugins:
+    - name: jwt-auth
+      config:
+        _meta:
+          disable: false
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: jwt-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /headers
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: jwt-auth-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-ingress-controller">
+
+ApisixConsumer CRD 存在一个已知问题，配置时会错误地要求提供 `private_key`。该问题将在后续版本中修复。目前，此示例无法通过 APISIX CRD 完成。
+
+</TabItem>
+
+</Tabs>
+
+</TabItem>
+
+</Tabs>
+
+如需为 `jack` 签发 JWT，可以使用 [JWT.io 的 JWT 编码器](https://jwt.io)或其他工具。若使用 [JWT.io 的 JWT 编码器](https://jwt.io)，请执行以下步骤：
+
+* 将算法填写为 `HS256`。
+* 在 __Valid secret__ 部分将密钥更新为 `jack-hs256-secret-that-is-very-long`。
+* 在 payload 中填入消费者密钥 `jack-key`，并以 UNIX 时间戳格式添加 `exp` 或 `nbf`。
+
+payload 应类似如下所示：
+
+```json
+{
+  "key": "jack-key",
+  "nbf": 1729132271
+}
+```
+
+复制生成的 JWT 并保存到变量：
 
 ```shell
 export jwt_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJqYWNrLWtleSIsIm5iZiI6MTcyOTEzMjI3MX0.UEPXy5jpid624T1XpfjM0PLY73LZPjV3Qt8yZ92kVuU
 ```
 
-使用 `Authorization` 标头中的 JWT 向路由发送请求：
+携带 JWT 在 `Authorization` 请求头中向路由发送请求：
 
 ```shell
 curl -i "http://127.0.0.1:9080/headers" -H "Authorization: ${jwt_token}"
 ```
 
-您应该收到类似于以下内容的 `HTTP/1.1 200 OK` 响应：
+您应收到类似如下的 `HTTP/1.1 200 OK` 响应：
 
 ```json
 {
@@ -177,23 +328,34 @@ curl -i "http://127.0.0.1:9080/headers" -H "Authorization: ${jwt_token}"
 }
 ```
 
-使用无效的令牌发送请求以验证：
+发送携带无效令牌的请求：
 
 ```shell
 curl -i "http://127.0.0.1:9080/headers" -H "Authorization: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE3MjY2NDk2NDAsImtleSI6ImphY2sta2V5In0.kdhumNWrZFxjU_random_random"
 ```
 
-您应该收到类似于以下内容的 `HTTP/1.1 401 Unauthorized` 响应：
+您应收到类似如下的 `HTTP/1.1 401 Unauthorized` 响应：
 
 ```text
 {"message":"failed to verify jwt"}
 ```
 
-### 在请求标头、查询字符串或 Cookie 中携带 JWT
+### 在请求头、查询字符串或 Cookie 中携带 JWT
 
-以下示例演示如何在指定的标头、查询字符串和 Cookie 中接受 JWT。
+以下示例演示如何从指定的请求头、查询字符串和 Cookie 中获取 JWT。
 
-创建一个消费者 `jack`：
+<Tabs
+groupId="api"
+defaultValue="dashboard"
+values={[
+{label: 'Admin API', value: 'dashboard'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'ingress'}
+]}>
+
+<TabItem value="dashboard">
+
+创建消费者 `jack`：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
@@ -203,7 +365,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   }'
 ```
 
-为消费者创建 `jwt-auth` 凭证：
+为消费者创建 `jwt-auth` 凭据：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
@@ -219,7 +381,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
   }'
 ```
 
-创建一个带有 `jwt-auth` 插件的路由，并指定请求可以在标头、查询或 cookie 中携带令牌：
+创建带有 `jwt-auth` 插件的路由，并指定携带令牌的请求参数：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
@@ -243,36 +405,176 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
-要为 `jack` 颁发 JWT，您可以使用 [JWT.io 的 JWT 编码器](https://jwt.io) 或其他实用程序。如果您使用 [JWT.io 的 JWT 编码器](https://jwt.io)，请执行以下操作：
+</TabItem>
 
-* 填写 `HS256` 作为算法。
-* 将 __Valid secret__ 部分中的密钥更新为 `jack-hs256-secret-that-is-very-long`。
-* 使用消费者密钥 `jack-key` 更新有效 payload；并添加 `exp` 或 `nbf` UNIX 时间戳。
+<TabItem value="adc">
 
-  您的 payload 应类似于以下内容：
+创建带有 `jwt-auth` 凭据的消费者和配置了 `jwt-auth` 插件的路由：
 
-  ```json
-  {
-    "key": "jack-key",
-    "nbf": 1729132271
-  }
-  ```
+```yaml title="adc.yaml"
+consumers:
+  - username: jack
+    credentials:
+      - name: jwt-auth
+        type: jwt-auth
+        config:
+          key: jack-key
+          secret: jack-hs256-secret-that-is-very-long
+services:
+  - name: jwt-auth-service
+    routes:
+      - name: jwt-route
+        uris:
+          - /get
+        plugins:
+          jwt-auth:
+            header: jwt-auth-header
+            query: jwt-query
+            cookie: jwt-cookie
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
 
-将生成的 JWT 保存到变量中：
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="ingress">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX Ingress Controller', value: 'apisix-ingress-controller'}
+]}>
+
+<TabItem value="gateway-api">
+
+创建带有 `jwt-auth` 凭据的消费者和配置了 `jwt-auth` 插件的路由：
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: jwt-auth
+      name: primary-cred
+      config:
+        key: jack-key
+        secret: jack-hs256-secret-that-is-very-long
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: jwt-auth-plugin-config
+spec:
+  plugins:
+    - name: jwt-auth
+      config:
+        _meta:
+          disable: false
+        header: jwt-auth-header
+        query: jwt-query
+        cookie: jwt-cookie
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: jwt-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /get
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: jwt-auth-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-ingress-controller">
+
+ApisixConsumer CRD 存在一个已知问题，配置时会错误地要求提供 `private_key`。该问题将在后续版本中修复。目前，此示例无法通过 APISIX CRD 完成。
+
+</TabItem>
+
+</Tabs>
+
+</TabItem>
+
+</Tabs>
+
+如需为 `jack` 签发 JWT，可以使用 [JWT.io 的 JWT 编码器](https://jwt.io)或其他工具。若使用 [JWT.io 的 JWT 编码器](https://jwt.io)，请执行以下步骤：
+
+* 将算法填写为 `HS256`。
+* 在 __Valid secret__ 部分将密钥更新为 `jack-hs256-secret-that-is-very-long`。
+* 在 payload 中填入消费者密钥 `jack-key`，并以 UNIX 时间戳格式添加 `exp` 或 `nbf`。
+
+payload 应类似如下所示：
+
+```json
+{
+  "key": "jack-key",
+  "nbf": 1729132271
+}
+```
+
+复制生成的 JWT 并保存到变量：
 
 ```shell
 export jwt_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJqYWNrLWtleSIsIm5iZiI6MTcyOTEzMjI3MX0.UEPXy5jpid624T1XpfjM0PLY73LZPjV3Qt8yZ92kVuU
 ```
 
-#### 使用标头中的 JWT 进行验证
+#### 通过请求头中的 JWT 验证
 
-发送标头中包含 JWT 的请求：
+携带 JWT 在请求头中发送请求：
 
 ```shell
 curl -i "http://127.0.0.1:9080/get" -H "jwt-auth-header: ${jwt_token}"
 ```
 
-您应该收到类似于以下内容的 `HTTP/1.1 200 OK` 响应：
+您应收到类似如下的 `HTTP/1.1 200 OK` 响应：
 
 ```json
 {
@@ -287,15 +589,15 @@ curl -i "http://127.0.0.1:9080/get" -H "jwt-auth-header: ${jwt_token}"
 }
 ```
 
-#### 在查询字符串中使用 JWT 进行验证
+#### 通过查询字符串中的 JWT 验证
 
-在查询字符串中使用 JWT 发送请求：
+携带 JWT 在查询字符串中发送请求：
 
 ```shell
 curl -i "http://127.0.0.1:9080/get?jwt-query=${jwt_token}"
 ```
 
-您应该收到类似于以下内容的 `HTTP/1.1 200 OK` 响应：
+您应收到类似如下的 `HTTP/1.1 200 OK` 响应：
 
 ```json
 {
@@ -311,15 +613,15 @@ curl -i "http://127.0.0.1:9080/get?jwt-query=${jwt_token}"
 }
 ```
 
-#### 使用 Cookie 中的 JWT 进行验证
+#### 通过 Cookie 中的 JWT 验证
 
-使用 cookie 中的 JWT 发送请求：
+携带 JWT 在 Cookie 中发送请求：
 
 ```shell
 curl -i "http://127.0.0.1:9080/get" --cookie jwt-cookie=${jwt_token}
 ```
 
-您应该收到类似于以下内容的 `HTTP/1.1 200 OK` 响应：
+您应收到类似如下的 `HTTP/1.1 200 OK` 响应：
 
 ```json
 {
@@ -335,23 +637,27 @@ curl -i "http://127.0.0.1:9080/get" --cookie jwt-cookie=${jwt_token}
 
 ### 在环境变量中管理密钥
 
-以下示例演示了如何将 `jwt-auth` 消费者密钥保存到环境变量并在配置中引用它。
+以下示例演示如何将 `jwt-auth` 消费者密钥保存到环境变量，并在配置中引用。
 
-APISIX 支持引用通过 [NGINX `env` 指令](https://nginx.org/en/docs/ngx_core_module.html#env) 配置的系统和用户环境变量。
+APISIX 支持通过 [NGINX `env` 指令](https://nginx.org/en/docs/ngx_core_module.html#env)引用系统和用户配置的环境变量。
 
-将密钥保存到环境变量中：
+将密钥保存到环境变量。若在 Docker 中运行 APISIX，需在启动容器时使用 `-e` 标志设置环境变量。
 
 ```shell
 export JACK_JWT_SECRET=jack-hs256-secret-that-is-very-long
 ```
 
-:::tip
+<Tabs
+groupId="api"
+defaultValue="dashboard"
+values={[
+{label: 'Admin API', value: 'dashboard'},
+{label: 'ADC', value: 'adc'}
+]}>
 
-如果您在 Docker 中运行 APISIX，需要在启动容器时使用 `-e` flag 设置环境变量。
+<TabItem value="dashboard">
 
-:::
-
-创建一个消费者 `jack`：
+创建消费者 `jack`：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
@@ -361,7 +667,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   }'
 ```
 
-为消费者创建 `jwt-auth` 凭证并引用环境变量：
+为消费者创建 `jwt-auth` 凭据，并引用环境变量：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
@@ -377,7 +683,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
   }'
 ```
 
-创建启用 `jwt-auth` 的路由：
+创建启用了 `jwt-auth` 的路由：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
@@ -397,38 +703,79 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
-要为 `jack` 颁发 JWT，您可以使用 [JWT.io 的 JWT 编码器](https://jwt.io) 或其他实用程序。如果您使用 [JWT.io 的 JWT 编码器](https://jwt.io)，请执行以下操作：
+</TabItem>
 
-* 填写 `HS256` 作为算法。
-* 将 __Valid secret__ 部分中的密钥更新为 `jack-hs256-secret-that-is-very-long`。
-* 使用消费者密钥 `jack-key` 更新有效 payload；并添加 `exp` 或 `nbf` UNIX 时间戳。
+<TabItem value="adc">
 
-  您的 payload 应类似于以下内容：
+创建引用环境变量的 `jwt-auth` 凭据的消费者和启用了 `jwt-auth` 插件的路由：
 
-  ```json
-  {
-    "key": "jack-key",
-    "nbf": 1729132271
-  }
-  ```
+```yaml title="adc.yaml"
+consumers:
+  - username: jack
+    credentials:
+      - name: jwt-auth
+        type: jwt-auth
+        config:
+          key: jack-key
+          secret: $env://JACK_JWT_SECRET
+services:
+  - name: jwt-auth-service
+    routes:
+      - name: jwt-route
+        uris:
+          - /get
+        plugins:
+          jwt-auth: {}
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
 
-将生成的 JWT 保存到变量中：
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
+如需为 `jack` 签发 JWT，可以使用 [JWT.io 的 JWT 编码器](https://jwt.io)或其他工具。若使用 [JWT.io 的 JWT 编码器](https://jwt.io)，请执行以下步骤：
+
+* 将算法填写为 `HS256`。
+* 在 __Valid secret__ 部分将密钥更新为 `jack-hs256-secret-that-is-very-long`。
+* 在 payload 中填入消费者密钥 `jack-key`，并以 UNIX 时间戳格式添加 `exp` 或 `nbf`。
+
+payload 应类似如下所示：
+
+```json
+{
+  "key": "jack-key",
+  "nbf": 1729132271
+}
+```
+
+复制生成的 JWT 并保存到变量：
 
 ```shell
 export jwt_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJqYWNrLWtleSIsIm5iZiI6MTcyOTEzMjI3MX0.UEPXy5jpid624T1XpfjM0PLY73LZPjV3Qt8yZ92kVuU
 ```
 
-发送标头中包含 JWT 的请求：
+携带 JWT 在请求头中发送请求：
 
 ```shell
 curl -i "http://127.0.0.1:9080/get" -H "Authorization: ${jwt_token}"
 ```
 
-您应该会收到 `HTTP/1.1 200 OK` 响应。
+您应收到 `HTTP/1.1 200 OK` 响应。
 
-### 在 Secret Manager 中管理 Secret
+### 在 Secret Manager 中管理密钥
 
-以下示例演示了如何在 [HashiCorp Vault](https://www.vaultproject.io) 中管理 `jwt-auth` 消费者密钥，并在插件配置中引用它。
+以下示例演示如何在 [HashiCorp Vault](https://www.vaultproject.io) 中管理 `jwt-auth` 消费者密钥，并在插件配置中引用。
 
 在 Docker 中启动 Vault 开发服务器：
 
@@ -443,25 +790,35 @@ docker run -d \
   vault server -dev
 ```
 
-APISIX 目前支持 [Vault KV 引擎版本 1](https://developer.hashicorp.com/vault/docs/secrets/kv#kv-version-1)。请在 Vault 中启用它：
+APISIX 目前支持 [Vault KV 引擎第 1 版](https://developer.hashicorp.com/vault/docs/secrets/kv#kv-version-1)。在 Vault 中启用它：
 
 ```shell
 docker exec -i vault sh -c "VAULT_TOKEN='root' VAULT_ADDR='http://0.0.0.0:8200' vault secrets enable -path=kv -version=1 kv"
 ```
 
-您应该会看到类似以下内容的响应：
+您应收到类似如下的响应：
 
 ```text
 Success! Enabled the kv secrets engine at: kv/
 ```
 
-创建一个 Secret，并配置 Vault 地址和其他连接信息。根据情况相应地更新 Vault 地址：
+<Tabs
+groupId="api"
+defaultValue="dashboard"
+values={[
+{label: 'Admin API', value: 'dashboard'},
+{label: 'ADC', value: 'adc'}
+]}>
+
+<TabItem value="dashboard">
+
+创建 [Secret](../terminology/secret.md) 并配置 Vault 地址及其他连接信息，请根据实际情况调整 Vault 地址：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/secrets/vault/jwt" -X PUT \
-  -H "X-API-KEY: ${ADMIN_API_KEY}" \
+  -H "X-API-KEY: ${admin_key}" \
   -d '{
-    "uri": "https://127.0.0.1:8200",
+    "uri": "http://127.0.0.1:8200",
     "prefix": "kv/apisix",
     "token": "root"
   }'
@@ -471,17 +828,17 @@ curl "http://127.0.0.1:9180/apisix/admin/secrets/vault/jwt" -X PUT \
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
-  -H "X-API-KEY: ${ADMIN_API_KEY}" \
+  -H "X-API-KEY: ${admin_key}" \
   -d '{
     "username": "jack"
   }'
 ```
 
-为消费者创建 `jwt-auth` 凭证并引用 Secret：
+为消费者创建 `jwt-auth` 凭据，并引用 Secret：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
-  -H "X-API-KEY: ${ADMIN_API_KEY}" \
+  -H "X-API-KEY: ${admin_key}" \
   -d '{
     "id": "cred-jack-jwt-auth",
     "plugins": {
@@ -493,11 +850,11 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
   }'
 ```
 
-创建启用 `jwt-auth` 的路由：
+创建启用了 `jwt-auth` 的路由：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
-  -H "X-API-KEY: ${ADMIN_API_KEY}" \
+  -H "X-API-KEY: ${admin_key}" \
   -d '{
     "id": "jwt-route",
     "uri": "/get",
@@ -513,32 +870,79 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
-在 Vault 中将 `jwt-auth` 键值设置为 `vault-hs256-secret-that-is-very-long`：
+</TabItem>
+
+<TabItem value="adc">
+
+创建 Secret 并配置 Vault 地址，请根据实际情况调整 Vault 地址：
+
+```yaml title="adc.yaml"
+secrets:
+  - name: vault-jwt
+    vault:
+      url: http://127.0.0.1:8200
+      prefix: kv/apisix
+      token: root
+consumers:
+  - username: jack
+    credentials:
+      - name: jwt-auth
+        type: jwt-auth
+        config:
+          key: jwt-vault-key
+          secret: $secret://vault-jwt/jack/jwt-secret
+services:
+  - name: jwt-auth-service
+    routes:
+      - name: jwt-route
+        uris:
+          - /get
+        plugins:
+          jwt-auth: {}
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
+在 Vault 中设置 `jwt-auth` 密钥值为 `vault-hs256-secret-that-is-very-long`：
 
 ```shell
 docker exec -i vault sh -c "VAULT_TOKEN='root' VAULT_ADDR='http://0.0.0.0:8200' vault kv put kv/apisix/jack jwt-secret=vault-hs256-secret-that-is-very-long"
 ```
 
-您应该会看到类似以下内容的响应：
+您应收到类似如下的响应：
 
 ```text
 Success! Data written to: kv/apisix/jack
 ```
 
-要为 `jack` 颁发 JWT，您可以使用 [JWT.io 的 JWT 编码器](https://jwt.io) 或其他实用程序。如果您使用 [JWT.io 的 JWT 编码器](https://jwt.io)，请执行以下操作：
+如需签发 JWT，可以使用 [JWT.io 的 JWT 编码器](https://jwt.io)或其他工具。若使用 [JWT.io 的 JWT 编码器](https://jwt.io)，请执行以下步骤：
 
-* 填写 `HS256` 作为算法。
-* 将 __Valid secret__ 部分中的密钥更新为 `vault-hs256-secret-that-is-very-long`。
-* 使用消费者密钥 `jwt-vault-key` 更新有效 payload；并添加 `exp` 或 `nbf` UNIX 时间戳。
+* 将算法填写为 `HS256`。
+* 在 __Valid secret__ 部分将密钥更新为 `vault-hs256-secret-that-is-very-long`。
+* 在 payload 中填入消费者密钥 `jwt-vault-key`，并以 UNIX 时间戳格式添加 `exp` 或 `nbf`。
 
-  您的 payload 应类似于以下内容：
+payload 应类似如下所示：
 
-  ```json
-  {
-    "key": "jwt-vault-key",
-    "nbf": 1729132271
-  }
-  ```
+```json
+{
+  "key": "jwt-vault-key",
+  "nbf": 1729132271
+}
+```
 
 复制生成的 JWT 并保存到变量：
 
@@ -546,41 +950,41 @@ Success! Data written to: kv/apisix/jack
 export jwt_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJqd3QtdmF1bHQta2V5IiwibmJmIjoxNzI5MTMyMjcxfQ.i2pLj7QcQvnlSjB7iV5V522tIV43boQRtee7L0rwlkQ
 ```
 
-发送带有令牌作为标头的请求：
+携带令牌在请求头中发送请求：
 
 ```shell
 curl -i "http://127.0.0.1:9080/get" -H "Authorization: ${jwt_token}"
 ```
 
-您应该会收到 `HTTP/1.1 200 OK` 响应。
+您应收到 `HTTP/1.1 200 OK` 响应。
 
 ### 使用 RS256 算法签名 JWT
 
-以下示例演示了如何在实现 JWT 消费者身份验证时使用非对称算法（例如 RS256）对 JWT 进行签名和验证。您将使用 [openssl](https://openssl-library.org/source/) 生成 RSA 密钥对，并使用 [JWT.io](https://jwt.io) 生成 JWT，以便更好地理解 JWT 的组成。
+以下示例演示如何使用 RS256 等非对称算法对 JWT 进行签名和验证。您将使用 [openssl](https://openssl-library.org/source/) 生成 RSA 密钥对，并使用 [JWT.io](https://jwt.io) 生成 JWT，以便更好地理解 JWT 的组成。
 
-生成一个 2048 位 RSA 私钥，并提取相应的 PEM 格式公钥：
+生成 2048 位 RSA 私钥并提取对应的 PEM 格式公钥：
 
 ```shell
 openssl genrsa -out jwt-rsa256-private.pem 2048
 openssl rsa -in jwt-rsa256-private.pem -pubout -out jwt-rsa256-public.pem
 ```
 
-您应该看到在当前工作目录中生成的 `jwt-rsa256-private.pem` 和 `jwt-rsa256-public.pem`。
+您应在当前工作目录中看到生成的 `jwt-rsa256-private.pem` 和 `jwt-rsa256-public.pem` 文件。
 
-访问 [JWT.io 的 JWT 编码器](https://jwt.io) 并执行以下操作：
+访问 [JWT.io 的 JWT 编码器](https://jwt.io)并执行以下步骤：
 
-* 填写 `RS256` 作为算法。
-* 将私钥内容复制并粘贴到 __SIGN JWT: PRIVATE KEY__ 部分。
-* 使用消费者密钥 `jack-key` 更新有效负载；并添加 `exp` 或 `nbf` UNIX 时间戳。
+* 将算法填写为 `RS256`。
+* 将私钥内容复制粘贴到 __SIGN JWT: PRIVATE KEY__ 部分。
+* 在 payload 中填入消费者密钥 `jack-key`，并以 UNIX 时间戳格式添加 `exp` 或 `nbf`。
 
-  您的 payload 应类似于以下内容：
+payload 应类似如下所示：
 
-  ```json
-  {
-    "key": "jack-key",
-    "nbf": 1729132271
-  }
-  ```
+```json
+{
+  "key": "jack-key",
+  "nbf": 1729132271
+}
+```
 
 复制生成的 JWT 并保存到变量：
 
@@ -588,7 +992,18 @@ openssl rsa -in jwt-rsa256-private.pem -pubout -out jwt-rsa256-public.pem
 export jwt_token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJqYWNrLWtleSIsIm5iZiI6MTcyOTEzMjI3MX0.K-I13em84kAcyH1jfIJl7ls_4jlwg1GzEzo5_xrDu-3wt3Xa3irS6naUsWpxX-a-hmcZZxRa9zqunqQjUP4kvn5e3xg2f_KyCR-_ZbwqYEPk3bXeFV1l4iypv6z5L7W1Niharun-dpMU03b1Tz64vhFx6UwxNL5UIZ7bunDAo_BXZ7Xe8rFhNHvIHyBFsDEXIBgx8lNYMq8QJk3iKxZhZZ5Om7lgYjOOKRgew4WkhBAY0v1AkO77nTlvSK0OEeeiwhkROyntggyx-S-U222ykMQ6mBLxkP4Cq5qHwXD8AUcLk5mhEij-3QhboYnt7yhKeZ3wDSpcjDvvL2aasC25ng
 ```
 
-创建一个消费者 `jack`：
+<Tabs
+groupId="api"
+defaultValue="dashboard"
+values={[
+{label: 'Admin API', value: 'dashboard'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'ingress'}
+]}>
+
+<TabItem value="dashboard">
+
+创建消费者 `jack`：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
@@ -598,7 +1013,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   }'
 ```
 
-为消费者创建 `jwt-auth` 凭证并配置 RSA 密钥：
+为消费者创建 `jwt-auth` 凭据，并配置 RSA 密钥。公钥的起始行与结束行之后需要添加换行符，例如 `-----BEGIN PUBLIC KEY-----\n......\n-----END PUBLIC KEY-----`，密钥内容可以直接拼接。
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
@@ -615,15 +1030,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
   }'
 ```
 
-:::tip
-
-您应该在起始行之后和结束行之前添加换行符，例如 `-----BEGIN PUBLIC KEY-----\n......\n-----END PUBLIC KEY-----`。
-
-密钥内容可以直接连接。
-
-:::
-
-使用 `jwt-auth` 插件创建路由：
+创建带有 `jwt-auth` 插件的路由：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
@@ -643,19 +1050,184 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
-使用 `Authorization` 标头中的 JWT 向路由发送请求：
+</TabItem>
+
+<TabItem value="adc">
+
+创建使用 RS256 算法的 `jwt-auth` 凭据的消费者和启用了 `jwt-auth` 插件的路由：
+
+```yaml title="adc.yaml"
+consumers:
+  - username: jack
+    credentials:
+      - name: jwt-auth
+        type: jwt-auth
+        config:
+          key: jack-key
+          algorithm: RS256
+          public_key: |
+            -----BEGIN PUBLIC KEY-----
+            MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoTxe7ZPycrEP0SK4OBA2
+            0OUQsDN9gSFSHVvx/t++nZNrFxzZnV6q6/TRsihNXUIgwaOu5icFlIcxPL9Mf9UJ
+            a5/XCQExp1TxpuSmjkhIFAJ/x5zXrC8SGTztP3SjkhYnQO9PKVXI6ljwgakVCfpl
+            umuTYqI+ev7e45NdK8gJoJxPp8bPMdf8/nHfLXZuqhO/btrDg1x+j7frDNrEw+6B
+            CK2SsuypmYN+LwHfaH4Of7MQFk3LNIxyBz0mdbsKJBzp360rbWnQeauWtDymZxLT
+            ATRNBVyl3nCNsURRTkc7eyknLaDt2N5xTIoUGHTUFYSdE68QWmukYMVGcEHEEPkp
+            aQIDAQAB
+            -----END PUBLIC KEY-----
+services:
+  - name: jwt-auth-service
+    routes:
+      - name: jwt-route
+        uris:
+          - /headers
+        plugins:
+          jwt-auth: {}
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="ingress">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX Ingress Controller', value: 'apisix-ingress-controller'}
+]}>
+
+<TabItem value="gateway-api">
+
+创建使用 RS256 算法的 `jwt-auth` 凭据的消费者和启用了 `jwt-auth` 插件的路由：
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: jwt-auth
+      name: primary-cred
+      config:
+        key: jack-key
+        algorithm: RS256
+        public_key: |
+          -----BEGIN PUBLIC KEY-----
+          MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoTxe7ZPycrEP0SK4OBA2
+          0OUQsDN9gSFSHVvx/t++nZNrFxzZnV6q6/TRsihNXUIgwaOu5icFlIcxPL9Mf9UJ
+          a5/XCQExp1TxpuSmjkhIFAJ/x5zXrC8SGTztP3SjkhYnQO9PKVXI6ljwgakVCfpl
+          umuTYqI+ev7e45NdK8gJoJxPp8bPMdf8/nHfLXZuqhO/btrDg1x+j7frDNrEw+6B
+          CK2SsuypmYN+LwHfaH4Of7MQFk3LNIxyBz0mdbsKJBzp360rbWnQeauWtDymZxLT
+          ATRNBVyl3nCNsURRTkc7eyknLaDt2N5xTIoUGHTUFYSdE68QWmukYMVGcEHEEPkp
+          aQIDAQAB
+          -----END PUBLIC KEY-----
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: jwt-auth-plugin-config
+spec:
+  plugins:
+    - name: jwt-auth
+      config:
+        _meta:
+          disable: false
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: jwt-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /headers
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: jwt-auth-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-ingress-controller">
+
+ApisixConsumer CRD 存在一个已知问题，配置时会错误地要求提供 `private_key`。该问题将在后续版本中修复。目前，此示例无法通过 APISIX CRD 完成。
+
+</TabItem>
+
+</Tabs>
+
+</TabItem>
+
+</Tabs>
+
+验证时，携带 JWT 在 `Authorization` 请求头中向路由发送请求：
 
 ```shell
 curl -i "http://127.0.0.1:9080/headers" -H "Authorization: ${jwt_token}"
 ```
 
-您应该会收到 `HTTP/1.1 200 OK` 响应。
+您应收到 `HTTP/1.1 200 OK` 响应。
 
-### 将消费者自定义 ID 添加到标头
+### 在请求头中添加消费者自定义 ID
 
-以下示例演示了如何在 `Consumer-Custom-Id` 标头中将消费者自定义 ID 附加到已验证的请求，该 ID 可用于根据需要实现其他逻辑。
+以下示例演示如何在已验证请求的 `Consumer-Custom-Id` 请求头中附加消费者自定义 ID，以便根据需要实现额外逻辑。
 
-创建一个带有自定义 ID 标签的消费者 `jack`：
+<Tabs
+groupId="api"
+defaultValue="dashboard"
+values={[
+{label: 'Admin API', value: 'dashboard'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'ingress'}
+]}>
+
+<TabItem value="dashboard">
+
+创建带有自定义 ID 标签的消费者 `jack`：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
@@ -668,7 +1240,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   }'
 ```
 
-为消费者创建 `jwt-auth` 凭证：
+为消费者创建 `jwt-auth` 凭据：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
@@ -684,7 +1256,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
   }'
 ```
 
-使用 `jwt-auth` 创建路由：
+创建带有 `jwt-auth` 的路由：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
@@ -704,20 +1276,69 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
-要为 `jack` 颁发 JWT，您可以使用 [JWT.io 的 JWT 编码器](https://jwt.io) 或其他实用程序。如果您使用 [JWT.io 的 JWT 编码器](https://jwt.io)，请执行以下操作：
+</TabItem>
 
-* 填写 `HS256` 作为算法。
-* 将 __Valid secret__ 部分中的密钥更新为 `jack-hs256-secret-that-is-very-long`。
-* 使用消费者密钥 `jack-key` 更新有效 payload；并添加 `exp` 或 `nbf` UNIX 时间戳。
+<TabItem value="adc">
 
-  您的 payload 应类似于以下内容：
+创建带有 `jwt-auth` 凭据的消费者和启用了 `jwt-auth` 插件的路由：
 
-  ```json
-  {
-    "key": "jack-key",
-    "nbf": 1729132271
-  }
-  ```
+```yaml title="adc.yaml"
+consumers:
+  - username: jack
+    labels:
+      custom_id: "495aec6a"
+    credentials:
+      - name: jwt-auth
+        type: jwt-auth
+        config:
+          key: jack-key
+          secret: jack-hs256-secret-that-is-very-long
+services:
+  - name: jwt-auth-service
+    routes:
+      - name: jwt-auth-route
+        uris:
+          - /anything
+        plugins:
+          jwt-auth: {}
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="ingress">
+
+通过 Ingress Controller 配置资源时，目前不支持消费者自定义标签，请求中也不会包含 `X-Consumer-Custom-Id` 请求头。目前，此示例无法通过 Ingress Controller 完成。
+
+</TabItem>
+
+</Tabs>
+
+如需为 `jack` 签发 JWT，可以使用 [JWT.io 的 JWT 编码器](https://jwt.io)或其他工具。若使用 [JWT.io 的 JWT 编码器](https://jwt.io)，请执行以下步骤：
+
+* 将算法填写为 `HS256`。
+* 在 __Valid secret__ 部分将密钥更新为 `jack-hs256-secret-that-is-very-long`。
+* 在 payload 中填入消费者密钥 `jack-key`，并以 UNIX 时间戳格式添加 `exp` 或 `nbf`。
+
+payload 应类似如下所示：
+
+```json
+{
+  "key": "jack-key",
+  "nbf": 1729132271
+}
+```
 
 复制生成的 JWT 并保存到变量：
 
@@ -725,13 +1346,13 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
 export jwt_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJqYWNrLWtleSIsIm5iZiI6MTcyOTEzMjI3MX0.UEPXy5jpid624T1XpfjM0PLY73LZPjV3Qt8yZ92kVuU
 ```
 
-为了验证，使用 `Authorization` 标头中的 JWT 向路由发送请求：
+验证时，携带 JWT 在 `Authorization` 请求头中向路由发送请求：
 
 ```shell
 curl -i "http://127.0.0.1:9080/headers" -H "Authorization: ${jwt_token}"
 ```
 
-您应该会看到类似以下内容的 `HTTP/1.1 200 OK` 响应：
+您应看到类似如下的 `HTTP/1.1 200 OK` 响应：
 
 ```json
 {
@@ -749,11 +1370,22 @@ curl -i "http://127.0.0.1:9080/headers" -H "Authorization: ${jwt_token}"
 }
 ```
 
-### 匿名消费者的速率限制
+### 使用匿名消费者进行限速
 
-以下示例演示了如何为普通消费者和匿名消费者配置不同的速率限制策略，其中匿名消费者无需身份验证，且配额较少。
+以下示例演示如何为普通消费者和匿名消费者配置不同的限速策略，其中匿名消费者无需身份验证，但配额较少。
 
-创建一个普通消费者 `jack`，并配置 `limit-count` 插件，允许在 30 秒内使用 3 个配额：
+<Tabs
+groupId="api"
+defaultValue="dashboard"
+values={[
+{label: 'Admin API', value: 'dashboard'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'ingress'}
+]}>
+
+<TabItem value="dashboard">
+
+创建普通消费者 `jack`，并配置 `limit-count` 插件，允许在 30 秒窗口内最多请求 3 次：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
@@ -770,7 +1402,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   }'
 ```
 
-为消费者 `jack` 创建 `jwt-auth` 凭证：
+为消费者 `jack` 创建 `jwt-auth` 凭据：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
@@ -786,7 +1418,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
   }'
 ```
 
-创建匿名用户 `anonymous`，并配置 `limit-count` 插件，以允许 30 秒内配额为 1：
+创建匿名用户 `anonymous`，并配置 `limit-count` 插件，允许在 30 秒窗口内最多请求 1 次：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
@@ -803,7 +1435,7 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   }'
 ```
 
-创建一个路由并配置 `jwt-auth` 插件以接受匿名消费者 `anonymous` 绕过身份验证：
+创建路由，并配置 `jwt-auth` 插件允许匿名消费者 `anonymous` 绕过身份验证：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
@@ -825,28 +1457,198 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
-要为 `jack` 颁发 JWT，您可以使用 [JWT.io 的 JWT 编码器](https://jwt.io) 或其他实用程序。如果您使用 [JWT.io 的 JWT 编码器](https://jwt.io)，请执行以下操作：
+</TabItem>
 
-* 填写 `HS256` 作为算法。
-* 将 __Valid secret__ 部分中的密钥更新为 `jack-hs256-secret-that-is-very-long`。
-* 使用消费者密钥 `jack-key` 更新有效 payload；并添加 `exp` 或 `nbf` UNIX 时间戳。
+<TabItem value="adc">
 
-  您的 payload 应类似于以下内容：
+配置具有不同限速策略的消费者和允许匿名用户的路由：
 
-  ```json
-  {
-    "key": "jack-key",
-    "nbf": 1729132271
-  }
-  ```
+```yaml title="adc.yaml"
+consumers:
+  - username: jack
+    plugins:
+      limit-count:
+        count: 3
+        time_window: 30
+        rejected_code: 429
+        policy: local
+    credentials:
+      - name: jwt-auth
+        type: jwt-auth
+        config:
+          key: jack-key
+          secret: jack-hs256-secret-that-is-very-long
+  - username: anonymous
+    plugins:
+      limit-count:
+        count: 1
+        time_window: 30
+        rejected_code: 429
+        policy: local
+services:
+  - name: anonymous-rate-limit-service
+    routes:
+      - name: jwt-auth-route
+        uris:
+          - /anything
+        plugins:
+          jwt-auth:
+            anonymous_consumer: anonymous
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
 
-将生成的 JWT 复制到 __Encoded__ 部分并保存到变量中：
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="ingress">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX Ingress Controller', value: 'apisix-ingress-controller'}
+]}>
+
+<TabItem value="gateway-api">
+
+配置具有不同限速策略的消费者和允许匿名用户的路由：
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: jwt-auth
+      name: primary-key
+      config:
+        key: jack-key
+        secret: jack-hs256-secret-that-is-very-long
+  plugins:
+    - name: limit-count
+      config:
+        count: 3
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: anonymous
+spec:
+  gatewayRef:
+    name: apisix
+  plugins:
+    - name: limit-count
+      config:
+        count: 1
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: jwt-auth-plugin-config
+spec:
+  plugins:
+    - name: jwt-auth
+      config:
+        anonymous_consumer: aic_anonymous  # namespace_consumername
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: jwt-auth-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: jwt-auth-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-ingress-controller">
+
+ApisixConsumer CRD 目前不支持在消费者上配置插件（`authParameter` 中允许的认证插件除外）。此示例无法通过 APISIX CRD 完成。
+
+</TabItem>
+
+</Tabs>
+
+</TabItem>
+
+</Tabs>
+
+如需为 `jack` 签发 JWT，可以使用 [JWT.io 的 JWT 编码器](https://jwt.io)或其他工具。若使用 [JWT.io 的 JWT 编码器](https://jwt.io)，请执行以下步骤：
+
+* 将算法填写为 `HS256`。
+* 在 __Valid secret__ 部分将密钥更新为 `jack-hs256-secret-that-is-very-long`。
+* 在 payload 中填入消费者密钥 `jack-key`，并以 UNIX 时间戳格式添加 `exp` 或 `nbf`。
+
+payload 应类似如下所示：
+
+```json
+{
+  "key": "jack-key",
+  "nbf": 1729132271
+}
+```
+
+复制生成的 JWT 并保存到变量：
 
 ```shell
 export jwt_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJqYWNrLWtleSIsIm5iZiI6MTcyOTEzMjI3MX0.UEPXy5jpid624T1XpfjM0PLY73LZPjV3Qt8yZ92kVuU
 ```
 
-为了验证速率限制，请使用 jack 的 JWT 连续发送五个请求：
+验证限速效果，连续发送 5 次携带 `jack` JWT 的请求：
 
 ```shell
 resp=$(seq 5 | xargs -I{} curl "http://127.0.0.1:9080/anything" -H "Authorization: ${jwt_token}" -o /dev/null -s -w "%{http_code}\n") && \
@@ -855,13 +1657,13 @@ resp=$(seq 5 | xargs -I{} curl "http://127.0.0.1:9080/anything" -H "Authorizatio
   echo "200": $count_200, "429": $count_429
 ```
 
-您应该看到以下响应，显示在 5 个请求中，3 个请求成功（状态代码 200），而其他请求被拒绝（状态代码 429）。
+您应看到如下响应，说明 5 次请求中有 3 次成功（状态码 200），其余被拒绝（状态码 429）：
 
 ```text
 200:    3, 429:    2
 ```
 
-发送五个匿名请求：
+发送 5 次匿名请求：
 
 ```shell
 resp=$(seq 5 | xargs -I{} curl "http://127.0.0.1:9080/anything" -o /dev/null -s -w "%{http_code}\n") && \
@@ -870,7 +1672,7 @@ resp=$(seq 5 | xargs -I{} curl "http://127.0.0.1:9080/anything" -o /dev/null -s 
   echo "200": $count_200, "429": $count_429
 ```
 
-您应该看到以下响应，表明只有一个请求成功：
+您应看到如下响应，说明只有 1 次请求成功：
 
 ```text
 200:    1, 429:    4


### PR DESCRIPTION
Re-ports the jwt-auth plugin documentation with Admin API, ADC, and Ingress Controller tab structure, updated attribute table, and canonical link.