### PR TITLE
feat: support filtering the key and value of labels

### DIFF
--- a/apisix/admin/v3_adapter.lua
+++ b/apisix/admin/v3_adapter.lua
@@ -174,8 +174,8 @@ local function filter(body, args, resource)
         if args.label then
             label_matched = false
             if body.list[i].value.labels then
-                for k, _ in pairs(body.list[i].value.labels) do
-                    if k == args.label then
+                for k, v in pairs(body.list[i].value.labels) do
+                    if k == args.label or k .. ":" .. v == args.label then
                         label_matched = true
                         break
                     end

--- a/t/admin/filter.t
+++ b/t/admin/filter.t
@@ -549,6 +549,14 @@ passed
             res = json.decode(res)
             assert(#res.list == 0)
 
+            -- match labels' key and value
+            code, body, res = t('/apisix/admin/routes/?label=env2:production',
+                ngx.HTTP_GET
+            )
+            res = json.decode(res)
+            assert(#res.list == 1)
+            assert(res.list[1].value.id == "2")
+
             ngx.status = code
             ngx.say(body)
         }


### PR DESCRIPTION
### Description
admin-api, only support filtering labels' key currently, however, in more scenarios, filtering is required based on both key and value, so support filtering the key and value of labels.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
