### PR TITLE
fix: split global rules phase execution for client-control compatibility

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -806,12 +806,15 @@ function _M.http_access_phase()
     api_ctx.route_id = route.value.id
     api_ctx.route_name = route.value.name
 
-    -- run global rule
+    -- Split global rule execution: run rewrite first so route/service plugins
+    -- can set overrides (e.g., client-control FFI) before global rule access
+    -- phase runs (e.g., logger body collection).
     local global_rules, conf_version = apisix_global_rules.global_rules()
-    plugin.run_global_rules(api_ctx, global_rules, conf_version, nil)
+    plugin.run_global_rules(api_ctx, global_rules, conf_version, "rewrite")
 
     if route.value.script then
         script.load(route, api_ctx)
+        plugin.run_global_rules(api_ctx, global_rules, conf_version, "access")
         script.run("access", api_ctx)
 
     else
@@ -850,6 +853,7 @@ function _M.http_access_phase()
                 plugin.run_plugin(phase, api_ctx.plugins, api_ctx)
             end
         end
+        plugin.run_global_rules(api_ctx, global_rules, conf_version, "access")
         plugin.run_plugin("access", plugins, api_ctx)
     end
     span:finish(ngx_ctx)

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -754,7 +754,8 @@ function _M.http_access_phase()
         match_span:finish(ngx.ctx)
         -- run global rule when there is no matching route
         local global_rules, conf_version = apisix_global_rules.global_rules()
