### PR TITLE
feat(discovery/k8s): make watch timeout and retry interval configurable

### DIFF
--- a/apisix/discovery/kubernetes/core.lua
+++ b/apisix/discovery/kubernetes/core.lua
@@ -29,6 +29,7 @@ local tostring      = tostring
 local os            = os
 local pcall         = pcall
 local setmetatable  = setmetatable
+local math          = math
 
 local core = require("apisix.core")
 local util = require("apisix.cli.util")
@@ -609,13 +610,21 @@ function _M.create_handle(conf, options)
 
     local default_weight = conf.default_weight or 50
 
+    -- Watch tuning (issue #8311). nil values fall through to factory defaults.
+    local informer_opts = {
+        watch_timeout_seconds = conf.watch_timeout_seconds,
+        watch_jitter_seconds  = conf.watch_jitter_seconds,
+    }
+
     local inf_factory = options.informer_factory or default_informer_factory
     local endpoints_informer
     if conf.watch_endpoint_slices then
         endpoints_informer, err = inf_factory.new(
-            "discovery.k8s.io", "v1", "EndpointSlice", "endpointslices", "")
+            "discovery.k8s.io", "v1", "EndpointSlice", "endpointslices", "",
+            informer_opts)
     else
-        endpoints_informer, err = inf_factory.new("", "v1", "Endpoints", "endpoints", "")
+        endpoints_informer, err = inf_factory.new(
+            "", "v1", "Endpoints", "endpoints", "", informer_opts)
     end
     if err then
         return nil, err
@@ -647,6 +656,9 @@ function _M.create_handle(conf, options)
         endpoint_dict  = endpoint_dict,
         apiserver      = apiserver,
         default_weight = default_weight,
+        -- Retry tuning consumed by start_fetch (issue #8311).
+        watch_retry_interval_seconds = conf.watch_retry_interval_seconds or 40,
+        watch_retry_max_seconds      = conf.watch_retry_max_seconds or 40,
     }, { __index = endpoints_informer })
 
     return handle
@@ -656,6 +668,15 @@ end
 -- ─── lifecycle ────────────────────────────────────────────────────────
 
 function _M.start_fetch(handle)
+    -- Retry tuning (issue #8311). Configurable per discovery instance.
+    -- Defaults preserve historical behaviour (fixed 40s on failure).
+    local base_interval = handle.watch_retry_interval_seconds or 40
+    local max_interval  = handle.watch_retry_max_seconds or base_interval
+    if max_interval < base_interval then
+        max_interval = base_interval
+    end
+    local current_interval = base_interval
+
     local timer_runner
     timer_runner = function(premature)
         if premature then
@@ -672,9 +693,17 @@ function _M.start_fetch(handle)
         if not ok then
             core.log.error("list_watch failed, kind: ", handle.kind,
                     ", reason: ", "RuntimeException", ", message : ", status)
-            retry_interval = 40
+            retry_interval = current_interval
         elseif not status then
-            retry_interval = 40
+            retry_interval = current_interval
+        end
+
+        if retry_interval > 0 then
+            -- Failure: exponential backoff up to max_interval.
+            current_interval = math.min(current_interval * 2, max_interval)
+        else
+            -- Success: reset.
+            current_interval = base_interval
         end
 
         if not handle.stop then

--- a/apisix/discovery/kubernetes/core.lua
+++ b/apisix/discovery/kubernetes/core.lua
@@ -28,6 +28,7 @@ local tonumber      = tonumber
 local tostring      = tostring
 local pcall         = pcall
 local setmetatable  = setmetatable
+local math          = math
 
 local core = require("apisix.core")
 local util = require("apisix.cli.util")
@@ -612,13 +613,21 @@ function _M.create_handle(conf, options)
 
     local default_weight = conf.default_weight or 50
 
+    -- Watch tuning (issue #8311). nil values fall through to factory defaults.
+    local informer_opts = {
+        watch_timeout_seconds = conf.watch_timeout_seconds,
+        watch_jitter_seconds  = conf.watch_jitter_seconds,
+    }
+
     local inf_factory = options.informer_factory or default_informer_factory
     local endpoints_informer
     if conf.watch_endpoint_slices then
         endpoints_informer, err = inf_factory.new(
-            "discovery.k8s.io", "v1", "EndpointSlice", "endpointslices", "")
+            "discovery.k8s.io", "v1", "EndpointSlice", "endpointslices", "",
+            informer_opts)
     else
-        endpoints_informer, err = inf_factory.new("", "v1", "Endpoints", "endpoints", "")
+        endpoints_informer, err = inf_factory.new(
+            "", "v1", "Endpoints", "endpoints", "", informer_opts)
     end
     if err then
         return nil, err
@@ -650,6 +659,9 @@ function _M.create_handle(conf, options)
         endpoint_dict  = endpoint_dict,
         apiserver      = apiserver,
         default_weight = default_weight,
+        -- Retry tuning consumed by start_fetch (issue #8311).
+        watch_retry_interval_seconds = conf.watch_retry_interval_seconds or 40,
+        watch_retry_max_seconds      = conf.watch_retry_max_seconds or 40,
     }, { __index = endpoints_informer })
 
     return handle
@@ -659,6 +671,15 @@ end
 -- ─── lifecycle ────────────────────────────────────────────────────────
 
 function _M.start_fetch(handle)
