### PR TITLE
fix(ai-prompt-*): handle nil err in JSON body parse path

### DIFF
--- a/apisix/core/request.lua
+++ b/apisix/core/request.lua
@@ -343,7 +343,7 @@ function _M.get_json_request_body_table()
 
     local body_tab, err = json.decode(body)
     if not body_tab then
-        return nil, { message = "could not parse JSON request body: " .. err }
+        return nil, { message = "could not parse JSON request body: " .. (err or "invalid JSON") }
     end
 
     return body_tab

--- a/apisix/plugins/ai-prompt-decorator.lua
+++ b/apisix/plugins/ai-prompt-decorator.lua
@@ -67,12 +67,12 @@ end
 local function get_request_body_table()
     local body, err = core.request.get_body()
     if not body then
-        return nil, { message = "could not get body: " .. err }
+        return nil, { message = "could not get body: " .. (err or "request body is empty") }
     end
 
     local body_tab, err = core.json.decode(body)
     if not body_tab then
-        return nil, { message = "could not parse JSON request body: " .. err }
+        return nil, { message = "could not parse JSON request body: " .. (err or "invalid JSON") }
     end
 
     return body_tab

--- a/apisix/plugins/ai-prompt-template.lua
+++ b/apisix/plugins/ai-prompt-template.lua
@@ -93,12 +93,12 @@ end
 local function get_request_body_table()
     local body, err = core.request.get_body()
     if not body then
-        return nil, { message = "could not get body: " .. err }
+        return nil, { message = "could not get body: " .. (err or "request body is empty") }
     end
 
     local body_tab, err = core.json.decode(body)
     if not body_tab then
-        return nil, { message = "could not parse JSON request body: " .. err }
+        return nil, { message = "could not parse JSON request body: " .. (err or "invalid JSON") }
     end
 
     return body_tab


### PR DESCRIPTION
### Description

Follow-up to #13096 (which corrected the wording of the JSON-parse error message in the AI prompt plugins). That patch left two nil-concatenation hazards behind that turn the affected plugins into 500s instead of returning the intended 4xx client error:

1. `core.request.get_body()` can return `nil` with `err == nil` for **empty** request bodies. With:

   ```lua
   return nil, { message = "could not get body: " .. err }
   ```

   the concatenation crashes with `attempt to concatenate local 'err' (a nil value)`.

2. `core.json.decode()` returning `nil` with `err == nil` is much rarer but still possible, and the same concatenation hazard applies.

Affected files:

- `apisix/core/request.lua` — `get_json_request_body_table()`. The `get_body()` branch already had an `(err or "request body is empty")` guard from a previous patch; this PR adds the matching guard on the `json.decode()` branch.
- `apisix/plugins/ai-prompt-template.lua` — `get_request_body_table()`. Both branches need the guard.
- `apisix/plugins/ai-prompt-decorator.lua` — `get_request_body_table()`. Both branches need the guard.

Reproduction (before this PR):

```
POST / HTTP/1.1
Content-Type: application/json
Content-Length: 0

```

with `ai-prompt-template` enabled returns 500 instead of the configured "could not get body: request body is empty" message.

#### Which issue(s) this PR fixes:

Follow-up to #13096; no separate issue.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change — *the existing `t/admin/routes_request_body.t` exercises the nil-`err` empty-body path and now correctly produces the configured error message; happy to add a focused regression test in `t/plugin/ai-prompt-template.t` if reviewers want one.*
- [x] I have updated the documentation to reflect this change — *no doc impact; behaviour is now the documented one.*
- [x] I have verified that this change is backward compatible
