### PR TITLE
fix: add fetch_secrets support for ai-rate-limiting, limit-conn, and limit-req plugins

### DIFF
--- a/apisix/plugins/ai-rate-limiting.lua
+++ b/apisix/plugins/ai-rate-limiting.lua
@@ -24,6 +24,7 @@ local load = load
 local math_floor = math.floor
 local math_huge = math.huge
 local core = require("apisix.core")
+local fetch_secrets = require("apisix.secret").fetch_secrets
 local limit_count = require("apisix.plugins.limit-count.init")
 
 local plugin_name = "ai-rate-limiting"
@@ -269,6 +270,7 @@ function _M.access(conf, ctx)
     if not limit_conf then
         return
     end
+    limit_conf = fetch_secrets(limit_conf, true)
     local code, msg = limit_count.rate_limit(limit_conf, ctx, plugin_name, 1, true)
     ctx.ai_rate_limiting = code and true or false
     return code, msg
@@ -303,6 +305,7 @@ function _M.check_instance_status(conf, ctx, instance_name)
         return true
     end
 
+    limit_conf = fetch_secrets(limit_conf, true)
     local code, _ = limit_count.rate_limit(limit_conf, ctx, plugin_name, 1, true)
     if code then
         core.log.info("rate limit for instance: ", instance_name, " code: ", code)
@@ -401,6 +404,7 @@ function _M.log(conf, ctx)
         limit_conf = limit_conf_kvs[instance_name]
     end
     if limit_conf then
+        limit_conf = fetch_secrets(limit_conf, true)
         limit_count.rate_limit(limit_conf, ctx, plugin_name, used_tokens)
     end
 end

--- a/apisix/plugins/limit-conn.lua
+++ b/apisix/plugins/limit-conn.lua
@@ -15,6 +15,7 @@
 -- limitations under the License.
 --
 local core                              = require("apisix.core")
+local fetch_secrets                     = require("apisix.secret").fetch_secrets
 local limit_conn                        = require("apisix.plugins.limit-conn.init")
 local redis_schema                      = require("apisix.utils.redis-schema")
 local plugin_name                       = "limit-conn"
@@ -120,6 +121,7 @@ end
 
 
 function _M.access(conf, ctx)
+    conf = fetch_secrets(conf, true)
     return limit_conn.increase(conf, ctx)
 end
 
@@ -134,6 +136,7 @@ function _M.workflow_handler()
         return core.schema.check(schema, conf)
     end,
     function (conf, ctx) -- handler run in access phase
+        conf = fetch_secrets(conf, true)
         return limit_conn.increase(conf, ctx, plugin_name, 1)
     end,
     function (conf, ctx) -- log_handler run in log phase

--- a/apisix/plugins/limit-req.lua
+++ b/apisix/plugins/limit-req.lua
@@ -16,6 +16,7 @@
 --
 local limit_req_new                     = require("resty.limit.req").new
 local core                              = require("apisix.core")
+local fetch_secrets                     = require("apisix.secret").fetch_secrets
 local redis_schema                      = require("apisix.utils.redis-schema")
 local policy_to_additional_properties   = redis_schema.schema
 local plugin_name                       = "limit-req"
@@ -135,6 +136,7 @@ end
 
 
 function _M.access(conf, ctx)
+    conf = fetch_secrets(conf, true)
     local lim, err = core.lrucache.plugin_ctx(lrucache, ctx, nil,
                                               create_limit_obj, conf)
     if not lim then

--- a/t/plugin/ai-rate-limiting-redis-env.t
+++ b/t/plugin/ai-rate-limiting-redis-env.t
@@ -57,63 +57,6 @@ _EOC_
 
     $block->set_value("extra_init_worker_by_lua", $extra_init_worker_by_lua);
 
