### PR TITLE
test: relax version assertions

### DIFF
--- a/t/admin/ssl4.t
+++ b/t/admin/ssl4.t
@@ -196,7 +196,7 @@ received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
-received: Server: APISIX/\d\.\d+(\.\d+)?
+received: Server: APISIX/[0-9A-Za-z._+-]+
 received: \nreceived: hello world
 close: 1 nil}
 --- error_log
@@ -222,7 +222,7 @@ received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
-received: Server: APISIX/\d\.\d+(\.\d+)?
+received: Server: APISIX/[0-9A-Za-z._+-]+
 received: \nreceived: hello world
 close: 1 nil}
 --- error_log
@@ -261,7 +261,7 @@ received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
-received: Server: APISIX/\d\.\d+(\.\d+)?
+received: Server: APISIX/[0-9A-Za-z._+-]+
 received: \nreceived: hello world
 close: 1 nil}
 --- ignore_error_log
@@ -337,7 +337,7 @@ received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
-received: Server: APISIX/\d\.\d+(\.\d+)?
+received: Server: APISIX/[0-9A-Za-z._+-]+
 received: \nreceived: hello world
 close: 1 nil}
 --- error_log

--- a/t/node/remote-addr-ipv6.t
+++ b/t/node/remote-addr-ipv6.t
@@ -101,7 +101,7 @@ received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
-received: Server: APISIX/\d\.\d+(\.\d+)?
+received: Server: APISIX/[0-9A-Za-z._+-]+
 received:
 received: hello world
 failed to receive a line: closed \[\]

--- a/t/plugin/loggly.t
+++ b/t/plugin/loggly.t
@@ -362,7 +362,7 @@ opentracing
 --- grep_error_log eval
 qr/message received: [ -~]+/
 --- grep_error_log_out eval
-qr/message received: <10>1 [\d\-T:.]+Z [\d.]+ apisix [\d]+ - \[token-1\@41058 tag="apisix"] \{"apisix_latency":[\d.]*,"client_ip":"127\.0\.0\.1","latency":[\d.]*,"request":\{"headers":\{"content-type":"application\/x-www-form-urlencoded","host":"127\.0\.0\.1:1984","user-agent":"lua-resty-http\/[\d.]* \(Lua\) ngx_lua\/[\d]*"\},"method":"GET","querystring":\{\},"size":[\d]+,"uri":"\/opentracing","url":"http:\/\/127\.0\.0\.1:1984\/opentracing"\},"response":\{"headers":\{"connection":"close","content-type":"text\/plain","server":"APISIX\/[\d.]+","transfer-encoding":"chunked"\},"size":[\d]*,"status":200\},"route_id":"1","server":\{"hostname":"[ -~]*","version":"[\d.]+"\},"service_id":"","start_time":[\d]*,"upstream":"127\.0\.0\.1:1982","upstream_latency":[\d]*\}/
+qr/message received: <10>1 [\d\-T:.]+Z [\d.]+ apisix [\d]+ - \[token-1\@41058 tag="apisix"] \{"apisix_latency":[\d.]*,"client_ip":"127\.0\.0\.1","latency":[\d.]*,"request":\{"headers":\{"content-type":"application\/x-www-form-urlencoded","host":"127\.0\.0\.1:1984","user-agent":"lua-resty-http\/[\d.]* \(Lua\) ngx_lua\/[\d]*"\},"method":"GET","querystring":\{\},"size":[\d]+,"uri":"\/opentracing","url":"http:\/\/127\.0\.0\.1:1984\/opentracing"\},"response":\{"headers":\{"connection":"close","content-type":"text\/plain","server":"APISIX\/[0-9A-Za-z._+-]+","transfer-encoding":"chunked"\},"size":[\d]*,"status":200\},"route_id":"1","server":\{"hostname":"[ -~]*","version":"[0-9A-Za-z._+-]+"\},"service_id":"","start_time":[\d]*,"upstream":"127\.0\.0\.1:1982","upstream_latency":[\d]*\}/
 
 
 
@@ -410,7 +410,7 @@ opentracing
 --- grep_error_log eval
 qr/message received: [ -~]+/
 --- grep_error_log_out eval