-        plugin.run_global_rules(api_ctx, global_rules, conf_version, nil)
+        plugin.run_global_rules(api_ctx, global_rules, conf_version, "rewrite")
+        plugin.run_global_rules(api_ctx, global_rules, conf_version, "access")
 
         core.log.info("not find any matched route")
         return core.response.exit(404,

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -1432,12 +1432,14 @@ end
 
 function _M.run_global_rules(api_ctx, global_rules, conf_version, phase_name)
     if global_rules and #global_rules > 0 then
-        local span = tracer.start(api_ctx.ngx_ctx, "run_global_rules", tracer.kind.internal)
+        local span_name = phase_name and ("run_global_rules." .. phase_name)
+                                      or "run_global_rules"
+        local span = tracer.start(api_ctx.ngx_ctx, span_name, tracer.kind.internal)
         local orig_conf_type = api_ctx.conf_type
         local orig_conf_version = api_ctx.conf_version
         local orig_conf_id = api_ctx.conf_id
 
-        if phase_name == nil then
+        if phase_name == nil or phase_name == "rewrite" then
             api_ctx.global_rules = global_rules
         end
 

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -1432,14 +1432,13 @@ end
 
 function _M.run_global_rules(api_ctx, global_rules, conf_version, phase_name)
     if global_rules and #global_rules > 0 then
-        local span_name = phase_name and ("run_global_rules." .. phase_name)
-                                      or "run_global_rules"
+        local span_name = "run_global_rules." .. phase_name
         local span = tracer.start(api_ctx.ngx_ctx, span_name, tracer.kind.internal)
         local orig_conf_type = api_ctx.conf_type
         local orig_conf_version = api_ctx.conf_version
         local orig_conf_id = api_ctx.conf_id
 
-        if phase_name == nil or phase_name == "rewrite" then
+        if phase_name == "rewrite" then
             api_ctx.global_rules = global_rules
         end
 
@@ -1458,12 +1457,7 @@ function _M.run_global_rules(api_ctx, global_rules, conf_version, phase_name)
         core.table.clear(plugins)
         plugins = _M.filter(api_ctx, dummy_global_rule, plugins, route)
 
-        if phase_name == nil then
-            _M.run_plugin("rewrite", plugins, api_ctx)
-            _M.run_plugin("access", plugins, api_ctx)
-        else
-            _M.run_plugin(phase_name, plugins, api_ctx)
-        end
+        _M.run_plugin(phase_name, plugins, api_ctx)
         core.tablepool.release("plugins", plugins)
 
         api_ctx.conf_type = orig_conf_type

--- a/t/plugin/client-control.t
+++ b/t/plugin/client-control.t
@@ -188,20 +188,24 @@ POST /hello
 
 
 
-=== TEST 8: setup global rule with body reader and route with client-control
+=== TEST 8: setup global rule and route with phase-logging functions
 --- config
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
 
-            -- global rule: read body in access phase (simulates logger with include_req_body)
+            -- global rule: log in rewrite and access to verify phase ordering
             local code, body = t('/apisix/admin/global_rules/1',
                 ngx.HTTP_PUT,
                 [[{
                     "plugins": {
+                        "serverless-pre-function": {
+                            "phase": "rewrite",
+                            "functions": ["return function() ngx.log(ngx.WARN, 'PHASE_ORDER: global-rewrite') end"]
+                        },
                         "serverless-post-function": {
                             "phase": "access",
-                            "functions": ["return function(conf, ctx) ngx.req.read_body() end"]
+                            "functions": ["return function() ngx.log(ngx.WARN, 'PHASE_ORDER: global-access') end"]
                         }
                     }
                 }]]
@@ -212,7 +216,7 @@ POST /hello
                 return
             end
 
-            -- route with client-control raising the body size limit
+            -- route with client-control + phase-logging
             code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
                 [[{
@@ -226,6 +230,14 @@ POST /hello
                     "plugins": {
                         "client-control": {
                             "max_body_size": 1048576
+                        },
+                        "serverless-pre-function": {
+                            "phase": "rewrite",
+                            "functions": ["return function() ngx.log(ngx.WARN, 'PHASE_ORDER: route-rewrite') end"]
+                        },
+                        "serverless-post-function": {
+                            "phase": "access",
+                            "functions": ["return function() ngx.log(ngx.WARN, 'PHASE_ORDER: route-access') end"]
                         }
                     }
                 }]]
@@ -246,69 +258,23 @@ passed
 
 
 
-=== TEST 9: client-control should override body limit before global rule reads body
-This test verifies the global rules phase split: global rule rewrite runs first,
-then route plugins rewrite (client-control sets FFI override), then global rule
-access (body reader runs with correct limit).
---- extra_yaml_config
-nginx_config:
-    http:
-        client_max_body_size: 8
---- request eval
-"POST /hello\n" . "A" x 20
---- error_code: 200
-
-
-
-=== TEST 10: without client-control the nginx limit still applies
---- extra_yaml_config
-nginx_config:
-    http:
-        client_max_body_size: 8
---- config
-    location /t {
-        content_by_lua_block {
-            local t = require("lib.test_admin").test
-            -- route without client-control
-            local code, body = t('/apisix/admin/routes/1',
-                ngx.HTTP_PUT,
-                [[{
-                    "uri": "/hello",
-                    "upstream": {
-                        "type": "roundrobin",
-                        "nodes": {
-                            "127.0.0.1:1980": 1
-                        }
-                    }
-                }]]
-            )
-            if code >= 300 then
-                ngx.status = code
-                ngx.say(body)
-                return
-            end
-            ngx.say("passed")
-        }
-    }
+=== TEST 9: verify phase ordering — global rewrite before route rewrite before global access
+Route plugins rewrite (including client-control) must run after global rule rewrite
+but before global rule access. This ensures client-control can set the body size
+override via FFI before any global rule access-phase plugin reads the request body.
 --- request
-GET /t
---- response_body
-passed
+GET /hello
+--- grep_error_log eval
+qr/PHASE_ORDER: \S+/
+--- grep_error_log_out
+PHASE_ORDER: global-rewrite
+PHASE_ORDER: route-rewrite
+PHASE_ORDER: global-access
+PHASE_ORDER: route-access
 
 
 
-=== TEST 11: hit without client-control, body exceeds nginx limit, expect 413
---- extra_yaml_config
-nginx_config:
-    http:
-        client_max_body_size: 8
---- request eval
-"POST /hello\n" . "A" x 20
---- error_code: 413
-
-
-
-=== TEST 12: cleanup global rules
+=== TEST 10: cleanup global rules
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/client-control.t
+++ b/t/plugin/client-control.t
@@ -189,6 +189,8 @@ POST /hello
 
 
 === TEST 8: setup global rule and route with phase-logging functions
+The functions construct the log marker dynamically to avoid false matches
+from config sync logs that contain the function source code.
 --- config
     location /t {
         content_by_lua_block {
@@ -201,11 +203,11 @@ POST /hello
                     "plugins": {
                         "serverless-pre-function": {
                             "phase": "rewrite",
-                            "functions": ["return function() ngx.log(ngx.WARN, 'PHASE_ORDER: global-rewrite') end"]
+                            "functions": ["return function() ngx.log(ngx.WARN, 'PO ' .. 'global-rewrite') end"]
                         },
                         "serverless-post-function": {
                             "phase": "access",
-                            "functions": ["return function() ngx.log(ngx.WARN, 'PHASE_ORDER: global-access') end"]
+                            "functions": ["return function() ngx.log(ngx.WARN, 'PO ' .. 'global-access') end"]
                         }
                     }
                 }]]
@@ -233,11 +235,11 @@ POST /hello
                         },
                         "serverless-pre-function": {
                             "phase": "rewrite",
-                            "functions": ["return function() ngx.log(ngx.WARN, 'PHASE_ORDER: route-rewrite') end"]
+                            "functions": ["return function() ngx.log(ngx.WARN, 'PO ' .. 'route-rewrite') end"]
                         },
                         "serverless-post-function": {
                             "phase": "access",
-                            "functions": ["return function() ngx.log(ngx.WARN, 'PHASE_ORDER: route-access') end"]
+                            "functions": ["return function() ngx.log(ngx.WARN, 'PO ' .. 'route-access') end"]
                         }
                     }
                 }]]
