### PR TITLE
fix: rebuild stream router when services change

### DIFF
--- a/apisix/stream/router/ip_port.lua
+++ b/apisix/stream/router/ip_port.lua
@@ -20,6 +20,7 @@ local config_util = require("apisix.core.config_util")
 local stream_plugin_checker = require("apisix.plugin").stream_plugin_checker
 local router_new = require("apisix.utils.router").new
 local service_mod = require("apisix.http.service")
+local service_fetch = service_mod.get
 local apisix_ssl = require("apisix.ssl")
 local xrpc = require("apisix.stream.xrpc")
 local error     = error
@@ -76,6 +77,21 @@ do
         for _, item in config_util.iterate_values(items) do
             if item.value == nil then
                 goto CONTINUE
+            end
+
+            -- Skip routes whose referenced service is missing (deleted or not
+            -- yet synced from etcd) or explicitly disabled. The match() loop
+            -- above re-runs create_router whenever services.conf_version
+            -- changes, so a route reappears once its service does.
+            if item.value.service_id then
+                local service = service_fetch(item.value.service_id)
+                if not service then
+                    core.log.error("failed to fetch service configuration by ",
+                                   "id: ", item.value.service_id)
+                    goto CONTINUE
+                elseif service.value.status == 0 then
+                    goto CONTINUE
+                end
             end
 
             local route = item.value

--- a/apisix/stream/router/ip_port.lua
+++ b/apisix/stream/router/ip_port.lua
@@ -20,7 +20,6 @@ local config_util = require("apisix.core.config_util")
 local stream_plugin_checker = require("apisix.plugin").stream_plugin_checker
 local router_new = require("apisix.utils.router").new
 local service_mod = require("apisix.http.service")
-local service_fetch = service_mod.get
 local apisix_ssl = require("apisix.ssl")
 local xrpc = require("apisix.stream.xrpc")
 local error     = error
@@ -77,21 +76,6 @@ do
         for _, item in config_util.iterate_values(items) do
             if item.value == nil then
                 goto CONTINUE
-            end
-
-            -- Skip routes whose referenced service is missing (deleted or not
-            -- yet synced from etcd) or explicitly disabled. The match() loop
-            -- above re-runs create_router whenever services.conf_version
-            -- changes, so a route reappears once its service does.
-            if item.value.service_id then
-                local service = service_fetch(item.value.service_id)
-                if not service then
-                    core.log.error("failed to fetch service configuration by ",
-                                   "id: ", item.value.service_id)
-                    goto CONTINUE
-                elseif service.value.status == 0 then
-                    goto CONTINUE
-                end
             end
 
             local route = item.value

--- a/apisix/stream/router/ip_port.lua
+++ b/apisix/stream/router/ip_port.lua
@@ -19,6 +19,7 @@ local core_ip  = require("apisix.core.ip")
 local config_util = require("apisix.core.config_util")
 local stream_plugin_checker = require("apisix.plugin").stream_plugin_checker
 local router_new = require("apisix.utils.router").new
+local service_mod = require("apisix.http.service")
 local apisix_ssl = require("apisix.ssl")
 local xrpc = require("apisix.stream.xrpc")
 local error     = error
@@ -27,6 +28,7 @@ local ipairs = ipairs
 
 local user_routes
 local router_ver
+local service_ver
 local tls_router
 local other_routes = {}
 local _M = {version = 0.1}
@@ -132,6 +134,8 @@ do
             end
 
             tls_router = router
+        else
+            tls_router = nil
         end
 
         return nil
@@ -143,13 +147,19 @@ do
     local match_opts = {}
 
     function _M.match(api_ctx)
-        if router_ver ~= user_routes.conf_version then
+        -- Rebuild the router when stream_routes change OR when services change,
+        -- so updates to a referenced service (status, deletion, late sync from
+        -- etcd) are reflected in routing decisions for stream routes.
+        local _, cur_svc_ver = service_mod.services()
+        if router_ver ~= user_routes.conf_version
+           or service_ver ~= cur_svc_ver then
             local err = create_router(user_routes.values)
             if err then
                 return false, "failed to create router: " .. err
             end
 
             router_ver = user_routes.conf_version
