### PR TITLE
feat(ai-proxy): add effective_model and effective_request_for_cache helpers

### DIFF
--- a/apisix/plugins/ai-providers/base.lua
+++ b/apisix/plugins/ai-providers/base.lua
@@ -34,7 +34,7 @@ local transport_http = require("apisix.plugins.ai-transport.http")
 local transport_auth = require("apisix.plugins.ai-transport.auth")
 local log_sanitize = require("apisix.utils.log-sanitize")
 local protocols = require("apisix.plugins.ai-protocols")
-local deep_merge = require("apisix.plugins.ai-proxy.merge").deep_merge
+local ai_proxy_base = require("apisix.plugins.ai-proxy.base")
 local ngx = ngx
 local ngx_now = ngx.now
 local tonumber = tonumber
@@ -198,33 +198,11 @@ function _M.build_request(self, ctx, conf, request_body, opts)
                           or opts.target_host or self.host,
     }
 
-    -- Inject model options (flat overwrite)
-    if opts.model_options then
-        for opt, val in pairs(opts.model_options) do
-            if request_body[opt] ~= nil then
-                core.log.info("model_options overwriting request field '", opt, "'")
-            end
-            request_body[opt] = val
-        end
-    end
-
-    -- Apply llm_options via provider capability hook (always force-overwrites)
-    if opts.override_llm_options then
-        local cap = self.capabilities and self.capabilities[ctx.ai_target_protocol]
-        if cap and cap.rewrite_request_body then
-            cap.rewrite_request_body(request_body, opts.override_llm_options, true)
-        end
-    end
-
-    -- Apply per-target-protocol request body override (deep merge)
-    if opts.request_body_override_map then
-        local patch = opts.request_body_override_map[ctx.ai_target_protocol]
-        if patch then
-            core.log.info("applying request_body override for target protocol '",
-                          ctx.ai_target_protocol, "'")
-            request_body = deep_merge(request_body, patch, opts.request_body_force_override)
-        end
-    end
+    -- Apply instance-level overrides (options + override.{llm_options, request_body}).
+    -- Runs after the converter so request_body is in target-protocol shape, and the
+    -- request_body[target_protocol] patch applies to the post-conversion body.
+    request_body = ai_proxy_base.apply_instance_overrides(
+        request_body, opts.ai_instance, self, ctx.ai_target_protocol)
     params.body = request_body
 
     if self.remove_model then

--- a/apisix/plugins/ai-proxy/base.lua
+++ b/apisix/plugins/ai-proxy/base.lua
@@ -28,6 +28,7 @@ local protocols = require("apisix.plugins.ai-protocols")
 local transport_http = require("apisix.plugins.ai-transport.http")
 local log_sanitize = require("apisix.utils.log-sanitize")
 local apisix_upstream = require("resty.apisix.upstream")
+local deep_merge = require("apisix.plugins.ai-proxy.merge").deep_merge
 
 local _M = {}
 
@@ -99,6 +100,55 @@ function _M.detect_request_type(ctx)
 end
 
 
+-- Apply instance-level overrides to the request body, returning the body
+-- that would be sent upstream. Encapsulates the precedence rules used by the
+-- ai-proxy / ai-proxy-multi instance config:
+--   1. ai_instance.options - flat overwrite onto request_body.
+--   2. override.llm_options - applied via the provider capability hook
+--      rewrite_request_body for target_protocol (force-overwrites).
+--   3. override.request_body[target_protocol] - deep-merged; force controlled
+--      by override.request_body_force_override.
+-- May mutate request_body in place; returns the same (mutated) table or the
+-- table produced by the final deep merge.
+-- Pure relative to its arguments: no ctx access, no I/O.
+function _M.apply_instance_overrides(request_body, ai_instance, ai_provider, target_protocol)
+    local model_options = ai_instance and ai_instance.options
+    if model_options then
+        for opt, val in pairs(model_options) do
+            if request_body[opt] ~= nil then
+                core.log.info("model_options overwriting request field '", opt, "'")
+            end
+            request_body[opt] = val
+        end
+    end
+
+    local override_llm_options =
+        core.table.try_read_attr(ai_instance, "override", "llm_options")
+    if override_llm_options then
+        local caps = ai_provider and ai_provider.capabilities
+        local cap = caps and caps[target_protocol]
+        if cap and cap.rewrite_request_body then
+            cap.rewrite_request_body(request_body, override_llm_options, true)
+        end
+    end
+
+    local request_body_override_map =
+        core.table.try_read_attr(ai_instance, "override", "request_body")
+    if request_body_override_map then
+        local patch = request_body_override_map[target_protocol]
+        if patch then
+            core.log.info("applying request_body override for target protocol '",
+                          target_protocol, "'")
+            local force = core.table.try_read_attr(ai_instance, "override",
+                                                   "request_body_force_override")
+            request_body = deep_merge(request_body, patch, force)
+        end
+    end
+
+    return request_body
+end
+
+
 -- Execute the AI proxy pipeline:
 --   1. Validate request
 --   2. Route client protocol to driver capability (passthrough / convert / error)
