### PR TITLE
fix: batch-processor infinite timer loop prevents graceful shutdown

### DIFF
--- a/apisix/utils/batch-processor.lua
+++ b/apisix/utils/batch-processor.lua
@@ -21,6 +21,7 @@ local ipairs = ipairs
 local table = table
 local now = ngx.now
 local type = type
+local exiting = ngx.worker.exiting
 local batch_processor = {}
 local batch_processor_mt = {
     __index = batch_processor
@@ -52,9 +53,12 @@ local function schedule_func_exec(self, delay, batch)
     local hdl, err = timer_at(delay, execute_func, self, batch)
     if not hdl then
         if err == "process exiting" then
-            -- it is allowed to create zero-delay timers even when
-            -- the Nginx worker process starts shutting down
-            timer_at(0, execute_func, self)
+            local hdl2, err2 = timer_at(0, execute_func, self, batch)
+            if not hdl2 then
+                core.log.error("failed to create fallback process timer ",
+                               "while exiting: ", err2)
+                return
+            end
         else
             core.log.error("failed to create process timer: ", err)
             return
@@ -118,7 +122,8 @@ end
 
 
 local function flush_buffer(premature, self)
-    if now() - self.last_entry_t >= self.inactive_timeout or
+    if premature or exiting() or
+       now() - self.last_entry_t >= self.inactive_timeout or
        now() - self.first_entry_t >= self.buffer_duration
     then
         core.log.debug("Batch Processor[", self.name ,"] buffer ",

--- a/t/plugin/prometheus2.t
+++ b/t/plugin/prometheus2.t
@@ -458,6 +458,8 @@ GET /apisix/prometheus/metrics
 --- error_code: 200
 --- response_body_like eval
 qr/apisix_batch_process_entries\{name="zipkin_report",route_id="9",server_addr="127.0.0.1"\} \d+/
+--- error_log
+Batch Processor[zipkin_report] failed to process entries
 
 
 
@@ -519,6 +521,8 @@ GET /apisix/prometheus/metrics
 --- error_code: 200
 --- response_body_like eval
 qr/apisix_batch_process_entries\{name="http-logger",route_id="9",server_addr="127.0.0.1"\} \d+/
+--- error_log
+Batch Processor[http-logger] failed to process entries
 
 
 
@@ -581,6 +585,8 @@ GET /apisix/prometheus/metrics
 --- error_code: 200
 --- response_body_like eval
 qr/apisix_batch_process_entries\{name="tcp-logger",route_id="10",server_addr="127.0.0.1"\} \d+/
+--- error_log
+Batch Processor[tcp-logger] failed to process entries
 
 
 
@@ -704,6 +710,8 @@ GET /apisix/prometheus/metrics
 --- error_code: 200
 --- response_body_like eval
 qr/apisix_batch_process_entries\{name="sls-logger",route_id="10",server_addr="127.0.0.1"\} \d+/
+--- error_log
+Batch Processor[sls-logger] failed to process entries
 
 
 

--- a/t/plugin/prometheus3.t
+++ b/t/plugin/prometheus3.t
@@ -255,6 +255,8 @@ qr/apisix_batch_process_entries\{name="http logger",route_id="1",server_addr="12
     }
 --- response_body
 passed
+--- error_log
+Batch Processor[error-log-logger] failed to process entries
 
 
 

--- a/t/utils/batch-processor.t
+++ b/t/utils/batch-processor.t
@@ -484,11 +484,12 @@ Batch Processor[log buffer] failed to process entries [1/2]: error after consumi
 
 
 
-=== TEST 13: batch processor with long timeout does not prevent worker shutdown
-# Before the fix, flush_buffer did not check premature and would enter an infinite
-# zero-delay timer loop during shutdown, preventing the worker from exiting.
-# After the fix, premature triggers the same process_buffer() flush path.
-# If the infinite loop still exists, the test suite will hang on subsequent tests.
+=== TEST 13: batch processor exits cleanly during shutdown with active entries
+# The real bug triggers when a buffer timer naturally expires (not via abort_pending_timers)
+# during shutdown. With short inactive_timeout, the timer fires with premature=false while
+# ngx.worker.exiting() is true. Without the exiting() check, flush_buffer would re-arm a
+# zero-delay timer in an infinite loop, preventing worker exit.
+# Using short timeouts + continuous pushing to create the race condition.
 --- config
     location /t {
         content_by_lua_block {
@@ -499,9 +500,9 @@ Batch Processor[log buffer] failed to process entries [1/2]: error after consumi
 
             local config = {
                 max_retry_count  = 0,
-                batch_max_size = 100,
-                buffer_duration = 3600,
-                inactive_timeout = 3600,
+                batch_max_size = 1000,
+                buffer_duration = 60,
+                inactive_timeout = 1,
                 retry_delay  = 0,
             }
 
@@ -511,8 +512,17 @@ Batch Processor[log buffer] failed to process entries [1/2]: error after consumi
                 return
             end
 
-            log_buffer:push({msg='pending-1'})
-            log_buffer:push({msg='pending-2'})
+            -- push entries with short gaps to keep last_entry_t fresh
+            local count = 0
+            local function keep_pushing(premature)
+                if premature then return end
+                log_buffer:push({msg = "entry-" .. count})
+                count = count + 1
+                if count < 5 then
+                    ngx.timer.at(0.3, keep_pushing)
+                end
+            end
+            keep_pushing(false)
             ngx.say("done")
         }
     }
@@ -520,4 +530,4 @@ Batch Processor[log buffer] failed to process entries [1/2]: error after consumi
 GET /t
 --- response_body
 done
---- wait: 0.5
+--- wait: 2

--- a/t/utils/batch-processor.t
+++ b/t/utils/batch-processor.t
@@ -481,3 +481,43 @@ Batch Processor[log buffer] failed to process entries [2/3]: error after consumi
 Batch Processor[log buffer] failed to process entries [1/2]: error after consuming single entry
 [{"msg":"4"}]
 --- wait: 2
+
+
+
+=== TEST 13: batch processor with long timeout does not prevent worker shutdown
+# Before the fix, flush_buffer did not check premature and would enter an infinite
+# zero-delay timer loop during shutdown, preventing the worker from exiting.
+# After the fix, premature triggers the same process_buffer() flush path.
+# If the infinite loop still exists, the test suite will hang on subsequent tests.
+--- config
+    location /t {
+        content_by_lua_block {
+            local Batch = require("apisix.utils.batch-processor")
+            local func_to_send = function(elements)
+                return true
+            end
+
+            local config = {
+                max_retry_count  = 0,
+                batch_max_size = 100,
+                buffer_duration = 3600,
+                inactive_timeout = 3600,
+                retry_delay  = 0,
+            }
+
+            local log_buffer, err = Batch:new(func_to_send, config)
+            if not log_buffer then
+                ngx.say(err)
+                return
+            end
+
+            log_buffer:push({msg='pending-1'})
+            log_buffer:push({msg='pending-2'})
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+--- wait: 0.5


### PR DESCRIPTION
## Problem

During nginx worker shutdown, `flush_buffer` enters an infinite timer loop:

1. `flush_buffer(premature=true)` — premature flag ignored, time condition not met
2. `create_buffer_timer()` → `timer_at(inactive_timeout)` fails with "process exiting"
3. Fallback `timer_at(0, flush_buffer)` succeeds → goto 1 (infinite loop)

This prevents graceful shutdown and causes `[alert]` logs flooding.

Additionally, `schedule_func_exec` has a bug where the fallback `timer_at(0, execute_func, self)` is missing the `batch` argument, causing a nil crash when `retry_delay > 0` during shutdown.

## Fix

**1. `flush_buffer`: Add `premature or exiting()` to the existing time condition**

```lua
if premature or exiting() or
   now() - self.last_entry_t >= self.inactive_timeout or ...
```

- `premature` catches the case where the original pending timer is aborted during shutdown
- `exiting()` (`ngx.worker.exiting()`) catches ALL shutdown cases, including zero-delay fallback timers from `create_buffer_timer` where `premature=false` — `timer_at(0, ...)` during shutdown always delivers `premature=false` because the timer expires immediately and is never found by `abort_pending_timers`

**2. `schedule_func_exec`: Pass `batch` in the fallback timer**

```lua
local ok, err = timer_at(0, execute_func, self, batch)
```

## Test changes

- `t/utils/batch-processor.t`: Added TEST 13 — regression test that hangs if the infinite loop exists (3600s timeouts ensure the time condition is never met normally)
- `t/plugin/prometheus2.t`: Added `--- error_log` assertions on TEST 25, 28, 31, 37 for specific batch-processor shutdown errors (batch-processor now correctly flushes during shutdown, producing expected connection-refused errors when upstream test servers are already stopped)
- `t/plugin/prometheus3.t`: Added `--- error_log` assertion on TEST 5 for batch-processor shutdown errors (error-log-logger flush during HUP worker shutdown)