@@ -265,12 +267,12 @@ override via FFI before any global rule access-phase plugin reads the request bo
 --- request
 GET /hello
 --- grep_error_log eval
-qr/PHASE_ORDER: \S+/
+qr/PO [a-z]+-[a-z]+/
 --- grep_error_log_out
-PHASE_ORDER: global-rewrite
-PHASE_ORDER: route-rewrite
-PHASE_ORDER: global-access
-PHASE_ORDER: route-access
+PO global-rewrite
+PO route-rewrite
+PO global-access
+PO route-access
 
 
 

--- a/t/plugin/client-control.t
+++ b/t/plugin/client-control.t
@@ -188,26 +188,23 @@ POST /hello
 
 
 
-=== TEST 8: setup global rule and route with phase-logging functions
-The functions construct the log marker dynamically to avoid false matches
-from config sync logs that contain the function source code.
+=== TEST 8: setup global rule with body reader and route with client-control
+The global rule reads the body in access phase (simulates a logger with
+include_req_body). The route has client-control raising the body size limit
+above nginx's default 1m so the body read succeeds.
 --- config
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
 
-            -- global rule: log in rewrite and access to verify phase ordering
+            -- global rule: read body in access phase
             local code, body = t('/apisix/admin/global_rules/1',
                 ngx.HTTP_PUT,
                 [[{
                     "plugins": {
-                        "serverless-pre-function": {
-                            "phase": "rewrite",
-                            "functions": ["return function() ngx.log(ngx.WARN, 'PO ' .. 'global-rewrite') end"]
-                        },
                         "serverless-post-function": {
                             "phase": "access",
-                            "functions": ["return function() ngx.log(ngx.WARN, 'PO ' .. 'global-access') end"]
+                            "functions": ["return function(conf, ctx) ngx.req.read_body() end"]
                         }
                     }
                 }]]
@@ -218,7 +215,7 @@ from config sync logs that contain the function source code.
                 return
             end
 
-            -- route with client-control + phase-logging
+            -- route with client-control raising the body size limit
             code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
                 [[{
@@ -231,15 +228,7 @@ from config sync logs that contain the function source code.
                     },
                     "plugins": {
                         "client-control": {
-                            "max_body_size": 1048576
-                        },
-                        "serverless-pre-function": {
-                            "phase": "rewrite",
-                            "functions": ["return function() ngx.log(ngx.WARN, 'PO ' .. 'route-rewrite') end"]
-                        },
-                        "serverless-post-function": {
-                            "phase": "access",
-                            "functions": ["return function() ngx.log(ngx.WARN, 'PO ' .. 'route-access') end"]
+                            "max_body_size": 10485760
                         }
                     }
                 }]]