-    my $http_config = $block->http_config // <<_EOC_;
-        server {
-            server_name openai;
-            listen 16725;
-
-            default_type 'application/json';
-
-            location /v1/chat/completions {
-                content_by_lua_block {
-                    local json = require("cjson.safe")
-
-                    if ngx.req.get_method() ~= "POST" then
-                        ngx.status = 400
-                        ngx.say("Unsupported request method: ", ngx.req.get_method())
-                        return
-                    end
-                    ngx.req.read_body()
-                    local body, err = ngx.req.get_body_data()
-                    body, err = json.decode(body)
-
-                    local header_auth = ngx.req.get_headers()["authorization"]
-                    if header_auth ~= "Bearer token" then
-                        ngx.status = 401
-                        ngx.say("Unauthorized")
-                        return
-                    end
-
-                    if not body.messages or #body.messages < 1 then
-                        ngx.status = 400
-                        ngx.say([[{ "error": "bad request"}]])
-                        return
-                    end
-
-                    ngx.status = 200
-                    ngx.say(string.format([[
-{
-  "choices": [
-    {
-      "finish_reason": "stop",
-      "index": 0,
-      "message": { "content": "1 + 1 = 2.", "role": "assistant" }
-    }
-  ],
-  "created": 1723780938,
-  "id": "chatcmpl-env-test",
-  "model": "%s",
-  "object": "chat.completion",
-  "system_fingerprint": "fp_abc28019ad",
-  "usage": { "completion_tokens": 5, "prompt_tokens": 8, "total_tokens": 10 }
-}
-                    ]], body.model))
-                }
-            }
-        }
-_EOC_
-
-    $block->set_value("http_config", $http_config);
 });
 
 run_tests();
@@ -141,7 +84,7 @@ __DATA__
                                 "model": "gpt-4"
                             },
                             "override": {
-                                "endpoint": "http://localhost:16725"
+                                "endpoint": "http://127.0.0.1:1980"
                             },
                             "ssl_verify": false
                         },
@@ -182,6 +125,7 @@ passed
 ]
 --- more_headers
 Authorization: Bearer token
+X-AI-Fixture: openai/chat-model-echo.json
 --- error_code eval
 [200, 200, 200, 503]
 --- response_headers eval
@@ -221,7 +165,7 @@ Authorization: Bearer token
                                         "model": "gpt-4"
                                     },
                                     "override": {
-                                        "endpoint": "http://localhost:16725"
+                                        "endpoint": "http://127.0.0.1:1980"
                                     }
                                 },
                                 {
@@ -238,7 +182,7 @@ Authorization: Bearer token
                                         "model": "gpt-3"
                                     },
                                     "override": {
-                                        "endpoint": "http://localhost:16725"
+                                        "endpoint": "http://127.0.0.1:1980"
                                     }
                                 }
                             ],
@@ -288,6 +232,7 @@ passed
                 nil,
                 {
                     ["Content-Type"] = "application/json",
+                    ["X-AI-Fixture"] = "openai/chat-model-echo.json",
                 }
             )
 
@@ -306,6 +251,7 @@ passed
                 nil,
                 {
                     ["Content-Type"] = "application/json",
+                    ["X-AI-Fixture"] = "openai/chat-model-echo.json",
                 }
             )
 