+    -- Retry tuning (issue #8311). Configurable per discovery instance.
+    -- Defaults preserve historical behaviour (fixed 40s on failure).
+    local base_interval = handle.watch_retry_interval_seconds or 40
+    local max_interval  = handle.watch_retry_max_seconds or base_interval
+    if max_interval < base_interval then
+        max_interval = base_interval
+    end
+    local current_interval = base_interval
+
     local timer_runner
     timer_runner = function(premature)
         if premature then
@@ -675,9 +696,17 @@ function _M.start_fetch(handle)
         if not ok then
             core.log.error("list_watch failed, kind: ", handle.kind,
                     ", reason: ", "RuntimeException", ", message : ", status)
-            retry_interval = 40
+            retry_interval = current_interval
         elseif not status then
-            retry_interval = 40
+            retry_interval = current_interval
+        end
+
+        if retry_interval > 0 then
+            -- Failure: exponential backoff up to max_interval.
+            current_interval = math.min(current_interval * 2, max_interval)
+        else
+            -- Success: reset.
+            current_interval = base_interval
         end
 
         if not handle.stop then

--- a/apisix/discovery/kubernetes/informer_factory.lua
+++ b/apisix/discovery/kubernetes/informer_factory.lua
@@ -24,22 +24,16 @@ local core = require("apisix.core")
 local http = require("resty.http")
 
 local function list_query(informer)
-    local arguments = {
-        limit = informer.limit,
-    }
-
+    local arguments = { limit = informer.limit }
     if informer.continue and informer.continue ~= "" then
         arguments.continue = informer.continue
     end
-
     if informer.label_selector and informer.label_selector ~= "" then
         arguments.labelSelector = informer.label_selector
     end
-
     if informer.field_selector and informer.field_selector ~= "" then
         arguments.fieldSelector = informer.field_selector
     end
-
     return ngx.encode_args(arguments)
 end
 
@@ -55,43 +49,24 @@ local function list(httpc, apiserver, informer)
             ["Connection"] = "keep-alive"
         }
     })
-
     core.log.info("--raw=", informer.path, "?", list_query(informer))
-
-    if not response then
-        return false, "RequestError", err or ""
-    end
-
-    if response.status ~= 200 then
-        return false, response.reason, response:read_body() or ""
-    end
-
-    local body, err = response:read_body()
-    if err then
-        return false, "ReadBodyError", err
-    end
-
+    if not response then return false, "RequestError", err or "" end
+    if response.status ~= 200 then return false, response.reason, response:read_body() or "" end
+    local body, err2 = response:read_body()
+    if err2 then return false, "ReadBodyError", err2 end
     local data = core.json.decode(body)
-    if not data or data.kind ~= informer.list_kind then
-        return false, "UnexpectedBody", body
-    end
-
+    if not data or data.kind ~= informer.list_kind then return false, "UnexpectedBody", body end
     informer.version = data.metadata.resourceVersion
-
     if informer.on_added then
         for _, item in ipairs(data.items or {}) do
             informer:on_added(item, "list")
         end
     end
-
     informer.continue = data.metadata.continue
     if informer.continue and informer.continue ~= "" then
-        if informer.stop then
-            return true
-        end
+        if informer.stop then return true end
         list(httpc, apiserver, informer)
     end
-
     return true
 end
 
@@ -102,99 +77,57 @@ local function watch_query(informer)
         allowWatchBookmarks = "true",
         timeoutSeconds = informer.overtime,
     }
-
     if informer.version and informer.version ~= "" then
         arguments.resourceVersion = informer.version
     end
-
     if informer.label_selector and informer.label_selector ~= "" then
         arguments.labelSelector = informer.label_selector
     end
-
     if informer.field_selector and informer.field_selector ~= "" then
         arguments.fieldSelector = informer.field_selector
     end
-
     return ngx.encode_args(arguments)
 end
 
 
-local function split_event (body, callback, ...)
+local function split_event(body, callback, ...)
     local gmatch_iterator, err = ngx.re.gmatch(body, "{\"type\":.*}\n", "jao")
-    if not gmatch_iterator then
-        return false, nil, "GmatchError", err
-    end
-
-    local captures
-    local captured_size = 0
+    if not gmatch_iterator then return false, nil, "GmatchError", err end
+    local captures, captured_size = nil, 0
     local ok, reason
     while true do
         captures, err = gmatch_iterator()
-
-        if err then
-            return false, nil, "GmatchError", err
-        end
-
-        if not captures then
-            break
-        end
-
+        if err then return false, nil, "GmatchError", err end
+        if not captures then break end
         captured_size = captured_size + #captures[0]
-
         ok, reason, err = callback(captures[0], ...)
-        if not ok then
-            return false, nil, reason, err
-        end
+        if not ok then return false, nil, reason, err end
     end
-
     local remainder_body
-    if captured_size == #body then
-        remainder_body = ""
-    elseif captured_size == 0 then
-        remainder_body = body
-    elseif captured_size < #body then
-        remainder_body = string.sub(body, captured_size + 1)
-    end
-
+    if captured_size == #body then remainder_body = ""
+    elseif captured_size == 0 then remainder_body = body
+    elseif captured_size < #body then remainder_body = string.sub(body, captured_size + 1) end
     return true, remainder_body
 end
 
 
 local function dispatch_event(event_string, informer)
     local event = core.json.decode(event_string)
-
-    if not event or not event.type or not event.object then
-        return false, "UnexpectedBody", event_string
-    end
-
+    if not event or not event.type or not event.object then return false, "UnexpectedBody", event_string end
     local tp = event.type
-
     if tp == "ERROR" then
-        if event.object.code == 410 then
-            return false, "ResourceGone", nil
-        end
+        if event.object.code == 410 then return false, "ResourceGone", nil end
         return false, "UnexpectedBody", event_string
     end
-
     local object = event.object
     informer.version = object.metadata.resourceVersion
-
     if tp == "ADDED" then
-        if informer.on_added then
-            informer:on_added(object, "watch")
-        end
+        if informer.on_added then informer:on_added(object, "watch") end
     elseif tp == "DELETED" then
-        if informer.on_deleted then
-            informer:on_deleted(object)
-        end
+        if informer.on_deleted then informer:on_deleted(object) end
     elseif tp == "MODIFIED" then
