### PR TITLE
fix(wolf-rbac): use trusted client IP source for access_check

### DIFF
--- a/apisix/plugins/wolf-rbac.lua
+++ b/apisix/plugins/wolf-rbac.lua
@@ -241,7 +241,7 @@ end
 function _M.rewrite(conf, ctx)
     local url = ctx.var.uri
     local action = ctx.var.request_method
-    local client_ip = ctx.var.http_x_real_ip or core.request.get_ip(ctx)
+    local client_ip = core.request.get_remote_client_ip(ctx)
     local perm_item = {action = action, url = url, clientIP = client_ip}
     core.log.info("hit wolf-rbac rewrite")
 

--- a/apisix/plugins/wolf-rbac.lua
+++ b/apisix/plugins/wolf-rbac.lua
@@ -422,7 +422,7 @@ local function get_wolf_token(ctx)
     if rbac_token == nil then
         local url = ctx.var.uri
         local action = ctx.var.request_method
-        local client_ip = core.request.get_ip(ctx)
+        local client_ip = core.request.get_remote_client_ip(ctx)
         local perm_item = {action = action, url = url, clientIP = client_ip}
         core.log.info("no permission to access ",
                       core.json.delay_encode(perm_item), ", need login!")

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -318,6 +318,7 @@ function _M.wolf_rbac_access_check()
 
     local args = ngx.req.get_uri_args()
     local resName = args.resName
+    ngx.log(ngx.WARN, "wolf_rbac_access_check clientIP: ", args.clientIP or "")
     if resName == '/hello' or resName == '/wolf/rbac/custom/headers' then
         ngx.say(json_encode({ok=true,
                             data={ userInfo={nickname="administrator",

--- a/t/plugin/wolf-rbac.t
+++ b/t/plugin/wolf-rbac.t
@@ -860,3 +860,33 @@ ssl_verify: true
 qr/ssl_verify/
 --- no_error_log
 [error]
+
+
+
+=== TEST 41: clientIP forwarded from trusted X-Real-IP source
+--- http_config
+real_ip_header X-Real-IP;
+set_real_ip_from 127.0.0.1;
+--- request
+GET /hello
+--- more_headers
+Authorization: V1#wolf-rbac-app#wolf-rbac-token
+X-Real-IP: 192.0.2.10
+--- error_log
+wolf_rbac_access_check clientIP: 192.0.2.10
+
+
+
+=== TEST 42: spoofed X-Real-IP from untrusted source is ignored
+--- http_config
+real_ip_header X-Real-IP;
+set_real_ip_from 192.0.2.1;
+--- request
+GET /hello
+--- more_headers
+Authorization: V1#wolf-rbac-app#wolf-rbac-token
+X-Real-IP: 192.0.2.10
+--- error_log
+wolf_rbac_access_check clientIP: 127.0.0.1
+--- no_error_log
+wolf_rbac_access_check clientIP: 192.0.2.10


### PR DESCRIPTION
### Description

The wolf-rbac plugin populates the `clientIP` parameter sent to wolf-server's `/wolf/rbac/access_check` endpoint by reading `ctx.var.http_x_real_ip`, the **raw** `X-Real-IP` request header. This bypasses nginx's `real_ip` module: even though APISIX configures `real_ip_from = { "127.0.0.1", "unix:" }` by default — meaning nginx correctly rejects `X-Real-IP` from untrusted sources when computing `$remote_addr` — the plugin reads the original header directly, so any external client can supply an arbitrary `clientIP` value.

This change replaces the raw-header read with `core.request.get_remote_client_ip(ctx)`, which returns `$remote_addr` after `real_ip` processing. The new behavior is:

- Behind a trusted proxy (listed in `real_ip_from`): forwards the real client IP from the trusted header — same behavior the previous code intended.
- From untrusted sources: forwards the actual TCP peer address; the spoofed header is ignored, matching nginx's standard handling.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->