### PR TITLE
fix: handle missing X-Etcd-Index header gracefully in config_etcd

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -150,7 +150,11 @@ local function do_run_watch(premature)
             local _, res = next(loaded_configuration)
             if res then
                 rev = tonumber(res.headers["X-Etcd-Index"])
-                assert(rev > 0, 'invalid res.headers["X-Etcd-Index"]')
+                if not rev or rev <= 0 then
+                    log.warn("invalid or missing X-Etcd-Index header, ",
+                             "will fetch revision from etcd directly")
+                    rev = 0
+                end
             end
         end
 

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -49,7 +49,6 @@ local string       = string
 local error        = error
 local pairs        = pairs
 local next         = next
-local assert       = assert
 local rand         = math.random
 local constants    = require("apisix.constants")
 local health_check = require("resty.etcd.health_check")

--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -567,3 +567,48 @@ passed
 qr/etcd watch timeout, upgrade revision to/
 --- grep_error_log_out eval
 qr/(etcd watch timeout, upgrade revision to\n){2,}/
+
+
+
+=== TEST 15: missing X-Etcd-Index header should not crash init worker
+--- yaml_config
+deployment:
+  role: traditional
+  role_traditional:
+    config_provider: etcd
+  etcd:
+    host:
+      - "http://127.0.0.1:2379"
+    prefix: /apisix
+--- extra_init_by_lua
+    -- Inject a fake loaded_configuration entry with missing X-Etcd-Index
+    -- header so do_run_watch exercises the fallback path.
+    local config_etcd = require("apisix.core.config_etcd")
+    for i = 1, 256 do
+        local name, val = debug.getupvalue(config_etcd.new, i)
+        if not name then
+            break
+        end
+        if name == "loaded_configuration" and type(val) == "table" then
+            val["__test_fake"] = {
+                body = { nodes = {} },
+                headers = {},
+            }
+            break
+        end
+    end
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.sleep(1)
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- grep_error_log eval
+qr/invalid or missing X-Etcd-Index header/
+--- grep_error_log_out eval
+qr/(invalid or missing X-Etcd-Index header\n){1,}/

--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -581,8 +581,8 @@ deployment:
       - "http://127.0.0.1:2379"
     prefix: /apisix
 --- extra_init_by_lua
-    -- Inject a fake loaded_configuration entry with missing X-Etcd-Index
-    -- header so do_run_watch exercises the fallback path.
+    -- Clear loaded_configuration and inject a fake entry with missing
+    -- X-Etcd-Index header so do_run_watch exercises the fallback path.
     local config_etcd = require("apisix.core.config_etcd")
     for i = 1, 256 do
         local name, val = debug.getupvalue(config_etcd.new, i)
@@ -590,6 +590,9 @@ deployment:
             break
         end
         if name == "loaded_configuration" and type(val) == "table" then
+            for k in pairs(val) do
+                val[k] = nil
+            end
             val["__test_fake"] = {
                 body = { nodes = {} },
                 headers = {},


### PR DESCRIPTION
When the etcd response is missing the `X-Etcd-Index` header (e.g. a reverse proxy strips non-standard headers), `tonumber(nil)` returns `nil` and the `assert(rev > 0)` raises — killing the init worker phase with no retry.

This replaces the assert with a nil/non-positive check that logs a warning and falls through to the existing `rev == 0` retry path, which fetches the current revision directly from etcd.

The fix makes a transient header anomaly recoverable instead of fatal.