### PR TITLE
perf(ctx): cache parsed request body to avoid repeated decode for post_arg.*

### DIFF
--- a/apisix/core/ctx.lua
+++ b/apisix/core/ctx.lua
@@ -43,8 +43,6 @@ local type         = type
 local error        = error
 local pcall        = pcall
 
-local PARSED_BODY_CACHE_KEY         = "_parsed_request_body"
-local PARSED_BODY_VERSION_CACHE_KEY = "_parsed_request_body_version"
 
 local _M = {version = 0.2}
 local GRAPHQL_DEFAULT_MAX_SIZE       = 1048576               -- 1MiB
@@ -178,19 +176,6 @@ local CONTENT_TYPE_MULTIPART_FORM = "multipart/form-data"
 
 local PARSED_BODY_CACHE_KEY = "_parsed_request_body"
 
--- Patch ngx.req.set_body_data to automatically invalidate the parsed body
--- cache whenever the request body is rewritten, regardless of call site.
-do
-    local _set_body_data = ngx.req.set_body_data
-    ngx.req.set_body_data = function(data)
-        local ctx = ngx.ctx.api_ctx
-        if ctx then
-            ctx[PARSED_BODY_CACHE_KEY] = nil
-        end
-        return _set_body_data(data)
-    end
-end
-
 local function _get_parsed_request_body(ctx)
     local ct_header = request.header(ctx, "Content-Type") or ""
 
@@ -228,22 +213,17 @@ local function _get_parsed_request_body(ctx)
 end
 
 -- Wrapper that caches the parsed body in ctx for the lifetime of the request.
--- The cache is versioned against ngx.ctx._body_version (incremented by the
--- ngx.req.set_body_data patch in patch.lua) so any body rewrite automatically
--- invalidates the cache without requiring manual intervention by callers.
--- Errors are intentionally not cached: a transient failure should not be frozen.
+-- Errors are intentionally not cached: plugins may call ngx.req.set_body_data()
+-- in a later phase, so a transient read failure should not be frozen.
 local function get_parsed_request_body(ctx)
-    local body_version = ngx.ctx._body_version or 0
-    if ctx[PARSED_BODY_CACHE_KEY] ~= nil and
-       ctx[PARSED_BODY_VERSION_CACHE_KEY] == body_version then
+    if ctx[PARSED_BODY_CACHE_KEY] ~= nil then
         log.debug("reuse parsed request body from ctx cache")
         return ctx[PARSED_BODY_CACHE_KEY]
     end
 
     local result, err = _get_parsed_request_body(ctx)
     if result then
-        ctx[PARSED_BODY_CACHE_KEY]         = result
-        ctx[PARSED_BODY_VERSION_CACHE_KEY] = body_version
+        ctx[PARSED_BODY_CACHE_KEY] = result
     end
     return result, err
 end

--- a/apisix/core/ctx.lua
+++ b/apisix/core/ctx.lua
@@ -174,7 +174,9 @@ local CONTENT_TYPE_JSON = "application/json"
 local CONTENT_TYPE_FORM_URLENCODED = "application/x-www-form-urlencoded"
 local CONTENT_TYPE_MULTIPART_FORM = "multipart/form-data"
 
-local function get_parsed_request_body(ctx)
+local PARSED_BODY_CACHE_KEY = "_parsed_request_body"
+
+local function _get_parsed_request_body(ctx)
     local ct_header = request.header(ctx, "Content-Type") or ""
 
     if core_str.find(ct_header, CONTENT_TYPE_JSON) then
@@ -208,6 +210,22 @@ local function get_parsed_request_body(ctx)
                 CONTENT_TYPE_FORM_URLENCODED .. ", " ..
                 CONTENT_TYPE_MULTIPART_FORM
     return nil, err
+end
+
+-- Wrapper that caches the parsed body in ctx for the lifetime of the request.
+-- Errors are intentionally not cached: plugins may call ngx.req.set_body_data()
+-- in a later phase, so a transient read failure should not be frozen.
+local function get_parsed_request_body(ctx)
+    if ctx[PARSED_BODY_CACHE_KEY] ~= nil then
+        log.debug("reuse parsed request body from ctx cache")
+        return ctx[PARSED_BODY_CACHE_KEY]
+    end
+
+    local result, err = _get_parsed_request_body(ctx)
+    if result then
+        ctx[PARSED_BODY_CACHE_KEY] = result
+    end
+    return result, err
 end
 
 