-        if informer.on_modified then
-            informer:on_modified(object)
-        end
-        -- elseif type == "BOOKMARK" then
-        --    do nothing
+        if informer.on_modified then informer:on_modified(object) end
     end
-
     return true
 end
 
@@ -202,11 +135,18 @@ end
 local function watch(httpc, apiserver, informer)
     local watch_times = 8
     for _ = 1, watch_times do
-        if informer.stop then
-            return true
-        end
+        if informer.stop then return true end
 
-        local watch_seconds = 1800 + math.random(9, 999)
+        -- Both base and jitter are configurable per informer (issue #8311).
+        -- Defaults preserve historical behaviour (1800 + random[9..999]).
+        local base = informer.watch_timeout_seconds or 1800
+        local jitter = informer.watch_jitter_seconds or 990
+        local watch_seconds
+        if jitter > 0 then
+            watch_seconds = base + math.random(0, jitter)
+        else
+            watch_seconds = base
+        end
         informer.overtime = watch_seconds
         local http_seconds = watch_seconds + 120
         httpc:set_timeouts(2000, 3000, http_seconds * 1000)
@@ -221,50 +161,25 @@ local function watch(httpc, apiserver, informer)
                 ["Connection"] = "keep-alive"
             }
         })
-
         core.log.info("--raw=", informer.path, "?", watch_query(informer))
-
-        if err then
-            return false, "RequestError", err
-        end
-
-        if response.status ~= 200 then
-            return false, response.reason, response:read_body() or ""
-        end
+        if err then return false, "RequestError", err end
+        if response.status ~= 200 then return false, response.reason, response:read_body() or "" end
 
         local ok
-        local remainder_body
-        local body
-        local reason
-
+        local remainder_body, body, reason
         while true do
-            if informer.stop then
-                return true
-            end
-
+            if informer.stop then return true end
             body, err = response.body_reader()
-            if err then
-                return false, "ReadBodyError", err
-            end
-
-            if not body then
-                break
-            end
-
-            if remainder_body and #remainder_body > 0 then
-                body = remainder_body .. body
-            end
-
+            if err then return false, "ReadBodyError", err end
+            if not body then break end
+            if remainder_body and #remainder_body > 0 then body = remainder_body .. body end
             ok, remainder_body, reason, err = split_event(body, dispatch_event, informer)
             if not ok then
-                if reason == "ResourceGone" then
-                    return true
-                end
+                if reason == "ResourceGone" then return true end
                 return false, reason, err
             end
         end
     end
-
     return true
 end
 
@@ -273,104 +188,86 @@ local function list_watch(informer, apiserver)
     local ok
     local reason, message
     local httpc = http.new()
-
     informer.continue = ""
     informer.version = ""
-
-    if informer.stop then
-        return true
-    end
-
+    if informer.stop then return true end
     informer.fetch_state = "connecting"
     core.log.info("begin to connect ", apiserver.host, ":", apiserver.port)
-
     local connect_opts = {
         scheme = apiserver.schema,
         host = apiserver.host,
         port = apiserver.port,
         ssl_verify = apiserver.ssl_verify or false,
     }
-
     if apiserver.ssl_server_name then
         connect_opts.ssl_server_name = apiserver.ssl_server_name
     end
-
     ok, message = httpc:connect(connect_opts)
-
     if not ok then
         informer.fetch_state = "connect failed"
         core.log.error("connect apiserver failed, apiserver.host: ", apiserver.host,
                 ", apiserver.port: ", apiserver.port, ", message : ", message)
         return false
     end
-
     core.log.info("begin to list ", informer.kind)
     informer.fetch_state = "listing"
-    if informer.pre_list then
-        informer:pre_list()
-    end
-
+    if informer.pre_list then informer:pre_list() end
     ok, reason, message = list(httpc, apiserver, informer)
     if not ok then
         informer.fetch_state = "list failed"
-        core.log.error("list failed, kind: ", informer.kind,
-                ", reason: ", reason, ", message : ", message)
+        core.log.error("list failed, kind: ", informer.kind, ", reason: ", reason, ", message : ", message)
         return false
     end
-
     informer.fetch_state = "list finished"
-    if informer.post_list and not informer.stop then
-        informer:post_list()
-    end
-
-    if informer.stop then
-        return true
-    end
-
+    if informer.post_list and not informer.stop then informer:post_list() end
+    if informer.stop then return true end
     core.log.info("begin to watch ", informer.kind)
     informer.fetch_state = "watching"
     ok, reason, message = watch(httpc, apiserver, informer)
     if not ok then
         informer.fetch_state = "watch failed"
-        core.log.error("watch failed, kind: ", informer.kind,
-                ", reason: ", reason, ", message : ", message)
+        core.log.error("watch failed, kind: ", informer.kind, ", reason: ", reason, ", message : ", message)
         return false
     end
-
     informer.fetch_state = "watch finished"
-
     return true
 end
 
-local _M = {
-}
 
-function _M.new(group, version, kind, plural, namespace)
+local _M = {}
+
+--- Create a new informer.
+--- group, version, kind, plural, namespace: Kubernetes resource identifiers.
+--- opts (table, optional): may contain
+---   - watch_timeout_seconds (integer, default 1800): k8s watch timeoutSeconds
+---   - watch_jitter_seconds  (integer, default 990):  random jitter added to the
+---                                                    watch timeout. 0 disables.
+function _M.new(group, version, kind, plural, namespace, opts)
     local tp
     tp = type(group)
     if tp ~= "nil" and tp ~= "string" then
         return nil, "group should set to string or nil type but " .. tp
     end
-
     tp = type(namespace)
     if tp ~= "nil" and tp ~= "string" then
         return nil, "namespace should set to string or nil type but " .. tp
     end
-
     tp = type(version)
     if tp ~= "string" or version == "" then
         return nil, "version should set to non-empty string"
     end
