### PR TITLE
docs(consumer-restriction): re-port with Admin API, ADC, and Ingress Controller tabs

### DIFF
--- a/docs/en/latest/plugins/consumer-restriction.md
+++ b/docs/en/latest/plugins/consumer-restriction.md
@@ -3,8 +3,9 @@ title: consumer-restriction
 keywords:
   - Apache APISIX
   - API Gateway
-  - Consumer restriction
-description: The Consumer Restriction Plugin allows users to configure access restrictions on Consumer, Route, Service, or Consumer Group.
+  - Plugin
+  - consumer-restriction
+description: The consumer-restriction Plugin implements access controls based on Consumer name, Route ID, Service ID, or Consumer Group ID, enhancing API security.
 ---
 
 <!--
@@ -26,322 +27,879 @@ description: The Consumer Restriction Plugin allows users to configure access re
 #
 -->
 
+<head>
+  <link rel="canonical" href="https://docs.api7.ai/hub/consumer-restriction" />
+</head>
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Description
 
-The `consumer-restriction` Plugin allows users to configure access restrictions on Consumer, Route, Service, or Consumer Group.
+The `consumer-restriction` Plugin enables access controls based on Consumer name, Route ID, Service ID, or Consumer Group ID.
+
+The Plugin needs to work with authentication plugins, such as [`key-auth`](./key-auth.md) and [`jwt-auth`](./jwt-auth.md), which means you should always create at least one [Consumer](../terminology/consumer.md) in your use case. See examples below for more details.
 
 ## Attributes
 
-| Name                       | Type          | Required | Default       | Valid values                                                 | Description                                                  |
-| -------------------------- | ------------- | -------- | ------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| type                       | string        | False    | consumer_name | ["consumer_name", "consumer_group_id", "service_id", "route_id"] | Type of object to base the restriction on.                   |
-| whitelist                  | array[string] | True     |               |                                                              | List of objects to whitelist. Has a higher priority than `allowed_by_methods`. |
-| blacklist                  | array[string] | True     |               |                                                              | List of objects to blacklist. Has a higher priority than `whitelist`. |
-| rejected_code              | integer       | False    | 403           | [200,...]                                                    | HTTP status code returned when the request is rejected.      |
-| rejected_msg               | string        | False    |               |                                                              | Message returned when the request is rejected.               |
-| allowed_by_methods         | array[object] | False    |               |                                                              | List of allowed configurations for Consumer settings, including a username of the Consumer and a list of allowed HTTP methods. |
-| allowed_by_methods.user    | string        | False    |               |                                                              | A username for a Consumer.                                   |
-| allowed_by_methods.methods | array[string] | False    |               | ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT", "TRACE", "PURGE"] | List of allowed HTTP methods for a Consumer.                 |
+| Name | Type | Required | Default | Valid values | Description |
+|------|------|----------|---------|--------------|-------------|
+| type | string | False | consumer_name | consumer_name, service_id, route_id, consumer_group_id | Basis for restriction. Determines what value is checked against the allowlist or denylist. |
+| whitelist | array[string] | False | | | List of allowed values. At least one of `whitelist`, `blacklist`, or `allowed_by_methods` must be configured. |
+| blacklist | array[string] | False | | | List of denied values. At least one of `whitelist`, `blacklist`, or `allowed_by_methods` must be configured. |
+| allowed_by_methods | array[object] | False | | | List of objects specifying allowed HTTP methods per Consumer. At least one of `whitelist`, `blacklist`, or `allowed_by_methods` must be configured. |
+| allowed_by_methods[].user | string | False | | | Consumer name. |
+| allowed_by_methods[].methods | array[string] | False | | GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, CONNECT, TRACE, PURGE | List of HTTP methods allowed for the Consumer. |
+| rejected_code | integer | False | 403 | >= 200 | HTTP status code returned when the request is rejected. |
+| rejected_msg | string | False | | | Message returned to the client when the request is rejected. |
+
+## Examples
+
+The examples below demonstrate how you can configure the `consumer-restriction` Plugin for different scenarios.
+
+While the examples use [`key-auth`](./key-auth.md) as the authentication method, you can easily adjust to other authentication plugins based on your needs.
 
 :::note
 
-The different values in the `type` attribute have these meanings:
-
-- `consumer_name`: Username of the Consumer to restrict access to a Route or a Service.
-- `consumer_group_id`: ID of the Consumer Group to restrict access to a Route or a Service.
-- `service_id`: ID of the Service to restrict access from a Consumer. Need to be used with an Authentication Plugin.
-- `route_id`: ID of the Route to restrict access from a Consumer.
-
-:::
-
-## Example usage
-
-### Restricting by `consumer_name`
-
-The example below shows how you can use the `consumer-restriction` Plugin on a Route to restrict specific consumers.
-
-You can first create two consumers `jack1` and `jack2`:
-
-:::note
 You can fetch the `admin_key` from `config.yaml` and save to an environment variable with the following command:
 
 ```bash
-admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
+admin_key=$(yq '.deployment.admin.admin_key[0].key' /usr/local/apisix/conf/config.yaml | sed 's/"//g')
 ```
 
 :::
 
-```shell
-curl http://127.0.0.1:9180/apisix/admin/consumers -H "X-API-KEY: $admin_key" -X PUT -i -d '
-{
-    "username": "jack1",
-    "plugins": {
-        "basic-auth": {
-            "username":"jack2019",
-            "password": "123456"
-        }
-    }
-}'
+### Restrict Access by Consumers
 
-curl http://127.0.0.1:9180/apisix/admin/consumers -H "X-API-KEY: $admin_key" -X PUT -i -d '
-{
-    "username": "jack2",
-    "plugins": {
-        "basic-auth": {
-            "username":"jack2020",
-            "password": "123456"
-        }
-    }
-}'
+The example below demonstrates how you can use the `consumer-restriction` Plugin on a Route to restrict Consumer access by Consumer names, where Consumers are authenticated with [`key-auth`](./key-auth.md).
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
+
+Create a Consumer `JohnDoe`:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "username": "JohnDoe"
+  }'
 ```
 
-Next, you can configure the Plugin to the Route:
+Create `key-auth` Credential for the Consumer:
 
 ```shell
-curl http://127.0.0.1:9180/apisix/admin/routes/1 -H "X-API-KEY: $admin_key" -X PUT -d '
-{
-    "uri": "/index.html",
-    "upstream": {
-        "type": "roundrobin",
-        "nodes": {
-            "127.0.0.1:1980": 1
-        }
+curl "http://127.0.0.1:9180/apisix/admin/consumers/JohnDoe/credentials" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "cred-john-key-auth",
+    "plugins": {
+      "key-auth": {
+        "key": "john-key"
+      }
+    }
+  }'
+```
+
+Create a second Consumer `JaneDoe`:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "username": "JaneDoe"
+  }'
+```
+
+Create `key-auth` Credential for the Consumer:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers/JaneDoe/credentials" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "cred-jane-key-auth",
+    "plugins": {
+      "key-auth": {
+        "key": "jane-key"
+      }
+    }
+  }'
+```
+
+Next, create a Route with key authentication enabled, and configure `consumer-restriction` to allow only Consumer `JaneDoe`:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "consumer-restricted-route",
+    "uri": "/get",
+    "plugins": {
+      "key-auth": {},
+      "consumer-restriction": {
+        "whitelist": ["JaneDoe"]
+      }
     },
-    "plugins": {
-        "basic-auth": {},
-        "consumer-restriction": {
-            "whitelist": [
-                "jack1"
-            ]
-        }
+    "upstream" : {
+      "nodes": {
+        "httpbin.org":1
+      }
     }
-}'
+  }'
 ```
 
-Now, this configuration will only allow `jack1` to access your Route:
+</TabItem>
 
-```shell
-curl -u jack2019:123456 http://127.0.0.1:9080/index.html
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+consumers:
+  - username: JohnDoe
+    credentials:
+      - name: cred-john-key-auth
+        type: key-auth
+        config:
+          key: john-key
+  - username: JaneDoe
+    credentials:
+      - name: cred-jane-key-auth
+        type: key-auth
+        config:
+          key: jane-key
+services:
+  - name: consumer-restriction-service
+    routes:
+      - name: consumer-restricted-route
+        uris:
+          - /get
+        plugins:
+          key-auth: {}
+          consumer-restriction:
+            whitelist:
+              - "JaneDoe"
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
 ```
 
+Synchronize the configuration to the gateway:
+
 ```shell
-HTTP/1.1 200 OK
+adc sync -f adc.yaml
 ```
 
-And requests from `jack2` are blocked:
+</TabItem>
 
-```shell
-curl -u jack2020:123456 http://127.0.0.1:9080/index.html -i
+<TabItem value="aic">
+
+When Consumers are configured using the Ingress Controller, the Consumer name is generated in the format `namespace_consumername`. For example, a Consumer named `janedoe` in the `aic` namespace becomes `aic_janedoe`. Use this format in the `whitelist` or `blacklist` of `consumer-restriction`.
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX Ingress Controller', value: 'apisix-ingress-controller'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="consumer-restriction-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: johndoe
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: john-key-auth
+      config:
+        key: john-key
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: janedoe
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: jane-key-auth
+      config:
+        key: jane-key
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: consumer-restriction-plugin-config
+spec:
+  plugins:
+    - name: key-auth
+      config:
+        _meta:
+          disable: false
+    - name: consumer-restriction
+      config:
+        whitelist:
+          - "aic_janedoe"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: consumer-restriction-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /get
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: consumer-restriction-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
 ```
 
+</TabItem>
+
+<TabItem value="apisix-ingress-controller">
+
+```yaml title="consumer-restriction-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: johndoe
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: john-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: janedoe
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: jane-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: consumer-restriction-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: consumer-restriction-route
+      match:
+        paths:
+          - /get
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: key-auth
+        enable: true
+      - name: consumer-restriction
+        enable: true
+        config:
+          whitelist:
+            - "aic_janedoe"
+```
+
+</TabItem>
+
+</Tabs>
+
+Apply the configuration to your cluster:
+
 ```shell
-HTTP/1.1 403 Forbidden
-...
+kubectl apply -f consumer-restriction-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
+Send a request to the Route as Consumer `JohnDoe`:
+
+```shell
+curl -i "http://127.0.0.1:9080/get" -H 'apikey: john-key'
+```
+
+You should receive an `HTTP/1.1 403 Forbidden` response with the following message:
+
+```text
 {"message":"The consumer_name is forbidden."}
 ```
 
-### Restricting by `allowed_by_methods`
-
-The example below configures the Plugin to a Route to restrict `jack1` to only make `POST` requests:
+Send another request to the Route as Consumer `JaneDoe`:
 
 ```shell
-curl http://127.0.0.1:9180/apisix/admin/routes/1 -H "X-API-KEY: $admin_key" -X PUT -d '
-{
-    "uri": "/index.html",
-    "upstream": {
-        "type": "roundrobin",
-        "nodes": {
-            "127.0.0.1:1980": 1
-        }
-    },
+curl -i "http://127.0.0.1:9080/get" -H 'apikey: jane-key'
+```
+
+You should receive an `HTTP/1.1 200 OK` response, showing the Consumer access is permitted.
+
+### Restrict Access by Consumers and HTTP Methods
+
+The example below demonstrates how you can use the `consumer-restriction` Plugin on a Route to restrict Consumer access by Consumer name and HTTP methods, where Consumers are authenticated with [`key-auth`](./key-auth.md).
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
+
+Create a Consumer `JohnDoe`:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "username": "JohnDoe"
+  }'
+```
+
+Create `key-auth` Credential for the Consumer:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers/JohnDoe/credentials" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "cred-john-key-auth",
     "plugins": {
-        "basic-auth": {},
-        "consumer-restriction": {
-            "allowed_by_methods":[{
-                "user": "jack1",
-                "methods": ["POST"]
-            }]
-        }
+      "key-auth": {
+        "key": "john-key"
+      }
     }
-}'
+  }'
 ```
 
-Now if `jack1` makes a `GET` request, the access is restricted:
+Create a second Consumer `JaneDoe`:
 
 ```shell
-curl -u jack2019:123456 http://127.0.0.1:9080/index.html
+curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "username": "JaneDoe"
+  }'
 ```
 
