### PR TITLE
feat: support custom_lua_shared_dict in global lua {} block and stream {} block

### DIFF
--- a/apisix/cli/config.lua
+++ b/apisix/cli/config.lua
@@ -106,7 +106,8 @@ local _M = {
         ["standalone-config"] = "10m",
         ["status-report"] = "1m",
         ["upstream-healthcheck"] = "10m",
-      }
+      },
+      custom_lua_shared_dict = {},
     },
     stream = {
       enable_access_log = false,
@@ -121,7 +122,8 @@ local _M = {
         ["plugin-limit-conn-stream"] = "10m",
         ["worker-events-stream"] = "10m",
         ["tars-stream"] = "1m",
-      }
+      },
+      custom_lua_shared_dict = {},
     },
     main_configuration_snippet = "",
     http_configuration_snippet = "",

--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -79,6 +79,13 @@ lua {
     {% end %}
     lua_shared_dict nacos 10m;
     lua_shared_dict upstream-healthcheck {* meta.lua_shared_dict["upstream-healthcheck"] *};
+
+    # for custom shared dict shared by http and stream subsystems
+    {% if meta.custom_lua_shared_dict then %}
+    {% for dict_name, dict_size in pairs(meta.custom_lua_shared_dict) do %}
+    lua_shared_dict {*dict_name*} {*dict_size*};
+    {% end %}
+    {% end %}
 }
 
 {% if enabled_stream_plugins["prometheus"] and not enable_http then %}
