### PR TITLE
docs(ip-restriction): re-port with Admin API, ADC, and Ingress Controller tabs

### DIFF
--- a/docs/en/latest/plugins/ip-restriction.md
+++ b/docs/en/latest/plugins/ip-restriction.md
@@ -32,24 +32,21 @@ description: The ip-restriction Plugin supports restricting access to upstream r
   <link rel="canonical" href="https://docs.api7.ai/hub/ip-restriction" />
 </head>
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Description
 
 The `ip-restriction` Plugin supports restricting access to upstream resources by IP addresses, through either configuring a whitelist or blacklist of IP addresses. Restricting IP to resources helps prevent unauthorized access and harden API security.
 
 ## Attributes
 
-| Name          | Type          | Required | Default                          | Valid values | Description                                                            |
-|---------------|---------------|----------|----------------------------------|--------------|------------------------------------------------------------------------|
-| whitelist     | array[string] | False    |                                  |              | List of IPs or CIDR ranges to whitelist.                               |
-| blacklist     | array[string] | False    |                                  |              | List of IPs or CIDR ranges to blacklist.                               |
-| message       | string        | False    | "Your IP address is not allowed" | [1, 1024]    | Message returned when the IP address is not allowed access.            |
-| response_code | integer       | False    | 403                              | [403, 404]   | HTTP response code returned when the IP address is not allowed access. |
-
-:::note
-
-At least one of the `whitelist` or `blacklist` should be configured, but they cannot be configured at the same time.
-
-:::
+| Name          | Type          | Required | Default                          | Valid values | Description                                                                                    |
+|---------------|---------------|----------|----------------------------------|--------------|------------------------------------------------------------------------------------------------|
+| whitelist     | array[string] | False    |                                  |              | List of IPs or CIDR ranges to allow. Exactly one of `whitelist` or `blacklist` must be configured. |
+| blacklist     | array[string] | False    |                                  |              | List of IPs or CIDR ranges to deny. Exactly one of `whitelist` or `blacklist` must be configured.  |
+| message       | string        | False    | "Your IP address is not allowed" | [1, 1024]    | Message returned to the client when the IP is blocked.                                         |
+| response_code | integer       | False    | 403                              | [403, 404]   | HTTP response code returned when the request is rejected due to IP address restriction.        |
 
 ## Examples
 
@@ -68,6 +65,17 @@ admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"/
 ### Restrict Access by Whitelisting
 
 The following example demonstrates how you can whitelist a list of IP addresses that should have access to the upstream resource and customize the error message for access denial.
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
 
 Create a Route with the `ip-restriction` Plugin to whitelist a range of IPs and customize the error message when the access is denied:
 
@@ -94,6 +102,156 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+services:
+  - name: ip-restriction-service
+    routes:
+      - name: ip-restriction-route
+        uris:
+          - /anything
+        plugins:
+          ip-restriction:
+            whitelist:
+              - "192.168.0.1/24"
+            message: "Access denied"
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX Ingress Controller', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="ip-restriction-ic.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: ip-restriction-plugin-config
+spec:
+  plugins:
+    - name: ip-restriction
+      config:
+        whitelist:
+          - "192.168.0.1/24"
+        message: "Access denied"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: ip-restriction-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: ip-restriction-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f ip-restriction-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="ip-restriction-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: ip-restriction-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: ip-restriction-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: ip-restriction
+        enable: true
+        config:
+          whitelist:
+            - "192.168.0.1/24"
+          message: "Access denied"
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f ip-restriction-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
+</TabItem>
+
+</Tabs>
+
 Send a request to the Route:
 
 ```shell
@@ -109,6 +267,17 @@ If your IP is allowed, you should receive an `HTTP/1.1 200 OK` response. If not,
 ### Restrict Access Using Modified IP
 
 The following example demonstrates how you can modify the IP used for IP restriction, using the `real-ip` Plugin. This is particularly useful if APISIX is behind a reverse proxy and the real client IP is not available to APISIX.
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
 
 Create a Route with the `ip-restriction` Plugin to whitelist a specific IP address and obtain client IP address from the URL parameter `realip`:
 
@@ -136,6 +305,162 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
     }
   }'
 ```