--- a/apisix/core/ctx.lua
+++ b/apisix/core/ctx.lua
@@ -43,6 +43,8 @@ local type         = type
 local error        = error
 local pcall        = pcall
 
+local PARSED_BODY_CACHE_KEY         = "_parsed_request_body"
+local PARSED_BODY_VERSION_CACHE_KEY = "_parsed_request_body_version"
 
 local _M = {version = 0.2}
 local GRAPHQL_DEFAULT_MAX_SIZE       = 1048576               -- 1MiB
@@ -176,6 +178,19 @@ local CONTENT_TYPE_MULTIPART_FORM = "multipart/form-data"
 
 local PARSED_BODY_CACHE_KEY = "_parsed_request_body"
 
+-- Patch ngx.req.set_body_data to automatically invalidate the parsed body
+-- cache whenever the request body is rewritten, regardless of call site.
+do
+    local _set_body_data = ngx.req.set_body_data
+    ngx.req.set_body_data = function(data)
+        local ctx = ngx.ctx.api_ctx
+        if ctx then
+            ctx[PARSED_BODY_CACHE_KEY] = nil
+        end
+        return _set_body_data(data)
+    end
+end
+
 local function _get_parsed_request_body(ctx)
     local ct_header = request.header(ctx, "Content-Type") or ""
 
@@ -213,17 +228,22 @@ local function _get_parsed_request_body(ctx)
 end
 
 -- Wrapper that caches the parsed body in ctx for the lifetime of the request.
--- Errors are intentionally not cached: plugins may call ngx.req.set_body_data()
--- in a later phase, so a transient read failure should not be frozen.
+-- The cache is versioned against ngx.ctx._body_version (incremented by the
+-- ngx.req.set_body_data patch in patch.lua) so any body rewrite automatically
+-- invalidates the cache without requiring manual intervention by callers.
+-- Errors are intentionally not cached: a transient failure should not be frozen.
 local function get_parsed_request_body(ctx)
-    if ctx[PARSED_BODY_CACHE_KEY] ~= nil then
+    local body_version = ngx.ctx._body_version or 0
+    if ctx[PARSED_BODY_CACHE_KEY] ~= nil and
+       ctx[PARSED_BODY_VERSION_CACHE_KEY] == body_version then
         log.debug("reuse parsed request body from ctx cache")
         return ctx[PARSED_BODY_CACHE_KEY]
     end
 
     local result, err = _get_parsed_request_body(ctx)
     if result then
-        ctx[PARSED_BODY_CACHE_KEY] = result
+        ctx[PARSED_BODY_CACHE_KEY]         = result
+        ctx[PARSED_BODY_VERSION_CACHE_KEY] = body_version
     end
     return result, err
 end

--- a/apisix/core/ctx.lua
+++ b/apisix/core/ctx.lua
@@ -174,7 +174,7 @@ local CONTENT_TYPE_JSON = "application/json"
 local CONTENT_TYPE_FORM_URLENCODED = "application/x-www-form-urlencoded"
 local CONTENT_TYPE_MULTIPART_FORM = "multipart/form-data"
 
-local PARSED_BODY_CACHE_KEY = "_parsed_request_body"
+local PARSED_BODY_CACHE_KEY = "_post_arg_request_body"
 
 local function _get_parsed_request_body(ctx)
     local ct_header = request.header(ctx, "Content-Type") or ""

--- a/apisix/patch.lua
+++ b/apisix/patch.lua
@@ -378,6 +378,26 @@ function _M.patch()
     ngx_socket.udp = function ()
         return patch_udp_socket(original_udp())
     end
+
+    -- Patch ngx.req.set_body_data to invalidate the parsed post_arg request body
+    -- cache in api_ctx. This ensures that post_arg.* variable lookups after a body
+    -- rewrite always reflect the new body content.
+    local _orig_set_body_data = ngx.req.set_body_data
+    ngx.req.set_body_data = function(data)
+        local api_ctx = ngx.ctx.api_ctx
+        if api_ctx and api_ctx._post_arg_request_body then
+            api_ctx._post_arg_request_body = nil
+            local cache = api_ctx._cache
+            if cache then
+                for key in pairs(cache) do
+                    if key:sub(1, 9) == "post_arg." then
+                        cache[key] = nil
+                    end
+                end
+            end
+        end
+        return _orig_set_body_data(data)
+    end
 end
 
 

