### PR TITLE
docs(jwt-auth): fix missing TabItem tag in zh docs

### DIFF
--- a/docs/zh/latest/plugins/jwt-auth.md
+++ b/docs/zh/latest/plugins/jwt-auth.md
@@ -1225,6 +1225,7 @@ values={[
 {label: 'Ingress Controller', value: 'ingress'}
 ]}>
 
+<TabItem value="dashboard">
 以下示例演示了如何在 `X-Consumer-Custom-Id` 标头中将消费者自定义 ID 附加到已验证的请求，该 ID 可用于根据需要实现其他逻辑。
 
 创建带有自定义 ID 标签的消费者 `jack`：


### PR DESCRIPTION
## Description

Fix a missing `<TabItem value="dashboard">` opening tag in the Chinese version of `jwt-auth.md`.

## Root Cause

PR #13248 introduced Admin API / ADC / Ingress Controller tabs to the jwt-auth documentation. The English version was correctly structured, but the Chinese version in the **"在请求头中添加消费者自定义 ID"** section was missing the opening `<TabItem value="dashboard">` tag, resulting in:

```
SyntaxError: Expected corresponding JSX closing tag for <Tabs>. (1112:0)
```

## Impact

This has been **breaking the `apisix-website` scheduled CI build** (`Test and Deploy Website` workflow) since **2026-04-24**, preventing any website deployments for 3+ weeks.

- ✅ Last successful build: [2026-04-23 (run 24819113515)](https://github.com/apache/apisix-website/actions/runs/24819113515)
- ❌ First failure: [2026-04-24 (run 24874475333)](https://github.com/apache/apisix-website/actions/runs/24874475333)

The April 23 build succeeded because the docs cache had not yet synced the broken file.

## Fix

Add the missing `<TabItem value="dashboard">` opening tag after the `<Tabs>` definition, matching the structure of the English version.