### PR TITLE
chore: update github labels

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -21,14 +21,12 @@ github:
   labels:
     - api-gateway
     - ai-gateway
-    - ai
     - cloud-native
+    - kubernetes-ingress
     - nginx
     - luajit
-    - apigateway
     - microservices
     - api
-    - apis
     - loadbalancing
     - reverse-proxy
     - api-management
@@ -37,9 +35,6 @@ github:
     - iot
     - devops
     - kubernetes
-    - docker
-    - kubernetes-ingress
-    - kubernetes-ingress-controller
   
   enabled_merge_buttons:
     squash:  true


### PR DESCRIPTION
### Description

Current number of github labels is more than allowed by asf (20).

Every PR merge to master would give this error in mail:
<img width="1000" height="422" alt="image" src="https://github.com/user-attachments/assets/7aa9a9af-4d81-478e-b719-f2165c59c2f3" />

And some labels (repetitive) looked very unprofessional.
<img width="674" height="838" alt="image" src="https://github.com/user-attachments/assets/2a502a91-5be3-494b-b407-5a52083f672f" />


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