-
     tp = type(kind)
     if tp ~= "string" or kind == "" then
         return nil, "kind should set to non-empty string"
     end
-
     tp = type(plural)
     if tp ~= "string" or plural == "" then
         return nil, "plural should set to non-empty string"
     end
+    if opts ~= nil and type(opts) ~= "table" then
+        return nil, "opts should be a table or nil but " .. type(opts)
+    end
+    opts = opts or {}
 
     local path = ""
     if group == nil or group == "" then
@@ -378,7 +275,6 @@ function _M.new(group, version, kind, plural, namespace)
     else
         path = path .. "/apis/" .. group .. "/" .. version
     end
-
     if namespace and namespace ~= "" then
         path = path .. "/namespaces/" .. namespace
     end
@@ -396,6 +292,8 @@ function _M.new(group, version, kind, plural, namespace)
         version = "",
         continue = "",
         stop = false,
+        watch_timeout_seconds = opts.watch_timeout_seconds,
+        watch_jitter_seconds = opts.watch_jitter_seconds,
         list_watch = list_watch
     }
 end

--- a/apisix/discovery/kubernetes/informer_factory.lua
+++ b/apisix/discovery/kubernetes/informer_factory.lua
@@ -23,17 +23,24 @@ local type = type
 local core = require("apisix.core")
 local http = require("resty.http")
 
+
 local function list_query(informer)
-    local arguments = { limit = informer.limit }
+    local arguments = {
+        limit = informer.limit,
+    }
+
     if informer.continue and informer.continue ~= "" then
         arguments.continue = informer.continue
     end
+
     if informer.label_selector and informer.label_selector ~= "" then
         arguments.labelSelector = informer.label_selector
     end
+
     if informer.field_selector and informer.field_selector ~= "" then
         arguments.fieldSelector = informer.field_selector
     end
+
     return ngx.encode_args(arguments)
 end
 
@@ -49,24 +56,43 @@ local function list(httpc, apiserver, informer)
             ["Connection"] = "keep-alive"
         }
     })
+
     core.log.info("--raw=", informer.path, "?", list_query(informer))
-    if not response then return false, "RequestError", err or "" end
-    if response.status ~= 200 then return false, response.reason, response:read_body() or "" end
-    local body, err2 = response:read_body()
-    if err2 then return false, "ReadBodyError", err2 end
+
+    if not response then
+        return false, "RequestError", err or ""
+    end
+
+    if response.status ~= 200 then
+        return false, response.reason, response:read_body() or ""
+    end
+
+    local body, err = response:read_body()
+    if err then
+        return false, "ReadBodyError", err
+    end
+
     local data = core.json.decode(body)
-    if not data or data.kind ~= informer.list_kind then return false, "UnexpectedBody", body end
+    if not data or data.kind ~= informer.list_kind then
+        return false, "UnexpectedBody", body
+    end
+
     informer.version = data.metadata.resourceVersion
+
     if informer.on_added then
         for _, item in ipairs(data.items or {}) do
             informer:on_added(item, "list")
         end
     end
+
     informer.continue = data.metadata.continue
     if informer.continue and informer.continue ~= "" then
-        if informer.stop then return true end
+        if informer.stop then
+            return true
+        end
         list(httpc, apiserver, informer)
     end
+
     return true
 end
 
@@ -77,76 +103,131 @@ local function watch_query(informer)
         allowWatchBookmarks = "true",
         timeoutSeconds = informer.overtime,
     }
+
     if informer.version and informer.version ~= "" then
         arguments.resourceVersion = informer.version
     end
+
     if informer.label_selector and informer.label_selector ~= "" then
         arguments.labelSelector = informer.label_selector
     end
+
     if informer.field_selector and informer.field_selector ~= "" then
         arguments.fieldSelector = informer.field_selector
     end
+
     return ngx.encode_args(arguments)
 end
 
 
-local function split_event(body, callback, ...)
+local function split_event (body, callback, ...)
     local gmatch_iterator, err = ngx.re.gmatch(body, "{\"type\":.*}\n", "jao")
-    if not gmatch_iterator then return false, nil, "GmatchError", err end
-    local captures, captured_size = nil, 0
+    if not gmatch_iterator then
+        return false, nil, "GmatchError", err
+    end
+
+    local captures
+    local captured_size = 0
     local ok, reason
     while true do
         captures, err = gmatch_iterator()
-        if err then return false, nil, "GmatchError", err end
-        if not captures then break end
+
+        if err then
+            return false, nil, "GmatchError", err
+        end
+
+        if not captures then
+            break
+        end
+
         captured_size = captured_size + #captures[0]
+
         ok, reason, err = callback(captures[0], ...)
-        if not ok then return false, nil, reason, err end
+        if not ok then
+            return false, nil, reason, err
+        end
     end
+
     local remainder_body
-    if captured_size == #body then remainder_body = ""
-    elseif captured_size == 0 then remainder_body = body
-    elseif captured_size < #body then remainder_body = string.sub(body, captured_size + 1) end
+    if captured_size == #body then
+        remainder_body = ""
+    elseif captured_size == 0 then
+        remainder_body = body
+    elseif captured_size < #body then
+        remainder_body = string.sub(body, captured_size + 1)
+    end
+
     return true, remainder_body
 end
 
 
 local function dispatch_event(event_string, informer)
     local event = core.json.decode(event_string)
-    if not event or not event.type or not event.object then return false, "UnexpectedBody", event_string end
-    local tp = event.type
-    if tp == "ERROR" then
-        if event.object.code == 410 then return false, "ResourceGone", nil end
+
+    if not event or not event.type or not event.object then
         return false, "UnexpectedBody", event_string
     end
+
+    local tp = event.type
+
+    if tp == "ERROR" then
+        if event.object.code == 410 then
+            return false, "ResourceGone", nil
+        end
+        return false, "UnexpectedBody", event_string
+    end
+
     local object = event.object
     informer.version = object.metadata.resourceVersion
+
     if tp == "ADDED" then
-        if informer.on_added then informer:on_added(object, "watch") end
+        if informer.on_added then
+            informer:on_added(object, "watch")
+        end
     elseif tp == "DELETED" then
-        if informer.on_deleted then informer:on_deleted(object) end
+        if informer.on_deleted then
+            informer:on_deleted(object)
+        end
     elseif tp == "MODIFIED" then
-        if informer.on_modified then informer:on_modified(object) end
+        if informer.on_modified then
+            informer:on_modified(object)
+        end
+        -- elseif type == "BOOKMARK" then
+        -- do nothing
     end
+
     return true
+end
+
+
+local function compute_watch_seconds(informer)
+    -- Preserve historical behaviour when neither field is configured (issue #8311).
+    if informer.watch_timeout_seconds == nil and informer.watch_jitter_seconds == nil then
+        return 1800 + math.random(9, 999)
+    end
+
+    local base = informer.watch_timeout_seconds or 1800
+    local jitter = informer.watch_jitter_seconds
+    if jitter == nil then
+        jitter = 990
+    end
+
+    if jitter > 0 then
+        return base + math.random(0, jitter)
+    end
+
+    return base
 end
 
 
 local function watch(httpc, apiserver, informer)
     local watch_times = 8
     for _ = 1, watch_times do
-        if informer.stop then return true end
-
-        -- Both base and jitter are configurable per informer (issue #8311).
-        -- Defaults preserve historical behaviour (1800 + random[9..999]).
-        local base = informer.watch_timeout_seconds or 1800
-        local jitter = informer.watch_jitter_seconds or 990
-        local watch_seconds
-        if jitter > 0 then
-            watch_seconds = base + math.random(0, jitter)
-        else
-            watch_seconds = base
+        if informer.stop then
+            return true
         end
+
+        local watch_seconds = compute_watch_seconds(informer)
         informer.overtime = watch_seconds
         local http_seconds = watch_seconds + 120
         httpc:set_timeouts(2000, 3000, http_seconds * 1000)
@@ -161,25 +242,50 @@ local function watch(httpc, apiserver, informer)
                 ["Connection"] = "keep-alive"
             }
         })
+
         core.log.info("--raw=", informer.path, "?", watch_query(informer))
-        if err then return false, "RequestError", err end
-        if response.status ~= 200 then return false, response.reason, response:read_body() or "" end
+
+        if err then
+            return false, "RequestError", err
+        end
+
+        if response.status ~= 200 then
+            return false, response.reason, response:read_body() or ""
+        end
 
         local ok
-        local remainder_body, body, reason
+        local remainder_body
+        local body
+        local reason
+
         while true do
-            if informer.stop then return true end
+            if informer.stop then
+                return true
+            end
+
             body, err = response.body_reader()
-            if err then return false, "ReadBodyError", err end
-            if not body then break end
-            if remainder_body and #remainder_body > 0 then body = remainder_body .. body end
+            if err then
+                return false, "ReadBodyError", err
+            end
+
+            if not body then
+                break
+            end
+
+            if remainder_body and #remainder_body > 0 then
+                body = remainder_body .. body
+            end
+
             ok, remainder_body, reason, err = split_event(body, dispatch_event, informer)
             if not ok then
-                if reason == "ResourceGone" then return true end
+                if reason == "ResourceGone" then
+                    return true
+                end
                 return false, reason, err
             end
         end
     end
+
     return true
 end
 
@@ -188,82 +294,107 @@ local function list_watch(informer, apiserver)
     local ok
     local reason, message
     local httpc = http.new()
+
     informer.continue = ""
     informer.version = ""
-    if informer.stop then return true end
+
+    if informer.stop then
+        return true
+    end
+
     informer.fetch_state = "connecting"
     core.log.info("begin to connect ", apiserver.host, ":", apiserver.port)
+
     local connect_opts = {
         scheme = apiserver.schema,
         host = apiserver.host,
         port = apiserver.port,
         ssl_verify = apiserver.ssl_verify or false,
     }
+
     if apiserver.ssl_server_name then
         connect_opts.ssl_server_name = apiserver.ssl_server_name
     end
+
     ok, message = httpc:connect(connect_opts)
+
     if not ok then
         informer.fetch_state = "connect failed"
         core.log.error("connect apiserver failed, apiserver.host: ", apiserver.host,
                 ", apiserver.port: ", apiserver.port, ", message : ", message)
         return false
     end
+
     core.log.info("begin to list ", informer.kind)
     informer.fetch_state = "listing"
-    if informer.pre_list then informer:pre_list() end
+    if informer.pre_list then
+        informer:pre_list()
+    end
+
     ok, reason, message = list(httpc, apiserver, informer)
     if not ok then
         informer.fetch_state = "list failed"
-        core.log.error("list failed, kind: ", informer.kind, ", reason: ", reason, ", message : ", message)
+        core.log.error("list failed, kind: ", informer.kind,
+                ", reason: ", reason, ", message : ", message)
         return false
     end
+
     informer.fetch_state = "list finished"
-    if informer.post_list and not informer.stop then informer:post_list() end
-    if informer.stop then return true end
+    if informer.post_list and not informer.stop then
+        informer:post_list()
+    end
+
+    if informer.stop then
+        return true
+    end
+
     core.log.info("begin to watch ", informer.kind)
     informer.fetch_state = "watching"
     ok, reason, message = watch(httpc, apiserver, informer)
     if not ok then
         informer.fetch_state = "watch failed"
-        core.log.error("watch failed, kind: ", informer.kind, ", reason: ", reason, ", message : ", message)
+        core.log.error("watch failed, kind: ", informer.kind,
+                ", reason: ", reason, ", message : ", message)
         return false
     end
+
     informer.fetch_state = "watch finished"
+
     return true
 end
 
 
-local _M = {}
+local _M = {
+}
 
---- Create a new informer.
---- group, version, kind, plural, namespace: Kubernetes resource identifiers.
---- opts (table, optional): may contain
----   - watch_timeout_seconds (integer, default 1800): k8s watch timeoutSeconds
----   - watch_jitter_seconds  (integer, default 990):  random jitter added to the
----                                                    watch timeout. 0 disables.
+
 function _M.new(group, version, kind, plural, namespace, opts)
     local tp
     tp = type(group)
     if tp ~= "nil" and tp ~= "string" then
         return nil, "group should set to string or nil type but " .. tp
     end
+
     tp = type(namespace)
     if tp ~= "nil" and tp ~= "string" then
         return nil, "namespace should set to string or nil type but " .. tp
     end
+
     tp = type(version)
     if tp ~= "string" or version == "" then
         return nil, "version should set to non-empty string"
     end
+
     tp = type(kind)
     if tp ~= "string" or kind == "" then
         return nil, "kind should set to non-empty string"
     end
+
     tp = type(plural)
     if tp ~= "string" or plural == "" then
         return nil, "plural should set to non-empty string"
     end
+
     if opts ~= nil and type(opts) ~= "table" then
         return nil, "opts should be a table or nil but " .. type(opts)
     end
@@ -275,6 +406,7 @@ function _M.new(group, version, kind, plural, namespace, opts)
     else
         path = path .. "/apis/" .. group .. "/" .. version
     end
+
     if namespace and namespace ~= "" then
         path = path .. "/namespaces/" .. namespace
     end

--- a/apisix/discovery/kubernetes/schema.lua
+++ b/apisix/discovery/kubernetes/schema.lua
@@ -110,6 +110,37 @@ local watch_endpoint_slices_schema = {
     default = false,
 }
 
