### PR TITLE
feat(jwt-auth): support key_claim_name in JWT header with tests and docs

### DIFF
--- a/apisix/plugins/jwt-auth.lua
+++ b/apisix/plugins/jwt-auth.lua
@@ -306,7 +306,7 @@ local function find_consumer(conf, ctx)
                    ", key claim name: ", conf.key_claim_name)
 
     local key_claim_name = conf.key_claim_name
-    local user_key = jwt.payload and jwt.payload[key_claim_name]
+    local user_key = (jwt.payload and jwt.payload[key_claim_name]) or (jwt.header and jwt.header[key_claim_name])
     if not user_key then
         return nil, nil, "missing user key in JWT token"
     end

--- a/docs/en/latest/plugins/jwt-auth.md
+++ b/docs/en/latest/plugins/jwt-auth.md
@@ -71,7 +71,7 @@ The following attributes are available for configurations on Routes or Services.
 | claims_to_verify | array[string] | False | ["exp", "nbf"] | combination of `exp` and `nbf` | Specify the JWT claim(s) to verify, to ensure that the token is used within its allowed timeframe. Note that this is not the claims required to be presented in the payload, but the claims to verify, if presented. |
 | store_in_ctx | boolean | False | false | | If true, store JWT payload in the request context variable `ctx.jwt_auth_payload`. This allows plugins executed after `jwt-auth` on the same request to retrieve and use the payload information. |
 | realm | string | False | jwt | | The realm to include in the `WWW-Authenticate` header when authentication fails. |
