### PR TITLE
fix: avoid logging plaintext value when encrypt/decrypt fails

### DIFF
--- a/apisix/ssl.lua
+++ b/apisix/ssl.lua
@@ -119,7 +119,7 @@ end
 local function encrypt(aes_128_cbc_with_iv, origin)
     local encrypted = aes_128_cbc_with_iv:encrypt(origin)
     if encrypted == nil then
-        core.log.error("failed to encrypt key[", origin, "] ")
+        core.log.error("failed to encrypt key")
         return origin
     end
 
@@ -159,8 +159,8 @@ local function aes_decrypt_pkey(origin, field)
 
     local decoded_key = ngx_decode_base64(origin)
     if not decoded_key then
-        core.log.error("base64 decode ssl key failed. key[", origin, "] ")
-        return nil
+        core.log.error("base64 decode ssl key failed")
+        return nil, "base64 decode ssl key failed"
     end
 
     for _, aes_128_cbc_with_iv in ipairs(aes_128_cbc_with_iv_tbl) do

--- a/t/lib/test_admin.lua
+++ b/t/lib/test_admin.lua
@@ -258,7 +258,7 @@ function _M.aes_encrypt(origin)
     if aes_128_cbc_with_iv ~= nil and str_find(origin, "---") then
         local encrypted = aes_128_cbc_with_iv:encrypt(origin)
         if encrypted == nil then
-            core.log.error("failed to encrypt key[", origin, "] ")
+            core.log.error("failed to encrypt key")
             return origin
         end
 

--- a/t/node/data_encrypt.t
+++ b/t/node/data_encrypt.t
@@ -335,6 +335,8 @@ bar
 bar
 --- error_log
 failed to decrypt the conf of plugin [basic-auth] key [password], err: decrypt ssl key failed
+--- no_error_log
+key\[bar\]
 
 
 
@@ -395,6 +397,8 @@ bar
 vU/ZHVJw7b0XscDJ1Fhtig==
 --- error_log
 failed to decrypt the conf of plugin [basic-auth] key [password], err: decrypt ssl key failed
+--- no_error_log
+key\[bar\]
 
 
 


### PR DESCRIPTION
When a plugin field is newly marked as `encrypt_fields`, pre-existing plaintext configs in etcd will fail to decrypt. The base64 decode and encrypt failure paths in `ssl.lua` previously logged the original value (e.g. `key[<plaintext>]`), leaking sensitive data to the error log.

This PR removes the raw value from all error log messages in `encrypt()` and `aes_decrypt_pkey()`.

### Changes
- `apisix/ssl.lua`: Remove `origin` from error logs in `encrypt()` and `aes_decrypt_pkey()`
- `t/lib/test_admin.lua`: Same fix in the test helper's `aes_encrypt()`
- `t/node/data_encrypt.t`: Add `no_error_log` assertions to verify plaintext is not logged


Fixes #11565
