### PR TITLE
docs: update AI plugin order in config example

### DIFF
--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -513,14 +513,16 @@ plugins:                           # plugin list (sorted by priority)
   #- error-log-logger              # priority: 1091
   - proxy-cache                    # priority: 1085
   - body-transformer               # priority: 1080
+  - ai-request-rewrite             # priority: 1073
+  - ai-prompt-guard                # priority: 1072
   - ai-prompt-template             # priority: 1071
   - ai-prompt-decorator            # priority: 1070
-  - ai-prompt-guard                # priority: 1072
   - ai-rag                         # priority: 1060
   - ai-aws-content-moderation      # priority: 1050
   - ai-proxy-multi                 # priority: 1041
   - ai-proxy                       # priority: 1040
   - ai-rate-limiting               # priority: 1030
+  - ai-aliyun-content-moderation   # priority: 1029
   - proxy-mirror                   # priority: 1010
   - proxy-rewrite                  # priority: 1008
   - workflow                       # priority: 1006


### PR DESCRIPTION
Description
This PR updates the AI plugin section in `conf/config.yaml.example`.

Changes
* Added missing `ai-request-rewrite` plugin
* Added missing `ai-aliyun-content-moderation` plugin
* Reordered AI plugins to match descending plugin priorities

Fixes #13108
