### PR TITLE
fix(stream/traffic-split): set route_id in stream preread phase

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -1344,6 +1344,8 @@ function _M.stream_preread_phase()
     api_ctx.conf_type = "stream/route"
     api_ctx.conf_version = matched_route.modifiedIndex
     api_ctx.conf_id = matched_route.value.id
+    api_ctx.route_id = matched_route.value.id
+    api_ctx.route_name = matched_route.value.name
 
     plugin.run_plugin("preread", plugins, api_ctx)
 

--- a/t/stream-plugin/traffic-split.t
+++ b/t/stream-plugin/traffic-split.t
@@ -343,3 +343,69 @@ GET /hit
 --- response_body
 hello world from port 1995
 --- stream_enable
+
+
+
+=== TEST 7: set stream route with traffic-split using route_id in match condition
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/stream_routes/3',
+                ngx.HTTP_PUT,
+                [=[{
+                    "plugins": {
+                        "traffic-split": {
+                            "rules": [{
+                                "match": [
+                                    {
+                                        "vars": [["route_id", "==", "3"]]
+                                    }
+                                ],
+                                "weighted_upstreams": [
+                                    {
+                                        "upstream": {
+                                            "name": "upstream_A",
+                                            "type": "roundrobin",
+                                            "nodes": {
+                                                "127.0.0.1:1995": 1
+                                            }
+                                        },
+                                        "weight": 1
+                                    }
+                                ]
+                            }]
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1997": 1
+                        },
+                        "type": "roundrobin"
+                    }
+                }]=]
+            )
+            if not code then
+                ngx.status = 500
+                ngx.say("failed to connect to admin API for stream_routes/3: ", body)
+                return
+            end
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 8: route_id match condition directs traffic to plugin upstream
+--- request
+GET /hit
+--- response_body
+hello world from port 1995
+--- stream_enable


### PR DESCRIPTION
In `stream_preread_phase`, `api_ctx.route_id` was never assigned after route matching, so `ctx.var.route_id` always returned nil in stream context. The HTTP `access_phase` sets it, but stream was missing it.

This caused match conditions using `route_id` in plugins like `traffic-split` to always evaluate as nil and never match.

The fix adds `api_ctx.route_id` (and `route_name`) assignment right before plugins run — matching the pattern already established in the HTTP path.

Also adds a test case that creates a stream route with a traffic-split rule matching on `route_id`, and verifies traffic is correctly directed to the plugin-configured upstream.