-| key_claim_name | string | False | key | | The claim in the JWT payload that identifies the associated secret, such as `iss`. |
+| key_claim_name | string | False | key | | The name of the claim used to identify the Consumer. The plugin first checks the JWT **Payload**; if the claim is absent there, it falls back to the JWT **Header**. This allows the identifying claim to be placed in the header only, as many identity providers do by default. Note that this lookup is used to match an APISIX Consumer `key` and is not full OIDC/JWKS key discovery. |
 
 You can implement `jwt-auth` with [HashiCorp Vault](https://www.vaultproject.io/) to store and fetch secrets and RSA key pairs from its [encrypted KV engine](https://developer.hashicorp.com/vault/docs/secrets/kv) using the [APISIX Secret](../terminology/secret.md) resource.
 
@@ -1677,3 +1677,90 @@ You should see the following response, showing that only one request was success
 ```text
 200:    1, 429:    4
 ```
+
+### Authenticate Consumer Using Claim in JWT Header
+
+The following example demonstrates how to authenticate a Consumer when the identifying claim is placed in the JWT **Header** rather than the Payload. This is the default behavior of many identity providers.
+
+By default, `jwt-auth` uses the claim named `key` (configurable via `key_claim_name`) to look up the Consumer. The plugin checks the JWT Payload first. If the claim is not found there, it falls back to the JWT Header. When the claim exists in both locations, the Payload value takes precedence.
+
+Create a Consumer `jack`:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "username": "jack"
+  }'
+```
+
+Create `jwt-auth` Credential for the Consumer:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "cred-jack-jwt-auth",
+    "plugins": {
+      "jwt-auth": {
+        "key": "jack-key",
+        "secret": "jack-hs256-secret-that-is-very-long"
+      }
+    }
+  }'
+```
+
+Create a Route with `jwt-auth`:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "jwt-route",
+    "uri": "/headers",
+    "plugins": {
+      "jwt-auth": {}
+    },
+    "upstream": {
+      "type": "roundrobin",
+      "nodes": {
+        "httpbin.org:80": 1
+      }
+    }
+  }'
+```
+
+Issue a JWT where the `key` claim is in the **Header** only, with no `key` in the Payload. Your token header and payload should look similar to the following:
+
+Header:
+```json
+{
+  "alg": "HS256",
+  "typ": "JWT",
+  "key": "jack-key"
+}
+```
+
+Payload:
+```json
+{
+  "nbf": 1729132271
+}
+```
+
+Copy the generated JWT and save to a variable:
+
+```shell
+export jwt_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtleSI6ImphY2sta2V5In0.eyJuYmYiOjE3MjkxMzIyNzF9.XyUXVSEvFyUDYdukQNUyBErzqJnMBe6v3gssncVLFXY
+```
+
+Send a request to the Route with the JWT in the `Authorization` header:
+
+```shell
+curl -i "http://127.0.0.1:9080/headers" -H "Authorization: ${jwt_token}"
+```
+
+You should receive an `HTTP/1.1 200 OK` response, confirming that the Consumer was identified from the JWT Header claim.
+
+> [!NOTE]
+> If the same claim appears in both the Payload and the Header with different values, the **Payload value always takes precedence**. The Header is consulted only as a fallback when the claim is absent from the Payload.

--- a/docs/zh/latest/plugins/jwt-auth.md
+++ b/docs/zh/latest/plugins/jwt-auth.md
@@ -71,7 +71,7 @@ import TabItem from '@theme/TabItem';
 | claims_to_verify | array[string] | 否 | ["exp", "nbf"] | `exp` 和 `nbf` 的组合 | 指定需要验证的 JWT 声明，以确保令牌在其允许的时间范围内使用。注意，这不是要求 payload 中必须存在的声明，而是在声明存在时进行验证。 |
 | store_in_ctx | boolean | 否 | false | | 若为 true，则将 JWT payload 存储在请求上下文变量 `ctx.jwt_auth_payload` 中，以便在同一请求中在 `jwt-auth` 之后执行的插件获取和使用 payload 信息。 |
 | realm | string | 否 | jwt | | 身份验证失败时，在 `WWW-Authenticate` 响应头中包含的 realm 值。 |
-| key_claim_name | string | 否 | key | | JWT payload 中用于标识关联密钥的声明，例如 `iss`。 |
+| key_claim_name | string | 否 | key | | 用于识别消费者的 claim 名称。插件首先在 JWT **Payload** 中查找该 claim；若不存在，则回退到 JWT **Header** 中查找。这使得识别性 claim 可以仅放置在 Header 中，这也是许多身份提供商的默认行为。注意，此查找用于匹配 APISIX Consumer 的 `key`，并非完整的 OIDC/JWKS 密钥发现机制。 |
 
 你可以将 `jwt-auth` 与 [HashiCorp Vault](https://www.vaultproject.io/) 结合使用，通过 [APISIX Secret](../terminology/secret.md) 资源从其[加密 KV 引擎](https://developer.hashicorp.com/vault/docs/secrets/kv)中存储和获取密钥及 RSA 密钥对。
 
@@ -1678,3 +1678,91 @@ resp=$(seq 5 | xargs -I{} curl "http://127.0.0.1:9080/anything" -o /dev/null -s 
 ```text
 200:    1, 429:    4
 ```
+
+
+### 通过 JWT Header 中的 Claim 认证消费者
+
+以下示例演示当识别性 claim 仅放置在 JWT **Header** 而非 Payload 中时，如何对消费者进行身份验证。这是许多身份提供商的默认行为。
+
+默认情况下，`jwt-auth` 使用名为 `key` 的 claim（可通过 `key_claim_name` 配置）来查找消费者。插件首先检查 JWT Payload，若未找到该 claim，则回退到 JWT Header。当两处均存在该 claim 时，Payload 中的值优先。
+
+创建消费者 `jack`：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "username": "jack"
+  }'
+```
+
+为消费者创建 `jwt-auth` 凭据：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers/jack/credentials" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "cred-jack-jwt-auth",
+    "plugins": {
+      "jwt-auth": {
+        "key": "jack-key",
+        "secret": "jack-hs256-secret-that-is-very-long"
+      }
+    }
+  }'
+```
+
+创建带有 `jwt-auth` 插件的路由：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "jwt-route",
+    "uri": "/headers",
+    "plugins": {
+      "jwt-auth": {}
+    },
+    "upstream": {
+      "type": "roundrobin",
+      "nodes": {
+        "httpbin.org:80": 1
+      }
+    }
+  }'
+```
+
+签发一个 `key` claim 仅在 **Header** 中、Payload 中不含 `key` 的 JWT。令牌的 Header 和 Payload 应类似如下所示：
+
+Header：
+```json
+{
+  "alg": "HS256",
+  "typ": "JWT",
+  "key": "jack-key"
+}
+```
+
+Payload：
+```json
+{
+  "nbf": 1729132271
+}
+```
+
+复制生成的 JWT 并保存到变量：
+
+```shell
+export jwt_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtleSI6ImphY2sta2V5In0.eyJuYmYiOjE3MjkxMzIyNzF9.XyUXVSEvFyUDYdukQNUyBErzqJnMBe6v3gssncVLFXY
+```
+
+携带 JWT 在 `Authorization` 请求头中向路由发送请求：
+
+```shell
+curl -i "http://127.0.0.1:9080/headers" -H "Authorization: ${jwt_token}"
+```
+
+你应收到 `HTTP/1.1 200 OK` 响应，确认消费者已通过 JWT Header 中的 claim 成功识别。
+
+> [!NOTE]
+> 若同一 claim 同时出现在 Payload 和 Header 中且值不同，**Payload 中的值始终优先**。仅当 Payload 中不存在该 claim 时，才会查找 Header。