--- a/t/plugin/ai-rate-limiting-redis-env.t
+++ b/t/plugin/ai-rate-limiting-redis-env.t
@@ -1,0 +1,320 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+BEGIN {
+    if ($ENV{TEST_NGINX_CHECK_LEAK}) {
+        $SkipReason = "unavailable for the hup tests";
+
+    } else {
+        $ENV{TEST_NGINX_USE_HUP} = 1;
+        undef $ENV{TEST_NGINX_USE_STAP};
+    }
+
+    $ENV{REDIS_HOST} = "127.0.0.1";
+}
+
+use t::APISIX;
+
+my $nginx_binary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
+my $version = eval { `$nginx_binary -V 2>&1` };
+
+if ($version !~ m/\/apisix-nginx-module/) {
+    plan(skip_all => "apisix-nginx-module not installed");
+} else {
+    plan('no_plan');
+}
+
+log_level("info");
+repeat_each(1);
+no_long_string();
+no_shuffle();
+no_root_location();
+workers(4);
+
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+    my $extra_init_worker_by_lua = <<_EOC_;
+        require("lib.test_redis").flush_all()
+_EOC_
+
+    $block->set_value("extra_init_worker_by_lua", $extra_init_worker_by_lua);
+
+    my $http_config = $block->http_config // <<_EOC_;
+        server {
+            server_name openai;
+            listen 16725;
+
+            default_type 'application/json';
+
+            location /v1/chat/completions {
+                content_by_lua_block {
+                    local json = require("cjson.safe")
+
+                    if ngx.req.get_method() ~= "POST" then
+                        ngx.status = 400
+                        ngx.say("Unsupported request method: ", ngx.req.get_method())
+                        return
+                    end
+                    ngx.req.read_body()
+                    local body, err = ngx.req.get_body_data()
+                    body, err = json.decode(body)
+
+                    local header_auth = ngx.req.get_headers()["authorization"]
+                    if header_auth ~= "Bearer token" then
+                        ngx.status = 401
+                        ngx.say("Unauthorized")
+                        return
+                    end
+
+                    if not body.messages or #body.messages < 1 then
+                        ngx.status = 400
+                        ngx.say([[{ "error": "bad request"}]])
+                        return
+                    end
+
+                    ngx.status = 200
+                    ngx.say(string.format([[
+{
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": { "content": "1 + 1 = 2.", "role": "assistant" }
+    }
+  ],
+  "created": 1723780938,
+  "id": "chatcmpl-env-test",
+  "model": "%s",
+  "object": "chat.completion",
+  "system_fingerprint": "fp_abc28019ad",
+  "usage": { "completion_tokens": 5, "prompt_tokens": 8, "total_tokens": 10 }
+}
+                    ]], body.model))
+                }
+            }
+        }
+_EOC_
+
+    $block->set_value("http_config", $http_config);
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: set route with redis_host via $ENV://
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/ai",
+                    "plugins": {
+                        "ai-proxy": {
+                            "provider": "openai",
+                            "auth": {
+                                "header": {
+                                    "Authorization": "Bearer token"
+                                }
+                            },
+                            "options": {
+                                "model": "gpt-4"
+                            },
+                            "override": {
+                                "endpoint": "http://localhost:16725"
+                            },
+                            "ssl_verify": false
+                        },
+                        "ai-rate-limiting": {
+                            "limit": 30,
+                            "time_window": 60,
+                            "policy": "redis",
+                            "redis_host": "$ENV://REDIS_HOST"
+                        }
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "canbeanything.com": 1
+                        }
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 2: verify ai-rate-limiting works with $ENV:// redis_host
+--- pipelined_requests eval
+[
+    "POST /ai\n" . "{ \"messages\": [ { \"role\": \"system\", \"content\": \"You are a mathematician\" }, { \"role\": \"user\", \"content\": \"What is 1+1?\"} ] }",
+    "POST /ai\n" . "{ \"messages\": [ { \"role\": \"system\", \"content\": \"You are a mathematician\" }, { \"role\": \"user\", \"content\": \"What is 1+1?\"} ] }",
+    "POST /ai\n" . "{ \"messages\": [ { \"role\": \"system\", \"content\": \"You are a mathematician\" }, { \"role\": \"user\", \"content\": \"What is 1+1?\"} ] }",
+    "POST /ai\n" . "{ \"messages\": [ { \"role\": \"system\", \"content\": \"You are a mathematician\" }, { \"role\": \"user\", \"content\": \"What is 1+1?\"} ] }",
+]
+--- more_headers
+Authorization: Bearer token
+--- error_code eval
+[200, 200, 200, 503]
+--- response_headers eval
+[
+    "X-AI-RateLimit-Remaining-ai-proxy-openai: 30",
+    "X-AI-RateLimit-Remaining-ai-proxy-openai: 20",
+    "X-AI-RateLimit-Remaining-ai-proxy-openai: 10",
+    "X-AI-RateLimit-Remaining-ai-proxy-openai: 0",
+]
+
+
+
+=== TEST 3: set route with ai-proxy-multi + ai-rate-limiting with $ENV:// redis_host (check_instance_status path)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/ai",
+                    "plugins": {
+                        "ai-proxy-multi": {
+                            "fallback_strategy": "instance_health_and_rate_limiting",
+                            "instances": [
+                                {
+                                    "name": "openai-gpt4",
+                                    "provider": "openai",
+                                    "weight": 1,
+                                    "priority": 1,
+                                    "auth": {
+                                        "header": {
+                                            "Authorization": "Bearer token"
+                                        }
+                                    },
+                                    "options": {
+                                        "model": "gpt-4"
+                                    },
+                                    "override": {
+                                        "endpoint": "http://localhost:16725"
+                                    }
+                                },
+                                {
+                                    "name": "openai-gpt3",
+                                    "provider": "openai",
+                                    "weight": 1,
+                                    "priority": 0,
+                                    "auth": {
+                                        "header": {
+                                            "Authorization": "Bearer token"
+                                        }
+                                    },
+                                    "options": {
+                                        "model": "gpt-3"
+                                    },
+                                    "override": {
+                                        "endpoint": "http://localhost:16725"
+                                    }
+                                }
+                            ],
+                            "ssl_verify": false
+                        },
+                        "ai-rate-limiting": {
+                            "limit": 10,
+                            "time_window": 60,
+                            "policy": "redis",
+                            "redis_host": "$ENV://REDIS_HOST"
+                        }
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "canbeanything.com": 1
+                        }
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 4: verify check_instance_status fallback with $ENV:// redis_host
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local core = require("apisix.core")
+            local code, _, body = t("/ai",
+                ngx.HTTP_POST,
+                [[{
+                    "messages": [
+                        { "role": "system", "content": "You are a mathematician" },
+                        { "role": "user", "content": "What is 1+1?" }
+                    ]
+                }]],
+                nil,
+                {
+                    ["Content-Type"] = "application/json",
+                }
+            )
+
+            assert(code == 200, "first request should be successful")
+            assert(core.string.find(body, "gpt-4"),
+                        "first request should be handled by higher priority instance")
+
+            local code, _, body = t("/ai",
+                ngx.HTTP_POST,
+                [[{
+                    "messages": [
+                        { "role": "system", "content": "You are a mathematician" },
+                        { "role": "user", "content": "What is 1+1?" }
+                    ]
+                }]],
+                nil,
+                {
+                    ["Content-Type"] = "application/json",
+                }
+            )
+
+            assert(code == 200, "second request should be successful")
+            assert(core.string.find(body, "gpt-3"),
+                        "second request should fall back to lower priority instance")
+
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed

--- a/t/plugin/limit-conn-redis-env.t
+++ b/t/plugin/limit-conn-redis-env.t
@@ -1,0 +1,151 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+BEGIN {
+    if ($ENV{TEST_NGINX_CHECK_LEAK}) {
+        $SkipReason = "unavailable for the hup tests";
+
+    } else {
+        $ENV{TEST_NGINX_USE_HUP} = 1;
+        undef $ENV{TEST_NGINX_USE_STAP};
+    }
+
+    $ENV{REDIS_HOST} = "127.0.0.1";
+}
+
+use t::APISIX;
+
+my $nginx_binary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
+my $version = eval { `$nginx_binary -V 2>&1` };
+
+if ($version !~ m/\/apisix-nginx-module/) {
+    plan(skip_all => "apisix-nginx-module not installed");
+} else {
+    plan('no_plan');
+}
+
+repeat_each(1);
+no_long_string();
+no_shuffle();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+    my $port = $ENV{TEST_NGINX_SERVER_PORT};
+
+    my $config = $block->config // <<_EOC_;
+    location /access_root_dir {
+        content_by_lua_block {
+            local httpc = require "resty.http"
+            local hc = httpc:new()
+
+            local res, err = hc:request_uri('http://127.0.0.1:$port/limit_conn')
+            if not res then
+                ngx.log(ngx.ERR, err or "failed to request /limit_conn")
+                ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
+            end
+
+            ngx.exit(res.status)
+        }
+    }
+
+    location /test_concurrency {
+        content_by_lua_block {
+            local reqs = {}
+            local status_map = {}
+            for i = 1, 10 do
+                reqs[i] = { "/access_root_dir" }
+            end
+            local resps = { ngx.location.capture_multi(reqs) }
+            for i, resp in ipairs(resps) do
+                local status_key = resp.status
+                if status_map[status_key] then
+                    status_map[status_key] = status_map[status_key] + 1
+                else
+                    status_map[status_key] = 1
+                end
+            end
+            if status_map[200] then
+                ngx.say("status:200, count:" .. status_map[200])
+            end
+            if status_map[503] then
+                ngx.say("status:503, count:" .. status_map[503])
+            end
+        }
+    }
+_EOC_
+
+    $block->set_value("config", $config);
+
+    if (!$block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+    if (!$block->error_log && !$block->no_error_log) {
+        $block->set_value("no_error_log", "[error]\n[alert]");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: set route with redis_host via $ENV://
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/limit_conn",
+                    "plugins": {
+                        "limit-conn": {
+                            "conn": 2,
+                            "burst": 1,
+                            "default_conn_delay": 0.1,
+                            "rejected_code": 503,
+                            "key": "remote_addr",
+                            "policy": "redis",
+                            "redis_host": "$ENV://REDIS_HOST"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    }
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 2: verify limit-conn works with $ENV:// redis_host
+--- request
+GET /test_concurrency
+--- timeout: 10s
+--- response_body
+status:200, count:3
+status:503, count:7

--- a/t/plugin/limit-req-redis-env.t
+++ b/t/plugin/limit-req-redis-env.t
@@ -1,0 +1,103 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+BEGIN {
+    if ($ENV{TEST_NGINX_CHECK_LEAK}) {
+        $SkipReason = "unavailable for the hup tests";
+
+    } else {
+        $ENV{TEST_NGINX_USE_HUP} = 1;
+        undef $ENV{TEST_NGINX_USE_STAP};
+    }
+
+    $ENV{REDIS_HOST} = "127.0.0.1";
+}
+
+use t::APISIX;
+
+my $nginx_binary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
+my $version = eval { `$nginx_binary -V 2>&1` };
+
+if ($version !~ m/\/apisix-nginx-module/) {
+    plan(skip_all => "apisix-nginx-module not installed");
+} else {
+    plan('no_plan');
+}
+
+repeat_each(1);
+no_long_string();
+no_shuffle();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!$block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+    if (!$block->error_log && !$block->no_error_log) {
+        $block->set_value("no_error_log", "[error]\n[alert]");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: set route with redis_host via $ENV://
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/hello",
+                    "plugins": {
+                        "limit-req": {
+                            "rate": 0.1,
+                            "burst": 0,
+                            "rejected_code": 503,
+                            "key": "remote_addr",
+                            "policy": "redis",
+                            "redis_host": "$ENV://REDIS_HOST"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    }
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 2: verify limit-req works with $ENV:// redis_host
+--- pipelined_requests eval
+["GET /hello", "GET /hello", "GET /hello", "GET /hello"]
+--- error_code eval
+[200, 503, 503, 503]


### PR DESCRIPTION
### Description

While testing distributed rate limiting with secret references, I noticed that `ai-rate-limiting`, `limit-conn`, and `limit-req` were passing literal strings such as `"$ENV://REDIS_HOST"` to Redis instead of resolving them, even though `limit-count` already supported this. The root cause is that those three plugins never invoked `apisix.secret.fetch_secrets` on their config before using it. This change adds the missing `fetch_secrets` calls in the relevant access/log/instance-status entry points so that `$ENV://` and `$secret://` references in fields like `redis_host` are resolved consistently across all rate-limiting plugins.

#### Which issue(s) this PR fixes:
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