-qr/message received: <14>1 [\d\-T:.]+Z [\d.]+ apisix [\d]+ - \[tok\@41058 tag="apisix"] \{"apisix_latency":[\d.]*,"client_ip":"127\.0\.0\.1","latency":[\d.]*,"request":\{"headers":\{"content-type":"application\/x-www-form-urlencoded","host":"127\.0\.0\.1:1984","user-agent":"lua-resty-http\/[\d.]* \(Lua\) ngx_lua\/[\d]*"\},"method":"GET","querystring":\{\},"size":[\d]+,"uri":"\/opentracing","url":"http:\/\/127\.0\.0\.1:1984\/opentracing"\},"response":\{"body":"opentracing\\n","headers":\{"connection":"close","content-type":"text\/plain","server":"APISIX\/[\d.]+","transfer-encoding":"chunked"\},"size":[\d]*,"status":200\},"route_id":"1","server":\{"hostname":"[ -~]*","version":"[\d.]+"\},"service_id":"","start_time":[\d]*,"upstream":"127\.0\.0\.1:1982","upstream_latency":[\d]*\}/
+qr/message received: <14>1 [\d\-T:.]+Z [\d.]+ apisix [\d]+ - \[tok\@41058 tag="apisix"] \{"apisix_latency":[\d.]*,"client_ip":"127\.0\.0\.1","latency":[\d.]*,"request":\{"headers":\{"content-type":"application\/x-www-form-urlencoded","host":"127\.0\.0\.1:1984","user-agent":"lua-resty-http\/[\d.]* \(Lua\) ngx_lua\/[\d]*"\},"method":"GET","querystring":\{\},"size":[\d]+,"uri":"\/opentracing","url":"http:\/\/127\.0\.0\.1:1984\/opentracing"\},"response":\{"body":"opentracing\\n","headers":\{"connection":"close","content-type":"text\/plain","server":"APISIX\/[0-9A-Za-z._+-]+","transfer-encoding":"chunked"\},"size":[\d]*,"status":200\},"route_id":"1","server":\{"hostname":"[ -~]*","version":"[0-9A-Za-z._+-]+"\},"service_id":"","start_time":[\d]*,"upstream":"127\.0\.0\.1:1982","upstream_latency":[\d]*\}/
 
 
 
@@ -463,7 +463,7 @@ opentracing
 --- grep_error_log eval
 qr/message received: [ -~]+/
 --- grep_error_log_out eval
-qr/message received: <14>1 [\d\-T:.]+Z [\d.]+ apisix [\d]+ - \[tok\@41058 tag="apisix"] \{"apisix_latency":[\d.]*,"client_ip":"127\.0\.0\.1","latency":[\d.]*,"request":\{"headers":\{"content-type":"application\/x-www-form-urlencoded","host":"127\.0\.0\.1:1984","user-agent":"lua-resty-http\/[\d.]* \(Lua\) ngx_lua\/[\d]*"\},"method":"GET","querystring":\{"bar":"bar"\},"size":[\d]+,"uri":"\/opentracing\?bar=bar","url":"http:\/\/127\.0\.0\.1:1984\/opentracing\?bar=bar"\},"response":\{"body":"opentracing\\n","headers":\{"connection":"close","content-type":"text\/plain","server":"APISIX\/[\d.]+","transfer-encoding":"chunked"\},"size":[\d]*,"status":200\},"route_id":"1","server":\{"hostname":"[ -~]*","version":"[\d.]+"\},"service_id":"","start_time":[\d]*,"upstream":"127\.0\.0\.1:1982","upstream_latency":[\d]*\}/
+qr/message received: <14>1 [\d\-T:.]+Z [\d.]+ apisix [\d]+ - \[tok\@41058 tag="apisix"] \{"apisix_latency":[\d.]*,"client_ip":"127\.0\.0\.1","latency":[\d.]*,"request":\{"headers":\{"content-type":"application\/x-www-form-urlencoded","host":"127\.0\.0\.1:1984","user-agent":"lua-resty-http\/[\d.]* \(Lua\) ngx_lua\/[\d]*"\},"method":"GET","querystring":\{"bar":"bar"\},"size":[\d]+,"uri":"\/opentracing\?bar=bar","url":"http:\/\/127\.0\.0\.1:1984\/opentracing\?bar=bar"\},"response":\{"body":"opentracing\\n","headers":\{"connection":"close","content-type":"text\/plain","server":"APISIX\/[0-9A-Za-z._+-]+","transfer-encoding":"chunked"\},"size":[\d]*,"status":200\},"route_id":"1","server":\{"hostname":"[ -~]*","version":"[0-9A-Za-z._+-]+"\},"service_id":"","start_time":[\d]*,"upstream":"127\.0\.0\.1:1982","upstream_latency":[\d]*\}/
 
 
 
@@ -487,7 +487,7 @@ opentracing
 --- grep_error_log eval
 qr/message received: [ -~]+/
 --- grep_error_log_out eval
