### PR TITLE
fix(core/json): stably_encode fails to encode cjson.null values

### DIFF
--- a/apisix/core/json.lua
+++ b/apisix/core/json.lua
@@ -33,6 +33,46 @@ local cached_tab = {}
 
 cjson.encode_escape_forward_slash(false)
 cjson.decode_array_with_array_mt(true)
+
+
+local dkjson = require("dkjson")
+local dkjson_null = dkjson.null
+
+
+local function convert_cjson_null(data, seen)
+    if data == cjson_null then
+        return dkjson_null
+    end
+
+    if type(data) ~= "table" then
+        return data
+    end
+
+    seen = seen or {}
+    if seen[data] then
+        return data
+    end
+    seen[data] = true
+
+    local t = {}
+    for k, v in pairs(data) do
+        t[convert_cjson_null(k, seen)] = convert_cjson_null(v, seen)
+    end
+
+    return t
+end
+
+
+local function stably_encode(data)
+    if data == cjson_null then
+        data = dkjson_null
+    elseif type(data) == "table" then
+        data = convert_cjson_null(data)
+    end
+    return dkjson.encode(data)
+end
+
+
 local _M = {
     version = 0.1,
     array_mt = cjson.array_mt,
@@ -40,7 +80,7 @@ local _M = {
     -- This method produces the same encoded string when the input is not changed.
     -- Different calls with cjson.encode will produce different string because
     -- it doesn't maintain the object key order.
-    stably_encode = require("dkjson").encode
+    stably_encode = stably_encode
 }
 
 

--- a/t/core/json.t
+++ b/t/core/json.t
@@ -193,3 +193,59 @@ b.d: 1
 e: text
 a or default: default
 top-level null: nil
+
+
+
+=== TEST 9: stably_encode with cjson.null
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local data = {a = 1, b = core.json.null}
+            ngx.say(core.json.stably_encode(data))
+        }
+    }
+--- response_body
+{"a":1,"b":null}
+
+
+
+=== TEST 10: stably_encode with nested cjson.null
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local data = {outer = {inner = core.json.null, val = "test"}}
+            ngx.say(core.json.stably_encode(data))
+        }
+    }
+--- response_body
+{"outer":{"inner":null,"val":"test"}}
+
+
+
+=== TEST 11: stably_encode stability with cjson.null
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local data1 = {z = 1, a = core.json.null}
+            local data2 = {a = core.json.null, z = 1}
+            ngx.say(core.json.stably_encode(data1) == core.json.stably_encode(data2))
+        }
+    }
+--- response_body
+true
+
+
+
+=== TEST 12: stably_encode top-level cjson.null
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            ngx.say(core.json.stably_encode(core.json.null))
+        }
+    }
+--- response_body
+null


### PR DESCRIPTION
The stably_encode function used dkjson.encode directly, which does not recognize cjson.null (a userdata) and fails to encode it properly.

This fix adds a convert_cjson_null helper that recursively converts cjson.null to dkjson.null before encoding. This ensures tables containing cjson.null values can be stably encoded as valid JSON with null literals.

Also added 4 test cases in t/core/json.t to cover:
- simple table with cjson.null
- nested table with cjson.null
- encoding stability with cjson.null
- top-level cjson.null encoding

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