@@ -124,15 +174,9 @@ function _M.before_proxy(conf, ctx, on_error)
         local extra_opts = {
             name = ai_instance.name,
             endpoint = core.table.try_read_attr(ai_instance, "override", "endpoint"),
-            model_options = ai_instance.options,
             conf = ai_instance.provider_conf or {},
             auth = ai_instance.auth,
-            override_llm_options =
-                core.table.try_read_attr(ai_instance, "override", "llm_options"),
-            request_body_override_map =
-                core.table.try_read_attr(ai_instance, "override", "request_body"),
-            request_body_force_override =
-                core.table.try_read_attr(ai_instance, "override", "request_body_force_override"),
+            ai_instance = ai_instance,
         }
         -- Step 1: Route client protocol to driver capability
         local client_protocol = ctx.ai_client_protocol

--- a/apisix/plugins/ai-proxy/base.lua
+++ b/apisix/plugins/ai-proxy/base.lua
@@ -149,6 +149,75 @@ function _M.apply_instance_overrides(request_body, ai_instance, ai_provider, tar
 end
 
 
+-- Effective model that would be sent upstream for the picked AI instance.
+-- Returns the operator-forced model (ai_instance.options.model) when set;
+-- otherwise the client-supplied model that detect_request_type mirrored to
+-- ctx.var.request_llm_model. Returns nil when neither is available.
+function _M.effective_model(ctx)
+    local ai_instance = ctx and ctx.picked_ai_instance
+    local options = ai_instance and ai_instance.options
+    if options and options.model then
+        return options.model
+    end
+    return ctx and ctx.var and ctx.var.request_llm_model
+end
+
+
+-- Resolve the target protocol the upstream LLM speaks for the picked instance,
+-- given the detected client protocol. Mirrors the routing in before_proxy so
+-- callers that run before before_proxy (peer plugins in access phase) can still
+-- compute it. Returns ctx.ai_target_protocol when already set; otherwise picks
+-- a passthrough target if the provider speaks the client protocol natively, the
+-- "passthrough" sentinel for the catch-all client protocol, or the converter's
+-- target when a converter bridges client to provider.
+local function resolve_target_protocol(ctx, ai_provider)
+    if ctx.ai_target_protocol then
+        return ctx.ai_target_protocol
+    end
+    local client_protocol = ctx.ai_client_protocol
+    if not client_protocol then
+        return nil
+    end
+    local caps = ai_provider and ai_provider.capabilities or {}
+    if caps[client_protocol] then
+        return client_protocol
+    end
+    if client_protocol == "passthrough" then
+        return "passthrough"
+    end
+    local _, target = protocols.find_converter(client_protocol, caps)
+    return target
+end
+
+
+-- Effective request body that would be sent upstream for the current request.
+-- Reads the parsed request body and applies apply_instance_overrides against
+-- ctx.picked_ai_instance and the resolved target protocol. Pure: no HTTP, no
+-- signing, no upstream call. Intended for ai-cache (and similar peer plugins)
+-- to compute a cache key over the post-override view of the body.
+-- Requires ctx.picked_ai_instance and ctx.ai_client_protocol to be populated
+-- (both set by ai-proxy / ai-proxy-multi access phase before any peer plugin
+-- with priority lower than 1040 runs).
+function _M.effective_request_for_cache(ctx)
+    local request_body, err = core.request.get_json_request_body_table()
+    if not request_body then
+        return nil, err
+    end
+    local ai_instance = ctx and ctx.picked_ai_instance
+    if not ai_instance then
+        return nil, "no picked_ai_instance on ctx"
+    end
+    local ok, ai_provider = pcall(require,
+        "apisix.plugins.ai-providers." .. ai_instance.provider)
+    if not ok then
+        return nil, "failed to load provider: " .. tostring(ai_instance.provider)
+    end
+    local target_protocol = resolve_target_protocol(ctx, ai_provider)
+    return _M.apply_instance_overrides(
+        request_body, ai_instance, ai_provider, target_protocol)
+end
+
+
 -- Execute the AI proxy pipeline:
 --   1. Validate request
 --   2. Route client protocol to driver capability (passthrough / convert / error)

--- a/t/plugin/ai-proxy-request-body-override.t
+++ b/t/plugin/ai-proxy-request-body-override.t
@@ -819,3 +819,64 @@ max_tokens=321
     }
 --- response_body
 max_completion_tokens=200 temperature=0.5
