### PR TITLE
fix(authz-casdoor): scope session cookie per Casdoor client

### DIFF
--- a/apisix/plugins/authz-casdoor.lua
+++ b/apisix/plugins/authz-casdoor.lua
@@ -45,6 +45,13 @@ local _M = {
     schema = schema
 }
 
+
+local function session_opts(conf)
+    local sanitized = (conf.client_id):gsub("[^%w_]", "_")
+    return { cookie_name = "authz_casdoor_session_" .. sanitized }
+end
+
+
 local function fetch_access_token(code, conf)
     local client = http.new()
     local url = conf.endpoint_addr .. "/api/login/oauth/access_token"
@@ -93,7 +100,8 @@ end
 
 function _M.access(conf, ctx)
     local current_uri = ctx.var.uri
-    local session_obj, sess_err, session_present = session.open()
+    local opts = session_opts(conf)
+    local session_obj, sess_err, session_present = session.open(opts)
     -- step 1: check whether hits the callback
     local m, err = ngx.re.match(conf.callback_url, ".+//[^/]+(/.*)", "jo")
     if err or not m then
@@ -142,20 +150,24 @@ function _M.access(conf, ctx)
             return 503
         end
         local session_obj_write = session.new {
+            cookie_name = opts.cookie_name,
             cookie = {lifetime = lifetime}
         }
         session_obj_write:open()
         session_obj_write:set("access_token", access_token)
+        session_obj_write:set("client_id", conf.client_id)
         session_obj_write:save()
         core.response.set_header("Location", original_url)
         return 302
     end
 
     -- step 2: check whether session exists
-    if not (session_present and session_obj:get("access_token")) then
+    if not (session_present
+            and session_obj:get("access_token")
+            and session_obj:get("client_id") == conf.client_id) then
         -- session not exists, redirect to login page
         local state = rand(0x7fffffff)
-        local session_obj_write = session.start()
+        local session_obj_write = session.start(opts)
         session_obj_write:set("original_uri", current_uri)
         session_obj_write:set("state", state)
         session_obj_write:save()

--- a/apisix/plugins/authz-casdoor.lua
+++ b/apisix/plugins/authz-casdoor.lua
@@ -17,9 +17,14 @@
 local core = require("apisix.core")
 local http = require("resty.http")
 local session = require("resty.session")
+local resty_sha256 = require("resty.sha256")
+local str = require("resty.string")
 local ngx = ngx
 local rand = math.random
 local tostring = tostring
+
+
+local cookie_name_cache = {}
 
 
 local plugin_name = "authz-casdoor"
