### PR TITLE
test(ai-aliyun-content-moderation): remove unused mock LLM location

### DIFF
--- a/t/plugin/ai-aliyun-content-moderation.t
+++ b/t/plugin/ai-aliyun-content-moderation.t
@@ -40,20 +40,6 @@ add_block_preprocessor(sub {
 
             default_type 'application/json';
 
-            location /v1/chat/completions {
-                content_by_lua_block {
-                    local fixture_loader = require("lib.fixture_loader")
-                    local content, err = fixture_loader.load("aliyun/chat-with-harmful.json")
-                    if not content then
-                        ngx.status = 500
-                        ngx.say(err)
-                        return
-                    end
-                    ngx.status = 200
-                    ngx.print(content)
-                }
-            }
-
             location / {
                 content_by_lua_block {
                     local core = require("apisix.core")


### PR DESCRIPTION
### Description

The `location /v1/chat/completions` block on the mock server at port 6724 in `t/plugin/ai-aliyun-content-moderation.t` is never reached by any of the 44 test blocks (130 subtests) in the file.

Every test that needs an upstream LLM points `ai-proxy`'s override endpoint to either:
- `127.0.0.1:1980` (the shared `X-AI-Fixture` test fixture mock), or
- `localhost:7737` (the `sse_server_example` Go process started by `ci/common.sh`)

No test points an upstream endpoint at port 6724. Port 6724 is only used as the Aliyun content moderation API mock, which is served by `location /`. The `/v1/chat/completions` block is dead code left over from an earlier shape of the test.

Removing it keeps the mock focused on the Aliyun moderation API and reduces noise for future readers.

#### Verification

Ran the full test file locally before and after the change with `sse_server_example` listening on port 7737:

- Before: 130 subtests pass
- After: 130 subtests pass

No behavior change; pure cleanup.

#### Which issue(s) this PR fixes:
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)