### PR TITLE
docs(changelog): fix typos, version number, PR reference, and heading levels in v3.x sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,7 +204,7 @@ title: Changelog
 - fix: add warning log when skipping check for disabled plugin [#12655](https://github.com/apache/apisix/pull/12655)
 - chore: add test for verifying lua-resty-openssl bug fix [#12656](https://github.com/apache/apisix/pull/12656)
 
-## Doc improvements
+### Doc improvements
 
 - docs: remove unnecessary sentence in opentelemetry plugin doc [#12660](https://github.com/apache/apisix/pull/12660)
 
@@ -293,7 +293,7 @@ title: Changelog
 - feat: add support for extra_headers in forward-auth plugin [#12405](https://github.com/apache/apisix/pull/12405)
 - feat: Add AIMLAPI provider support to AI plugins [#12379](https://github.com/apache/apisix/pull/12379)
 
-## Doc improvements
+### Doc improvements
 
 - docs: update admin api documentation for plugin metadata list endpoint [#12621](https://github.com/apache/apisix/pull/12621)
 - docs: add new dashboard documentation [#12616](https://github.com/apache/apisix/pull/12616)
@@ -366,7 +366,7 @@ This PR sets additionalProperties to false for consumer credentials.
 - feat: add headers attribute for loki-logger [#12243](https://github.com/apache/apisix/pull/12243)
 - feat: expose apisix version in prometheus node info metric [#12367](https://github.com/apache/apisix/pull/12367)
 
-## Doc improvements
+### Doc improvements
 
 - docs: update stream proxy doc for proxy_mode and some formatting [#12108](https://github.com/apache/apisix/pull/12108)
 - docs: improve loki-logger plugin docs [#11921](https://github.com/apache/apisix/pull/11921)
@@ -387,7 +387,7 @@ This PR sets additionalProperties to false for consumer credentials.
 - docs: fix typo in real-ip.md [#12236](https://github.com/apache/apisix/pull/12236)
 - docs: the configuration type of the WASM plugin can be an object. [#12251](https://github.com/apache/apisix/pull/12251)
 
-## Developer productivity
+### Developer productivity
 
 - feat: support devcontainer for containerized development of APISIX [#11765](https://github.com/apache/apisix/pull/11765)
 
@@ -440,7 +440,7 @@ This PR returns `405 Method not allowed` instead of `400 Bad Request` when reque
 ### Core
 
 - set default value of ssl_trusted_certificate to system [#11993](https://github.com/apache/apisix/pull/11993)
-- upgrade openresty version to v1.27.11 [#11936](https://github.com/apache/apisix/pull/11936)
+- upgrade openresty version to 1.27.1.1 [#11936](https://github.com/apache/apisix/pull/11936)
 - Support the use of system-provided CA certs in `ssl_trusted_certificate` [#11809](https://github.com/apache/apisix/pull/11809)
 - support _meta.pre_function to execute custom logic before execution of each phase [#11793](https://github.com/apache/apisix/pull/11793)
 - support anonymous consumer [#11917](https://github.com/apache/apisix/pull/11917)
@@ -481,7 +481,7 @@ This PR returns `405 Method not allowed` instead of `400 Bad Request` when reque
 ### Plugins
 
 - allow configuring keepalive_timeout in splunk-logger [#11611](https://github.com/apache/apisix/pull/11611)
-- add plugin attach-consmer-label [#11604](https://github.com/apache/apisix/pull/11604)
+- add plugin attach-consumer-label [#11604](https://github.com/apache/apisix/pull/11604)
 - ai-proxy plugin [#11499](https://github.com/apache/apisix/pull/11499)
 - ai-prompt-decorator plugin [#11515](https://github.com/apache/apisix/pull/11515)
 - ai-prompt-template plugin [#11517](https://github.com/apache/apisix/pull/11517)
@@ -749,7 +749,7 @@ This function now always returns strings, previously it returned tables when dup
 - :sunrise: Support vars for file-logger plugin: [#9712](https://github.com/apache/apisix/pull/9712)
 - :sunrise: Support adding response headers for mock plugin: [#9720](https://github.com/apache/apisix/pull/9720)
 - :sunrise: Support regex_uri with unsafe_uri for proxy-rewrite plugin: [#9813](https://github.com/apache/apisix/pull/9813)
-- :sunrise: Support set client_email field for google-cloud-logging plugin: [#9813](https://github.com/apache/apisix/pull/9813)
+- :sunrise: Support set client_email field for google-cloud-logging plugin: [#9622](https://github.com/apache/apisix/pull/9622)
 - :sunrise: Support sending headers upstream returned by OPA server for opa plugin: [#9710](https://github.com/apache/apisix/pull/9710)
 - :sunrise: Support configuring proxy server for openid-connect plugin: [#9948](https://github.com/apache/apisix/pull/9948)
 
@@ -926,7 +926,7 @@ This function now always returns strings, previously it returned tables when dup
 
 ### Change
 
-- `enable_cpu_affinity` is disabled by default to avoid this configuration affecting the behavior of APSISIX deployed in the container: [#8074](https://github.com/apache/apisix/pull/8074)
+- `enable_cpu_affinity` is disabled by default to avoid this configuration affecting the behavior of APISIX deployed in the container: [#8074](https://github.com/apache/apisix/pull/8074)
 
 ### Core
 


### PR DESCRIPTION
### Description

Eight small CHANGELOG corrections across the 3.x sections — typos, a wrong PR reference, a wrong OpenResty version string, and four H2 headings that should be H3.

This is the first follow-up PR for the audit findings tracked in #13359. Scope is intentionally limited to objective, low-risk edits in `CHANGELOG.md`; content/classification revisions will be split into separate PRs per release.

### Changes

| File / Section | Before | After |
|---|---|---|
| 3.14.1 | `## Doc improvements` (H2 — breaks TOC, looks like a new release) | `### Doc improvements` (H3) |
| 3.14.0 | `## Doc improvements` (H2) | `### Doc improvements` (H3) |
| 3.13.0 | `## Doc improvements` (H2) | `### Doc improvements` (H3) |
| 3.13.0 | `## Developer productivity` (H2) | `### Developer productivity` (H3) |
| 3.12.0 #11936 | `upgrade openresty version to v1.27.11` | `upgrade openresty version to 1.27.1.1` |
| 3.11.0 #11604 | `add plugin attach-consmer-label` | `add plugin attach-consumer-label` |
| 3.5.0 google-cloud-logging | `client_email field ... [#9813]` | `client_email field ... [#9622]` (the actual PR; #9813 is the proxy-rewrite entry on the line above) |
| 3.0.0 #8074 | `behavior of APSISIX` | `behavior of APISIX` |

### Why these (and only these) here

- All edits are objectively verifiable: each PR number resolves to a real PR title that confirms the intended wording, and `v1.27.11` is not a real OpenResty version (the rockspec at #11936 lands on `1.27.1.1`, matching the predecessor of `1.27.1.2` from #12307).
- No reclassification, no `:warning:` additions, no rockspec backfills — those need per-release discussion and will come as separate PRs.

Refs #13359.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to the changes introduced in this PR (N/A — CHANGELOG-only)
- [ ] I have added proper labels to this PR
- [x] I have installed and executed `pre-commit` (no code changes; markdown only)