### PR TITLE
fix(ai-proxy-multi): resolve _dns_value in construct_upstream when nil

### DIFF
--- a/apisix/plugins/ai-proxy-multi.lua
+++ b/apisix/plugins/ai-proxy-multi.lua
@@ -253,22 +253,12 @@ local function fetch_health_instances(conf, checkers)
             local port = ins.checks and ins.checks.active and ins.checks.active.port
 
             local node = ins._dns_value
-            if not node then
-                resolve_endpoint(ins)
-                node = ins._dns_value
-            end
-            if node then
-                local ok, err = checker:get_target_status(node.host, port or node.port, host)
-                if ok then
-                    transform_instances(new_instances, ins)
-                elseif err then
-                    core.log.warn("failed to get health check target status, addr: ",
-                        node.host, ":", port or node.port, ", host: ", host, ", err: ", err)
-                end
-            else
-                core.log.warn("failed to resolve endpoint for instance: ", ins.name,
-                    ", treating as healthy")
+            local ok, err = checker:get_target_status(node.host, port or node.port, host)
+            if ok then
                 transform_instances(new_instances, ins)
+            elseif err then
+                core.log.warn("failed to get health check target status, addr: ",
+                    node.host, ":", port or node.port, ", host: ", host, ", err: ", err)
             end
         else
             transform_instances(new_instances, ins)

--- a/apisix/plugins/ai-proxy-multi.lua
+++ b/apisix/plugins/ai-proxy-multi.lua
@@ -253,12 +253,22 @@ local function fetch_health_instances(conf, checkers)
             local port = ins.checks and ins.checks.active and ins.checks.active.port
 
             local node = ins._dns_value
-            local ok, err = checker:get_target_status(node.host, port or node.port, host)
-            if ok then
+            if not node then
+                resolve_endpoint(ins)
+                node = ins._dns_value
+            end
+            if node then
+                local ok, err = checker:get_target_status(node.host, port or node.port, host)
+                if ok then
+                    transform_instances(new_instances, ins)
+                elseif err then
+                    core.log.warn("failed to get health check target status, addr: ",
+                        node.host, ":", port or node.port, ", host: ", host, ", err: ", err)
+                end
+            else
+                core.log.warn("failed to resolve endpoint for instance: ", ins.name,
+                    ", treating as healthy")
                 transform_instances(new_instances, ins)
-            elseif err then
-                core.log.warn("failed to get health check target status, addr: ",
-                    node.host, ":", port or node.port, ", host: ", host, ", err: ", err)
             end
         else
             transform_instances(new_instances, ins)

--- a/apisix/plugins/ai-proxy-multi.lua
+++ b/apisix/plugins/ai-proxy-multi.lua
@@ -439,7 +439,11 @@ function _M.construct_upstream(instance)
     local upstream = {}
     local node = instance._dns_value
     if not node then
-        return nil, "failed to resolve endpoint for instance: " .. instance.name
+        resolve_endpoint(instance)
+        node = instance._dns_value
+        if not node then
+            return nil, "failed to resolve endpoint for instance: " .. instance.name
+        end
     end
 
     if not node.host or not node.port then

--- a/t/plugin/ai-proxy-multi3.t
+++ b/t/plugin/ai-proxy-multi3.t
@@ -1063,7 +1063,7 @@ releasing existing checker
 
 
 
-=== TEST 16: construct_upstream resolves _dns_value when nil (config table replacement scenario)
+=== TEST 14: construct_upstream resolves _dns_value when nil (config table replacement scenario)
 --- config
     location /t {
         content_by_lua_block {
@@ -1076,7 +1076,7 @@ releasing existing checker
                 weight = 1,
                 priority = 0,
                 override = {
-                    endpoint = "https://api.openai.com:443",
+                    endpoint = "https://127.0.0.1:443",
                 },
                 auth = {
                     header = {
@@ -1104,6 +1104,6 @@ releasing existing checker
         }
     }
 --- response_body
-host: api.openai.com
+host: 127.0.0.1
 port: 443
 passed

--- a/t/plugin/ai-proxy-multi3.t
+++ b/t/plugin/ai-proxy-multi3.t
@@ -1060,3 +1060,50 @@ failed to get health check target status
 --- error_log
 releasing existing checker
 --- timeout: 5
+
+
+
+=== TEST 16: construct_upstream resolves _dns_value when nil (config table replacement scenario)
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ai-proxy-multi")
+
+            -- Simulate an instance after config table replacement: _dns_value is lost
+            local instance = {
+                name = "test-instance",
+                provider = "openai",
+                weight = 1,
+                priority = 0,
+                override = {
+                    endpoint = "https://api.openai.com:443",
+                },
+                auth = {
+                    header = {
+                        Authorization = "Bearer test-key",
+                    },
+                },
+            }
+
+            -- Confirm _dns_value is nil (simulating config table replacement)
+            assert(instance._dns_value == nil, "_dns_value should be nil initially")
+
+            -- construct_upstream should resolve _dns_value as fallback
+            local upstream, err = plugin.construct_upstream(instance)
+            if not upstream then
+                ngx.say("FAIL: " .. err)
+                return
+            end
+
+            -- Verify _dns_value was populated
+            assert(instance._dns_value ~= nil, "_dns_value should be set after construct_upstream")
+
+            ngx.say("host: ", upstream.nodes[1].host)
+            ngx.say("port: ", upstream.nodes[1].port)
+            ngx.say("passed")
+        }
+    }
+--- response_body
+host: api.openai.com
+port: 443
+passed


### PR DESCRIPTION
When the config store replaces the config table (e.g. `modifiedIndex` incremented), the runtime `_dns_value` field is lost because it lived on the old table. This causes `construct_upstream()` to return an error during periodic health check validation in `timer_working_pool_check()`, logging a noisy warning:

```
[checking checker] unable to construct upstream for plugin: ai-proxy-multi ...
```

The fix calls `resolve_endpoint()` as fallback when `_dns_value` is nil. This is safe because:

- The DNS resolver has TTL-based caching (microsecond-level cache hit)
- This path only triggers after config table replacement, not every check tick
- The checker will still be destroyed via version mismatch — the only difference is it takes the clean path instead of the error path


Fixes #13101