+Create `key-auth` Credential for the Consumer:
+
 ```shell
-HTTP/1.1 403 Forbidden
-...
+curl "http://127.0.0.1:9180/apisix/admin/consumers/JaneDoe/credentials" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "cred-jane-key-auth",
+    "plugins": {
+      "key-auth": {
+        "key": "jane-key"
+      }
+    }
+  }'
+```
+
+Next, create a Route with key authentication enabled, and use `consumer-restriction` to allow only the configured HTTP methods by Consumers:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "consumer-restricted-route",
+    "uri": "/anything",
+    "plugins": {
+      "key-auth": {},
+      "consumer-restriction": {
+        "allowed_by_methods":[
+          {
+            "user": "JohnDoe",
+            "methods": ["GET"]
+          },
+          {
+            "user": "JaneDoe",
+            "methods": ["POST"]
+          }
+        ]
+      }
+    },
+    "upstream" : {
+      "nodes": {
+        "httpbin.org":1
+      }
+    }
+  }'
+```
+
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+consumers:
+  - username: JohnDoe
+    credentials:
+      - name: cred-john-key-auth
+        type: key-auth
+        config:
+          key: john-key
+  - username: JaneDoe
+    credentials:
+      - name: cred-jane-key-auth
+        type: key-auth
+        config:
+          key: jane-key
+services:
+  - name: consumer-restriction-service
+    routes:
+      - name: consumer-restricted-route
+        uris:
+          - /anything
+        plugins:
+          key-auth: {}
+          consumer-restriction:
+            allowed_by_methods:
+              - user: "JohnDoe"
+                methods:
+                  - "GET"
+              - user: "JaneDoe"
+                methods:
+                  - "POST"
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX Ingress Controller', value: 'apisix-ingress-controller'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="consumer-restriction-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: johndoe
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: john-key-auth
+      config:
+        key: john-key
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: janedoe
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: jane-key-auth
+      config:
+        key: jane-key
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: consumer-restriction-methods-config
+spec:
+  plugins:
+    - name: key-auth
+      config:
+        _meta:
+          disable: false
+    - name: consumer-restriction
+      config:
+        allowed_by_methods:
+          - user: "aic_johndoe"
+            methods:
+              - "GET"
+          - user: "aic_janedoe"
+            methods:
+              - "POST"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: consumer-restriction-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: consumer-restriction-methods-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f consumer-restriction-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-ingress-controller">
+
+```yaml title="consumer-restriction-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: johndoe
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: john-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: janedoe
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: jane-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: consumer-restriction-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: consumer-restriction-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: key-auth
+        enable: true
+      - name: consumer-restriction
+        enable: true
+        config:
+          allowed_by_methods:
+            - user: "aic_johndoe"
+              methods:
+                - "GET"
+            - user: "aic_janedoe"
+              methods:
+                - "POST"
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f consumer-restriction-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
+</TabItem>
+
+</Tabs>
+
+Send a POST request to the Route as Consumer `JohnDoe`:
+
+```shell
+curl -i "http://127.0.0.1:9080/anything" -X POST -H 'apikey: john-key'
+```
+
+You should receive an `HTTP/1.1 403 Forbidden` response with the following message:
+
+```text
 {"message":"The consumer_name is forbidden."}
 ```
 
-To also allow `GET` requests, you can update the Plugin configuration and it would be reloaded automatically:
+Now, send a GET request to the Route as Consumer `JohnDoe`:
 
 ```shell
-curl http://127.0.0.1:9180/apisix/admin/routes/1 -H "X-API-KEY: $admin_key" -X PUT -d '
-{
-    "uri": "/index.html",
+curl -i "http://127.0.0.1:9080/anything" -X GET -H 'apikey: john-key'
+```
+
+You should receive an `HTTP/1.1 200 OK` response, showing the Consumer access is permitted.
+
+You can also verify the configurations by sending requests as Consumer `JaneDoe` and observe the behaviours match up to what was configured in the `consumer-restriction` Plugin on the Route.
+
+### Restricting by Service ID
+
+The example below demonstrates how you can use the `consumer-restriction` Plugin to restrict Consumer access by Service ID, where the Consumer is authenticated with [`key-auth`](./key-auth.md).
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
+
+Create two sample Services:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/services" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "srv-1",
     "upstream": {
-        "type": "roundrobin",
-        "nodes": {
-            "127.0.0.1:1980": 1
-        }
-    },
-    "plugins": {
-        "basic-auth": {},
-        "consumer-restriction": {
-            "allowed_by_methods":[{
-                "user": "jack1",
-                "methods": ["POST","GET"]
-            }]
-        }
+      "type": "roundrobin",
+      "nodes": {
+        "httpbin.org":1
+      }
     }
-}'
-```
-
-Now, if a `GET` request is made:
-
-```shell
-curl -u jack2019:123456 http://127.0.0.1:9080/index.html
+  }'
 ```
 
 ```shell
-HTTP/1.1 200 OK
-```
-
-### Restricting by `service_id`
-
-To restrict a Consumer from accessing a Service, you also need to use an Authentication Plugin. The example below uses the [key-auth](./key-auth.md) Plugin.
-
-First, you can create two services:
-
-```shell
-curl http://127.0.0.1:9180/apisix/admin/services/1 -H "X-API-KEY: $admin_key" -X PUT -d '
-{
+curl "http://127.0.0.1:9180/apisix/admin/services" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "srv-2",
     "upstream": {
-        "nodes": {
-            "127.0.0.1:1980": 1
-        },
-        "type": "roundrobin"
-    },
-    "desc": "new service 001"
-}'
-
-curl http://127.0.0.1:9180/apisix/admin/services/2 -H "X-API-KEY: $admin_key" -X PUT -d '
-{
-    "upstream": {
-        "nodes": {
-            "127.0.0.1:1980": 1
-        },
-        "type": "roundrobin"
-    },
-    "desc": "new service 002"
-}'
-```
-
-Then configure the `consumer-restriction` Plugin on the Consumer with the `key-auth` Plugin and the `service_id` to whitelist.
-
-```shell
-curl http://127.0.0.1:9180/apisix/admin/consumers -H "X-API-KEY: $admin_key" -X PUT -d '
-{
-    "username": "new_consumer",
-    "plugins": {
-    "key-auth": {
-        "key": "auth-jack"
-    },
-    "consumer-restriction": {
-           "type": "service_id",
-            "whitelist": [
-                "1"
-            ],
-            "rejected_code": 403
-        }
+      "type": "roundrobin",
+      "nodes": {
+        "mock.api7.ai":1
+      }
     }
-}'
+  }'
 ```
 
-Finally, you can configure the `key-auth` Plugin and bind the service to the Route:
+Next, create a Consumer with `key-auth` and configure `consumer-restriction` to allow only `srv-1` Service:
 
 ```shell
-curl http://127.0.0.1:9180/apisix/admin/routes/1 -H "X-API-KEY: $admin_key" -X PUT -d '
-{
-    "uri": "/index.html",
-    "upstream": {
-        "type": "roundrobin",
-        "nodes": {
-            "127.0.0.1:1980": 1
-        }
-    },
-    "service_id": 1,
+curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "username": "JohnDoe",
     "plugins": {
-         "key-auth": {
-        }
+      "key-auth": {
+        "key": "john-key"
+      },
+      "consumer-restriction": {
+        "type": "service_id",
+        "whitelist": ["srv-1"]
+      }
     }
-}'
+  }'
 ```
 
-Now, if you test the Route, you should be able to access the Service:
+Finally, create two Routes, with each belonging to one of the Services created earlier:
 
 ```shell
-curl http://127.0.0.1:9080/index.html -H 'apikey: auth-jack' -i
-```
-
-```shell
-HTTP/1.1 200 OK
-...
-```
-
-Now, if the Route is configured to the Service with `service_id` `2`:
-
-```shell
-curl http://127.0.0.1:9180/apisix/admin/routes/1 -H "X-API-KEY: $admin_key" -X PUT -d '
-{
-    "uri": "/index.html",
-    "upstream": {
-        "type": "roundrobin",
-        "nodes": {
-            "127.0.0.1:1980": 1
-        }
-    },
-    "service_id": 2,
-    "plugins": {
-         "key-auth": {
-        }
-    }
-}'
-```
-
-Since the Service is not in the whitelist, it cannot be accessed:
-
-```shell
-curl http://127.0.0.1:9080/index.html -H 'apikey: auth-jack' -i
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "srv-1-route",
+    "uri": "/anything",
+    "service_id": "srv-1"
+  }'
 ```
 
 ```shell