--- a/t/plugin/jwt-auth.t
+++ b/t/plugin/jwt-auth.t
@@ -1301,3 +1301,116 @@ passed
 {"message":"failed to verify jwt"}
 --- error_log
 failed to verify jwt: algorithm mismatch, expected RS256
+
+
+
+=== TEST 53: add consumer for key_claim_name header fallback tests
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack",
+                    "plugins": {
+                        "jwt-auth": {
+                            "key": "user-key",
+                            "secret": "my-secret-key"
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 54: enable jwt-auth on route for key_claim_name header fallback tests
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "jwt-auth": {}
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 55: verify key_claim_name in JWT header only — consumer is found, request succeeds
+--- request
+GET /hello
+--- more_headers
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtleSI6InVzZXIta2V5In0.eyJleHAiOjE4NzkzMTg1NDF9.mfdV56taaBg98nlxspmAKc8FTrfM3LeyaXfU6v8hi5k
+--- response_body
+hello world
+
+
+
+=== TEST 56: verify key_claim_name in JWT payload only — backward compatibility preserved
+--- request
+GET /hello
+--- more_headers
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTg3OTMxODU0MX0.fNtFJnNmJgzbiYmGB0Yjvm-l6A6M4jRV1l4mnVFSYjs
+--- response_body
+hello world
+
+
+
+=== TEST 57: verify payload takes priority — correct payload key succeeds even if header key differs
+--- request
+GET /hello
+--- more_headers
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtleSI6Indyb25nLWtleSJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTg3OTMxODU0MX0.3IGMKrA9hHuh-FXvwLGKD63NjzXp5x8l3Iw0Nt45Ytc
+--- response_body
+hello world
+
+
+
+=== TEST 58: verify payload takes priority — wrong payload key causes 401 even if header key is correct
+--- request
+GET /hello
+--- more_headers
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtleSI6InVzZXIta2V5In0.eyJrZXkiOiJ3cm9uZy1rZXkiLCJleHAiOjE4NzkzMTg1NDF9.WYH4_8p30eBrTjoV234YrVvjHWnJOlMueyKHfMfaRmU
+--- error_code: 401
+--- response_body
+{"message":"failed to find consumer"}
+
+
+
+=== TEST 59: verify key_claim_name missing from both header and payload — returns "missing user key in JWT token"
+--- request
+GET /hello
+--- more_headers
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJub2JvZHkiLCJleHAiOjE4NzkzMTg1NDF9.7ChRgz00VVF_5HC3q8oVGYsBPXqTowZUBmVFWr0QQbA
+--- error_code: 401
+--- response_body
+{"message":"missing user key in JWT token"}


### PR DESCRIPTION
# Description

### Summary
Currently, the `jwt-auth` plugin strictly searches for the `key_claim_name` (used to identify the Consumer) within the **JWT Payload**. However, many identity providers and standard JWT implementations place the Key ID (`kid`) or issuer (`iss`) solely in the **JWT Header**.

This PR enhances the plugin to fall back to the JWT **Header** when the configured key_claim_name claim is absent from the **Payload**, making jwt-auth compatible with standard OIDC and third-party JWT providers without requiring payload modifications.

### Why this is needed
In many security architectures, the **Header** contains the metadata required to identify which key or secret should be used to verify the signature. By restricting the lookup to the Payload, APISIX currently forces developers to either:
1. **Non-standardly duplicate** the `kid` into the Payload.
2. **Write custom serverless functions** or modify core code to handle standard JWTs.

This change makes the `jwt-auth` plugin more robust and "plug-and-play" for modern authentication flows.

### Changes
- **Plugin Logic:** Modified `find_consumer` in `apisix/plugins/jwt-auth.lua`.
- **Fallback Mechanism:** Updated the `user_key` lookup to check the JWT Header if the claim is missing from the Payload.
- **Backward Compatibility:** Maintained existing behavior by prioritizing the Payload if the claim exists in both locations.
- **Tests:** Added test cases to `t/plugin/jwt-auth.t` covering:
  * claim in JWT Header only -> Consumer identified, request succeeds
  * claim in JWT Payload only -> backward compatibility confirmed
  * claim in both Header and Payload -> Payload value takes precedence
  * claim missing from both -> original error message preserved
- **Docs:** Updated key_claim_name attribute description and added a new
  example section in both English and Chinese documentation.

### Verification Results
- [x] **Test Case 1:** JWT with `kid` in Header only (HS512) -> **Passed** (Consumer identified, Signature verified).
- [x] **Test Case 2:** JWT with claim in Payload only -> **Passed** (Backward compatibility confirmed).
- [x] **Test Case 3:** JWT with claim in both Header and Payload -> **Passed** (Payload prioritized).