@@ -162,6 +169,13 @@ stream {
     {% if discovery_shared_dicts then %}
     {% for key, size in pairs(discovery_shared_dicts) do %}
     lua_shared_dict {*key*}-stream {*size*};
+    {% end %}
+    {% end %}
+
+    # for custom shared dict
+    {% if stream.custom_lua_shared_dict then %}
+    {% for dict_name, dict_size in pairs(stream.custom_lua_shared_dict) do %}
+    lua_shared_dict {*dict_name*} {*dict_size*};
     {% end %}
     {% end %}
 

--- a/apisix/cli/schema.lua
+++ b/apisix/cli/schema.lua
@@ -279,7 +279,23 @@ local config_schema = {
                     items = {
                         type = "string",
                     }
-                }
+                },
+                meta = {
+                    type = "object",
+                    properties = {
+                        custom_lua_shared_dict = {
+                            type = "object",
+                        }
+                    }
+                },
+                stream = {
+                    type = "object",
+                    properties = {
+                        custom_lua_shared_dict = {
+                            type = "object",
+                        }
+                    }
+                },
             },
         },
         http = {

--- a/t/cli/test_custom_shared_dict.sh
+++ b/t/cli/test_custom_shared_dict.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+. ./t/cli/common.sh
+
+# test: custom_lua_shared_dict in meta (global lua {} block, shared by http and stream)
+git checkout conf/config.yaml
+
+echo '
+nginx_config:
+  meta:
+    custom_lua_shared_dict:
+      my-global-dict: 1m
+      another-global-dict: 5m
+' > conf/config.yaml
+
+make init
+
+# The meta custom_lua_shared_dict should be rendered in the global lua {} block
+if ! grep "lua_shared_dict my-global-dict 1m;" conf/nginx.conf > /dev/null; then
+    echo "failed: meta custom_lua_shared_dict 'my-global-dict' not in nginx.conf"
+    exit 1
+fi
+
+if ! grep "lua_shared_dict another-global-dict 5m;" conf/nginx.conf > /dev/null; then
+    echo "failed: meta custom_lua_shared_dict 'another-global-dict' not in nginx.conf"
+    exit 1
+fi
+
+echo "passed: meta custom_lua_shared_dict rendered in global lua {} block"
+
+# test: custom_lua_shared_dict in stream {} block
+git checkout conf/config.yaml
+
+echo '
+apisix:
+  proxy_mode: http&stream
+  stream_proxy:
+    tcp:
+      - addr: 9100
+nginx_config:
+  stream:
+    custom_lua_shared_dict:
+      my-stream-dict: 2m
+      another-stream-dict: 8m
+' > conf/config.yaml
+
+make init
+
+if ! grep "lua_shared_dict my-stream-dict 2m;" conf/nginx.conf > /dev/null; then
+    echo "failed: stream custom_lua_shared_dict 'my-stream-dict' not in nginx.conf"
+    exit 1
+fi
+
+if ! grep "lua_shared_dict another-stream-dict 8m;" conf/nginx.conf > /dev/null; then
+    echo "failed: stream custom_lua_shared_dict 'another-stream-dict' not in nginx.conf"
+    exit 1
+fi
+
+echo "passed: stream custom_lua_shared_dict rendered in stream {} block"
+
+# test: meta and stream custom_lua_shared_dict together
+git checkout conf/config.yaml
+
+echo '
+apisix:
+  proxy_mode: http&stream
+  stream_proxy:
+    tcp:
+      - addr: 9100
+nginx_config:
+  meta:
+    custom_lua_shared_dict:
+      shared-between-subsystems: 3m
+  http:
+    custom_lua_shared_dict:
+      http-only-dict: 4m
+  stream:
+    custom_lua_shared_dict:
+      stream-only-dict: 6m
+' > conf/config.yaml
+
+make init
+
+if ! grep "lua_shared_dict shared-between-subsystems 3m;" conf/nginx.conf > /dev/null; then
+    echo "failed: meta custom_lua_shared_dict 'shared-between-subsystems' not in nginx.conf"
+    exit 1
+fi
+
+if ! grep "lua_shared_dict http-only-dict 4m;" conf/nginx.conf > /dev/null; then
+    echo "failed: http custom_lua_shared_dict 'http-only-dict' not in nginx.conf"
+    exit 1
+fi
+
+if ! grep "lua_shared_dict stream-only-dict 6m;" conf/nginx.conf > /dev/null; then
+    echo "failed: stream custom_lua_shared_dict 'stream-only-dict' not in nginx.conf"
+    exit 1
+fi
+
+echo "passed: meta, http, and stream custom_lua_shared_dict all rendered correctly"
+
+# test: empty custom_lua_shared_dict should not break anything
+git checkout conf/config.yaml
+
+echo '
+nginx_config:
+  meta:
+    custom_lua_shared_dict: {}
+  stream:
+    custom_lua_shared_dict: {}
+' > conf/config.yaml
+
+make init
+
+echo "passed: empty custom_lua_shared_dict does not break init"


### PR DESCRIPTION
## What this PR does

Currently, `custom_lua_shared_dict` only works in the `http {}` block (added in #5030). This PR extends the same mechanism to:

1. **The global `lua {}` block** (requires `apisix-nginx-module`) — for shared dicts accessible by both HTTP and Stream subsystems
2. **The `stream {}` block** — for stream-only shared dicts

## Why

Users who need cross-subsystem shared dicts (e.g., for lifecycle management, custom metrics, global state sharing) currently have to manually patch `ngx_tpl.lua`. This PR allows them to simply configure it in `config.yaml`:

```yaml
nginx_config:
  meta:
    custom_lua_shared_dict:
      my-global-dict: 1m       # shared between http and stream
  stream:
    custom_lua_shared_dict:
      my-stream-dict: 5m       # stream only
```

## Changes

| File | Change |
|------|--------|
| `apisix/cli/ngx_tpl.lua` | Add dynamic rendering loop in `lua {}` and `stream {}` blocks |
| `apisix/cli/config.lua` | Add default empty `custom_lua_shared_dict` for `meta` and `stream` |
| `apisix/cli/schema.lua` | Add schema validation for `meta` and `stream` custom_lua_shared_dict |
| `t/cli/test_custom_shared_dict.sh` | Test cases covering meta, stream, combined, and empty configs |

## Backward Compatibility

100% backward compatible. Default `custom_lua_shared_dict` is an empty table — no behavior change without explicit configuration.

**Note:** The `meta.custom_lua_shared_dict` feature only takes effect when `apisix-nginx-module` is compiled in (i.e., `use_apisix_base` is true), since the global `lua {}` block itself is only rendered in that case.