### PR TITLE
fix(gcp): report auth_file path instead of file contents in parse error

### DIFF
--- a/apisix/plugins/google-cloud-logging.lua
+++ b/apisix/plugins/google-cloud-logging.lua
@@ -170,7 +170,7 @@ local function fetch_oauth_conf(conf)
     local config_tab
     config_tab, err = core.json.decode(file_content)
     if not config_tab then
-        return nil, "config parse failure, file: " .. conf.auth_file .. " , err: " .. err
+        return nil, "config parse failure, file: " .. conf.auth_file .. ", err: " .. err
     end
 
     return config_tab

--- a/apisix/plugins/google-cloud-logging.lua
+++ b/apisix/plugins/google-cloud-logging.lua
@@ -170,7 +170,7 @@ local function fetch_oauth_conf(conf)
     local config_tab
     config_tab, err = core.json.decode(file_content)
     if not config_tab then
-        return nil, "config parse failure, data: " .. file_content .. " , err: " .. err
+        return nil, "config parse failure, file: " .. conf.auth_file .. " , err: " .. err
     end
 
     return config_tab

--- a/apisix/secret/gcp.lua
+++ b/apisix/secret/gcp.lua
@@ -83,7 +83,7 @@ local function fetch_oauth_conf(conf)
 
     local config_tab, err = core.json.decode(file_content)
     if not config_tab then
-        return nil, "config parse failure, data: " .. file_content .. ", err: " .. err
+        return nil, "config parse failure, file: " .. conf.auth_file .. ", err: " .. err
     end
 
     local config = {

--- a/t/secret/conf/invalid.json
+++ b/t/secret/conf/invalid.json
@@ -1,0 +1,1 @@
+gcp-service-account-placeholder

--- a/t/secret/gcp.t
+++ b/t/secret/gcp.t
@@ -735,3 +735,27 @@ kEJQcmfVew5mFXyxuEn3zA==
 GET /t
 --- response_body
 err
+
+
+
+=== TEST 15: get value from gcp by auth_file(invalid json content)
+--- config
+    location /t {
+        content_by_lua_block {
+            local conf = {
+                auth_file = "t/secret/conf/invalid.json",
+            }
+            local gcp = require("apisix.secret.gcp")
+            local value, err = gcp.get(conf, "jack/key")
+            if not value then
+                return ngx.say(err)
+            end
+            ngx.say(value)
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+config parse failure, file: t/secret/conf/invalid.json
+--- response_body_unlike
+gcp-service-account-placeholder

--- a/t/secret/gcp.t
+++ b/t/secret/gcp.t
@@ -747,13 +747,17 @@ err
             }
             local gcp = require("apisix.secret.gcp")
             local value, err = gcp.get(conf, "jack/key")
-            if not value then
-                return ngx.say(err)
+            if value then
+                return ngx.say(value)
             end
-            ngx.say(value)
+            if err:find("file: t/secret/conf/invalid.json", 1, true) then
+                ngx.say("path reported")
+            else
+                ngx.say(err)
+            end
         }
     }
 --- request
 GET /t
---- response_body_like
-config parse failure, file: t/secret/conf/invalid\.json, err:
+--- response_body
+path reported

--- a/t/secret/gcp.t
+++ b/t/secret/gcp.t
@@ -756,6 +756,4 @@ err
 --- request
 GET /t
 --- response_body_like
-config parse failure, file: t/secret/conf/invalid.json
---- response_body_unlike
-gcp-service-account-placeholder
+config parse failure, file: t/secret/conf/invalid\.json, err:


### PR DESCRIPTION
### Description

The GCP secret backend (`apisix/secret/gcp.lua`) and the `google-cloud-logging` plugin both read a credentials file configured via `auth_file`. When that file fails to parse as JSON, the error message embedded the entire raw file content.

This change reports the configured `auth_file` path in the parse-failure message instead of the file content, making it consistent with the adjacent read-failure and schema-check error messages in the same functions. The underlying JSON decode error is still included.

#### Which issue(s) this PR fixes:
N/A

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)