### PR TITLE
fix(stream/traffic-split): handle upstream_id set by plugin in stream context

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -1347,6 +1347,15 @@ function _M.stream_preread_phase()
 
     plugin.run_plugin("preread", plugins, api_ctx)
 
+    if api_ctx.upstream_id then
+        local new_upstream = apisix_upstream.get_by_id(api_ctx.upstream_id)
+        if not new_upstream then
+            core.log.error("failed to get upstream by upstream_id: ", api_ctx.upstream_id)
+            return ngx_exit(1)
+        end
+        api_ctx.matched_upstream = new_upstream
+    end
+
     if matched_route.value.protocol then
         xrpc.run_protocol(matched_route.value.protocol, api_ctx)
         return

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -1350,7 +1350,6 @@ function _M.stream_preread_phase()
     if api_ctx.upstream_id then
         local new_upstream = apisix_upstream.get_by_id(api_ctx.upstream_id)
         if not new_upstream then
-            core.log.error("failed to get upstream by upstream_id: ", api_ctx.upstream_id)
             return ngx_exit(1)
         end
         api_ctx.matched_upstream = new_upstream

--- a/t/stream-plugin/traffic-split.t
+++ b/t/stream-plugin/traffic-split.t
@@ -255,7 +255,8 @@ Connection refused
             -- remove earlier catch-all routes so route 3 is the only active stream route
             local del_code, del_body = t('/apisix/admin/stream_routes/1', ngx.HTTP_DELETE)
             if not del_code then
-                ngx.say("failed to connect to admin API for stream_routes/1")
+                ngx.status = 500
+                ngx.say("failed to connect to admin API for stream_routes/1: ", del_body)
                 return
             end
             if del_code >= 300 and del_code ~= 404 then
@@ -265,7 +266,8 @@ Connection refused
             end
             del_code, del_body = t('/apisix/admin/stream_routes/2', ngx.HTTP_DELETE)
             if not del_code then
-                ngx.say("failed to connect to admin API for stream_routes/2")
+                ngx.status = 500
+                ngx.say("failed to connect to admin API for stream_routes/2: ", del_body)
                 return
             end
             if del_code >= 300 and del_code ~= 404 then
@@ -283,6 +285,11 @@ Connection refused
                     "type": "roundrobin"
                 }]]
             )
+            if not code then
+                ngx.status = 500
+                ngx.say("failed to connect to admin API for upstreams/2: ", body)
+                return
+            end
             if code >= 300 then
                 ngx.status = code
                 ngx.say(body)
@@ -312,6 +319,11 @@ Connection refused
                     }
                 }]]
             )
+            if not code then
+                ngx.status = 500
+                ngx.say("failed to connect to admin API for stream_routes/3: ", body)
+                return
+            end
             if code >= 300 then
                 ngx.status = code
             end

