### PR TITLE
docs: sign digest header in hmac-auth example

### DIFF
--- a/docs/en/latest/plugins/hmac-auth.md
+++ b/docs/en/latest/plugins/hmac-auth.md
@@ -887,6 +887,10 @@ body = '{"name": "world"}'          # example request body
 # skew to prolong the validity within the advised security boundary
 gmt_time = datetime.now(timezone.utc).strftime('%a, %d %b %Y %H:%M:%S GMT')
 
+# create the SHA-256 digest of the request body and base64 encode it
+body_digest = hashlib.sha256(body.encode('utf-8')).digest()
+body_digest_base64 = base64.b64encode(body_digest).decode('utf-8')
+
 # construct the signing string (ordered)
 # the date and any subsequent custom headers should be lowercased and separated by a
 # single space character, i.e. `<key>:<space><value>`
@@ -895,15 +899,12 @@ signing_string = (
     f"{key_id}\n"
     f"{request_method} {request_path}\n"
     f"date: {gmt_time}\n"
+    f"digest: SHA-256={body_digest_base64}\n"
 )
 
 # create signature
 signature = hmac.new(secret_key, signing_string.encode('utf-8'), hashlib.sha256).digest()
 signature_base64 = base64.b64encode(signature).decode('utf-8')
-
-# create the SHA-256 digest of the request body and base64 encode it
-body_digest = hashlib.sha256(body.encode('utf-8')).digest()
-body_digest_base64 = base64.b64encode(body_digest).decode('utf-8')
 
 # construct the request headers
 headers = {
@@ -911,7 +912,7 @@ headers = {
     "Digest": f"SHA-256={body_digest_base64}",
     "Authorization": (
         f'Signature keyId="{key_id}",algorithm="hmac-sha256",'
-        f'headers="@request-target date",'
+        f'headers="@request-target date digest",'
         f'signature="{signature_base64}"'
     )
 }
@@ -919,6 +920,9 @@ headers = {
 # print headers
 print(headers)
 ```
+
+When `validate_request_body` is enabled, APISIX validates the `Digest` header against the request body.
+Include `digest` in the signed headers, as shown above, to bind that body digest to the HMAC signature.
 
 Run the script:
 
@@ -929,7 +933,7 @@ python3 hmac-sig-digest-header-gen.py
 You should see the request headers printed:
 
 ```text
-{'Date': 'Fri, 06 Sep 2024 09:16:16 GMT', 'Digest': 'SHA-256=78qzJuLwSpZ8HacsTdFCQJWxzPMOf8bYctRk2ySLpS8=', 'Authorization': 'Signature keyId="john-key",algorithm="hmac-sha256",headers="@request-target date",signature="rjS6NxOBKmzS8CZL05uLiAfE16hXdIpMD/L/HukOTYE="'}
+{'Date': 'Fri, 06 Sep 2024 09:16:16 GMT', 'Digest': 'SHA-256=78qzJuLwSpZ8HacsTdFCQJWxzPMOf8bYctRk2ySLpS8=', 'Authorization': 'Signature keyId="john-key",algorithm="hmac-sha256",headers="@request-target date digest",signature="LGBTz7bVQQWlkijeyDpEwJWo+ppwX735uRZk5F8KhmU="'}
 ```
 
 Using the headers generated, send a request to the Route:
@@ -938,7 +942,7 @@ Using the headers generated, send a request to the Route:
 curl "http://127.0.0.1:9080/post" -X POST \
   -H "Date: Fri, 06 Sep 2024 09:16:16 GMT" \
   -H "Digest: SHA-256=78qzJuLwSpZ8HacsTdFCQJWxzPMOf8bYctRk2ySLpS8=" \
-  -H 'Authorization: Signature keyId="john-key",algorithm="hmac-sha256",headers="@request-target date",signature="rjS6NxOBKmzS8CZL05uLiAfE16hXdIpMD/L/HukOTYE="' \
+  -H 'Authorization: Signature keyId="john-key",algorithm="hmac-sha256",headers="@request-target date digest",signature="LGBTz7bVQQWlkijeyDpEwJWo+ppwX735uRZk5F8KhmU="' \
   -d '{"name": "world"}'
 ```
 
@@ -954,7 +958,7 @@ You should see an `HTTP/1.1 200 OK` response similar to the following:
   },
   "headers": {
     "Accept": "*/*",
-    "Authorization": "Signature keyId=\"john-key\",algorithm=\"hmac-sha256\",headers=\"@request-target date\",signature=\"rjS6NxOBKmzS8CZL05uLiAfE16hXdIpMD/L/HukOTYE=\"",
+    "Authorization": "Signature keyId=\"john-key\",algorithm=\"hmac-sha256\",headers=\"@request-target date digest\",signature=\"LGBTz7bVQQWlkijeyDpEwJWo+ppwX735uRZk5F8KhmU=\"",
     "Content-Length": "17",
     "Content-Type": "application/x-www-form-urlencoded",
     "Date": "Fri, 06 Sep 2024 09:16:16 GMT",
@@ -977,8 +981,8 @@ If you send a request without the digest or with an invalid digest:
 ```shell
 curl "http://127.0.0.1:9080/post" -X POST \
   -H "Date: Fri, 06 Sep 2024 09:16:16 GMT" \
-  -H "Digest: SHA-256=78qzJuLwSpZ8HacsTdFCQJWxzPMOf8bYctRk2ySLpS8=" \
-  -H 'Authorization: Signature keyId="john-key",algorithm="hmac-sha256",headers="@request-target date",signature="rjS6NxOBKmzS8CZL05uLiAfE16hXdIpMD/L/HukOTYE="' \
+  -H "Digest: SHA-256=invalid" \
+  -H 'Authorization: Signature keyId="john-key",algorithm="hmac-sha256",headers="@request-target date digest",signature="LGBTz7bVQQWlkijeyDpEwJWo+ppwX735uRZk5F8KhmU="' \
   -d '{"name": "world"}'
 ```
 


### PR DESCRIPTION
### Description

Update the `hmac-auth` body-validation example so the generated HMAC signature also covers the `Digest` header:

- compute the request body digest before building the signing string
- add `digest: ...` to the signing string
- include `digest` in `headers="@request-target date digest"`
- refresh the printed header, curl, and response examples
- add a short note explaining that `validate_request_body` validates the body against `Digest`, and signing `digest` binds that digest to the HMAC signature

Fixes #13395

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

### Validation

- `git diff --check`
- extracted the documented Python snippet, fixed the timestamp to the sample output value, and verified it prints:
  - `Digest: SHA-256=78qzJuLwSpZ8HacsTdFCQJWxzPMOf8bYctRk2ySLpS8=`
  - `headers="@request-target date digest"`
  - `signature="LGBTz7bVQQWlkijeyDpEwJWo+ppwX735uRZk5F8KhmU="`