-HTTP/1.1 403 Forbidden
-...
-{"message":"The service_id is forbidden."}
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "srv-2-route",
+    "uri": "/srv-2",
+    "service_id": "srv-2"
+  }'
 ```
 
-## Delete Plugin
+</TabItem>
 
-To remove the `consumer-restriction` Plugin, you can delete the corresponding JSON configuration from the Plugin configuration. APISIX will automatically reload and you do not have to restart for this to take effect.
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+consumers:
+  - username: JohnDoe
+    plugins:
+      key-auth:
+        key: john-key
+      consumer-restriction:
+        type: service_id
+        whitelist:
+          - "srv-1"
+services:
+  - name: srv-1
+    routes:
+      - name: srv-1-route
+        uris:
+          - /anything
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+  - name: srv-2
+    routes:
+      - name: srv-2-route
+        uris:
+          - /srv-2
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: mock.api7.ai
+          port: 80
+          weight: 1
+```
+
+Synchronize the configuration to the gateway:
 
 ```shell
-curl http://127.0.0.1:9180/apisix/admin/routes/1 -H "X-API-KEY: $admin_key" -X PUT -d '
-{
-    "uri": "/index.html",
-    "upstream": {
-        "type": "roundrobin",
-        "nodes": {
-            "127.0.0.1:1980": 1
-        }
-    },
-    "plugins": {
-        "basic-auth": {}
-    }
-}'
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+When Routes are configured using the Ingress Controller, APISIX Service IDs are auto-generated as the hash of `{namespace}_{routeName}_{ruleIndex}`. These IDs cannot be easily predetermined. Consider using Consumer name-based restriction instead.
+
+</TabItem>
+
+</Tabs>
+
+Send a request to the Route in the `srv-1` Service:
+
+```shell
+curl -i "http://127.0.0.1:9080/anything" -H 'apikey: john-key'
+```
+
+You should receive an `HTTP/1.1 200 OK` response, showing the Consumer access is permitted.
+
+Send a request to the Route in the `srv-2` Service:
+
+```shell
+curl -i "http://127.0.0.1:9080/srv-2" -H 'apikey: john-key'
+```
+
+You should receive an `HTTP/1.1 401 Unauthorized` response with the following message:
+
+```text
+{"message":"The request is rejected, please check the service_id for this request"}
 ```

--- a/docs/en/latest/plugins/consumer-restriction.md
+++ b/docs/en/latest/plugins/consumer-restriction.md
@@ -765,6 +765,9 @@ curl "http://127.0.0.1:9180/apisix/admin/services" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
     "id": "srv-1",
+    "plugins": {
+      "key-auth": {}
+    },
     "upstream": {
       "type": "roundrobin",
       "nodes": {
@@ -779,6 +782,9 @@ curl "http://127.0.0.1:9180/apisix/admin/services" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
     "id": "srv-2",
+    "plugins": {
+      "key-auth": {}
+    },
     "upstream": {
       "type": "roundrobin",
       "nodes": {
@@ -788,7 +794,7 @@ curl "http://127.0.0.1:9180/apisix/admin/services" -X PUT \
   }'
 ```
 
-Next, create a Consumer with `key-auth` and configure `consumer-restriction` to allow only `srv-1` Service:
+Next, create a Consumer and configure `consumer-restriction` to allow only `srv-1` Service:
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
@@ -796,12 +802,24 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   -d '{
     "username": "JohnDoe",
     "plugins": {
-      "key-auth": {
-        "key": "john-key"
-      },
       "consumer-restriction": {
         "type": "service_id",
         "whitelist": ["srv-1"]
+      }
+    }
+  }'
+```
+
+Create a `key-auth` credential for the Consumer:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers/JohnDoe/credentials" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "cred-john-key-auth",
+    "plugins": {
+      "key-auth": {
+        "key": "john-key"
       }
     }
   }'
@@ -836,15 +854,20 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
 ```yaml title="adc.yaml"
 consumers:
   - username: JohnDoe
+    credentials:
+      - name: cred-john-key-auth
+        plugins:
+          key-auth:
+            key: john-key
     plugins:
-      key-auth:
-        key: john-key
       consumer-restriction:
         type: service_id
         whitelist:
           - "srv-1"
 services:
   - name: srv-1
+    plugins:
+      key-auth: {}
     routes:
       - name: srv-1-route
         uris:
@@ -856,6 +879,8 @@ services:
           port: 80
           weight: 1
   - name: srv-2
+    plugins:
+      key-auth: {}
     routes:
       - name: srv-2-route
         uris:
@@ -901,5 +926,5 @@ curl -i "http://127.0.0.1:9080/srv-2" -H 'apikey: john-key'
 You should receive an `HTTP/1.1 403 Forbidden` response with the following message:
 
 ```text
-{"message":"The request is rejected, please check the service_id for this request"}
+{"message":"The service_id is forbidden."}
 ```

--- a/docs/en/latest/plugins/consumer-restriction.md
+++ b/docs/en/latest/plugins/consumer-restriction.md
@@ -898,7 +898,7 @@ Send a request to the Route in the `srv-2` Service:
 curl -i "http://127.0.0.1:9080/srv-2" -H 'apikey: john-key'
 ```
 
-You should receive an `HTTP/1.1 401 Unauthorized` response with the following message:
+You should receive an `HTTP/1.1 403 Forbidden` response with the following message:
 
 ```text
 {"message":"The request is rejected, please check the service_id for this request"}

--- a/docs/zh/latest/plugins/consumer-restriction.md
+++ b/docs/zh/latest/plugins/consumer-restriction.md
@@ -765,6 +765,9 @@ curl "http://127.0.0.1:9180/apisix/admin/services" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
     "id": "srv-1",