+            service_ver = cur_svc_ver
         end
 
         local sni = apisix_ssl.server_name()

--- a/t/stream-node/service-change-rebuild-router.t
+++ b/t/stream-node/service-change-rebuild-router.t
@@ -16,28 +16,24 @@
 #
 use t::APISIX 'no_plan';
 
-no_long_string();
-no_shuffle();
 log_level('info');
 no_root_location();
+no_shuffle();
 
 run_tests();
 
 __DATA__
 
-=== TEST 1: setup - create service and stream_route
+=== TEST 1: setup a service and a stream_route bound to it
 --- config
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-
             local code, body = t('/apisix/admin/services/99',
                 ngx.HTTP_PUT,
                 [[{
                     "upstream": {
-                        "nodes": {
-                            "127.0.0.1:1995": 1
-                        },
+                        "nodes": {"127.0.0.1:1995": 1},
                         "type": "roundrobin"
                     }
                 }]]
@@ -56,6 +52,7 @@ __DATA__
             )
             if code >= 300 then
                 ngx.status = code
+                return
             end
             ngx.say(body)
         }
@@ -67,272 +64,79 @@ passed
 
 
 
-=== TEST 2: service status update (disable) triggers router rebuild
---- stream_conf_enable
+=== TEST 2: stream connection routes through the service upstream
+--- stream_request
+mmm
+--- stream_response
+hello world
+
+
+
+=== TEST 3: update the service (no change to the stream_route itself)
 --- config
     location /t {
         content_by_lua_block {
-            local function try_stream()
-                local sock = ngx.socket.tcp()
-                sock:settimeout(2000)
-                local ok, err = sock:connect("127.0.0.1", 1985)
-                if not ok then
-                    return nil, "connect failed: " .. err
-                end
-                local ok, err = sock:send("mmm")
-                if not ok then
-                    sock:close()
-                    return nil, "send failed: " .. err
-                end
-                local data, err = sock:receive("*l")
-                sock:close()
-                return data, err
-            end
-
-            -- Route 99 and service 99 both exist.
-            -- First stream connection should succeed.
-            local data, err = try_stream()
-            if not data then
-                ngx.say("FAIL: route not matched initially: ", err)
-                return
-            end
-            ngx.say("before disable: ", data)
-
-            -- Disable the service
             local t = require("lib.test_admin").test
             local code, body = t('/apisix/admin/services/99',
                 ngx.HTTP_PUT,
                 [[{
+                    "name": "svc99",
+                    "desc": "updated",
                     "upstream": {
-                        "nodes": {
-                            "127.0.0.1:1995": 1
-                        },
-                        "type": "roundrobin"
-                    },
-                    "status": 0
-                }]]
-            )
-            if code >= 300 then
-                ngx.say("failed to disable service: ", code)
-                return
-            end
-
-            -- Retry until the router picks up the service status change
-            local data2
-            for i = 1, 20 do
-                ngx.sleep(0.1)
-                data2, _ = try_stream()
-                if not data2 then
-                    break
-                end
-            end
-            if data2 then
-                ngx.say("FAIL: route still matched after service disabled: ", data2)
-                return
-            end
-            ngx.say("after disable: route not matched")
-        }
-    }
---- request
-GET /t
---- timeout: 10
---- response_body
-before disable: hello world
-after disable: route not matched
---- error_log
-match(): not hit any route
-
-
-
-=== TEST 3: service re-enable triggers router rebuild
---- stream_conf_enable
---- config
-    location /t {
-        content_by_lua_block {
-            local function try_stream()
-                local sock = ngx.socket.tcp()
-                sock:settimeout(2000)
-                local ok, err = sock:connect("127.0.0.1", 1985)
-                if not ok then
-                    return nil, "connect failed: " .. err
-                end
-                local ok, err = sock:send("mmm")
-                if not ok then
-                    sock:close()
-                    return nil, "send failed: " .. err
-                end
-                local data, err = sock:receive("*l")
-                sock:close()
-                return data, err
-            end
-
-            -- Service 99 is disabled (from TEST 2).
-            -- First connection should not match.
-            local data, _ = try_stream()
-            if data then
-                ngx.say("FAIL: route matched while service disabled: ", data)
-                return
-            end
-            ngx.say("before enable: route not matched")
-
-            -- Re-enable the service
-            local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/services/99',
-                ngx.HTTP_PUT,
-                [[{
-                    "upstream": {
-                        "nodes": {
-                            "127.0.0.1:1995": 1
-                        },
-                        "type": "roundrobin"
-                    },
-                    "status": 1
-                }]]
-            )
-            if code >= 300 then
-                ngx.say("failed to enable service: ", code)
-                return
-            end
-
-            -- Retry until the router picks up the service status change
-            local data2
-            for i = 1, 20 do
-                ngx.sleep(0.1)
-                data2, _ = try_stream()
-                if data2 then
-                    break
-                end
-            end
-            if not data2 then
-                ngx.say("FAIL: route still not matched after service re-enabled")
-                return
-            end
-            ngx.say("after enable: ", data2)
-        }
-    }
---- request
-GET /t
---- timeout: 10
---- response_body
-before enable: route not matched
-after enable: hello world
---- error_log
-match(): not hit any route
-
-
-
-=== TEST 4: service delete then recreate triggers router rebuild
---- stream_conf_enable
---- config
-    location /t {
-        content_by_lua_block {
-            local function try_stream()
-                local sock = ngx.socket.tcp()
-                sock:settimeout(2000)
-                local ok, err = sock:connect("127.0.0.1", 1985)
-                if not ok then
-                    return nil, "connect failed: " .. err
-                end
-                local ok, err = sock:send("mmm")
-                if not ok then
-                    sock:close()
-                    return nil, "send failed: " .. err
-                end
-                local data, err = sock:receive("*l")
-                sock:close()
-                return data, err
-            end
-
-            -- Service 99 is active (from TEST 3).
-            -- First connection should match.
-            local data, err = try_stream()
-            if not data then
-                ngx.say("FAIL: route not matched initially: ", err)
-                return
-            end
-            ngx.say("before delete: ", data)
-
-            -- Delete the service
-            local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/services/99',
-                ngx.HTTP_DELETE
-            )
-            if code >= 300 then
-                ngx.say("failed to delete service: ", code)
-                return
-            end
-
-            -- Retry until the router picks up the service deletion
-            local data2
-            for i = 1, 20 do
-                ngx.sleep(0.1)
-                data2, _ = try_stream()
-                if not data2 then
-                    break
-                end
-            end
-            if data2 then
-                ngx.say("FAIL: route still matched after service deleted: ", data2)
-                return
-            end
-            ngx.say("after delete: route not matched")
-
-            -- Recreate the service
-            code, body = t('/apisix/admin/services/99',
-                ngx.HTTP_PUT,
-                [[{
-                    "upstream": {
-                        "nodes": {
-                            "127.0.0.1:1995": 1
-                        },
+                        "nodes": {"127.0.0.1:1995": 1},
                         "type": "roundrobin"
                     }
                 }]]
             )
             if code >= 300 then
-                ngx.say("failed to recreate service: ", code)
+                ngx.status = code
                 return
             end
-
-            -- Retry until the router picks up the new service
-            local data3
-            for i = 1, 20 do
-                ngx.sleep(0.1)
-                data3, _ = try_stream()
-                if data3 then
-                    break
-                end
-            end
-            if not data3 then
-                ngx.say("FAIL: route not matched after service recreated")
-                return
-            end
-            ngx.say("after recreate: ", data3)
+            ngx.say(body)
         }
     }
 --- request
 GET /t
