### PR TITLE
fix(admin): require admin key for schema validate endpoint

### DIFF
--- a/apisix/admin/init.lua
+++ b/apisix/admin/init.lua
@@ -384,6 +384,8 @@ end
 
 
 local function schema_validate()
+    set_ctx_and_check_token()
+
     local uri_segs = core.utils.split_uri(ngx.var.uri)
     core.log.info("uri: ", core.json.delay_encode(uri_segs))
 

--- a/t/admin/token.t
+++ b/t/admin/token.t
@@ -177,3 +177,92 @@ PUT /apisix/admin/plugins/reload?api_key=4054f7cf07e344346cd3f287985e76a2
 --- request
 GET /apisix/admin/routes??api_key=4054f7cf07e344346cd3f287985e76a2
 --- error_code: 401
+
+
+
+=== TEST 10: schema validate without token
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").req_self_with_http
+            local res, err = t('/apisix/admin/schema/validate/routes',
+                "POST",
+                [[{
+                    "uri": "/httpbin/*",
+                    "upstream": {
+                        "scheme": "https",
+                        "type": "roundrobin",
+                        "nodes": {
+                            "nghttp2.org": 1
+                        }
+                    }
+                }]]
+                )
+
+            ngx.status = res.status
+            ngx.print(res.body)
+        }
+    }
+--- request
+GET /t
+--- error_code: 401
+
+
+
+=== TEST 11: schema validate with wrong token
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").req_self_with_http
+            local res, err = t('/apisix/admin/schema/validate/routes',
+                "POST",
+                [[{
+                    "uri": "/httpbin/*",
+                    "upstream": {
+                        "scheme": "https",
+                        "type": "roundrobin",
+                        "nodes": {
+                            "nghttp2.org": 1
+                        }
+                    }
+                }]],
+                {apikey = "wrong_key"}
+                )
+
+            ngx.status = res.status
+            ngx.print(res.body)
+        }
+    }
+--- request
+GET /t
+--- error_code: 401
+
+
+
+=== TEST 12: schema validate with correct token
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").req_self_with_http
+            local res, err = t('/apisix/admin/schema/validate/routes',
+                "POST",
+                [[{
+                    "uri": "/httpbin/*",
+                    "upstream": {
+                        "scheme": "https",
+                        "type": "roundrobin",
+                        "nodes": {
+                            "nghttp2.org": 1
+                        }
+                    }
+                }]],
+                {x_api_key = "edd1c9f034335f136f87ad84b625c8f1"}
+                )
+
+            ngx.status = res.status
+            ngx.print(res.body)
+        }
+    }
+--- request
+GET /t
+--- error_code: 200


### PR DESCRIPTION
### Description

The `/apisix/admin/schema/validate/*` handler in `apisix/admin/init.lua` does not call `set_ctx_and_check_token()`, unlike every other Admin API handler. As a result, the endpoint accepts unauthenticated requests even when `admin_key_required` is enabled (the default in production), returning the body validation result (e.g. `400`) instead of the expected `401 Unauthorized`.

Reproduction (against a default-config 3.x APISIX instance):

```
$ curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9180/apisix/admin/routes
401

$ curl -s -w "\nHTTP: %{http_code}\n" -X POST \
    http://127.0.0.1:9180/apisix/admin/schema/validate/routes \
    -H "Content-Type: application/json" -d '{}'
{"error_msg":"allOf 1 failed: value should match only one schema, but matches none"}
HTTP: 400
```

The behaviour also contradicts the [Admin API documentation](https://apisix.apache.org/docs/apisix/admin-api/#schema-validation-1), which shows the request being sent with `X-API-KEY: $admin_key`.

#### Impact
- Unauthenticated access to schema validation
- Information disclosure via detailed validation error messages
- Potential ReDoS surface without rate limiting
- Affects the etcd config provider (default production deployment)

#### Fix
Add `set_ctx_and_check_token()` as the first call in `schema_validate()`, matching every other handler in the file (`run`, `get_plugins_list`, `post_reload_plugins`, `standalone_run`, `validate_configs`).

#### Tests
Added three cases in `t/admin/token.t` covering the schema-validate endpoint:
- without token -> 401
- with wrong token -> 401
- with the correct token -> 200

Reported privately by Kacper.

#### Which issue(s) this PR fixes:
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)