+    "plugins": {
+      "key-auth": {}
+    },
     "upstream": {
       "type": "roundrobin",
       "nodes": {
@@ -779,6 +782,9 @@ curl "http://127.0.0.1:9180/apisix/admin/services" -X PUT \
   -H "X-API-KEY: ${admin_key}" \
   -d '{
     "id": "srv-2",
+    "plugins": {
+      "key-auth": {}
+    },
     "upstream": {
       "type": "roundrobin",
       "nodes": {
@@ -788,7 +794,7 @@ curl "http://127.0.0.1:9180/apisix/admin/services" -X PUT \
   }'
 ```
 
-创建一个使用 `key-auth` 的消费者，并配置 `consumer-restriction` 仅允许访问 `srv-1` 服务：
+创建一个消费者，并配置 `consumer-restriction` 仅允许访问 `srv-1` 服务：
 
 ```shell
 curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
@@ -796,12 +802,24 @@ curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
   -d '{
     "username": "JohnDoe",
     "plugins": {
-      "key-auth": {
-        "key": "john-key"
-      },
       "consumer-restriction": {
         "type": "service_id",
         "whitelist": ["srv-1"]
+      }
+    }
+  }'
+```
+
+为该消费者创建 `key-auth` 凭证：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers/JohnDoe/credentials" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "cred-john-key-auth",
+    "plugins": {
+      "key-auth": {
+        "key": "john-key"
       }
     }
   }'
@@ -836,15 +854,20 @@ curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
 ```yaml title="adc.yaml"
 consumers:
   - username: JohnDoe
+    credentials:
+      - name: cred-john-key-auth
+        plugins:
+          key-auth:
+            key: john-key
     plugins:
-      key-auth:
-        key: john-key
       consumer-restriction:
         type: service_id
         whitelist:
           - "srv-1"
 services:
   - name: srv-1
+    plugins:
+      key-auth: {}
     routes:
       - name: srv-1-route
         uris:
@@ -856,6 +879,8 @@ services:
           port: 80
           weight: 1
   - name: srv-2
+    plugins:
+      key-auth: {}
     routes:
       - name: srv-2-route
         uris:
@@ -901,5 +926,5 @@ curl -i "http://127.0.0.1:9080/srv-2" -H 'apikey: john-key'
 你应收到 `HTTP/1.1 403 Forbidden` 响应，包含以下消息：
 
 ```text
-{"message":"The request is rejected, please check the service_id for this request"}
+{"message":"The service_id is forbidden."}
 ```

--- a/docs/zh/latest/plugins/consumer-restriction.md
+++ b/docs/zh/latest/plugins/consumer-restriction.md
@@ -3,8 +3,9 @@ title: consumer-restriction
 keywords:
   - Apache APISIX
   - API 网关
-  - Consumer restriction
-description: Consumer Restriction 插件允许用户根据 Route、Service、Consumer 或 Consumer Group 来设置相应的访问限制。
+  - 插件
+  - consumer-restriction
+description: consumer-restriction 插件基于消费者名称、路由 ID、服务 ID 或消费者组 ID 实现访问控制，增强 API 安全性。
 ---
 
 <!--
@@ -26,328 +27,879 @@ description: Consumer Restriction 插件允许用户根据 Route、Service、Con
 #
 -->
 
+<head>
+  <link rel="canonical" href="https://docs.api7.ai/hub/consumer-restriction" />
+</head>
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## 描述
 
-`consumer-restriction` 插件允许用户根据 Route、Service、Consumer 或 Consumer Group 来设置相应的访问限制。
+`consumer-restriction` 插件基于消费者名称、路由 ID、服务 ID 或消费者组 ID 实现访问控制。
+
+该插件需要与认证插件配合使用，例如 [`key-auth`](./key-auth.md) 和 [`jwt-auth`](./jwt-auth.md)，这意味着在使用场景中至少需要创建一个[消费者](../terminology/consumer.md)。详情请参见下方示例。
 
 ## 属性
 
-| 名称                       | 类型          | 必选项 | 默认值        | 有效值                                                       | 描述                                                         |
-| -------------------------- | ------------- | ------ | ------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| type                       | string        | 否     | consumer_name | ["consumer_name", "consumer_group_id", "service_id", "route_id"] | 支持设置访问限制的对象类型。                                 |
-| whitelist                  | array[string] | 是     |               |                                                              | 加入白名单的对象，优先级高于`allowed_by_methods`。           |
-| blacklist                  | array[string] | 是     |               |                                                              | 加入黑名单的对象，优先级高于`whitelist`。                    |
-| rejected_code              | integer       | 否     | 403           | [200,...]                                                    | 当请求被拒绝时，返回的 HTTP 状态码。                         |
-| rejected_msg               | string        | 否     |               |                                                              | 当请求被拒绝时，返回的错误信息。                             |
-| allowed_by_methods         | array[object] | 否     |               |                                                              | 一组为 Consumer 设置允许的配置，包括用户名和允许的 HTTP 方法列表。 |
-| allowed_by_methods.user    | string        | 否     |               |                                                              | 为 Consumer 设置的用户名。                                   |
-| allowed_by_methods.methods | array[string] | 否     |               | ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT", "TRACE", "PURGE"] | 为 Consumer 设置的允许的 HTTP 方法列表。                     |
+| 名称 | 类型 | 必选项 | 默认值 | 有效值 | 描述 |
+|------|------|--------|--------|--------|------|
+| type | string | 否 | consumer_name | consumer_name, service_id, route_id, consumer_group_id | 限制的依据。决定对白名单或黑名单检查哪个值。 |
+| whitelist | array[string] | 否 | | | 允许访问的值列表。`whitelist`、`blacklist` 和 `allowed_by_methods` 中至少需要配置一个。 |
+| blacklist | array[string] | 否 | | | 拒绝访问的值列表。`whitelist`、`blacklist` 和 `allowed_by_methods` 中至少需要配置一个。 |
+| allowed_by_methods | array[object] | 否 | | | 指定每个消费者允许的 HTTP 方法的对象列表。`whitelist`、`blacklist` 和 `allowed_by_methods` 中至少需要配置一个。 |
+| allowed_by_methods[].user | string | 否 | | | 消费者名称。 |
+| allowed_by_methods[].methods | array[string] | 否 | | GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, CONNECT, TRACE, PURGE | 该消费者允许的 HTTP 方法列表。 |
+| rejected_code | integer | 否 | 403 | >= 200 | 请求被拒绝时返回的 HTTP 状态码。 |
+| rejected_msg | string | 否 | | | 请求被拒绝时返回给客户端的消息。 |
+
+## 示例
+
+以下示例演示了如何针对不同场景配置 `consumer-restriction` 插件。
+
+示例中使用 [`key-auth`](./key-auth.md) 作为认证方式，你可以根据需要灵活调整为其他认证插件。
 
 :::note
 
-不同的 `type` 属性值分别代表以下含义：
-
-- `consumer_name`：把 Consumer 的 `username` 列入白名单或黑名单来限制 Consumer 对 Route 或 Service 的访问。
-- `consumer_group_id`: 把 Consumer Group 的 `id` 列入白名单或黑名单来限制 Consumer 对 Route 或 Service 的访问。
-- `service_id`：把 Service 的 `id` 列入白名单或黑名单来限制 Consumer 对 Service 的访问，需要结合授权插件一起使用。
-- `route_id`：把 Route 的 `id` 列入白名单或黑名单来限制 Consumer 对 Route 的访问。
-
-:::
-
-## 启用并测试插件
-
-### 通过 `consumer_name` 限制访问
-
-首先，创建两个 Consumer，分别为 `jack1` 和 `jack2`：
-
-:::note
-
-您可以这样从 `config.yaml` 中获取 `admin_key` 并存入环境变量：
+你可以使用以下命令从 `config.yaml` 中获取 `admin_key` 并保存到环境变量中：
 
 ```bash
-admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
+admin_key=$(yq '.deployment.admin.admin_key[0].key' /usr/local/apisix/conf/config.yaml | sed 's/"//g')
 ```
 
 :::
 
-```shell
-curl http://127.0.0.1:9180/apisix/admin/consumers -H "X-API-KEY: $admin_key" -X PUT -i -d '
-{
-    "username": "jack1",
-    "plugins": {
-        "basic-auth": {
-            "username":"jack2019",
-            "password": "123456"
-        }
-    }
-}'
+### 通过消费者名称限制访问
 
-curl http://127.0.0.1:9180/apisix/admin/consumers -H "X-API-KEY: $admin_key" -X PUT -i -d '
-{
-    "username": "jack2",
-    "plugins": {
-        "basic-auth": {
-            "username":"jack2020",
-            "password": "123456"
-        }
-    }
-}'
+以下示例演示如何在路由上使用 `consumer-restriction` 插件，按消费者名称限制消费者访问，消费者通过 [`key-auth`](./key-auth.md) 进行认证。
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
+
+创建消费者 `JohnDoe`：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "username": "JohnDoe"
+  }'
 ```
 
-然后，在指定路由上启用并配置 `consumer-restriction` 插件，并通过将 `consumer_name` 加入 `whitelist` 来限制不同 Consumer 的访问：
+为该消费者创建 `key-auth` 凭证：
 
 ```shell
-curl http://127.0.0.1:9180/apisix/admin/routes/1 -H "X-API-KEY: $admin_key" -X PUT -d '
-{
-    "uri": "/index.html",
-    "upstream": {
-        "type": "roundrobin",
-        "nodes": {
-            "127.0.0.1:1980": 1
-        }
+curl "http://127.0.0.1:9180/apisix/admin/consumers/JohnDoe/credentials" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "cred-john-key-auth",
+    "plugins": {
+      "key-auth": {
+        "key": "john-key"
+      }
+    }
+  }'
+```
+
+创建第二个消费者 `JaneDoe`：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "username": "JaneDoe"
+  }'
+```
+
+为该消费者创建 `key-auth` 凭证：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers/JaneDoe/credentials" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "cred-jane-key-auth",
+    "plugins": {
+      "key-auth": {
+        "key": "jane-key"
+      }
+    }
+  }'
+```
+
+创建启用 key 认证的路由，并配置 `consumer-restriction` 仅允许消费者 `JaneDoe` 访问：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "consumer-restricted-route",
+    "uri": "/get",
+    "plugins": {
+      "key-auth": {},
+      "consumer-restriction": {
+        "whitelist": ["JaneDoe"]
+      }
     },
-    "plugins": {
-        "basic-auth": {},
-        "consumer-restriction": {
-            "whitelist": [
-                "jack1"
-            ]
-        }
+    "upstream" : {
+      "nodes": {
+        "httpbin.org":1
+      }
     }
-}'
+  }'
 ```
 
-**测试插件**
+</TabItem>
 
-`jack1` 发出访问请求，返回 `200` HTTP 状态码，代表访问成功：
+<TabItem value="adc">
 
-```shell
-curl -u jack2019:123456 http://127.0.0.1:9080/index.html -i
+```yaml title="adc.yaml"
+consumers:
+  - username: JohnDoe
+    credentials:
+      - name: cred-john-key-auth
+        type: key-auth
+        config:
+          key: john-key
+  - username: JaneDoe
+    credentials:
+      - name: cred-jane-key-auth
+        type: key-auth
+        config:
+          key: jane-key
+services:
+  - name: consumer-restriction-service
+    routes:
+      - name: consumer-restricted-route
+        uris:
+          - /get
+        plugins:
+          key-auth: {}
+          consumer-restriction:
+            whitelist:
+              - "JaneDoe"
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
 ```
 