--- a/apisix/patch.lua
+++ b/apisix/patch.lua
@@ -391,10 +391,15 @@ function _M.patch()
             local var = api_ctx.var
             local cache = var and var._cache
             if cache then
+                local keys_to_clear = {}
                 for key in pairs(cache) do
                     if type(key) == "string" and key:sub(1, 9) == "post_arg." then
-                        cache[key] = nil
+                        keys_to_clear[#keys_to_clear + 1] = key
                     end
+                end
+
+                for i = 1, #keys_to_clear do
+                    cache[keys_to_clear[i]] = nil
                 end
             end
         end

--- a/apisix/patch.lua
+++ b/apisix/patch.lua
@@ -378,6 +378,15 @@ function _M.patch()
     ngx_socket.udp = function ()
         return patch_udp_socket(original_udp())
     end
+
+    -- Increment body version on each rewrite so any body-dependent cache
+    -- can detect staleness by comparing against ngx.ctx._body_version.
+    local _set_body_data = ngx.req.set_body_data
+    -- luacheck: ignore
+    ngx.req.set_body_data = function(data)
+        ngx.ctx._body_version = (ngx.ctx._body_version or 0) + 1
+        return _set_body_data(data)
+    end
 end
 
 

--- a/apisix/patch.lua
+++ b/apisix/patch.lua
@@ -31,6 +31,7 @@ local new_tab = require("table.new")
 local log = ngx.log
 local WARN = ngx.WARN
 local ipairs = ipairs
+local pairs = pairs
 local select = select
 local setmetatable = setmetatable
 local string = string

--- a/apisix/patch.lua
+++ b/apisix/patch.lua
@@ -378,15 +378,6 @@ function _M.patch()
     ngx_socket.udp = function ()
         return patch_udp_socket(original_udp())
     end
-
-    -- Increment body version on each rewrite so any body-dependent cache
-    -- can detect staleness by comparing against ngx.ctx._body_version.
-    local _set_body_data = ngx.req.set_body_data
-    -- luacheck: ignore
-    ngx.req.set_body_data = function(data)
-        ngx.ctx._body_version = (ngx.ctx._body_version or 0) + 1
-        return _set_body_data(data)
-    end
 end
 
 

--- a/apisix/patch.lua
+++ b/apisix/patch.lua
@@ -388,7 +388,8 @@ function _M.patch()
         local api_ctx = ngx.ctx.api_ctx
         if api_ctx and api_ctx._post_arg_request_body then
             api_ctx._post_arg_request_body = nil
-            local cache = api_ctx._cache
+            local var = api_ctx.var
+            local cache = var and var._cache
             if cache then
                 for key in pairs(cache) do
                     if key:sub(1, 9) == "post_arg." then

--- a/apisix/patch.lua
+++ b/apisix/patch.lua
@@ -392,7 +392,7 @@ function _M.patch()
             local cache = var and var._cache
             if cache then
                 for key in pairs(cache) do
-                    if key:sub(1, 9) == "post_arg." then
+                    if type(key) == "string" and key:sub(1, 9) == "post_arg." then
                         cache[key] = nil
                     end
                 end

--- a/t/core/ctx3.t
+++ b/t/core/ctx3.t
@@ -99,3 +99,67 @@ qr/serving ctx value from cache for key: graphql_name/
 serving ctx value from cache for key: graphql_name
 serving ctx value from cache for key: graphql_name
 serving ctx value from cache for key: graphql_name
+
+
+
+=== TEST 3: parse post body only once when multiple different post_arg.* keys are accessed
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [=[{
+                        "methods": ["POST"],
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "plugins": {
+                            "serverless-post-function": {
+                                "phase": "rewrite",
+                                "functions" : ["return function(conf, ctx)
+                                                ngx.log(ngx.WARN, 'model: ', ctx.var['post_arg.model']);
+                                                ngx.log(ngx.WARN, 'stream: ', ctx.var['post_arg.stream']);
+                                                ngx.log(ngx.WARN, 'temperature: ', tostring(ctx.var['post_arg.temperature']));
+                                                end"]
+                            }
+                        },
+                        "uri": "/hello",
+                        "vars": [
+                            ["post_arg.model", "==", "gpt-4"]
+                        ]
+                }]=]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 4: send request with multiple post_arg fields - body parsed only once
+--- request
+POST /hello
+{"model":"gpt-4","stream":true,"temperature":0.7}
+--- more_headers
+Content-Type: application/json
+--- response_body
+hello world
+--- error_code: 200
+--- error_log
+model: gpt-4
+stream: true
+temperature: 0.7
+--- grep_error_log eval
+qr/reuse parsed request body from ctx cache/
+--- grep_error_log_out
+reuse parsed request body from ctx cache
+reuse parsed request body from ctx cache

--- a/t/core/ctx3.t
+++ b/t/core/ctx3.t
@@ -163,3 +163,67 @@ qr/reuse parsed request body from ctx cache/
 --- grep_error_log_out
 reuse parsed request body from ctx cache
 reuse parsed request body from ctx cache
+
+
+
+=== TEST 5: set_body_data invalidates both body-level cache and post_arg.* variable cache
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [=[{
+                        "methods": ["POST"],
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "plugins": {
+                            "serverless-pre-function": {
+                                "phase": "rewrite",
+                                "functions" : ["return function(conf, ctx)
+                                                -- first access: parse and cache body
+                                                local v1 = ctx.var['post_arg.model']
+                                                ngx.log(ngx.WARN, 'before rewrite model: ', tostring(v1));
+                                                -- rewrite body: must invalidate both caches
+                                                ngx.req.set_body_data('{\"model\":\"claude\",\"temperature\":0.9}')
+                                                -- same key: must reflect new body, not stale cache
+                                                local v2 = ctx.var['post_arg.model']
+                                                ngx.log(ngx.WARN, 'after rewrite model: ', tostring(v2));
+                                                -- different key: must also reflect new body
+                                                local v3 = ctx.var['post_arg.temperature']
+                                                ngx.log(ngx.WARN, 'after rewrite temperature: ', tostring(v3));
+                                                end"]
+                            }
+                        },
+                        "uri": "/hello"
+                }]=]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 6: send request - set_body_data invalidation is reflected in post_arg.* access
+--- request
+POST /hello
+{"model":"gpt-4","temperature":0.1}
+--- more_headers
+Content-Type: application/json
+--- response_body
+hello world
+--- error_code: 200
+--- error_log
+before rewrite model: gpt-4
+after rewrite model: claude
+after rewrite temperature: 0.9


### PR DESCRIPTION
## Summary

When multiple `post_arg.*` variables are evaluated in a single request
(e.g. `vars` expressions in route matching or plugin-level `vars` conditions
in `traffic-split` / `fault-injection`), each access independently
triggers a full body read + `json.decode` cycle. For large request
bodies at high QPS, this causes unnecessary repeated CPU and memory
overhead.

## Changes

### `apisix/core/ctx.lua`

Split `get_parsed_request_body` into two layers:

- `_get_parsed_request_body(ctx)` — pure parsing logic, no side effects
- `get_parsed_request_body(ctx)` — wrapper that caches the decoded table in `ctx._post_arg_request_body` for the lifetime of the request

On the first access, the decoded table is stored in `ctx._post_arg_request_body`.
Subsequent accesses to different `post_arg.*` keys within the same request
reuse the cached result, so `json.decode` runs at most once per request.

Errors are intentionally **not cached**: a failed parse leaves the cache
empty so that a later access (e.g. after a plugin sets a valid body) can
still succeed.

### `apisix/patch.lua`

Patch `ngx.req.set_body_data` to automatically invalidate both cache layers
when the request body is rewritten mid-request:

- Clears `api_ctx._post_arg_request_body` (body-level cache)
- Removes all `post_arg.*` entries from `api_ctx.var._cache` (variable-level cache)

The invalidation is skipped entirely when `_post_arg_request_body` is nil,
avoiding any overhead on requests that never access `post_arg.*` variables.

## Tests

- **TEST 3/4** (`t/core/ctx3.t`): verifies all fields are read correctly and
  that `reuse parsed request body from ctx cache` appears exactly twice when
  three different `post_arg.*` keys are accessed in one request.
- **TEST 5/6** (`t/core/ctx3.t`): verifies that after `ngx.req.set_body_data()`,
  both the same key and a different key reflect the new body content.