@@ -260,23 +249,60 @@ passed
 
 
 
-=== TEST 9: verify phase ordering — global rewrite before route rewrite before global access
-Route plugins rewrite (including client-control) must run after global rule rewrite
-but before global rule access. This ensures client-control can set the body size
-override via FFI before any global rule access-phase plugin reads the request body.
+=== TEST 9: client-control should override body limit before global rule reads body
+With the global rules phase split, client-control runs in route rewrite
+(setting FFI override to 10MB) before the global rule access phase reads
+the body. The body exceeds nginx's default 1m but is within the 10MB
+override, so the request should succeed.
+--- request eval
+"POST /hello\n" . "A" x 1048577
+--- error_code: 200
+
+
+
+=== TEST 10: remove client-control from route
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/hello",
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.say("passed")
+        }
+    }
 --- request
-GET /hello
---- grep_error_log eval
-qr/PO [a-z]+-[a-z]+/
---- grep_error_log_out
-PO global-rewrite
-PO route-rewrite
-PO global-access
-PO route-access
+GET /t
+--- response_body
+passed
 
 
 
-=== TEST 10: cleanup global rules
+=== TEST 11: without client-control, body exceeds nginx default limit
+Without client-control the FFI override is not set, so the global rule's
+read_body() triggers nginx's default 1m body size check. The same body
+that succeeded in TEST 9 now gets rejected with 413.
+--- request eval
+"POST /hello\n" . "A" x 1048577
+--- error_code: 413
+
+
+
+=== TEST 12: cleanup global rules
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/client-control.t
+++ b/t/plugin/client-control.t
@@ -28,6 +28,7 @@ if ($version !~ m/\/apisix-nginx-module/) {
 repeat_each(1);
 log_level('info');
 no_root_location();
+no_long_string();
 no_shuffle();
 
 add_block_preprocessor(sub {

--- a/t/plugin/client-control.t
+++ b/t/plugin/client-control.t
@@ -185,3 +185,139 @@ passed
 --- request
 POST /hello
 1
+
+
+
+=== TEST 8: setup global rule with body reader and route with client-control
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+
+            -- global rule: read body in access phase (simulates logger with include_req_body)
+            local code, body = t('/apisix/admin/global_rules/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "serverless-post-function": {
+                            "phase": "access",
+                            "functions": ["return function(conf, ctx) ngx.req.read_body() end"]
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            -- route with client-control raising the body size limit
+            code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/hello",
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        }
+                    },
+                    "plugins": {
+                        "client-control": {
+                            "max_body_size": 1048576
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 9: client-control should override body limit before global rule reads body
+This test verifies the global rules phase split: global rule rewrite runs first,
+then route plugins rewrite (client-control sets FFI override), then global rule
+access (body reader runs with correct limit).
+--- extra_yaml_config
+nginx_config:
+    http:
+        client_max_body_size: 8
+--- request eval
+"POST /hello\n" . "A" x 20
+--- error_code: 200
+
+
+
+=== TEST 10: without client-control the nginx limit still applies
+--- extra_yaml_config
+nginx_config:
+    http:
+        client_max_body_size: 8
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            -- route without client-control
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/hello",
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 11: hit without client-control, body exceeds nginx limit, expect 413
+--- extra_yaml_config
+nginx_config:
+    http:
+        client_max_body_size: 8
+--- request eval
+"POST /hello\n" . "A" x 20
+--- error_code: 413
+
+
+
+=== TEST 12: cleanup global rules
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/global_rules/1', ngx.HTTP_DELETE)
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed

--- a/t/plugin/client-control.t
+++ b/t/plugin/client-control.t
@@ -309,6 +309,8 @@ that succeeded in TEST 9 now gets rejected with 413.
 --- request eval
 "POST /hello\n" . "A" x (31 * 1024 * 1024)
 --- error_code: 413
+--- error_log
+client intended to send too large body
 --- timeout: 30
 
 

--- a/t/plugin/client-control.t
+++ b/t/plugin/client-control.t
@@ -191,7 +191,9 @@ POST /hello
 === TEST 8: setup global rule with body reader and route with client-control
 The global rule reads the body in access phase (simulates a logger with
 include_req_body). The route has client-control raising the body size limit
-above nginx's default 1m so the body read succeeds.
+above test-nginx's hardcoded 30M so the body read succeeds.
+--- upstream_server_config
+    client_max_body_size 0;
 --- config
     location /t {
         content_by_lua_block {
@@ -215,7 +217,7 @@ above nginx's default 1m so the body read succeeds.
                 return
             end
 
-            -- route with client-control raising the body size limit
+            -- route with client-control raising the limit above 30M
             code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
                 [[{
@@ -228,7 +230,7 @@ above nginx's default 1m so the body read succeeds.
                     },
                     "plugins": {
                         "client-control": {
-                            "max_body_size": 10485760
+                            "max_body_size": 52428800
                         }
                     }
                 }]]
@@ -251,16 +253,21 @@ passed
 
 === TEST 9: client-control should override body limit before global rule reads body
 With the global rules phase split, client-control runs in route rewrite
-(setting FFI override to 10MB) before the global rule access phase reads
-the body. The body exceeds nginx's default 1m but is within the 10MB
-override, so the request should succeed.
+(setting FFI override to 50MB) before the global rule access phase reads
+the body. The body exceeds test-nginx's hardcoded 30M but is within the
+50MB override, so the request should succeed.
+--- upstream_server_config
+    client_max_body_size 0;
 --- request eval
-"POST /hello\n" . "A" x 1048577
+"POST /hello\n" . "A" x (31 * 1024 * 1024)
 --- error_code: 200
+--- timeout: 30
 
 
 
 === TEST 10: remove client-control from route
+--- upstream_server_config
+    client_max_body_size 0;
 --- config
     location /t {
         content_by_lua_block {
@@ -292,17 +299,22 @@ passed
 
 
 
-=== TEST 11: without client-control, body exceeds nginx default limit
+=== TEST 11: without client-control, body exceeds hardcoded 30M limit
 Without client-control the FFI override is not set, so the global rule's
-read_body() triggers nginx's default 1m body size check. The same body
+read_body() triggers the hardcoded 30M body size check. The same body
 that succeeded in TEST 9 now gets rejected with 413.
+--- upstream_server_config
+    client_max_body_size 0;
 --- request eval
-"POST /hello\n" . "A" x 1048577
+"POST /hello\n" . "A" x (31 * 1024 * 1024)
 --- error_code: 413
+--- timeout: 30
 
 
 
 === TEST 12: cleanup global rules
+--- upstream_server_config
+    client_max_body_size 0;
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
## Description

Split global rules phase execution so that route/service rewrite plugins run between global rule rewrite and global rule access phases. This fixes a conflict where `client-control` (route rewrite, priority 22000) cannot set the nginx body size override via FFI before a global rule access-phase plugin (e.g., a logger with `include_req_body`) calls `ngx.req.read_body()`.

### Before
```
global_rules rewrite + access → route/service rewrite → route/service access
```
A global rule logger reading the body in access phase triggers nginx body size check before `client-control` can set the FFI override → 413.

### After
```
global_rules rewrite → route/service rewrite → global_rules access → route/service access
```
`client-control` sets the FFI override in route rewrite, then the global rule access phase reads the body using the overridden limit.

### Changes
- `apisix/init.lua`: Split `run_global_rules(nil)` into separate `"rewrite"` and `"access"` calls in both the no-route and matched-route paths
- `apisix/plugin.lua`: Simplified `run_global_rules()` — removed nil phase_name handling, always uses explicit phase name with phase-specific tracer span naming
- `t/plugin/client-control.t`: Added regression tests with 31MB body exceeding nginx's 30M limit, verifying client-control FFI override works when global rule reads body in access phase

### Behavioral Changes
1. Global rule access now runs after route/service rewrite (more correct phase ordering)
2. `consumer-restriction` on global rule now works correctly (consumer info available after merge)
3. If route/service rewrite terminates request (401/403), global rule access won't run — but `log` phase always runs