### PR TITLE
fix(log-rotate): reopen logs after partial rotation

### DIFF
--- a/apisix/plugins/log-rotate.lua
+++ b/apisix/plugins/log-rotate.lua
@@ -218,11 +218,13 @@ local function rotate_file(files, now_time, max_kept, timeout)
     for _, file in ipairs(files) do
         local now_date = os_date("%Y-%m-%d_%H-%M-%S", now_time)
         local new_file = rename_file(default_logs[file], now_date)
-        if not new_file then
-            return
+        if new_file then
+            core.table.insert(new_files, new_file)
         end
+    end
 
-        core.table.insert(new_files, new_file)
+    if core.table.isempty(new_files) then
+        return
     end
 
     -- send signal to reopen log files

--- a/t/plugin/log-rotate.t
+++ b/t/plugin/log-rotate.t
@@ -28,6 +28,12 @@ add_block_preprocessor(sub {
     my $extra_yaml_config = <<_EOC_;
 plugins:                          # plugin list
   - log-rotate
+  - serverless-post-function
+
+nginx_config:
+  error_log_level: info
+  http:
+    access_log_buffer: 1
 
 plugin_attr:
   log-rotate:
@@ -216,3 +222,116 @@ true
     }
 --- response_body
 passed
+
+
+
+=== TEST 6: reopen plugin and access logs even if one configured log file is missing
+# Log-phase plugins run after the response is sent to the client. Keep the
+# rotation setup, request trigger, and assertions in separate requests so the
+# previous request's log-phase output is flushed before checking the log files.
+--- timeout: 30
+--- config
+    location /setup {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local prefix = ngx.config.prefix()
+            local access_log = prefix .. "/logs/access.log"
+            local function fail(msg)
+                ngx.status = 500
+                ngx.say(msg)
+                ngx.exit(ngx.HTTP_OK)
+            end
+
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "plugins": {
+                        "serverless-post-function": {
+                            "phase": "log",
+                            "functions" : ["return function(conf, ctx) require('apisix.core').log.info('serverless post-rotation marker') end"]
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                fail(body)
+            end
+
+            os.remove(access_log)
+
+            ngx.sleep(2.5)
+
+            local data = [[
+apisix:
+  node_listen: 1984
+  admin_key: null
+plugins:
+  - serverless-post-function
+nginx_config:
+  error_log_level: info
+  http:
+    access_log_buffer: 1
+            ]]
+            require("lib.test_admin").set_config_yaml(data)
+            code, _, body = t('/apisix/admin/plugins/reload',
+                              ngx.HTTP_PUT)
+            if code >= 300 then
+                fail(body)
+            end
+
+            ngx.say("passed")
+        }
+    }
+    location /verify {
+        content_by_lua_block {
+            local prefix = ngx.config.prefix()
+            local access_log = prefix .. "/logs/access.log"
+            local error_log = prefix .. "/logs/error.log"
+            local marker = "serverless post-rotation marker"
+            local function fail(msg)
+                ngx.status = 500
+                ngx.say(msg)
+                ngx.exit(ngx.HTTP_OK)
+            end
+
+            ngx.sleep(0.5)
+
+            local f, err = io.open(error_log, "r")
+            if not f then
+                fail("failed to open current error log: " .. err)
+            end
+            local error_content = f:read("*all")
+            f:close()
+
+            f, err = io.open(access_log, "r")
+            if not f then
+                fail("failed to open current access log: " .. err)
+            end
+            local access_content = f:read("*all")
+            f:close()
+
+            if not string.find(error_content, marker, 1, true) then
+                fail("current error log missed post-rotation plugin log")
+            end
+
+            if not string.find(access_content, "GET /hello", 1, true) then
+                fail("current access log missed post-rotation request")
+            end
+
+            ngx.say("passed")
+        }
+    }
+--- pipelined_requests eval
+["GET /setup", "GET /hello", "GET /verify"]
+--- error_code eval
+[200, 200, 200]
+--- response_body eval
+["passed\n", "hello world\n", "passed\n"]

--- a/t/plugin/log-rotate.t
+++ b/t/plugin/log-rotate.t
@@ -30,11 +30,6 @@ plugins:                          # plugin list
   - log-rotate
   - serverless-post-function
 
-nginx_config:
-  error_log_level: info
-  http:
-    access_log_buffer: 1
-
 plugin_attr:
   log-rotate:
     interval: 1
@@ -265,7 +260,15 @@ passed
                 fail(body)
             end
 
-            os.remove(access_log)
+            -- remove access.log so the rotation renames error.log but fails on
+            -- access.log, exercising the partial-rotation path. Confirm the
+            -- file is actually gone, otherwise the test would silently rotate
+            -- both logs and pass for the wrong path.
+            local lfs = require("lfs")
+            local ok, err = os.remove(access_log)
+            if not ok and lfs.attributes(access_log) then
+                fail("failed to remove access log: " .. (err or "unknown error"))
+            end
 
             ngx.sleep(2.5)
 
@@ -275,16 +278,41 @@ apisix:
   admin_key: null
 plugins:
   - serverless-post-function
-nginx_config:
-  error_log_level: info
-  http:
-    access_log_buffer: 1
             ]]
             require("lib.test_admin").set_config_yaml(data)
             code, _, body = t('/apisix/admin/plugins/reload',
                               ngx.HTTP_PUT)
             if code >= 300 then
                 fail(body)