-qr/message received: <14>1 [\d\-T:.]+Z [\d.]+ apisix [\d]+ - \[tok\@41058 tag="apisix"] \{"apisix_latency":[\d.]*,"client_ip":"127\.0\.0\.1","latency":[\d.]*,"request":\{"headers":\{"content-type":"application\/x-www-form-urlencoded","host":"127\.0\.0\.1:1984","user-agent":"lua-resty-http\/[\d.]* \(Lua\) ngx_lua\/[\d]*"\},"method":"GET","querystring":\{"foo":"bar"\},"size":[\d]+,"uri":"\/opentracing\?foo=bar","url":"http:\/\/127\.0\.0\.1:1984\/opentracing\?foo=bar"\},"response":\{"headers":\{"connection":"close","content-type":"text\/plain","server":"APISIX\/[\d.]+","transfer-encoding":"chunked"\},"size":[\d]*,"status":200\},"route_id":"1","server":\{"hostname":"[ -~]*","version":"[\d.]+"\},"service_id":"","start_time":[\d]*,"upstream":"127\.0\.0\.1:1982","upstream_latency":[\d]*\}/
+qr/message received: <14>1 [\d\-T:.]+Z [\d.]+ apisix [\d]+ - \[tok\@41058 tag="apisix"] \{"apisix_latency":[\d.]*,"client_ip":"127\.0\.0\.1","latency":[\d.]*,"request":\{"headers":\{"content-type":"application\/x-www-form-urlencoded","host":"127\.0\.0\.1:1984","user-agent":"lua-resty-http\/[\d.]* \(Lua\) ngx_lua\/[\d]*"\},"method":"GET","querystring":\{"foo":"bar"\},"size":[\d]+,"uri":"\/opentracing\?foo=bar","url":"http:\/\/127\.0\.0\.1:1984\/opentracing\?foo=bar"\},"response":\{"headers":\{"connection":"close","content-type":"text\/plain","server":"APISIX\/[0-9A-Za-z._+-]+","transfer-encoding":"chunked"\},"size":[\d]*,"status":200\},"route_id":"1","server":\{"hostname":"[ -~]*","version":"[0-9A-Za-z._+-]+"\},"service_id":"","start_time":[\d]*,"upstream":"127\.0\.0\.1:1982","upstream_latency":[\d]*\}/
 
 
 

--- a/t/plugin/redirect.t
+++ b/t/plugin/redirect.t
@@ -695,7 +695,7 @@ received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
-received: Server: APISIX/\d\.\d+(\.\d+)?
+received: Server: APISIX/[0-9A-Za-z._+-]+
 received: \nreceived: hello world
 close: 1 nil}
 --- no_error_log

--- a/t/plugin/server-info.t
+++ b/t/plugin/server-info.t
@@ -76,7 +76,7 @@ location /t {
     }
 }
 --- response_body eval
-qr/^{"boot_time":\d+,"etcd_version":"[\d\.]+","hostname":"[a-zA-Z\-0-9\.]+","id":[a-zA-Z\-0-9]+,"version":"[\d\.]+"}$/
+qr/^{"boot_time":\d+,"etcd_version":"[\d\.]+","hostname":"[a-zA-Z\-0-9\.]+","id":[a-zA-Z\-0-9]+,"version":"[0-9A-Za-z._+-]+"}$/
 
 
 
@@ -101,4 +101,4 @@ location /t {
     }
 }
 --- response_body eval
-qr/^{"boot_time":\d+,"etcd_version":"[\d\.]+","hostname":"[a-zA-Z\-0-9\.]+","id":[a-zA-Z\-0-9]+,"version":"[\d\.]+"}$/
+qr/^{"boot_time":\d+,"etcd_version":"[\d\.]+","hostname":"[a-zA-Z\-0-9\.]+","id":[a-zA-Z\-0-9]+,"version":"[0-9A-Za-z._+-]+"}$/

--- a/t/router/multi-ssl-certs.t
+++ b/t/router/multi-ssl-certs.t
@@ -154,7 +154,7 @@ received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
-received: Server: APISIX/\d\.\d+(\.\d+)?
+received: Server: APISIX/[0-9A-Za-z._+-]+
 received: \nreceived: hello world
 close: 1 nil}
 --- error_log

--- a/t/router/radixtree-sni.t
+++ b/t/router/radixtree-sni.t
@@ -157,7 +157,7 @@ received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
-received: Server: APISIX/\d\.\d+(\.\d+)?
+received: Server: APISIX/[0-9A-Za-z._+-]+
 received: \nreceived: hello world
 close: 1 nil}
 --- error_log
@@ -300,7 +300,7 @@ received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
-received: Server: APISIX/\d\.\d+(\.\d+)?
+received: Server: APISIX/[0-9A-Za-z._+-]+
 received: \nreceived: hello world
 close: 1 nil}
 --- error_log
@@ -405,7 +405,7 @@ received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
-received: Server: APISIX/\d\.\d+(\.\d+)?
+received: Server: APISIX/[0-9A-Za-z._+-]+
 received: \nreceived: hello world
 close: 1 nil}
 --- error_log

--- a/t/router/radixtree-sni3.t
+++ b/t/router/radixtree-sni3.t
@@ -278,7 +278,7 @@ received: HTTP/1.1 200 OK
 received: Content-Type: text/plain
 received: Content-Length: 12
 received: Connection: close
-received: Server: APISIX/\d\.\d+(\.\d+)?
+received: Server: APISIX/[0-9A-Za-z._+-]+
 received: \nreceived: hello world
 close: 1 nil}
 --- error_log


### PR DESCRIPTION
This relaxes a few test assertions that only accepted dotted numeric versions.

Release/build versions can include suffixes such as `-alpha.1`, while these tests only need to verify that the server reports a valid version token. The assertions now accept letters, digits, dots, underscores, plus signs, and hyphens.