### PR TITLE
fix(loki-logger): prevent log_labels cross-request leakage

### DIFF
--- a/apisix/plugins/loki-logger.lua
+++ b/apisix/plugins/loki-logger.lua
@@ -202,6 +202,20 @@ function _M.body_filter(conf, ctx)
 end
 
 
+local function resolve_labels(conf_labels, ctx)
+    local labels = new_tab(0, 4)
+    for key, value in pairs(conf_labels) do
+        local new_val, err, n_resolved = core.utils.resolve_var(value, ctx.var)
+        if not err and n_resolved > 0 then
+            labels[key] = new_val
+        else
+            labels[key] = value
+        end
+    end
+    return labels
+end
+
+
 function _M.log(conf, ctx)
     local metadata = plugin.plugin_metadata(plugin_name)
     local max_pending_entries = metadata and metadata.value and
@@ -218,43 +232,47 @@ function _M.log(conf, ctx)
     -- and then add 6 zeros by string concatenation
     entry.loki_log_time = tostring(ngx.req.start_time() * 1000) .. "000000"
 
+    -- Resolve labels per request into a fresh table and attach to the entry.
+    -- Mutating `conf.log_labels` in place would leak the first request's
+    -- resolved values to every later request that shares the same conf
+    -- (e.g. when this plugin is configured in a global rule).
+    entry.loki_labels = resolve_labels(conf.log_labels, ctx)
+
     if batch_processor_manager:add_entry(conf, entry, max_pending_entries) then
         return
     end
 
-    local labels = conf.log_labels
-
-    -- parsing possible variables in label value
-    for key, value in pairs(labels) do
-        local new_val, err, n_resolved = core.utils.resolve_var(value, ctx.var)
-        if not err and n_resolved > 0 then
-            labels[key] = new_val
-        end
-    end
-
-    -- generate a function to be executed by the batch processor
+    -- generate a function to be executed by the batch processor.
+    -- Group entries by their resolved label set so each unique set
+    -- becomes its own Loki stream within the push.
     local func = function(entries)