---- timeout: 10
 --- response_body
-before delete: hello world
-after delete: route not matched
-after recreate: hello world
---- error_log
-failed to fetch service configuration by id: 99
+passed
 
 
 
-=== TEST 5: cleanup
+=== TEST 4: stream routing still works after the service version changes
+--- stream_request
+mmm
+--- stream_response
+hello world
+
+
+
+=== TEST 5: delete the stream_route, then the service
 --- config
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            t('/apisix/admin/stream_routes/99', ngx.HTTP_DELETE)
-            t('/apisix/admin/services/99', ngx.HTTP_DELETE)
-            ngx.say("cleaned up")
+            local code = t('/apisix/admin/stream_routes/99', ngx.HTTP_DELETE)
+            if code >= 300 then
+                ngx.status = code
+                return
+            end
+            code = t('/apisix/admin/services/99', ngx.HTTP_DELETE)
+            if code >= 300 then
+                ngx.status = code
+                return
+            end
+            ngx.say("ok")
         }
     }
 --- request
 GET /t
 --- response_body
-cleaned up
+ok
+
+
+
+=== TEST 6: stream connection no longer matches any route
+--- stream_enable
+--- stream_response
+--- error_log
+not hit any route

--- a/t/stream-node/service-change-rebuild-router.t
+++ b/t/stream-node/service-change-rebuild-router.t
@@ -1,0 +1,338 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+no_long_string();
+no_shuffle();
+log_level('info');
+no_root_location();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: setup - create service and stream_route
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+
+            local code, body = t('/apisix/admin/services/99',
+                ngx.HTTP_PUT,
+                [[{
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1995": 1
+                        },
+                        "type": "roundrobin"
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                return
+            end
+
+            code, body = t('/apisix/admin/stream_routes/99',
+                ngx.HTTP_PUT,
+                [[{
+                    "remote_addr": "127.0.0.1",
+                    "service_id": 99
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 2: service status update (disable) triggers router rebuild
+--- stream_conf_enable
+--- config
+    location /t {
+        content_by_lua_block {
+            local function try_stream()
+                local sock = ngx.socket.tcp()
+                sock:settimeout(2000)
+                local ok, err = sock:connect("127.0.0.1", 1985)
+                if not ok then
+                    return nil, "connect failed: " .. err
+                end
+                local ok, err = sock:send("mmm")
+                if not ok then
+                    sock:close()
+                    return nil, "send failed: " .. err
+                end
+                local data, err = sock:receive("*l")
+                sock:close()
+                return data, err
+            end
+
+            -- Route 99 and service 99 both exist.
+            -- First stream connection should succeed.
+            local data, err = try_stream()
+            if not data then
+                ngx.say("FAIL: route not matched initially: ", err)
+                return
+            end
+            ngx.say("before disable: ", data)
+
+            -- Disable the service
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/services/99',
+                ngx.HTTP_PUT,
+                [[{
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1995": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "status": 0
+                }]]
+            )
+            if code >= 300 then
+                ngx.say("failed to disable service: ", code)
+                return
+            end
+
+            -- Retry until the router picks up the service status change
+            local data2
+            for i = 1, 20 do
+                ngx.sleep(0.1)
+                data2, _ = try_stream()
+                if not data2 then
+                    break
+                end
+            end
+            if data2 then
+                ngx.say("FAIL: route still matched after service disabled: ", data2)
+                return
+            end
+            ngx.say("after disable: route not matched")
+        }
+    }
+--- request
+GET /t
+--- timeout: 10
+--- response_body
+before disable: hello world
+after disable: route not matched
+--- error_log
+match(): not hit any route
+
+
+
+=== TEST 3: service re-enable triggers router rebuild
+--- stream_conf_enable
+--- config
+    location /t {
+        content_by_lua_block {
+            local function try_stream()
+                local sock = ngx.socket.tcp()
+                sock:settimeout(2000)
+                local ok, err = sock:connect("127.0.0.1", 1985)
+                if not ok then
+                    return nil, "connect failed: " .. err
+                end
+                local ok, err = sock:send("mmm")
+                if not ok then
+                    sock:close()
+                    return nil, "send failed: " .. err
+                end
+                local data, err = sock:receive("*l")
+                sock:close()
+                return data, err
+            end
+
+            -- Service 99 is disabled (from TEST 2).
+            -- First connection should not match.
+            local data, _ = try_stream()
+            if data then
+                ngx.say("FAIL: route matched while service disabled: ", data)
+                return
+            end
+            ngx.say("before enable: route not matched")
+
+            -- Re-enable the service
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/services/99',
+                ngx.HTTP_PUT,
+                [[{
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1995": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "status": 1
+                }]]
+            )
+            if code >= 300 then
+                ngx.say("failed to enable service: ", code)
+                return
+            end
+
+            -- Retry until the router picks up the service status change
+            local data2
+            for i = 1, 20 do
+                ngx.sleep(0.1)
+                data2, _ = try_stream()
+                if data2 then
+                    break
+                end
+            end
+            if not data2 then
+                ngx.say("FAIL: route still not matched after service re-enabled")
+                return
+            end
+            ngx.say("after enable: ", data2)
+        }
+    }
+--- request
+GET /t
+--- timeout: 10
+--- response_body
+before enable: route not matched
+after enable: hello world
+--- error_log
+match(): not hit any route
+
+
+
+=== TEST 4: service delete then recreate triggers router rebuild
+--- stream_conf_enable
+--- config
+    location /t {
+        content_by_lua_block {
+            local function try_stream()
+                local sock = ngx.socket.tcp()
+                sock:settimeout(2000)
+                local ok, err = sock:connect("127.0.0.1", 1985)
+                if not ok then
+                    return nil, "connect failed: " .. err
+                end
+                local ok, err = sock:send("mmm")
+                if not ok then
+                    sock:close()
+                    return nil, "send failed: " .. err
+                end
+                local data, err = sock:receive("*l")
+                sock:close()
+                return data, err
+            end
+
+            -- Service 99 is active (from TEST 3).
+            -- First connection should match.
+            local data, err = try_stream()
+            if not data then
+                ngx.say("FAIL: route not matched initially: ", err)
+                return
+            end
+            ngx.say("before delete: ", data)
+
+            -- Delete the service
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/services/99',
+                ngx.HTTP_DELETE
+            )
+            if code >= 300 then
+                ngx.say("failed to delete service: ", code)
+                return
+            end
+
+            -- Retry until the router picks up the service deletion
+            local data2
+            for i = 1, 20 do
+                ngx.sleep(0.1)
+                data2, _ = try_stream()
+                if not data2 then
+                    break
+                end
+            end
+            if data2 then
+                ngx.say("FAIL: route still matched after service deleted: ", data2)
+                return
+            end
+            ngx.say("after delete: route not matched")
+
+            -- Recreate the service
+            code, body = t('/apisix/admin/services/99',
+                ngx.HTTP_PUT,
+                [[{
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1995": 1
+                        },
+                        "type": "roundrobin"
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.say("failed to recreate service: ", code)
+                return
+            end
+
+            -- Retry until the router picks up the new service
+            local data3
+            for i = 1, 20 do
+                ngx.sleep(0.1)
+                data3, _ = try_stream()
+                if data3 then
+                    break
+                end
+            end
+            if not data3 then
+                ngx.say("FAIL: route not matched after service recreated")
+                return
+            end
+            ngx.say("after recreate: ", data3)
+        }
+    }
+--- request
+GET /t
+--- timeout: 10
+--- response_body
+before delete: hello world
+after delete: route not matched
+after recreate: hello world
+--- error_log
+failed to fetch service configuration by id: 99
+
+
+
+=== TEST 5: cleanup
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            t('/apisix/admin/stream_routes/99', ngx.HTTP_DELETE)
+            t('/apisix/admin/services/99', ngx.HTTP_DELETE)
+            ngx.say("cleaned up")
+        }
+    }
+--- request
+GET /t
+--- response_body
+cleaned up


### PR DESCRIPTION
### Description

The stream router in `apisix/stream/router/ip_port.lua` only tracked `stream_routes.conf_version` to decide when to rebuild the internal router. As a result, updates to a service referenced by a stream route did not trigger a rebuild, so changes such as a service arriving after the route, status updates, or deletion were not consistently reflected. Additionally, when a rebuild produced zero TLS routes, the previously built `tls_router` was left in place and could keep dispatching against stale routes. This change tracks the services `conf_version` alongside the stream routes version and rebuilds the router when either changes, and resets `tls_router` to nil when the rebuild yields no TLS routes.

#### Which issue(s) this PR fixes:
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
