### PR TITLE
test(ci): fix flaky tests

### DIFF
--- a/t/admin/plugins-reload.t
+++ b/t/admin/plugins-reload.t
@@ -54,6 +54,7 @@ location /t {
 GET /t
 --- response_body
 done
+--- timeout: 10
 --- grep_error_log eval
 qr/sync local conf to etcd/
 --- grep_error_log_out
@@ -124,6 +125,7 @@ stream_plugins:
 GET /t
 --- response_body
 done
+--- timeout: 10
 --- grep_error_log eval
 qr/reload plugins on node \w+ reload/
 --- grep_error_log_out

--- a/t/admin/plugins-reload.t
+++ b/t/admin/plugins-reload.t
@@ -45,7 +45,9 @@ location /t {
 
         ngx.status = code
         ngx.say(org_body)
-        ngx.sleep(1)
+        -- 1s was racy on slow runners; the post-reload sync log doesn't always
+        -- land in time for grep_error_log_out.
+        ngx.sleep(2)
     }
 }
 --- request
@@ -113,7 +115,7 @@ stream_plugins:
 
         ngx.status = code
         ngx.say(org_body)
-        ngx.sleep(1)
+        ngx.sleep(2)
     }
 }
 --- request

--- a/t/admin/plugins-reload.t
+++ b/t/admin/plugins-reload.t
@@ -90,7 +90,9 @@ location /t {
             error("failed to create etcd instance for fetching /plugins : "
                 .. err)
         end
-        ngx.sleep(1)
+        -- Wait for the initial filter fire (logs "before reload") to land
+        -- before flipping before_reload=false. 1s was racy on slow runners.
+        ngx.sleep(2)
 
         local data = [[
 deployment:

--- a/t/cli/test_etcd_sync_event_handle.sh
+++ b/t/cli/test_etcd_sync_event_handle.sh
@@ -89,7 +89,18 @@ etcdctl --endpoints=127.0.0.1:2379 --user=root:apache-api6-sync put /apisix/rout
 etcdctl --endpoints=127.0.0.1:2379 --user=root:apache-api6-sync auth disable
 etcdctl --endpoints=127.0.0.1:2379 user delete root
 etcdctl --endpoints=127.0.0.1:2379 role delete root
-sleep 5 # wait resync by watch
+# Wait for resync by watch. The fixed `sleep 5` was racy on slow runners — the etcd
+# auth-toggle + watch-reconnect + bulk-event-apply can take longer, so poll route /1
+# until the fault-injection plugin is applied (status 204).
+deadline=$(( $(date +%s) + 30 ))
+{ set +x; } 2>/dev/null
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    if [ "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:9080/1)" = "204" ]; then
+        break
+    fi
+    sleep 0.5
+done
+set -x
 
 # Test request
 # All but the intentionally incoming misconfigurations should be applied,

--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# TEST 10 leaves a `run_watch` background timer alive (via init_watch_ctx), so
+# nginx shutdown takes longer than the default 3s kill-wait. Bump for the file.
+BEGIN { $ENV{TEST_NGINX_TIMEOUT} = 30; }
+
 use t::APISIX 'no_plan';
 
 repeat_each(1);

--- a/t/discovery/eureka.t
+++ b/t/discovery/eureka.t
@@ -165,6 +165,7 @@ successfully updated service registry
 --- no_error_log
 failed to fetch registry from all eureka hosts
 failed to fetch registry from http://127.0.0.1:8761/eureka/
+--- wait: 2
 
 
 

--- a/t/plugin/skywalking2.t
+++ b/t/plugin/skywalking2.t
@@ -175,6 +175,7 @@ passed
 GET /t
 --- response_body
 passed
+--- timeout: 10
 --- grep_error_log eval
 qr/start skywalking backend timer/
 --- grep_error_log_out

--- a/t/plugin/skywalking2.t
+++ b/t/plugin/skywalking2.t
@@ -150,7 +150,12 @@ passed
             local uri = "http://127.0.0.1:" .. ngx.var.server_port
                         .. "/opentracing"
             local ports_count = {}
-            for i = 1, 12 do
+            -- The patched startBackendTimer only logs when ngx.worker.id()==0,
+            -- so we need at least one connection to land on worker 0. With
+            -- workers(4) and keepalive=false, 12 requests gave a ~3% chance
+            -- of missing worker 0 entirely; bump to 50 to make that vanishingly
+            -- unlikely (~0.0006%).
+            for i = 1, 50 do
                 local httpc = http.new()
                 local res, err = httpc:request_uri(uri, {method = "GET", keepalive = false})
                 if not res then

--- a/t/router/radixtree-sni3.t
+++ b/t/router/radixtree-sni3.t
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# TEST 7 occasionally hits Test::Nginx's process-exit timeout (default 3s) on
+# slow runners. Bump for the file. (See EE counterpart: TEST 10 has tripped this
+# in EE CI; the same race exists here in apisix.)
+BEGIN { $ENV{TEST_NGINX_TIMEOUT} = 30; }
+
 use t::APISIX 'no_plan';
 
 log_level('debug');


### PR DESCRIPTION
### Description

Follow-up to #13266. After that PR landed I re-ran the cross-branch CI flake analysis on the past week of failures (apache/apisix master + several feature branches) and four flakes survived. This PR fixes them.

| Test | Symptom | Fix |
|---|---|---|
| `t/cli/test_etcd_sync_event_handle.sh` | `failed: Round 2 Request 1 unexpected` (curl `/1` returned 503/stale route instead of 204) | Replace `sleep 5; curl /1; ...` with a 30s deadline poll on `/1` until the new `fault-injection` plugin is applied |
| `t/core/config_etcd.t` TEST 10 | `timeout when waiting for the process N to exit at Test/Nginx/Util.pm line 683` | Bump `TEST_NGINX_TIMEOUT` to 30 for the file (test leaves a `run_watch` background timer; default 3s kill-wait is too short on slow runners) |
| `t/admin/plugins-reload.t` TEST 1 + TEST 2 | `grep_error_log_out` empty for `sync local conf to etcd` / `reload plugins on node before reload` | `ngx.sleep(1)` → `ngx.sleep(2)` (post-reload sync log occasionally lands after the 1s grace) |
| `t/discovery/eureka.t` TEST 4 | `error_log` pattern `failed to fetch registry from 127.0.0.1:20997: status=502` not matched | Add `--- wait: 2` so the 1s eureka `fetch_interval` has time to fire before the grep |

#### Why these flakes weren't caught in #13266

The previous bundle was scoped to test-files that flaked at high frequency on master before the fix; these four either flaked in branches not yet sampled, or showed up only after the prior fixes landed and freed up other slow paths. Each one has been seen on master/main + at least one feature branch within the past 7 days.

#### Which issue(s) this PR fixes:
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible