### PR TITLE
docs: add missing AI plugins and fix ordering in config.yaml.example

### DIFF
--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -518,14 +518,16 @@ plugins:                           # plugin list (sorted by priority)
   #- error-log-logger              # priority: 1091
   - proxy-cache                    # priority: 1085
   - body-transformer               # priority: 1080
+  - ai-request-rewrite             # priority: 1073
+  - ai-prompt-guard                # priority: 1072
   - ai-prompt-template             # priority: 1071
   - ai-prompt-decorator            # priority: 1070
-  - ai-prompt-guard                # priority: 1072
   - ai-rag                         # priority: 1060
   - ai-aws-content-moderation      # priority: 1050
   - ai-proxy-multi                 # priority: 1041
   - ai-proxy                       # priority: 1040
   - ai-rate-limiting               # priority: 1030
+  - ai-aliyun-content-moderation   # priority: 1029
   - proxy-mirror                   # priority: 1010
   - proxy-rewrite                  # priority: 1008
   - workflow                       # priority: 1006

--- a/docs/en/latest/plugins/hmac-auth.md
+++ b/docs/en/latest/plugins/hmac-auth.md
@@ -887,6 +887,10 @@ body = '{"name": "world"}'          # example request body
 # skew to prolong the validity within the advised security boundary
 gmt_time = datetime.now(timezone.utc).strftime('%a, %d %b %Y %H:%M:%S GMT')
 
+# create the SHA-256 digest of the request body and base64 encode it first
+body_digest = hashlib.sha256(body.encode('utf-8')).digest()
+body_digest_base64 = base64.b64encode(body_digest).decode('utf-8')
+
 # construct the signing string (ordered)
 # the date and any subsequent custom headers should be lowercased and separated by a
 # single space character, i.e. `<key>:<space><value>`
@@ -895,15 +899,12 @@ signing_string = (
     f"{key_id}\n"
     f"{request_method} {request_path}\n"
     f"date: {gmt_time}\n"
+    f"digest: SHA-256={body_digest_base64}\n"
 )
 
 # create signature
 signature = hmac.new(secret_key, signing_string.encode('utf-8'), hashlib.sha256).digest()
 signature_base64 = base64.b64encode(signature).decode('utf-8')
-
-# create the SHA-256 digest of the request body and base64 encode it
-body_digest = hashlib.sha256(body.encode('utf-8')).digest()
-body_digest_base64 = base64.b64encode(body_digest).decode('utf-8')
 
 # construct the request headers
 headers = {
@@ -911,7 +912,7 @@ headers = {
     "Digest": f"SHA-256={body_digest_base64}",
     "Authorization": (
         f'Signature keyId="{key_id}",algorithm="hmac-sha256",'
-        f'headers="@request-target date",'
+        f'headers="@request-target date digest",'
         f'signature="{signature_base64}"'
     )
 }


### PR DESCRIPTION
Fixes #13108

- Add missing `ai-request-rewrite` plugin (priority 1073)
- Add missing `ai-aliyun-content-moderation` plugin (priority 1029)
- Reorder AI plugins list by descending priority (ai-prompt-guard before ai-prompt-template)