### PR TITLE
ci: wait for stream subsystem readiness in test_prometheus_stream.sh

### DIFF
--- a/t/cli/test_prometheus_stream.sh
+++ b/t/cli/test_prometheus_stream.sh
@@ -36,7 +36,18 @@ plugin_attr:
 " > conf/config.yaml
 
 make run
-sleep 0.5
+
+# Wait until the stream subsystem's prometheus exporter is ready by polling
+# for the metric's HELP line, which appears once the stream plugin is loaded.
+# Without this, the test is flaky on slow CI runners where `sleep 0.5` is not
+# enough for the stream subsystem to come up after `make run`.
+for _ in $(seq 1 20); do
+    if curl -s --max-time 2 http://127.0.0.1:9091/apisix/prometheus/metrics \
+            2>/dev/null | grep -q "# HELP apisix_stream_connection_total"; then
+        break
+    fi
+    sleep 0.5
+done
 
 admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
 curl -v -k -i -m 20 -o /dev/null -s -X PUT http://127.0.0.1:9180/apisix/admin/stream_routes/1 \
@@ -83,7 +94,16 @@ plugin_attr:
 " > conf/config.yaml
 
 make run
-sleep 0.5
+
+# Same readiness wait as above, since admin is disabled here we can't probe
+# admin API; the prometheus HELP line is still a reliable readiness signal.
+for _ in $(seq 1 20); do
+    if curl -s --max-time 2 http://127.0.0.1:9091/apisix/prometheus/metrics \
+            2>/dev/null | grep -q "# HELP apisix_stream_connection_total"; then
+        break
+    fi
+    sleep 0.5
+done
 
 curl http://127.0.0.1:9100 || true
 sleep 1 # wait for sync


### PR DESCRIPTION
### Description

`t/cli/test_prometheus_stream.sh` is flaky on the CI: many recent runs on `master` and feature branches fail with `failed: prometheus can't work in stream subsystem`. A few examples just from the last few days:

- master `41775ef5` — https://github.com/apache/apisix/actions/runs/24496623331
- master `ddddeafc` — https://github.com/apache/apisix/actions/runs/24488366032
- branch `feat-support-bedrock` `8bf841b4` — https://github.com/apache/apisix/actions/runs/24561304700

### Root cause

The script does:

```bash
make run
sleep 0.5
# ...
curl http://127.0.0.1:9100 || true   # probe stream proxy
sleep 1
out="$(curl http://127.0.0.1:9091/apisix/prometheus/metrics)"
grep "apisix_stream_connection_total{route=\"1\"} 1"
```

On slower GitHub Actions runners, 0.5s is not enough for the stream subsystem's prometheus exporter to come up after `make run`. The probe to port 9100 hits a half-initialized listener and gets `Connection reset by peer`, so the connection counter is never bumped, and the metric grep fails. Confirmed by inspecting the failure logs:

- HELP/TYPE lines for `apisix_stream_connection_total` are absent from the metrics output in the failing runs (they're present in the passing runs).

### Fix

Replace the fixed `sleep 0.5` with a polling loop (up to ~10s) that waits until the prometheus metrics endpoint exposes the stream metric's HELP line, which is a reliable signal that the stream prometheus plugin is loaded and ready to record traffic.

The downstream `curl ... :9100; sleep 1` is left as-is — once the plugin is loaded, that single probe + 1s flush window already works (the metric has `refresh_interval: 1`).

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to the changes introduced in this PR — N/A, this PR fixes an existing test
- [x] I have added proper labels to this PR
- [x] Review and CI completed successfully