+将配置同步到网关：
+
 ```shell
-HTTP/1.1 200 OK
+adc sync -f adc.yaml
 ```
 
-`jack2` 发出访问请求，返回 `403` HTTP 状态码，代表访问被限制，插件生效：
+</TabItem>
 
-```shell
-curl -u jack2020:123456 http://127.0.0.1:9080/index.html -i
+<TabItem value="aic">
+
+通过 Ingress Controller 配置消费者时，消费者名称格式为 `namespace_consumername`。例如，`aic` 命名空间中名为 `janedoe` 的消费者，其名称变为 `aic_janedoe`。在 `consumer-restriction` 的 `whitelist` 或 `blacklist` 中请使用此格式。
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX Ingress Controller', value: 'apisix-ingress-controller'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="consumer-restriction-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: johndoe
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: john-key-auth
+      config:
+        key: john-key
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: janedoe
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: jane-key-auth
+      config:
+        key: jane-key
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: consumer-restriction-plugin-config
+spec:
+  plugins:
+    - name: key-auth
+      config:
+        _meta:
+          disable: false
+    - name: consumer-restriction
+      config:
+        whitelist:
+          - "aic_janedoe"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: consumer-restriction-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /get
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: consumer-restriction-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
 ```
 
+</TabItem>
+
+<TabItem value="apisix-ingress-controller">
+
+```yaml title="consumer-restriction-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: johndoe
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: john-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: janedoe
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: jane-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: consumer-restriction-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: consumer-restriction-route
+      match:
+        paths:
+          - /get
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: key-auth
+        enable: true
+      - name: consumer-restriction
+        enable: true
+        config:
+          whitelist:
+            - "aic_janedoe"
+```
+
+</TabItem>
+
+</Tabs>
+
+将配置应用到集群：
+
 ```shell
-HTTP/1.1 403 Forbidden
-...
+kubectl apply -f consumer-restriction-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
+以消费者 `JohnDoe` 的身份向路由发送请求：
+
+```shell
+curl -i "http://127.0.0.1:9080/get" -H 'apikey: john-key'
+```
+
+你应收到 `HTTP/1.1 403 Forbidden` 响应，包含以下消息：
+
+```text
 {"message":"The consumer_name is forbidden."}
 ```
 
-### 通过 `allowed_by_methods` 限制访问
-
-首先，创建两个 Consumer，分别为 `jack1` 和 `jack2`，创建方法请参考[通过 `consumer_name` 限制访问](#通过-consumername-限制访问)。
-
-然后，在指定路由上启用并配置 `consumer-restriction` 插件，并且仅允许 `jack1` 使用 `POST` 方法进行访问：
+再以消费者 `JaneDoe` 的身份发送请求：
 
 ```shell