+
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+services:
+  - name: ip-restriction-service
+    routes:
+      - name: ip-restriction-route
+        uris:
+          - /anything
+        plugins:
+          ip-restriction:
+            whitelist:
+              - "192.168.1.241"
+          real-ip:
+            source: arg_realip
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX Ingress Controller', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="ip-restriction-ic.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: ip-restriction-realip-plugin-config
+spec:
+  plugins:
+    - name: ip-restriction
+      config:
+        whitelist:
+          - "192.168.1.241"
+    - name: real-ip
+      config:
+        source: arg_realip
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: ip-restriction-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: ip-restriction-realip-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f ip-restriction-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="ip-restriction-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: ip-restriction-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: ip-restriction-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: ip-restriction
+        enable: true
+        config:
+          whitelist:
+            - "192.168.1.241"
+      - name: real-ip
+        enable: true
+        config:
+          source: arg_realip
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f ip-restriction-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
+</TabItem>
+
+</Tabs>
 
 Send a request to the Route:
 

--- a/docs/en/latest/plugins/ip-restriction.md
+++ b/docs/en/latest/plugins/ip-restriction.md
@@ -6,7 +6,7 @@ keywords:
   - Plugin
   - IP restriction
   - ip-restriction
-description: The ip-restriction Plugin supports restricting access to upstream resources by IP addresses, through either configuring a whitelist or blacklist of IP addresses.
+description: The ip-restriction Plugin supports restricting access to Upstream resources by IP addresses, through either configuring a whitelist or blacklist of IP addresses.
 ---
 
 <!--
@@ -37,7 +37,7 @@ import TabItem from '@theme/TabItem';
 
 ## Description
 
-The `ip-restriction` Plugin supports restricting access to upstream resources by IP addresses, through either configuring a whitelist or blacklist of IP addresses. Restricting IP to resources helps prevent unauthorized access and harden API security.
+The `ip-restriction` Plugin supports restricting access to Upstream resources by IP addresses, through either configuring a whitelist or blacklist of IP addresses. Restricting IP to resources helps prevent unauthorized access and harden API security.
 
 ## Attributes
 
@@ -64,7 +64,7 @@ admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"/
 
 ### Restrict Access by Whitelisting
 
-The following example demonstrates how you can whitelist a list of IP addresses that should have access to the upstream resource and customize the error message for access denial.
+The following example demonstrates how you can whitelist a list of IP addresses that should have access to the Upstream resource and customize the error message for access denial.
 
 <Tabs
 groupId="api"

--- a/docs/zh/latest/plugins/ip-restriction.md
+++ b/docs/zh/latest/plugins/ip-restriction.md
@@ -32,23 +32,21 @@ description: ip-restriction 插件支持通过配置 IP 地址白名单或黑名
   <link rel="canonical" href="https://docs.api7.ai/hub/ip-restriction" />
 </head>
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## 描述
 
 `ip-restriction` 插件支持通过配置 IP 地址白名单或黑名单来限制 IP 地址对上游资源的访问。限制 IP 对资源的访问有助于防止未经授权的访问并加强 API 安全性。
 
 ## 属性
 
-| 参数名    | 类型          | 必选项 | 默认值 | 有效值 | 描述                             |
-| --------- | ------------- | ------ | ------ | ------ | -------------------------------- |
-| whitelist | array[string] | 否   |        |        | 要列入白名单的 IP 列表。支持 IPv4、IPv6 和 CIDR 表示法。 |
-| blacklist | array[string] | 否   |        |        | 要列入黑名单的 IP 列表。支持 IPv4、IPv6 和 CIDR 表示法。 |
-| message | string | 否   | "Your IP address is not allowed" | [1, 1024] | 在未允许的 IP 访问的情况下返回的信息。 |
-
-:::note
-
-`whitelist` 或 `blacklist` 至少配置一个，但不能同时配置。
-
-:::
+| 名称          | 类型          | 必选项 | 默认值                           | 有效值    | 描述                                                                     |
+|---------------|---------------|--------|----------------------------------|-----------|--------------------------------------------------------------------------|
+| whitelist     | array[string] | 否     |                                  |           | 允许访问的 IP 或 CIDR 范围列表。`whitelist` 和 `blacklist` 必须且只能配置其中一个。 |
+| blacklist     | array[string] | 否     |                                  |           | 拒绝访问的 IP 或 CIDR 范围列表。`whitelist` 和 `blacklist` 必须且只能配置其中一个。 |
+| message       | string        | 否     | "Your IP address is not allowed" | [1, 1024] | IP 被拒绝时返回给客户端的消息。                                           |
+| response_code | integer       | 否     | 403                              | [403, 404] | 因 IP 地址限制而拒绝请求时返回的 HTTP 响应码。                            |
 
 ## 示例
 
@@ -67,6 +65,17 @@ admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"/
 ### 通过白名单限制访问
 
 以下示例演示了如何将有权访问上游资源的 IP 地址列表列入白名单，并自定义拒绝访问的错误消息。
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
 
 使用 `ip-restriction` 插件创建路由，将一系列 IP 列入白名单，并自定义拒绝访问时的错误消息：
 