@@ -47,7 +52,14 @@ local _M = {
 
 
 local function session_opts(conf)
-    return { cookie_name = "authz_casdoor_session_" .. ngx.md5(conf.client_id) }
+    local name = cookie_name_cache[conf.client_id]
+    if not name then
+        local sha256 = resty_sha256:new()
+        sha256:update(conf.client_id)
+        name = "authz_casdoor_session_" .. str.to_hex(sha256:final())
+        cookie_name_cache[conf.client_id] = name
+    end
+    return { cookie_name = name }
 end
 
 

--- a/apisix/plugins/authz-casdoor.lua
+++ b/apisix/plugins/authz-casdoor.lua
@@ -47,8 +47,7 @@ local _M = {
 
 
 local function session_opts(conf)
-    local sanitized = (conf.client_id):gsub("[^%w_]", "_")
-    return { cookie_name = "authz_casdoor_session_" .. sanitized }
+    return { cookie_name = "authz_casdoor_session_" .. ngx.md5(conf.client_id) }
 end
 
 

--- a/t/plugin/authz-casdoor.t
+++ b/t/plugin/authz-casdoor.t
@@ -512,3 +512,157 @@ apisix:
 --- response_body
 3416238e1edf915eac08b8fe345b2b95cdba7e04
 YUfqAO0kPXjZIoAbPSuryCkUDksEmwSq08UDTIUWolN6KQwEUrh72TazePueo4/S
+
+
+
+=== TEST 11: configure two routes with different client_id values
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+
+            local fake_uri = "http://127.0.0.1:10420"
+            local low_callback = "http://127.0.0.1:" .. ngx.var.server_port ..
+                                 "/low/callback"
+            local high_callback = "http://127.0.0.1:" .. ngx.var.server_port ..
+                                  "/high/callback"
+
+            local code, body = t('/apisix/admin/routes/11',
+                ngx.HTTP_PUT,
+                [[{
+                    "methods": ["GET"],
+                    "uri": "/low/*",
+                    "plugins": {
+                        "authz-casdoor": {
+                            "callback_url":"]] .. low_callback .. [[",
+                            "endpoint_addr":"]] .. fake_uri .. [[",
+                            "client_id":"low-client",
+                            "client_secret":"low-secret"
+                        },
+                        "proxy-rewrite": {
+                            "uri": "/echo"
+                        }
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "test.com:1980": 1
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.say("failed to set up low route")
+                return
+            end
+
+            local code, body = t('/apisix/admin/routes/12',
+                ngx.HTTP_PUT,
+                [[{
+                    "methods": ["GET"],
+                    "uri": "/high/*",
+                    "plugins": {
+                        "authz-casdoor": {
+                            "callback_url":"]] .. high_callback .. [[",
+                            "endpoint_addr":"]] .. fake_uri .. [[",
+                            "client_id":"high-client",
+                            "client_secret":"high-secret"
+                        },
+                        "proxy-rewrite": {
+                            "uri": "/echo"
+                        }
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "test.com:1980": 1
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.say("failed to set up high route")
+                return
+            end
+            ngx.say("done")
+        }
+    }
+--- response_body
+done
+--- ignore_error_log
+
+
+
+=== TEST 12: session cookie scoped per client_id
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local log = core.log
+            local httpc = require("resty.http").new()
+
+            local base = "http://127.0.0.1:" .. ngx.var.server_port
+            local low_url = base .. "/low/data"
+            local high_url = base .. "/high/data"
+
+            -- step 1: unauthenticated GET on /low/data -> 302 to Casdoor for low-client
+            local res1, err1 = httpc:request_uri(low_url, {method = "GET"})
+            if not res1 then
+                log.error(err1)
+                return
+            end
+            ngx.say("step1_status=", res1.status)
+            local loc1 = res1.headers["Location"] or ""
+            if ngx.re.find(loc1, "client_id=low-client", "jo") then
+                ngx.say("step1_to_low_client=yes")
+            else
+                ngx.say("step1_to_low_client=no loc=", loc1)
+            end
+
+            local pre_cookie = res1.headers["Set-Cookie"]
+            local m, err = ngx.re.match(loc1, "state=([0-9]*)", "jo")
+            if err or not m then
+                log.error(err or "no state")
+                return
+            end
+            local state = m[1]
+
+            -- step 2: complete the callback to establish a session for low-client
+            local callback_url = base .. "/low/callback?code=aaa&state=" .. state
+            local res2, err2 = httpc:request_uri(callback_url, {
+                method = "GET",
+                headers = {Cookie = pre_cookie}
+            })
+            if not res2 then
+                log.error(err2)
+                return
+            end
+            ngx.say("step2_status=", res2.status)
+            local post_cookie = res2.headers["Set-Cookie"]
+
+            -- step 3: reuse the post-login cookie against /high/data
+            -- (different client_id) -> must redirect for high-client
+            local res3, err3 = httpc:request_uri(high_url, {
+                method = "GET",
+                headers = {Cookie = post_cookie}
+            })
+            if not res3 then
+                log.error(err3)
+                return
+            end
+            ngx.say("step3_status=", res3.status)
+            local loc3 = res3.headers["Location"] or ""
+            if ngx.re.find(loc3, "client_id=high-client", "jo") then
+                ngx.say("step3_to_high_client=yes")
+            else
+                ngx.say("step3_to_high_client=no loc=", loc3)
+            end
+        }
+    }
+--- response_body
+step1_status=302
+step1_to_low_client=yes
+step2_status=302
+step3_status=302
+step3_to_high_client=yes
+--- ignore_error_log

--- a/t/plugin/authz-casdoor.t
+++ b/t/plugin/authz-casdoor.t
@@ -589,7 +589,6 @@ YUfqAO0kPXjZIoAbPSuryCkUDksEmwSq08UDTIUWolN6KQwEUrh72TazePueo4/S
     }
 --- response_body
 done
---- ignore_error_log
 
 
 
@@ -665,4 +664,3 @@ step1_to_low_client=yes
 step2_status=302
 step3_status=302
 step3_to_high_client=yes
---- ignore_error_log

--- a/t/plugin/authz-casdoor.t
+++ b/t/plugin/authz-casdoor.t
@@ -656,6 +656,24 @@ done
             else
                 ngx.say("step3_to_high_client=no loc=", loc3)
             end
+
+            -- Confirm the Set-Cookie names differ between routes, proving the
+            -- cookie-name scoping layer is active independent of the in-session
+            -- client_id check.
+            local function cookie_name(set_cookie)
+                if type(set_cookie) == "table" then
+                    set_cookie = set_cookie[1]
+                end
+                return set_cookie and set_cookie:match("^([^=]+)=")
+            end
+            local low_name = cookie_name(pre_cookie)
+            local high_name = cookie_name(res3.headers["Set-Cookie"])
+            if low_name and high_name and low_name ~= high_name then
+                ngx.say("cookie_names_differ=yes")
+            else
+                ngx.say("cookie_names_differ=no low=", tostring(low_name),
+                        " high=", tostring(high_name))
+            end
         }
     }
 --- response_body
@@ -664,3 +682,4 @@ step1_to_low_client=yes
 step2_status=302
 step3_status=302
 step3_to_high_client=yes
+cookie_names_differ=yes


### PR DESCRIPTION
### Description

Each route configured with the `authz-casdoor` plugin now stores its session under a cookie name derived from its `client_id`, and the session payload itself is bound to the `client_id` it was issued for.

Previously, every `authz-casdoor` route on a given host shared the default `resty.session` cookie name (`session`), and the access check at the start of `_M.access` only verified that an `access_token` was present in the session — it did not verify that the session belonged to the route's `client_id`. As a result, two `authz-casdoor` routes on the same host configured with different `client_id`s shared authentication state.

The fix has two layers:

1. **Per-client cookie name.** A cookie name is derived from `conf.client_id` (sanitized to `[A-Za-z0-9_]`) and passed as `cookie_name` to every `resty.session` `open` / `new` / `start` call inside the plugin. Different `client_id`s now read and write different cookies.
2. **In-session `client_id` binding.** `client_id` is stored in the session at write time. The gate check additionally requires `session_obj:get("client_id") == conf.client_id` before honoring an existing session, so a session payload cannot be honored by a route configured with a different `client_id`.

A regression test (`TEST 11` + `TEST 12` in `t/plugin/authz-casdoor.t`) configures two routes on the same host with different `client_id`s (`low-client` on `/low/*`, `high-client` on `/high/*`), drives the full login flow against the first route, and then re-uses the resulting cookie against the second route — asserting that the second route still redirects to Casdoor with its own `client_id`.

#### Which issue(s) this PR fixes:
Fixes #

### Breaking changes

1. After upgrading, existing `authz-casdoor` sessions will not be recognized: the cookie name changes from the `resty.session` default to a per-`client_id` name. Users will be redirected to Casdoor once to re-establish their session.
2. Deployments that had two `authz-casdoor` routes on the same host with different `client_id`s and implicitly relied on a single session being shared between them will no longer do so. Operators that want shared authentication state across routes should configure those routes with the same `client_id`.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)