### PR TITLE
fix: preserve stream service plugin context

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -1352,9 +1352,11 @@ function _M.stream_preread_phase()
     api_ctx.plugins = plugin.stream_filter(matched_route, plugins)
     -- core.log.info("valid plugins: ", core.json.delay_encode(plugins, true))
 
-    api_ctx.conf_type = "stream/route"
-    api_ctx.conf_version = matched_route.modifiedIndex
-    api_ctx.conf_id = matched_route.value.id
+    if not api_ctx.conf_type then
+        api_ctx.conf_type = "stream/route"
+        api_ctx.conf_version = matched_route.modifiedIndex
+        api_ctx.conf_id = matched_route.value.id
+    end
     api_ctx.route_id = matched_route.value.id
     api_ctx.route_name = matched_route.value.name
 

--- a/t/stream-plugin/syslog.t
+++ b/t/stream-plugin/syslog.t
@@ -349,7 +349,123 @@ sending a batch logs to 127.0.0.1:5045
 
 
 
-=== TEST 8: log format in plugin
+=== TEST 8: check service plugin configuration updating
+--- stream_conf_enable
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body1 = t('/apisix/admin/services/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "syslog": {
+                                "host" : "127.0.0.1",
+                                "port" : 5044,
+                                "batch_max_size": 1
+                            }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1995": 1
+                        },
+                        "type": "roundrobin"
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say("fail")
+                return
+            end
+
+            local code, body2 = t('/apisix/admin/stream_routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "service_id": "1"
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say("fail")
+                return
+            end
+
+            ngx.sleep(0.5)
+
+            local sock = ngx.socket.tcp()
+            local ok, err = sock:connect("127.0.0.1", 1985)
+            if not ok then
+                ngx.status = code
+                ngx.say("fail")
+                return
+            end
+
+            assert(sock:send("mmm"))
+            local body3 = assert(sock:receive("*a"))
+
+            local code, body4 = t('/apisix/admin/services/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "syslog": {
+                                "host" : "127.0.0.1",
+                                "port" : 5045,
+                                "batch_max_size": 1
+                            }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1995": 1
+                        },
+                        "type": "roundrobin"
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say("fail")
+                return
+            end
+
+            ngx.sleep(0.5)
+
+            local sock = ngx.socket.tcp()
+            local ok, err = sock:connect("127.0.0.1", 1985)
+            if not ok then
+                ngx.status = code
+                ngx.say("fail")
+                return
+            end
+
+            assert(sock:send("mmm"))
+            local body5 = assert(sock:receive("*a"))
+
+            ngx.print(body1)
+            ngx.print(body2)
+            ngx.print(body3)
+            ngx.print(body4)
+            ngx.print(body5)
+        }
+    }
+--- request
+GET /t
+--- wait: 0.5
+--- response_body
+passedpassedhello world
+passedhello world
+--- grep_error_log eval
+qr/sending a batch logs to 127.0.0.1:(\d+)/
+--- grep_error_log_out
+sending a batch logs to 127.0.0.1:5044
+sending a batch logs to 127.0.0.1:5045
+
+
+
+=== TEST 9: log format in plugin
 --- config
     location /t {
         content_by_lua_block {
@@ -393,7 +509,7 @@ passed
 
 
 
-=== TEST 9: access
+=== TEST 10: access
 --- stream_extra_init_by_lua
     local syslog = require("apisix.plugins.syslog.init")
     local json = require("apisix.core.json")

--- a/t/stream-plugin/syslog.t
+++ b/t/stream-plugin/syslog.t
@@ -355,6 +355,34 @@ sending a batch logs to 127.0.0.1:5045
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
+            local function request_stream()
+                local sock = ngx.socket.tcp()
+                local ok, err = sock:connect("127.0.0.1", 1985)
+                if not ok then
+                    ngx.status = 500
+                    ngx.say("failed to connect: ", err)
+                    return nil
+                end
+
+                local ok, err = sock:send("mmm")
+                if not ok then
+                    sock:close()
+                    ngx.status = 500
+                    ngx.say("failed to send: ", err)
+                    return nil
+                end
+
+                local body, err = sock:receive("*a")
+                sock:close()
+                if not body then
+                    ngx.status = 500
+                    ngx.say("failed to receive: ", err)
+                    return nil
+                end
+
+                return body
+            end
+
             local code, body1 = t('/apisix/admin/services/1',
                 ngx.HTTP_PUT,
                 [[{
@@ -395,16 +423,10 @@ sending a batch logs to 127.0.0.1:5045
 
             ngx.sleep(0.5)
 
-            local sock = ngx.socket.tcp()
-            local ok, err = sock:connect("127.0.0.1", 1985)
-            if not ok then
-                ngx.status = code
-                ngx.say("fail")
+            local body3 = request_stream()
+            if not body3 then
                 return
             end
-
-            assert(sock:send("mmm"))
-            local body3 = assert(sock:receive("*a"))
 
             local code, body4 = t('/apisix/admin/services/1',
                 ngx.HTTP_PUT,
@@ -433,16 +455,10 @@ sending a batch logs to 127.0.0.1:5045
 
             ngx.sleep(0.5)
 
-            local sock = ngx.socket.tcp()
-            local ok, err = sock:connect("127.0.0.1", 1985)
-            if not ok then
-                ngx.status = code
-                ngx.say("fail")
+            local body5 = request_stream()
+            if not body5 then
                 return
             end
-
-            assert(sock:send("mmm"))
-            local body5 = assert(sock:receive("*a"))
 
             ngx.print(body1)
             ngx.print(body2)


### PR DESCRIPTION
When a stream route references a service, APISIX already builds a merged stream route and records a `stream_route&service` context. That context was then overwritten with route-only values before plugin execution, so plugin-level caches could keep using the old service plugin config until the route changed or the worker restarted.

This keeps the service-aware context for stream routes backed by a service, while preserving the existing route-only context for standalone stream routes.