-curl http://127.0.0.1:9180/apisix/admin/routes/1 -H "X-API-KEY: $admin_key" -X PUT -d '
-{
-    "uri": "/index.html",
-    "upstream": {
-        "type": "roundrobin",
-        "nodes": {
-            "127.0.0.1:1980": 1
-        }
-    },
+curl -i "http://127.0.0.1:9080/get" -H 'apikey: jane-key'
+```
+
+你应收到 `HTTP/1.1 200 OK` 响应，表示该消费者访问被允许。
+
+### 通过消费者名称和 HTTP 方法限制访问
+
+以下示例演示如何在路由上使用 `consumer-restriction` 插件，按消费者名称和 HTTP 方法限制消费者访问，消费者通过 [`key-auth`](./key-auth.md) 进行认证。
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
+
+创建消费者 `JohnDoe`：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "username": "JohnDoe"
+  }'
+```
+
+为该消费者创建 `key-auth` 凭证：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers/JohnDoe/credentials" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "cred-john-key-auth",
     "plugins": {
-        "basic-auth": {},
-        "consumer-restriction": {
-            "allowed_by_methods":[{
-                "user": "jack1",
-                "methods": ["POST"]
-            }]
-        }
+      "key-auth": {
+        "key": "john-key"
+      }
     }
-}'
+  }'
 ```
 
-**测试插件**
-
-`jack1` 发出访问请求，返回 `403` HTTP 状态码，代表访问被限制：
+创建第二个消费者 `JaneDoe`：
 
 ```shell
-curl -u jack2019:123456 http://127.0.0.1:9080/index.html
+curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "username": "JaneDoe"
+  }'
 ```
 
+为该消费者创建 `key-auth` 凭证：
+
 ```shell
-HTTP/1.1 403 Forbidden
-...
+curl "http://127.0.0.1:9180/apisix/admin/consumers/JaneDoe/credentials" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "cred-jane-key-auth",
+    "plugins": {
+      "key-auth": {
+        "key": "jane-key"
+      }
+    }
+  }'
+```
+
+创建启用 key 认证的路由，并使用 `consumer-restriction` 仅允许消费者使用所配置的 HTTP 方法：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "consumer-restricted-route",
+    "uri": "/anything",
+    "plugins": {
+      "key-auth": {},
+      "consumer-restriction": {
+        "allowed_by_methods":[
+          {
+            "user": "JohnDoe",
+            "methods": ["GET"]
+          },
+          {
+            "user": "JaneDoe",
+            "methods": ["POST"]
+          }
+        ]
+      }
+    },
+    "upstream" : {
+      "nodes": {
+        "httpbin.org":1
+      }
+    }
+  }'
+```
+
+</TabItem>
+
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+consumers:
+  - username: JohnDoe
+    credentials:
+      - name: cred-john-key-auth
+        type: key-auth
+        config:
+          key: john-key
+  - username: JaneDoe
+    credentials:
+      - name: cred-jane-key-auth
+        type: key-auth
+        config:
+          key: jane-key
+services:
+  - name: consumer-restriction-service
+    routes:
+      - name: consumer-restricted-route
+        uris:
+          - /anything
+        plugins:
+          key-auth: {}
+          consumer-restriction:
+            allowed_by_methods:
+              - user: "JohnDoe"
+                methods:
+                  - "GET"
+              - user: "JaneDoe"
+                methods:
+                  - "POST"
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+```
+
+将配置同步到网关：
+
+```shell
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX Ingress Controller', value: 'apisix-ingress-controller'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="consumer-restriction-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: johndoe
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: john-key-auth
+      config:
+        key: john-key
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: janedoe
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: jane-key-auth
+      config:
+        key: jane-key
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: consumer-restriction-methods-config
+spec:
+  plugins:
+    - name: key-auth
+      config:
+        _meta:
+          disable: false
+    - name: consumer-restriction
+      config:
+        allowed_by_methods:
+          - user: "aic_johndoe"
+            methods:
+              - "GET"
+          - user: "aic_janedoe"
+            methods:
+              - "POST"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: consumer-restriction-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: consumer-restriction-methods-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f consumer-restriction-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-ingress-controller">
+
+```yaml title="consumer-restriction-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: johndoe
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: john-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: janedoe
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: jane-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+  - type: Domain
+    name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: consumer-restriction-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: consumer-restriction-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+      - name: httpbin-external-domain
+      plugins:
+      - name: key-auth
+        enable: true
+      - name: consumer-restriction
+        enable: true
+        config:
+          allowed_by_methods:
+            - user: "aic_johndoe"
+              methods:
+                - "GET"
+            - user: "aic_janedoe"
+              methods:
+                - "POST"
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f consumer-restriction-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
+
+</TabItem>
+
+</Tabs>
+
+以消费者 `JohnDoe` 的身份发送 POST 请求到路由：
+
+```shell
+curl -i "http://127.0.0.1:9080/anything" -X POST -H 'apikey: john-key'
+```
+
+你应收到 `HTTP/1.1 403 Forbidden` 响应，包含以下消息：
+
+```text
 {"message":"The consumer_name is forbidden."}
 ```
 
-现在更新插件配置，增加 `jack1` 的 `GET` 访问能力：
+再以消费者 `JohnDoe` 的身份发送 GET 请求：
 
 ```shell
