### PR TITLE
fix(xrpc): load protocol schemas for stream_proxy in HTTP workers

### DIFF
--- a/apisix/stream/xrpc.lua
+++ b/apisix/stream/xrpc.lua
@@ -56,8 +56,11 @@ function _M.init()
         return
     end
 
-    if is_http and not local_conf.apisix.enable_admin then
-        -- we need to register xRPC protocols in HTTP only when Admin API is enabled
+    local apisix_conf = local_conf.apisix or {}
+    if is_http and not apisix_conf.enable_admin and not apisix_conf.stream_proxy then
+        -- in HTTP workers we only need xRPC protocol schemas for:
+        -- 1. Admin API schema checks
+        -- 2. stream route checks when stream proxy is enabled
         return
     end
 

--- a/t/config-center-yaml/stream-route.t
+++ b/t/config-center-yaml/stream-route.t
@@ -125,3 +125,47 @@ upstreams:
 "\x10\x0f\x00\x04\x4d\x51\x54\x54\x04\x02\x00\x3c\x00\x03\x66\x6f\x6f"
 --- stream_response
 hello world
+
+
+
+=== TEST 5: xrpc stream route works in data plane with stream_proxy enabled
+--- yaml_config
+apisix:
+    node_listen: 1984
+    enable_admin: false
+    stream_proxy:
+      tcp:
+        - 9100
+deployment:
+    role: data_plane
+    role_data_plane:
+        config_provider: yaml
+--- apisix_yaml
+xrpc:
+  protocols:
+    - name: pingpong
+stream_routes:
+  - server_addr: 127.0.0.1
+    server_port: 1985
+    id: 1
+    protocol:
+      name: pingpong
+    upstream:
+      nodes:
+        "127.0.0.1:1995": 1
+      type: roundrobin
+#END
+--- stream_upstream_code
+            local sock = ngx.req.socket(true)
+            sock:settimeout(10)
+            while true do
+                local data = sock:receiveany(4096)
+                if not data then
+                    return
+                end
+                sock:send(data)
+            end
+--- stream_request eval
+"pp\x02\x00\x00\x00\x00\x00\x00\x03ABC"
+--- stream_response eval
+"pp\x02\x00\x00\x00\x00\x00\x00\x03ABC"


### PR DESCRIPTION
### Description

This PR fixes [#13325](https://github.com/apache/apisix/issues/13325):
`xRPC`-based `stream_routes` fail schema check in HTTP workers when `enable_admin: false`, even though stream proxy is enabled.

Since #12996, HTTP workers initialize stream router when `apisix.stream_proxy` is configured (for control API access).
However, `apisix/stream/xrpc.lua` still skipped xRPC protocol schema registration in HTTP workers unless Admin API was enabled.
That caused `unknown protocol [<name>]` during stream route checks in HTTP workers.

### What changed

1. Update `apisix/stream/xrpc.lua`
- keep lazy loading behavior in HTTP workers
- but allow schema registration when either:
  - Admin API is enabled, or
  - `apisix.stream_proxy` is configured

2. Add regression coverage in `t/config-center-yaml/stream-route.t`
- add a data-plane YAML test (`enable_admin: false`) with `stream_proxy` enabled
- configure an xRPC stream route (`pingpong`)
- verify stream request/response works without schema-check failure in HTTP workers

### Why this fix

This mirrors the routing condition introduced in `apisix/router.lua` for stream router initialization in HTTP workers, so the HTTP-side checker has the required xRPC schemas.

### Verification

- Added regression test block: `TEST 5` in `t/config-center-yaml/stream-route.t`
- Local execution note: full `prove` run could not be completed in this environment because `Test::Nginx::Socket::Lua::Stream` is not installed.