--- a/t/stream-plugin/traffic-split.t
+++ b/t/stream-plugin/traffic-split.t
@@ -252,6 +252,10 @@ Connection refused
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
+            -- remove earlier catch-all routes so route 3 is the only active stream route
+            t('/apisix/admin/stream_routes/1', ngx.HTTP_DELETE)
+            t('/apisix/admin/stream_routes/2', ngx.HTTP_DELETE)
+
             local code, body = t('/apisix/admin/upstreams/2',
                 ngx.HTTP_PUT,
                 [[{

--- a/t/stream-plugin/traffic-split.t
+++ b/t/stream-plugin/traffic-split.t
@@ -244,3 +244,68 @@ hello world from port 1995
 --- stream_enable
 --- error_log
 Connection refused
+
+
+
+=== TEST 5: set stream route with traffic-split using upstream_id reference
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/upstreams/2',
+                ngx.HTTP_PUT,
+                [[{
+                    "nodes": {
+                        "127.0.0.1:1995": 1
+                    },
+                    "type": "roundrobin"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            local code, body = t('/apisix/admin/stream_routes/3',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "traffic-split": {
+                            "rules": [{
+                                "weighted_upstreams": [
+                                    {
+                                        "upstream_id": "2",
+                                        "weight": 1
+                                    }
+                                ]
+                            }]
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1997": 1
+                        },
+                        "type": "roundrobin"
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 6: upstream_id reference in traffic-split directs to correct upstream
+--- request
+GET /hit
+--- response_body
+hello world from port 1995
+--- stream_enable

--- a/t/stream-plugin/traffic-split.t
+++ b/t/stream-plugin/traffic-split.t
@@ -304,6 +304,7 @@ Connection refused
 GET /t
 --- response_body
 passed
+--- stream_enable
 
 
 

--- a/t/stream-plugin/traffic-split.t
+++ b/t/stream-plugin/traffic-split.t
@@ -254,13 +254,13 @@ Connection refused
             local t = require("lib.test_admin").test
             -- remove earlier catch-all routes so route 3 is the only active stream route
             local del_code = t('/apisix/admin/stream_routes/1', ngx.HTTP_DELETE)
-            if del_code >= 300 and del_code ~= 404 then
+            if del_code and del_code >= 300 and del_code ~= 404 then
                 ngx.status = del_code
                 ngx.say("failed to delete stream_routes/1")
                 return
             end
             del_code = t('/apisix/admin/stream_routes/2', ngx.HTTP_DELETE)
-            if del_code >= 300 and del_code ~= 404 then
+            if del_code and del_code >= 300 and del_code ~= 404 then
                 ngx.status = del_code
                 ngx.say("failed to delete stream_routes/2")
                 return

--- a/t/stream-plugin/traffic-split.t
+++ b/t/stream-plugin/traffic-split.t
@@ -253,8 +253,18 @@ Connection refused
         content_by_lua_block {
             local t = require("lib.test_admin").test
             -- remove earlier catch-all routes so route 3 is the only active stream route
-            t('/apisix/admin/stream_routes/1', ngx.HTTP_DELETE)
-            t('/apisix/admin/stream_routes/2', ngx.HTTP_DELETE)
+            local del_code = t('/apisix/admin/stream_routes/1', ngx.HTTP_DELETE)
+            if del_code >= 300 and del_code ~= 404 then
+                ngx.status = del_code
+                ngx.say("failed to delete stream_routes/1")
+                return
+            end
+            del_code = t('/apisix/admin/stream_routes/2', ngx.HTTP_DELETE)
+            if del_code >= 300 and del_code ~= 404 then
+                ngx.status = del_code
+                ngx.say("failed to delete stream_routes/2")
+                return
+            end
 
             local code, body = t('/apisix/admin/upstreams/2',
                 ngx.HTTP_PUT,

--- a/t/stream-plugin/traffic-split.t
+++ b/t/stream-plugin/traffic-split.t
@@ -253,16 +253,24 @@ Connection refused
         content_by_lua_block {
             local t = require("lib.test_admin").test
             -- remove earlier catch-all routes so route 3 is the only active stream route
-            local del_code = t('/apisix/admin/stream_routes/1', ngx.HTTP_DELETE)
-            if del_code and del_code >= 300 and del_code ~= 404 then
-                ngx.status = del_code
-                ngx.say("failed to delete stream_routes/1")
+            local del_code, del_body = t('/apisix/admin/stream_routes/1', ngx.HTTP_DELETE)
+            if not del_code then
+                ngx.say("failed to connect to admin API for stream_routes/1")
                 return
             end
-            del_code = t('/apisix/admin/stream_routes/2', ngx.HTTP_DELETE)
-            if del_code and del_code >= 300 and del_code ~= 404 then
+            if del_code >= 300 and del_code ~= 404 then
                 ngx.status = del_code
-                ngx.say("failed to delete stream_routes/2")
+                ngx.say("failed to delete stream_routes/1: ", del_body)
+                return
+            end
+            del_code, del_body = t('/apisix/admin/stream_routes/2', ngx.HTTP_DELETE)
+            if not del_code then
+                ngx.say("failed to connect to admin API for stream_routes/2")
+                return
+            end
+            if del_code >= 300 and del_code ~= 404 then
+                ngx.status = del_code
+                ngx.say("failed to delete stream_routes/2: ", del_body)
                 return
             end
 

--- a/t/stream-plugin/traffic-split.t
+++ b/t/stream-plugin/traffic-split.t
@@ -304,7 +304,6 @@ Connection refused
 GET /t
 --- response_body
 passed
---- stream_enable
 
 
 


### PR DESCRIPTION
When the traffic-split plugin selects an upstream via `upstream_id`, it sets `api_ctx.upstream_id`. In the HTTP path this is handled in `handle_upstream()` which re-fetches the upstream and updates `api_ctx.matched_upstream`. The stream path was missing this handling.

`set_by_route()` only checks `api_ctx.upstream_conf` (set when using inline upstream objects), but doesn't handle `api_ctx.upstream_id`. So even when the plugin selected a different upstream by ID, the route's original upstream was still used.

The fix adds a check after `plugin.run_plugin("preread")`: if `api_ctx.upstream_id` is set, fetch that upstream and update `api_ctx.matched_upstream` before calling `set_upstream()`.

Also adds a test case that configures a stream route with a traffic-split rule using `upstream_id` and verifies traffic is correctly forwarded to the referenced upstream.