+
+
+
+=== TEST 17: effective_model + effective_request_for_cache reflect post-override view
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            -- ai-proxy applies overrides; serverless-post-function (priority -2000)
+            -- runs after ai-proxy access (priority 1040) in the access phase, invokes
+            -- the helpers, and logs their output. The test then asserts BOTH the
+            -- upstream-received body AND the helper outputs reflect the same
+            -- post-override view.
+            local code = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "uri": "/chat",
+                    "plugins": {
+                        "ai-proxy": {
+                            "provider": "openai",
+                            "auth": { "header": { "Authorization": "Bearer t" } },
+                            "options": { "model": "options-model" },
+                            "override": {
+                                "endpoint": "http://localhost:6732",
+                                "request_body": {
+                                    "openai-chat": { "temperature": 0.42 }
+                                }
+                            },
+                            "ssl_verify": false
+                        },
+                        "serverless-post-function": {
+                            "functions": [
+                                "return function(_, ctx) local b = require('apisix.plugins.ai-proxy.base'); local cjson = require('cjson.safe'); local m = b.effective_model(ctx); local body, err = b.effective_request_for_cache(ctx); ngx.log(ngx.WARN, 'EFFECTIVE_MODEL=', m or 'nil'); ngx.log(ngx.WARN, 'EFFECTIVE_BODY=', body and cjson.encode(body) or ('ERR:'..tostring(err))) end"
+                            ]
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then ngx.status = code; return end
+
+            local http = require("resty.http").new()
+            local res = assert(http:request_uri("http://127.0.0.1:" .. ngx.var.server_port .. "/chat", {
+                method = "POST",
+                body = '{"messages":[{"role":"user","content":"hi"}],"model":"client-model"}',
+                headers = { ["Content-Type"] = "application/json" },
+            }))
+            local cjson = require("cjson.safe")
+            local body = cjson.decode(res.body)
+            local echoed = cjson.decode(body.choices[1].message.content)
+            ngx.say("upstream model=", echoed.model,
+                    " upstream temperature=", echoed.temperature)
+        }
+    }
+--- response_body
+upstream model=options-model upstream temperature=0.42
+--- error_log eval
+[
+    qr/EFFECTIVE_MODEL=options-model/,
+    qr/EFFECTIVE_BODY=.*"model":"options-model"/,
+    qr/EFFECTIVE_BODY=.*"temperature":0\.42/,
+]


### PR DESCRIPTION
### Description

Two pure helpers on top of `apply_instance_overrides` (introduced in #13370), both in `apisix/plugins/ai-proxy/base.lua`:

- **`effective_model(ctx) -> string`** returns `ai_instance.options.model` when the operator forces a model on the picked instance, falling back to `ctx.var.request_llm_model` (the client-supplied model that `detect_request_type` mirrored to that var).
- **`effective_request_for_cache(ctx) -> table`** returns the request body as it would be sent upstream: reads the parsed body via `core.request.get_json_request_body_table`, resolves the target protocol from `ctx.ai_client_protocol` against the provider's capabilities, and applies `apply_instance_overrides`. Pure — no HTTP, no signing, no upstream call.

A small internal `resolve_target_protocol(ctx, ai_provider)` mirrors the protocol-routing logic in `before_proxy` so callers running in access phase (before `before_proxy` populates `ctx.ai_target_protocol`) can still compute the post-override view of the body. The helper prefers `ctx.ai_target_protocol` when it's already set, falling back to the capability lookup (passthrough), the `"passthrough"` sentinel, or the converter's target — same order `before_proxy` uses.

**Motivation: same as #13370.** A planned `ai-cache` plugin needs to compute its cache key over the post-override effective body from its own access phase, before `before_proxy` makes the upstream call. Without these helpers it would have to either re-implement override application + protocol routing itself, or accept a cache key that's blind to operator-configured overrides.

#### Stacked on #13370

This PR is built on top of #13370 (the `apply_instance_overrides` refactor). The diff visible here will shrink to just the helpers + their test once that lands. Please review them together; this PR has no value without the helper it builds on.

#### Which issue(s) this PR fixes:
N/A — new internal API surface.

### Behavior change

None for the existing ai-proxy / ai-proxy-multi request flow. The helpers are additive: the existing `before_proxy` → `build_request` path is unchanged, and the helpers are not called from any phase yet. They become useful when `ai-cache` (next PR series) starts calling them.

### Tests

Added one block to `t/plugin/ai-proxy-request-body-override.t` (TEST 17). The block:

1. Configures a route with `ai-proxy` + `options.model` + `override.request_body.openai-chat.temperature`, plus `serverless-post-function` (priority `-2000`, default access phase) to act as a "later peer plugin".
2. The serverless function calls `effective_model(ctx)` and `effective_request_for_cache(ctx)` and writes their output to the error log.
3. The test sends a real request through ai-proxy to the existing echo upstream (which returns the upstream-received body as the response content).
4. Asserts BOTH the upstream-received body (via `--- response_body`) AND the helper output (via `--- error_log eval`) reflect the same post-override view — same model, same temperature.

This proves the helpers produce exactly what `build_request` would send upstream, since both are observed in the same vertical test against the same route.

Verification:
- `prove -I../test-nginx/lib -I./ t/plugin/ai-proxy-request-body-override.t` — 53/53 pass (50 pre-existing + 3 new assertions in TEST 17).
- Broader sanity: 17 ai-proxy test files (679 tests) — all pass.
- `make lint` — luacheck and lj-releng both clean.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change — N/A, internal helper surface; not user-facing.
- [x] I have verified that this change is backward compatible