@@ -93,6 +102,156 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
   }'
 ```
 
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+services:
+  - name: ip-restriction-service
+    routes:
+      - name: ip-restriction-route
+        uris:
+          - /anything
+        plugins:
+          ip-restriction:
+            whitelist:
+              - "192.168.0.1/24"
+            message: "Access denied"
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX Ingress Controller', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="ip-restriction-ic.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: ip-restriction-plugin-config
+spec:
+  plugins:
+    - name: ip-restriction
+      config:
+        whitelist:
+          - "192.168.0.1/24"
+        message: "Access denied"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: ip-restriction-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: ip-restriction-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f ip-restriction-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="ip-restriction-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: ip-restriction-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: ip-restriction-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: ip-restriction
+        enable: true
+        config:
+          whitelist:
+            - "192.168.0.1/24"
+          message: "Access denied"
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f ip-restriction-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
+</TabItem>
+
+</Tabs>
+
 向路由发送请求：
 
 ```shell
@@ -108,6 +267,17 @@ curl -i "http://127.0.0.1:9080/anything"
 ### 使用修改后的 IP 限制访问
 
 以下示例演示了如何使用 `real-ip` 插件修改用于 IP 限制的 IP。如果 APISIX 位于反向代理之后，并且 APISIX 无法获得真实客户端 IP，则此功能特别有用。
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
 
 使用 `ip-restriction` 插件创建路由，将特定 IP 地址列入白名单，并从 URL 参数 `realip` 获取客户端 IP 地址：
 
@@ -135,6 +305,162 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
     }
   }'
 ```
+
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+services:
+  - name: ip-restriction-service
+    routes:
+      - name: ip-restriction-route
+        uris:
+          - /anything
+        plugins:
+          ip-restriction:
+            whitelist:
+              - "192.168.1.241"
+          real-ip:
+            source: arg_realip
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX Ingress Controller', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="ip-restriction-ic.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: ip-restriction-realip-plugin-config
+spec:
+  plugins:
+    - name: ip-restriction
+      config:
+        whitelist:
+          - "192.168.1.241"
+    - name: real-ip
+      config:
+        source: arg_realip
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: ip-restriction-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: ip-restriction-realip-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f ip-restriction-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="ip-restriction-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: ip-restriction-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: ip-restriction-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: ip-restriction
+        enable: true
+        config:
+          whitelist:
+            - "192.168.1.241"
+      - name: real-ip
+        enable: true
+        config:
+          source: arg_realip
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f ip-restriction-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
+</TabItem>
+
+</Tabs>
 
 向路由发送请求：
 

--- a/docs/zh/latest/plugins/ip-restriction.md
+++ b/docs/zh/latest/plugins/ip-restriction.md
@@ -54,7 +54,7 @@ import TabItem from '@theme/TabItem';
 
 :::note
 
-您可以这样从 `config.yaml` 中获取 `admin_key` 并存入环境变量：
+你可以这样从 `config.yaml` 中获取 `admin_key` 并存入环境变量：
 
 ```bash
 admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
@@ -258,7 +258,7 @@ kubectl apply -f ip-restriction-ic.yaml
 curl -i "http://127.0.0.1:9080/anything"
 ```
 
-如果您的 IP 被允许，您应该会收到 `HTTP/1.1 200 OK` 响应。如果不允许，您应该会收到 `HTTP/1.1 403 Forbidden` 响应，并显示以下错误消息：
+如果你的 IP 被允许，你应该会收到 `HTTP/1.1 200 OK` 响应。如果不允许，你应该会收到 `HTTP/1.1 403 Forbidden` 响应，并显示以下错误消息：
 
 ```text
 {"message":"Access denied"}
@@ -468,7 +468,7 @@ kubectl apply -f ip-restriction-ic.yaml
 curl -i "http://127.0.0.1:9080/anything?realip=192.168.1.241"
 ```
 
-您应该会收到 `HTTP/1.1 200 OK` 响应。
+你应该会收到 `HTTP/1.1 200 OK` 响应。
 
 使用不同的 IP 地址发送另一个请求：
 
@@ -476,4 +476,4 @@ curl -i "http://127.0.0.1:9080/anything?realip=192.168.1.241"
 curl -i "http://127.0.0.1:9080/anything?realip=192.168.10.24"
 ```
 
-您应该会收到 `HTTP/1.1 403 Forbidden` 响应。
+你应该会收到 `HTTP/1.1 403 Forbidden` 响应。


### PR DESCRIPTION
Re-ports the ip-restriction plugin documentation with Admin API, ADC, and Ingress Controller tab structure, updated attribute table including the previously missing response_code attribute, and canonical link.