### PR TITLE
fix(core/etcd): nil-deref on response without header field

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -160,6 +160,9 @@ local function do_run_watch(premature)
                 if not res then
                     log.error("etcd get: ", err)
                     ngx_sleep(3)
+                elseif not (res.body and res.body.header and res.body.header.revision) then
+                    log.error("etcd response missing header.revision")
+                    ngx_sleep(3)
                 else
                     rev = tonumber(res.body.header.revision)
                     break

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -165,7 +165,13 @@ local function do_run_watch(premature)
                     ngx_sleep(3)
                 else
                     rev = tonumber(res.body.header.revision)
-                    break
+                    if not rev then
+                        log.error("etcd response has invalid header.revision: ",
+                                  tostring(res.body.header.revision))
+                        ngx_sleep(3)
+                    else
+                        break
+                    end
                 end
             end
         end

--- a/apisix/core/etcd.lua
+++ b/apisix/core/etcd.lua
@@ -576,9 +576,9 @@ function _M.push(key, value, ttl)
     end
 
     -- manually add suffix
-    local index = res.body.header and res.body.header.revision
+    local index, rev_err = get_header_revision(res)
     if not index then
-        return nil, "etcd response missing header.revision"
+        return nil, rev_err
     end
     index = string.format("%020d", index)
 

--- a/apisix/core/etcd.lua
+++ b/apisix/core/etcd.lua
@@ -257,6 +257,15 @@ local function not_found(res)
 end
 
 
+local function get_header_revision(res)
+    local header = res.body.header
+    if not (header and header.revision) then
+        return nil, "etcd response missing header.revision"
+    end
+    return header.revision
+end
+
+
 -- When `is_dir` is true, returns the value of both the dir key and its descendants.
 -- Otherwise, return the value of key only.
 function _M.get_format(res, real_key, is_dir, formatter)
@@ -273,7 +282,11 @@ function _M.get_format(res, real_key, is_dir, formatter)
         return nil, res.body.error
     end
 
-    res.headers["X-Etcd-Index"] = res.body.header.revision
+    local revision, err = get_header_revision(res)
+    if not revision then
+        return nil, err
+    end
+    res.headers["X-Etcd-Index"] = revision
 
     if not res.body.kvs then
         return not_found(res)
@@ -452,7 +465,11 @@ local function set(key, value, ttl)
         return nil, res.body.error
     end
 
-    res.headers["X-Etcd-Index"] = res.body.header.revision
+    local revision, rev_err = get_header_revision(res)
+    if not revision then
+        return nil, rev_err
+    end
+    res.headers["X-Etcd-Index"] = revision
 
     -- etcd v3 set would not return kv info
     v3_adapter.to_v3(res.body, "set")
@@ -521,7 +538,11 @@ function _M.atomic_set(key, value, ttl, mod_revision)
         return nil, "value changed before overwritten"
     end
 
-    res.headers["X-Etcd-Index"] = res.body.header.revision
+    local revision, rev_err = get_header_revision(res)
+    if not revision then
+        return nil, rev_err
+    end
+    res.headers["X-Etcd-Index"] = revision
     -- etcd v3 set would not return kv info
     v3_adapter.to_v3(res.body, "compareAndSwap")
     res.body.node = {
@@ -555,7 +576,10 @@ function _M.push(key, value, ttl)
     end
 
     -- manually add suffix
-    local index = res.body.header.revision
+    local index = res.body.header and res.body.header.revision
+    if not index then
+        return nil, "etcd response missing header.revision"
+    end
     index = string.format("%020d", index)
 
     -- set the basic id attribute
@@ -588,7 +612,11 @@ function _M.delete(key)
         return nil, err
     end
 
-    res.headers["X-Etcd-Index"] = res.body.header.revision
+    local revision, rev_err = get_header_revision(res)
+    if not revision then
+        return nil, rev_err
+    end
+    res.headers["X-Etcd-Index"] = revision
 
     if not res.body.deleted then
         return not_found(res), nil
@@ -618,7 +646,11 @@ function _M.rmdir(key, opts)
         return nil, err
     end
 
-    res.headers["X-Etcd-Index"] = res.body.header.revision
+    local revision, rev_err = get_header_revision(res)
+    if not revision then
+        return nil, rev_err
+    end
+    res.headers["X-Etcd-Index"] = revision
 
     if not res.body.deleted then
         return not_found(res), nil

--- a/t/core/etcd-nil-header.t
+++ b/t/core/etcd-nil-header.t
@@ -18,6 +18,7 @@ use t::APISIX 'no_plan';
 
 repeat_each(1);
 no_long_string();
+no_shuffle();
 no_root_location();
 
 add_block_preprocessor(sub {

--- a/t/core/etcd-nil-header.t
+++ b/t/core/etcd-nil-header.t
@@ -1,0 +1,103 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+    if (!defined $block->ignore_error_log) {
+        $block->set_value("ignore_error_log", "");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: get_format returns error when body has no header field
+--- config
+    location /t {
+        content_by_lua_block {
+            local etcd_apisix = require("apisix.core.etcd")
+            local res = {
+                headers = {},
+                body = {
+                    kvs = {{key = "/test", value = "v"}},
+                },
+            }
+            local ok, err = etcd_apisix.get_format(res, "/test", false)
+            ngx.say("ok: ", ok ~= nil)
+            ngx.say("err: ", err)
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok: false
+err: etcd response missing header.revision
+
+
+
+=== TEST 2: get_format returns error when body is an empty table
+--- config
+    location /t {
+        content_by_lua_block {
+            local etcd_apisix = require("apisix.core.etcd")
+            local res = {
+                headers = {},
+                body = {},
+            }
+            local ok, err = etcd_apisix.get_format(res, "/test", false)
+            ngx.say("ok: ", ok ~= nil)
+            ngx.say("err: ", err)
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok: false
+err: etcd response missing header.revision
+
+
+
+=== TEST 3: get_format succeeds when header.revision is present
+--- config
+    location /t {
+        content_by_lua_block {
+            local etcd_apisix = require("apisix.core.etcd")
+            local res = {
+                headers = {},
+                body = {
+                    header = {revision = 100},
+                    kvs = {{key = "/test", value = "v", create_revision = "1", mod_revision = "2"}},
+                },
+            }
+            local ok, err = etcd_apisix.get_format(res, "/test", false)
+            ngx.say("ok: ", ok ~= nil)
+            ngx.say("err: ", err)
+            ngx.say("revision: ", res.headers["X-Etcd-Index"])
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok: true
+err: nil
+revision: 100


### PR DESCRIPTION
Several functions in `apisix/core/etcd.lua` access `res.body.header.revision` without checking whether `header` exists. When the response body lacks an etcd v3 `header` field — e.g. a reverse proxy returns its own JSON error, or the upstream returns a non-etcd response — this raises `attempt to index field 'header' (a nil value)`.

Since `get_format` is called from `config_etcd.lua` during `init_worker_by_lua`, a malformed response during bootstrap crashes the worker init phase entirely (CrashLoopBackoff in K8s deployments).

This PR adds a `get_header_revision()` helper that returns `nil, err` when `header` or `revision` is missing, and uses it in all 6 affected call sites in `etcd.lua`. It also guards the direct `res.body.header.revision` access in `config_etcd.lua`'s watch init retry loop to log and retry instead of crashing.