+-- Watch and retry tuning. Allow operators to override fixed defaults so that
+-- discovery behaves correctly behind LBs / API server proxies that impose
+-- their own idle timeouts. See issue #8311.
+local watch_timeout_seconds_schema = {
+    type = "integer",
+    default = 1800,
+    minimum = 5,
+    maximum = 86400,
+}
+
+local watch_jitter_seconds_schema = {
+    type = "integer",
+    default = 990,
+    minimum = 0,
+    maximum = 86400,
+}
+
+local watch_retry_interval_seconds_schema = {
+    type = "integer",
+    default = 40,
+    minimum = 0,
+    maximum = 3600,
+}
+
+local watch_retry_max_seconds_schema = {
+    type = "integer",
+    default = 40,
+    minimum = 0,
+    maximum = 3600,
+}
+
 return {
     anyOf = {
         {
@@ -169,6 +200,10 @@ return {
                 default_weight = default_weight_schema,
                 shared_size = shared_size_schema,
                 watch_endpoint_slices = watch_endpoint_slices_schema,
+                watch_timeout_seconds = watch_timeout_seconds_schema,
+                watch_jitter_seconds = watch_jitter_seconds_schema,
+                watch_retry_interval_seconds = watch_retry_interval_seconds_schema,
+                watch_retry_max_seconds = watch_retry_max_seconds_schema,
             },
         },
         {
@@ -215,6 +250,10 @@ return {
                     default_weight = default_weight_schema,
                     shared_size = shared_size_schema,
                     watch_endpoint_slices = watch_endpoint_slices_schema,
+                    watch_timeout_seconds = watch_timeout_seconds_schema,
+                    watch_jitter_seconds = watch_jitter_seconds_schema,
+                    watch_retry_interval_seconds = watch_retry_interval_seconds_schema,
+                    watch_retry_max_seconds = watch_retry_max_seconds_schema,
                 },
                 required = { "id", "service", "client" }
             },

--- a/docs/en/latest/discovery/kubernetes.md
+++ b/docs/en/latest/discovery/kubernetes.md
@@ -407,3 +407,67 @@ Which will yield the following response:
   ]
 }
 ```
+
+# Tuning Kubernetes service discovery watch and retry behaviour
+
+The Kubernetes service discovery module performs a long-poll **watch** against
+the API server and re-establishes the connection when it ends or fails. Until
+APISIX 3.x, the timing of those watches and reconnects was hard-coded:
+
+| Behaviour | Old hard-coded value |
+|-----------|---------------------|
+| `timeoutSeconds` sent to the API server | `1800 + random(9..999)` seconds |
+| Sleep between failed `list_watch` cycles | `40` seconds (fixed) |
+
+When APISIX runs behind a cloud LB or API server proxy whose **idle timeout is
+shorter than the watch's `timeoutSeconds`**, the *server* drops the connection
+first and the discovery module sees the failure as a transient error. Until
+the next 40-second retry, endpoint changes are missed.
+
+Starting from this release, four optional configuration items let operators
+tune that behaviour without code changes:
+
+```yaml
+discovery:
+  kubernetes:
+    service:
+      schema: "https"
+      host: "${KUBERNETES_SERVICE_HOST}"
+      port: "${KUBERNETES_SERVICE_PORT}"
+    client:
+      token_file: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    # New tuning knobs (all optional; defaults preserve historical behaviour)
+    watch_timeout_seconds: 240          # base k8s watch timeoutSeconds (default: 1800)
+    watch_jitter_seconds: 30            # random 0..N added to base   (default: 990; set 0 to disable)
+    watch_retry_interval_seconds: 5     # initial backoff after failure (default: 40)
+    watch_retry_max_seconds: 60         # exponential backoff cap       (default: 40)
+```
+
+## Field reference
+
+| Field | Type | Default | Range | Description |
+|-------|------|---------|-------|-------------|
+| `watch_timeout_seconds` | integer | 1800 | 5–86400 | The `timeoutSeconds` value passed to the Kubernetes API server when initiating a watch. |
+| `watch_jitter_seconds` | integer | 990 | 0–86400 | A uniformly random value in `[0, watch_jitter_seconds]` is added to `watch_timeout_seconds` to spread reconnect storms. Set to `0` to use a deterministic timeout. |
+| `watch_retry_interval_seconds` | integer | 40 | 0–3600 | Initial backoff between consecutive failed `list_watch` cycles. |
+| `watch_retry_max_seconds` | integer | 40 | 0–3600 | Upper bound for exponential backoff. After each consecutive failure the backoff is doubled until it hits this cap; on the next successful cycle it resets to `watch_retry_interval_seconds`. If `watch_retry_max_seconds < watch_retry_interval_seconds`, the value is coerced up to `watch_retry_interval_seconds` (i.e. backoff stays constant). |
+
+## Recommended settings behind a 5-minute idle LB
+
+```yaml
+discovery:
+  kubernetes:
+    watch_timeout_seconds: 240   # ≤ LB idle timeout − a safety margin
+    watch_jitter_seconds:  30
+    watch_retry_interval_seconds: 5
+    watch_retry_max_seconds: 60
+```
+
+This causes APISIX itself to terminate each watch every ~4 minutes (well below
+the 5-minute LB idle timeout), and in case of a real failure the module
+backs off 5s → 10s → 20s → 40s → 60s before plateauing.
+
+## Backward compatibility
+
+If none of these fields are present in `config.yaml`, the module behaves
+exactly as before this change.

--- a/docs/en/latest/discovery/kubernetes.md
+++ b/docs/en/latest/discovery/kubernetes.md
@@ -448,7 +448,7 @@ discovery:
 | Field | Type | Default | Range | Description |
 |-------|------|---------|-------|-------------|
 | `watch_timeout_seconds` | integer | 1800 | 5–86400 | The `timeoutSeconds` value passed to the Kubernetes API server when initiating a watch. |
-| `watch_jitter_seconds` | integer | 990 | 0–86400 | A uniformly random value in `[0, watch_jitter_seconds]` is added to `watch_timeout_seconds` to spread reconnect storms. Set to `0` to use a deterministic timeout. |
+| `watch_jitter_seconds` | integer | 990 | 0–86400 | When either tuning field is set, a uniformly random value in `[0, watch_jitter_seconds]` is added to `watch_timeout_seconds` to spread reconnect storms. Set to `0` to use a deterministic timeout. When **both** fields are omitted, APISIX keeps the historical formula `1800 + random(9..999)`. |
 | `watch_retry_interval_seconds` | integer | 40 | 0–3600 | Initial backoff between consecutive failed `list_watch` cycles. |
 | `watch_retry_max_seconds` | integer | 40 | 0–3600 | Upper bound for exponential backoff. After each consecutive failure the backoff is doubled until it hits this cap; on the next successful cycle it resets to `watch_retry_interval_seconds`. If `watch_retry_max_seconds < watch_retry_interval_seconds`, the value is coerced up to `watch_retry_interval_seconds` (i.e. backoff stays constant). |
 

--- a/t/discovery/kubernetes_watch_tuning.t
+++ b/t/discovery/kubernetes_watch_tuning.t
@@ -1,0 +1,174 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+log_level('info');
+no_long_string();
+no_shuffle();
+no_root_location();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: schema accepts new watch tuning fields (single mode)
+--- yaml_config
+apisix:
+  node_listen: 1984
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+discovery:
+  kubernetes:
+    service:
+      schema: "https"
+      host: "127.0.0.1"
+      port: "6443"
+    client:
+      token: "fake-token"
+    watch_timeout_seconds: 60
+    watch_jitter_seconds: 0
+    watch_retry_interval_seconds: 5
+    watch_retry_max_seconds: 60
+--- config
+    location /t {
+        content_by_lua_block {
+            local schema = require("apisix.discovery.kubernetes.schema")
+            local jsonschema = require("jsonschema")
+            local validator = jsonschema.generate_validator(schema)
+            local ok, err = validator({
+                service = { schema = "https", host = "127.0.0.1", port = "6443" },
+                client  = { token = "fake-token" },
+                watch_timeout_seconds        = 60,
+                watch_jitter_seconds         = 0,
+                watch_retry_interval_seconds = 5,
+                watch_retry_max_seconds      = 60,
+            })
+            ngx.say(ok and "ok" or err)
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok
+
+
+
+=== TEST 2: schema rejects out-of-range watch_timeout_seconds
+--- config
+    location /t {
+        content_by_lua_block {
+            local schema = require("apisix.discovery.kubernetes.schema")
+            local jsonschema = require("jsonschema")
+            local validator = jsonschema.generate_validator(schema)
+            local ok, err = validator({
+                service = { schema = "https", host = "127.0.0.1", port = "6443" },
+                client  = { token = "fake-token" },
+                watch_timeout_seconds = 0,  -- minimum is 5
+            })
+            ngx.say(ok and "ok" or "rejected: " .. tostring(err))
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+^rejected: .*
+
+
+
+=== TEST 3: informer_factory.new() accepts opts and threads them through
+--- config
+    location /t {
+        content_by_lua_block {
+            local factory = require("apisix.discovery.kubernetes.informer_factory")
+            local informer = factory.new("", "v1", "Endpoints", "endpoints", "",
+                { watch_timeout_seconds = 60, watch_jitter_seconds = 0 })
+            ngx.say("watch_timeout_seconds=", tostring(informer.watch_timeout_seconds))
+            ngx.say("watch_jitter_seconds=",  tostring(informer.watch_jitter_seconds))
+        }
+    }
+--- request
+GET /t
+--- response_body
+watch_timeout_seconds=60
+watch_jitter_seconds=0
+
+
+
+=== TEST 4: informer_factory.new() rejects non-table opts
+--- config
+    location /t {
+        content_by_lua_block {
+            local factory = require("apisix.discovery.kubernetes.informer_factory")
+            local _, err = factory.new("", "v1", "Endpoints", "endpoints", "", "bogus")
+            ngx.say(err)
+        }
+    }
+--- request
+GET /t
+--- response_body
+opts should be a table or nil but string
+
+
+
+=== TEST 5: informer_factory.new() with nil opts preserves backward compatibility
+--- config
+    location /t {
+        content_by_lua_block {
+            local factory = require("apisix.discovery.kubernetes.informer_factory")
+            local informer = factory.new("", "v1", "Endpoints", "endpoints", "")
+            -- Defaults are applied later in watch(); the table fields are nil
+            -- so the watch() function falls back to the historical 1800 / 990.
+            ngx.say("default fields nil: ",
+                tostring(informer.watch_timeout_seconds == nil and
+                         informer.watch_jitter_seconds  == nil))
+        }
+    }
+--- request
+GET /t
+--- response_body
+default fields nil: true
+
+
+
+=== TEST 6: schema accepts tuning fields in multi-mode (array form)
+--- config
+    location /t {
+        content_by_lua_block {
+            local schema = require("apisix.discovery.kubernetes.schema")
+            local jsonschema = require("jsonschema")
+            local validator = jsonschema.generate_validator(schema)
+            local ok, err = validator({
+                {
+                    id      = "release",
+                    service = { schema = "https", host = "127.0.0.1", port = "6443" },
+                    client  = { token = "fake-token" },
+                    watch_timeout_seconds        = 120,
+                    watch_jitter_seconds         = 30,
+                    watch_retry_interval_seconds = 10,
+                    watch_retry_max_seconds      = 120,
+                },
+            })
+            ngx.say(ok and "ok" or err)
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok

--- a/t/discovery/kubernetes_watch_tuning.t
+++ b/t/discovery/kubernetes_watch_tuning.t
@@ -172,3 +172,84 @@ default fields nil: true
 GET /t
 --- response_body
 ok
+
+
+
+=== TEST 7: create_handle threads watch tuning conf into informer factory and handle
+--- config
+    location /t {
+        content_by_lua_block {
+            local k8s_core = require("apisix.discovery.kubernetes.core")
+
+            local captured_opts
+            local mock_factory = {
+                new = function(group, version, kind, plural, namespace, opts)
+                    captured_opts = opts
+                    return { kind = kind }, nil
+                end,
+            }
+
+            local conf = {
+                service = { schema = "https", host = "127.0.0.1", port = "6443" },
+                client  = { token = "fake-token" },
+                watch_timeout_seconds        = 120,
+                watch_jitter_seconds         = 30,
+                watch_retry_interval_seconds = 10,
+                watch_retry_max_seconds      = 80,
+            }
+
+            local handle, err = k8s_core.create_handle(conf, {
+                endpoint_dict    = {},
+                informer_factory = mock_factory,
+            })
+            assert(handle, err)
+
+            ngx.say("informer watch_timeout_seconds=",
+                tostring(captured_opts.watch_timeout_seconds))
+            ngx.say("informer watch_jitter_seconds=",
+                tostring(captured_opts.watch_jitter_seconds))
+            ngx.say("handle watch_retry_interval_seconds=",
+                tostring(handle.watch_retry_interval_seconds))
+            ngx.say("handle watch_retry_max_seconds=",
+                tostring(handle.watch_retry_max_seconds))
+        }
+    }
+--- request
+GET /t
+--- response_body
+informer watch_timeout_seconds=120
+informer watch_jitter_seconds=30
+handle watch_retry_interval_seconds=10
+handle watch_retry_max_seconds=80
+
+
+
+=== TEST 8: create_handle applies default retry intervals when omitted
+--- config
+    location /t {
+        content_by_lua_block {
+            local k8s_core = require("apisix.discovery.kubernetes.core")
+            local mock_factory = {
+                new = function()
+                    return { kind = "Endpoints" }, nil
+                end,
+            }
+
+            local handle, err = k8s_core.create_handle({
+                service = { schema = "https", host = "127.0.0.1", port = "6443" },
+                client  = { token = "fake-token" },
+            }, {
+                endpoint_dict    = {},
+                informer_factory = mock_factory,
+            })
+            assert(handle, err)
+
+            ngx.say("retry_interval=", tostring(handle.watch_retry_interval_seconds))
+            ngx.say("retry_max=", tostring(handle.watch_retry_max_seconds))
+        }
+    }
+--- request
+GET /t
+--- response_body
+retry_interval=40
+retry_max=40


### PR DESCRIPTION
Closes #8311.

### Description

When APISIX Kubernetes service discovery runs behind a cloud load balancer or apiserver proxy whose idle timeout is shorter than the hard-coded watch duration (`1800 + random(9..999)` seconds), the proxy terminates the connection first. Discovery treats this as a failure and waits a fixed **40 seconds** before the next `list_watch` cycle, during which endpoint updates can be missed.

This PR adds four optional `discovery.kubernetes` configuration items so operators can tune watch timeout, jitter, and retry backoff without code changes:

| Field | Purpose |
|-------|---------|
| `watch_timeout_seconds` | Base `timeoutSeconds` sent to the Kubernetes API server |
| `watch_jitter_seconds` | Random `[0..N]` added to the base timeout (0 = deterministic) |
| `watch_retry_interval_seconds` | Initial backoff after a failed `list_watch` cycle |
| `watch_retry_max_seconds` | Cap for exponential backoff (doubled on each failure, reset on success) |

When **both** watch tuning fields are omitted, behavior is unchanged: `1800 + random(9..999)` watch timeout and a fixed 40s retry interval.

#### Which issue(s) this PR fixes:

Fixes #8311

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