-curl http://127.0.0.1:9180/apisix/admin/routes/1 -H "X-API-KEY: $admin_key" -X PUT -d '
-{
-    "uri": "/index.html",
+curl -i "http://127.0.0.1:9080/anything" -X GET -H 'apikey: john-key'
+```
+
+你应收到 `HTTP/1.1 200 OK` 响应，表示该消费者访问被允许。
+
+你还可以以消费者 `JaneDoe` 的身份发送请求，验证配置是否与路由上 `consumer-restriction` 插件中的设置一致。
+
+### 通过服务 ID 限制访问
+
+以下示例演示如何使用 `consumer-restriction` 插件按服务 ID 限制消费者访问，消费者通过 [`key-auth`](./key-auth.md) 进行认证。
+
+<Tabs
+groupId="api"
+defaultValue="admin-api"
+values={[
+{label: 'Admin API', value: 'admin-api'},
+{label: 'ADC', value: 'adc'},
+{label: 'Ingress Controller', value: 'aic'}
+]}>
+
+<TabItem value="admin-api">
+
+创建两个示例服务：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/services" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "srv-1",
     "upstream": {
-        "type": "roundrobin",
-        "nodes": {
-            "127.0.0.1:1980": 1
-        }
-    },
-    "plugins": {
-        "basic-auth": {},
-        "consumer-restriction": {
-            "allowed_by_methods":[{
-                "user": "jack1",
-                "methods": ["POST","GET"]
-            }]
-        }
+      "type": "roundrobin",
+      "nodes": {
+        "httpbin.org":1
+      }
     }
-}'
-```
-
-`jack1` 再次发出访问请求，返回 `200` HTTP 状态码，代表访问成功：
-
-```shell
-curl -u jack2019:123456 http://127.0.0.1:9080/index.html
+  }'
 ```
 
 ```shell
-HTTP/1.1 200 OK
-```
-
-### 通过 `service_id` 限制访问
-
-使用 `service_id` 的方式需要与授权插件一起配合使用，这里以 [`key-auth`](./key-auth.md) 授权插件为例。
-
-首先，创建两个 Service：
-
-```shell
-curl http://127.0.0.1:9180/apisix/admin/services/1 -H "X-API-KEY: $admin_key" -X PUT -d '
-{
+curl "http://127.0.0.1:9180/apisix/admin/services" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "srv-2",
     "upstream": {
-        "nodes": {
-            "127.0.0.1:1980": 1
-        },
-        "type": "roundrobin"
-    },
-    "desc": "new service 001"
-}'
-
-curl http://127.0.0.1:9180/apisix/admin/services/2 -H "X-API-KEY: $admin_key" -X PUT -d '
-{
-    "upstream": {
-        "nodes": {
-            "127.0.0.1:1980": 1
-        },
-        "type": "roundrobin"
-    },
-    "desc": "new service 002"
-}'
-```
-
-在指定 Consumer 上配置 `key-auth` 和 `consumer-restriction` 插件，并通过将 `service_id` 加入 `whitelist` 来限制 Consumer 对 Service 的访问：
-
-```shell
-curl http://127.0.0.1:9180/apisix/admin/consumers -H "X-API-KEY: $admin_key" -X PUT -d '
-{
-    "username": "new_consumer",
-    "plugins": {
-    "key-auth": {
-        "key": "auth-jack"
-    },
-    "consumer-restriction": {
-           "type": "service_id",
-            "whitelist": [
-                "1"
-            ],
-            "rejected_code": 403
-        }
+      "type": "roundrobin",
+      "nodes": {
+        "mock.api7.ai":1
+      }
     }
-}'
+  }'
 ```
 
-**测试插件**
-
-在指定路由上启用并配置 `key-auth` 插件，并绑定 `service_id` 为 `1`：
+创建一个使用 `key-auth` 的消费者，并配置 `consumer-restriction` 仅允许访问 `srv-1` 服务：
 
 ```shell
-curl http://127.0.0.1:9180/apisix/admin/routes/1 -H "X-API-KEY: $admin_key" -X PUT -d '
-{
-    "uri": "/index.html",
-    "upstream": {
-        "type": "roundrobin",
-        "nodes": {
-            "127.0.0.1:1980": 1
-        }
-    },
-    "service_id": 1,
+curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "username": "JohnDoe",
     "plugins": {
-         "key-auth": {
-        }
+      "key-auth": {
+        "key": "john-key"
+      },
+      "consumer-restriction": {
+        "type": "service_id",
+        "whitelist": ["srv-1"]
+      }
     }
-}'
+  }'
 ```
 
-对 Service 发出访问请求，返回 `403` HTTP 状态码，说明在白名单列中的 `service_id` 允许访问，插件生效：
+分别创建两条路由，各绑定到上面创建的一个服务：
 
 ```shell
-curl http://127.0.0.1:9080/index.html -H 'apikey: auth-jack' -i
-```
-
-```shell
-HTTP/1.1 200 OK
-```
-
-更新配置 `key-auth` 插件，并绑定 `service_id` 为 `2`：
-
-```shell
-curl http://127.0.0.1:9180/apisix/admin/routes/1 -H "X-API-KEY: $admin_key" -X PUT -d '
-{
-    "uri": "/index.html",
-    "upstream": {
-        "type": "roundrobin",
-        "nodes": {
-            "127.0.0.1:1980": 1
-        }
-    },
-    "service_id": 2,
-    "plugins": {
-         "key-auth": {
-        }
-    }
-}'
-```
-
-再次对 Service 发出访问请求，返回 `403` HTTP 状态码，说明不在白名单列表的 `service_id` 被拒绝访问，插件生效：
-
-```shell
-curl http://127.0.0.1:9080/index.html -H 'apikey: auth-jack' -i
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "srv-1-route",
+    "uri": "/anything",
+    "service_id": "srv-1"
+  }'
 ```
 
 ```shell
-HTTP/1.1 403 Forbidden
-...
-{"message":"The service_id is forbidden."}
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "srv-2-route",
+    "uri": "/srv-2",
+    "service_id": "srv-2"
+  }'
 ```
 
-## 删除插件
+</TabItem>
 
-当你需要删除该插件时，可以通过以下命令删除相应的 JSON 配置，APISIX 将会自动重新加载相关配置，无需重启服务：
+<TabItem value="adc">
+
+```yaml title="adc.yaml"
+consumers:
+  - username: JohnDoe
+    plugins:
+      key-auth:
+        key: john-key
+      consumer-restriction:
+        type: service_id
+        whitelist:
+          - "srv-1"
+services:
+  - name: srv-1
+    routes:
+      - name: srv-1-route
+        uris:
+          - /anything
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: httpbin.org
+          port: 80
+          weight: 1
+  - name: srv-2
+    routes:
+      - name: srv-2-route
+        uris:
+          - /srv-2
+    upstream:
+      type: roundrobin
+      nodes:
+        - host: mock.api7.ai
+          port: 80
+          weight: 1
+```
+
+将配置同步到网关：
 
 ```shell
-curl http://127.0.0.1:9180/apisix/admin/routes/1 -H "X-API-KEY: $admin_key" -X PUT -d '
-{
-    "uri": "/index.html",
-    "upstream": {
-        "type": "roundrobin",
-        "nodes": {
-            "127.0.0.1:1980": 1
-        }
-    },
-    "plugins": {
-        "basic-auth": {}
-    }
-}'
+adc sync -f adc.yaml
+```
+
+</TabItem>
+
+<TabItem value="aic">
+
+通过 Ingress Controller 配置路由时，APISIX 服务 ID 会自动生成为 `{namespace}_{routeName}_{ruleIndex}` 的哈希值，无法预先确定。建议改用基于消费者名称的限制方式。
+
+</TabItem>
+
+</Tabs>
+
+向 `srv-1` 服务中的路由发送请求：
+
+```shell
+curl -i "http://127.0.0.1:9080/anything" -H 'apikey: john-key'
+```
+
+你应收到 `HTTP/1.1 200 OK` 响应，表示该消费者访问被允许。
+
+向 `srv-2` 服务中的路由发送请求：
+
+```shell
+curl -i "http://127.0.0.1:9080/srv-2" -H 'apikey: john-key'
+```
+
+你应收到 `HTTP/1.1 401 Unauthorized` 响应，包含以下消息：
+
+```text
+{"message":"The request is rejected, please check the service_id for this request"}
 ```

--- a/docs/zh/latest/plugins/consumer-restriction.md
+++ b/docs/zh/latest/plugins/consumer-restriction.md
@@ -898,7 +898,7 @@ curl -i "http://127.0.0.1:9080/anything" -H 'apikey: john-key'
 curl -i "http://127.0.0.1:9080/srv-2" -H 'apikey: john-key'
 ```
 
-你应收到 `HTTP/1.1 401 Unauthorized` 响应，包含以下消息：
+你应收到 `HTTP/1.1 403 Forbidden` 响应，包含以下消息：
 
 ```text
 {"message":"The request is rejected, please check the service_id for this request"}


### PR DESCRIPTION
Re-ports the consumer-restriction plugin documentation with Admin API, ADC, and Ingress Controller tab structure, corrected attribute table (whitelist/blacklist/allowed_by_methods are not individually required; rejected_code valid range >= 200), and canonical link.