+            end
+
+            -- plugins/reload only posts an event; the privileged agent where
+            -- the log-rotate timer runs handles it asynchronously, so a late
+            -- rotation tick can still fire after reload returns. Wait until no
+            -- new rotated file shows up for a full interval, otherwise a stray
+            -- rotation between /hello and /verify would move the freshly
+            -- written logs away and make the assertions flaky.
+            local function count_rotated()
+                local n = 0
+                for file_name in lfs.dir(prefix .. "/logs/") do
+                    if string.match(file_name, "__error.log$") then
+                        n = n + 1
+                    end
+                end
+                return n
+            end
+
+            local prev = count_rotated()
+            local stable = 0
+            while stable < 2 do
+                ngx.sleep(1.2)
+                local cur = count_rotated()
+                if cur == prev then
+                    stable = stable + 1
+                else
+                    prev = cur
+                    stable = 0
+                end
             end
 
             ngx.say("passed")


### PR DESCRIPTION
### Description

Fixes #13368.

This updates `log-rotate` so a partial rotation failure does not prevent Nginx from reopening the log files that were rotated successfully. The regression test covers the reported behavior where a custom plugin writes through `core.log.info` after rotation and access logs should continue landing in the current `access.log`.

### Root cause

`rotate_file()` iterates over the configured log files in `apisix/plugins/log-rotate.lua`. Before this patch, if `rename_file()` returned `nil` for any configured file, `rotate_file()` returned immediately from the loop before reaching the USR1 reopen step.

That means this sequence could happen:

1. `error.log` is renamed to a timestamped file.
2. `access.log` is missing, so `rename_file()` returns `nil`.
3. `rotate_file()` returns before sending USR1 to the master process.
4. The master keeps writing through stale file descriptors, so later plugin logs and access logs do not appear at the canonical current log paths.

### Fix

- Continue rotating the remaining configured files when one file is missing or cannot be renamed.
- Track only files that actually have a rotated target.
- Send USR1 if at least one log file was rotated.
- Keep the degenerate both-files-missing case as a no-op by skipping USR1 when there are no rotated files.

### Tests

- Added a regression test in `t/plugin/log-rotate.t` using three pipelined requests:
  - `/setup`: configure a log-phase `serverless-post-function`, remove `access.log`, wait for partial rotation, then disable `log-rotate` to stabilize assertions.
  - `/hello`: trigger both plugin error-log output and access-log output.
  - `/verify`: assert the current `error.log` contains the plugin marker and current `access.log` contains the request.
- The test explicitly avoids a single-request assertion shape because log-phase plugins run after the response has been sent.

Validation run:

```bash
PATH=/usr/local/openresty/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/luajit/bin:$PATH \
FLUSH_ETCD=1 prove -Itest-nginx/lib -I. t/plugin/log-rotate.t
```

Result after the fix:

```text
t/plugin/log-rotate.t .. ok
All tests successful.
Files=1, Tests=23, Result: PASS
```

Additional manual check:

- Temporarily changed the regression setup to remove `error.log` while leaving `access.log` present; the same command passed all 23 tests after the fix.