-        -- build loki request data
-        local data = {
-            streams = {
-                {
+        local streams_by_key = {}
+        local streams = new_tab(1, 0)
+
+        for _, e in ipairs(entries) do
+            local labels = e.loki_labels
+            e.loki_labels = nil -- clean logger internal field
+
+            local key = core.json.stably_encode(labels)
+            local stream = streams_by_key[key]
+            if not stream then
+                stream = {
                     stream = labels,
                     values = new_tab(1, 0),
                 }
-            }
-        }
+                streams_by_key[key] = stream
+                table_insert(streams, stream)
+            end
 
-        -- add all entries to the batch
-        for _, entry in ipairs(entries) do
-            local log_time = entry.loki_log_time
-            entry.loki_log_time = nil -- clean logger internal field
+            local log_time = e.loki_log_time
+            e.loki_log_time = nil -- clean logger internal field
 
-            table_insert(data.streams[1].values, {
-                log_time, core.json.encode(entry)
+            table_insert(stream.values, {
+                log_time, core.json.encode(e)
             })
         end
 
-        return send_http_data(conf, data)
+        return send_http_data(conf, { streams = streams })
     end
 
     batch_processor_manager:add_entry_to_new_processor(conf, entry, ctx, func, max_pending_entries)

--- a/t/plugin/loki-logger.t
+++ b/t/plugin/loki-logger.t
@@ -423,3 +423,74 @@ GET /hello
 hello world
 --- error_log
 go(): authorization: test1234
+
+
+
+=== TEST 17: setup route ($variable in log_labels must resolve per request)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "loki-logger": {
+                            "endpoint_addrs": ["http://127.0.0.1:3100"],
+                            "tenant_id": "tenant_1",
+                            "log_labels": {
+                                "custom_label": "$arg_X"
+                            },
+                            "batch_max_size": 1
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 18: hit route twice with distinct $arg_X values
+--- request eval
+["GET /hello?X=alpha", "GET /hello?X=beta"]
+--- response_body eval
+["hello world\n", "hello world\n"]
+
+
+
+=== TEST 19: both label values must appear in Loki
+--- config
+    location /t {
+        content_by_lua_block {
+            local cjson = require("cjson")
+            local now = ngx.now() * 1000
+            local data, err = require("lib.grafana_loki").fetch_logs_from_loki(
+                tostring(now - 3000) .. "000000", -- from
+                tostring(now) .. "000000",        -- to
+                { query = [[{custom_label="beta"} | json]] }
+            )
+
+            assert(err == nil, "fetch logs error: " .. (err or ""))
+            assert(data.status == "success", "loki response error: " .. cjson.encode(data))
+            -- Without the fix, the first request mutates conf.log_labels in
+            -- place ("alpha"), so every subsequent entry flushes with that
+            -- frozen value and no stream with custom_label="beta" exists.
+            assert(#data.data.result > 0, "no entries with custom_label=beta -- $arg_X did not resolve per request")
+        }
+    }
+--- error_code: 200

--- a/t/plugin/loki-logger.t
+++ b/t/plugin/loki-logger.t
@@ -494,3 +494,83 @@ passed
         }
     }
 --- error_code: 200
+
+
+
+=== TEST 20: setup route (batch_max_size > 1, same flush carries distinct labels)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "loki-logger": {
+                            "endpoint_addrs": ["http://127.0.0.1:3100"],
+                            "tenant_id": "tenant_1",
+                            "log_labels": {
+                                "batch_label": "$arg_X"
+                            },
+                            "batch_max_size": 2,
+                            "inactive_timeout": 1
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 21: two requests with distinct $arg_X fill one batch (batch_max_size = 2)
+--- request eval
+["GET /hello?X=gamma", "GET /hello?X=delta"]
+--- response_body eval
+["hello world\n", "hello world\n"]
+
+
+
+=== TEST 22: the single batch flush must produce two distinct label streams
+--- config
+    location /t {
+        content_by_lua_block {
+            local cjson = require("cjson")
+            local now = ngx.now() * 1000
+            -- NOTE: deliberately no `| json` pipeline here. `| json` would
+            -- promote per-entry body fields to labels and split a single
+            -- stream into multiple results, masking the bug. We want to
+            -- count actual Loki streams, which group purely by stream labels.
+            local data, err = require("lib.grafana_loki").fetch_logs_from_loki(
+                tostring(now - 3000) .. "000000", -- from
+                tostring(now) .. "000000",        -- to
+                { query = [[{batch_label=~"gamma|delta"}]] }
+            )
+
+            assert(err == nil, "fetch logs error: " .. (err or ""))
+            assert(data.status == "success", "loki response error: " .. cjson.encode(data))
+            -- Both requests are processed in the same batch flush. The fix
+            -- groups entries by their resolved label set, so the flush must
+            -- produce two streams: batch_label="gamma" and batch_label="delta".
+            -- Without the fix, the whole batch shares one frozen label value
+            -- and only a single stream (gamma, holding both entries) exists.
+            assert(#data.data.result == 2,
+                "expected 2 distinct label streams from one batch flush, got "
+                .. #data.data.result .. ": " .. cjson.encode(data.data.result))
+        }
+    }
+--- error_code: 200


### PR DESCRIPTION
### Description

`loki-logger` mutates `conf.log_labels` in place when substituting
`$variable` placeholders, then captures that shared table in the
batch-processor flush closure. The early return at `add_entry` causes
all subsequent requests on the same worker to skip the resolution
block, so every later entry flushes with the **first** request's
resolved labels. Symptom: log entries where `log_labels` and
`log_format` disagree on the same line (#12485), or a stream label
that carries a value from a different request than the one whose
body it accompanies.

The bug affects `loki-logger` at any scope where multiple requests
share the same conf and a `$variable` in `log_labels` resolves to
different values per request — so it surfaces in real deployments
both at global-rule and at service scope.

#### Root cause (pre-fix)

```lua
if batch_processor_manager:add_entry(conf, entry, max_pending_entries) then
    return                          -- subsequent requests bypass everything below
end

local labels = conf.log_labels      -- alias, NOT a copy
for key, value in pairs(labels) do
    local new_val, err, n_resolved = core.utils.resolve_var(value, ctx.var)
    if not err and n_resolved > 0 then
        labels[key] = new_val       -- mutates conf.log_labels
    end
end

local func = function(entries)      -- closure captures the shared table
    local data = { streams = { { stream = labels, values = ... } } }
    ...
end
```

#### Fix

- Resolve labels **per request** into a fresh table; never mutate
  `conf.log_labels`.
- Attach the resolved labels to each entry (`entry.loki_labels`).
- At flush time, group entries by their resolved label set and emit
  one Loki stream per group within the push (Loki's `streams` API
  already supports this, so batching is preserved).

The change is fully contained to `apisix/plugins/loki-logger.lua` —
nothing in `plugin.lua`, `batch-processor-manager.lua`, or other
plugins is touched.

#### Test

`t/plugin/loki-logger.t` TEST 17–19 (modeled on the existing TEST
12–14 pattern):

1. Configure a route with `log_labels: { custom_label: "$arg_X" }`
   and `batch_max_size: 1`.
2. Hit `/hello?X=alpha` then `/hello?X=beta`.
3. Query Loki for `{custom_label="beta"}`. Without the fix the
   second request's value never reaches Loki (the worker resolved
   `"alpha"` once and reused it forever), so the assertion fails.
   With the fix, both stream labels exist.

Verified locally:

| Plugin source                          | Result   |
|----------------------------------------|----------|
| Pre-fix (master before this PR)        | TEST 19 fails: `no entries with custom_label=beta` |
| Post-fix (this PR)                     | All 54 subtests pass |

#### Which issue(s) this PR fixes:

Fixes #12485

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change *(no doc change needed; bug fix, no surface change)*
- [x] I have verified that this change is backward compatible