### PR TITLE
docs: sign Digest header in hmac-auth body validation example

### DIFF
--- a/docs/en/latest/plugins/hmac-auth.md
+++ b/docs/en/latest/plugins/hmac-auth.md
@@ -617,6 +617,10 @@ You should see an `HTTP/1.1 200 OK` response and notice the `Authorization` head
 
 The following example demonstrates how to enable body validation to ensure the integrity of the request body.
 
+:::note
+`validate_request_body` only checks the `Digest` header against the request body; it does not automatically bind the body to the HMAC signature. To ensure the body itself is covered by the signature (preventing tampering without detection), you **must** include the `Digest` header in the signed headers list (the `headers` field in the `Authorization` header). This example shows how to do that.
+:::
+
 <Tabs
 groupId="api"
 defaultValue="admin-api"
@@ -907,6 +911,7 @@ body_digest = hashlib.sha256(body.encode('utf-8')).digest()
 body_digest_base64 = base64.b64encode(body_digest).decode('utf-8')
 
 # construct the request headers
+# Note: To ensure the body is bound to the signature, include the Digest header in the signed headers list.
 headers = {
     "Date": gmt_time,
     "Digest": f"SHA-256={body_digest_base64}",

--- a/docs/en/latest/plugins/hmac-auth.md
+++ b/docs/en/latest/plugins/hmac-auth.md
@@ -895,6 +895,7 @@ signing_string = (
     f"{key_id}\n"
     f"{request_method} {request_path}\n"
     f"date: {gmt_time}\n"
+    f"digest: SHA-256={body_digest_base64}\n"
 )
 
 # create signature
@@ -911,7 +912,7 @@ headers = {
     "Digest": f"SHA-256={body_digest_base64}",
     "Authorization": (
         f'Signature keyId="{key_id}",algorithm="hmac-sha256",'
-        f'headers="@request-target date",'
+        f'headers="@request-target date digest",'
         f'signature="{signature_base64}"'
     )
 }


### PR DESCRIPTION
The body validation example under the `hmac-auth` plugin currently computes a Digest header but does not sign it. This leads to a setup where the body integrity is not bound to the HMAC signature, which can mislead users.

Changes:
- Move body digest computation before signature generation.
- Append the `digest` header to the signing string.
- Include `digest` in the `headers` list of the Authorization header.
- Update the printed example output accordingly.

This ensures the example correctly demonstrates end‑to‑end body integrity, where the body digest is part of the signed material.

Resolves #13395