### PR TITLE
feat(cas-auth): support configuring an absolute callback URL

### DIFF
--- a/apisix/plugins/cas-auth.lua
+++ b/apisix/plugins/cas-auth.lua
@@ -36,7 +36,13 @@ local schema = {
     type = "object",
     properties = {
         idp_uri = {type = "string"},
-        cas_callback_uri = {type = "string"},
+        cas_callback_uri = {
+            type = "string",
+            description = "CAS callback location. Either a relative path " ..
+                "(the CAS service URL is then built from the request scheme/host/port) " ..
+                "or an absolute URL (e.g. https://app.example.com/cas_callback), " ..
+                "which is used verbatim as the CAS service URL.",
+        },
         logout_uri = {type = "string"},
         cookie = {
             type = "object",
@@ -74,6 +80,24 @@ local function cookie_attrs(conf)
     return attrs
 end
 
+local function is_absolute_callback(cas_callback_uri)
+    return cas_callback_uri:find("^https?://") ~= nil
+end
+
+-- Path component of cas_callback_uri, used to match against ctx.var.uri
+-- (which is always a path). For an absolute URL the scheme://authority
+-- prefix is stripped; an absolute URL with no path resolves to "/".
+local function callback_path(cas_callback_uri)
+    if not is_absolute_callback(cas_callback_uri) then
+        return cas_callback_uri
+    end
+    local path = cas_callback_uri:gsub("^https?://[^/]+", "")
+    if path == "" then
+        return "/"
+    end
+    return path
+end
+
 function _M.check_schema(conf)
     local check = {"idp_uri"}
     core.utils.check_https(check, conf, plugin_name)
@@ -85,10 +109,18 @@ function _M.check_schema(conf)
         return false,
             "cookie.secure must be true when cookie.samesite is \"None\""
     end
+    if not is_absolute_callback(conf.cas_callback_uri) then
+        core.log.warn("cas-auth: cas_callback_uri is a relative path; the CAS ",
+            "service URL will be derived from the request Host header. ",
+            "Configure an absolute cas_callback_uri to avoid relying on it.")
+    end
     return true
 end
 
 local function uri_without_ticket(conf, ctx)
+    if is_absolute_callback(conf.cas_callback_uri) then
+        return conf.cas_callback_uri
+    end
     return ctx.var.scheme .. "://" .. ctx.var.host .. ":" ..
         ctx.var.server_port .. conf.cas_callback_uri
 end
@@ -155,6 +187,7 @@ _M._test_helpers = {
     sign_value = sign_value,
     verify_value = verify_value,
     is_safe_redirect = is_safe_redirect,
+    callback_path = callback_path,
 }
 
 local function first_access(conf, ctx)
@@ -260,12 +293,13 @@ end
 function _M.access(conf, ctx)
     local method = core.request.get_method()
     local uri = ctx.var.uri
+    local cas_callback_path = callback_path(conf.cas_callback_uri)
 
     if method == "GET" and uri == conf.logout_uri then
         return logout(conf, ctx)
     end
 
-    if method == "POST" and uri == conf.cas_callback_uri then
+    if method == "POST" and uri == cas_callback_path then
         local data = core.request.get_body()
         local ticket = data:match("<samlp:SessionIndex>(.*)</samlp:SessionIndex>")
         if ticket == nil then
@@ -286,7 +320,7 @@ function _M.access(conf, ctx)
         end
 
         local ticket = ctx.var.arg_ticket
-        if ticket ~= nil and uri == conf.cas_callback_uri then
+        if ticket ~= nil and uri == cas_callback_path then
             return validate_with_cas(conf, ctx, ticket)
         else
             return first_access(conf, ctx)

--- a/apisix/plugins/cas-auth.lua
+++ b/apisix/plugins/cas-auth.lua
@@ -86,12 +86,14 @@ end
 
 -- Path component of cas_callback_uri, used to match against ctx.var.uri
 -- (which is always a path). For an absolute URL the scheme://authority
--- prefix is stripped; an absolute URL with no path resolves to "/".
+-- prefix and any query/fragment are stripped; an absolute URL with no
+-- path resolves to "/".
 local function callback_path(cas_callback_uri)
     if not is_absolute_callback(cas_callback_uri) then
         return cas_callback_uri
     end
     local path = cas_callback_uri:gsub("^https?://[^/]+", "")
+    path = path:gsub("[?#].*$", "")
     if path == "" then
         return "/"
     end
@@ -99,8 +101,6 @@ local function callback_path(cas_callback_uri)
 end
 
 function _M.check_schema(conf)
-    local check = {"idp_uri"}
-    core.utils.check_https(check, conf, plugin_name)
     local ok, err = core.schema.check(schema, conf)
     if not ok then
         return false, err
@@ -109,11 +109,17 @@ function _M.check_schema(conf)
         return false,
             "cookie.secure must be true when cookie.samesite is \"None\""
     end
-    if not is_absolute_callback(conf.cas_callback_uri) then
+
+    local check = {"idp_uri"}
+    if is_absolute_callback(conf.cas_callback_uri) then
+        core.table.insert(check, "cas_callback_uri")
+    else
         core.log.warn("cas-auth: cas_callback_uri is a relative path; the CAS ",
             "service URL will be derived from the request Host header. ",
             "Configure an absolute cas_callback_uri to avoid relying on it.")
     end
+    core.utils.check_https(check, conf, plugin_name)
+
     return true
 end
 

--- a/t/plugin/cas-auth.t
+++ b/t/plugin/cas-auth.t
@@ -382,3 +382,101 @@ passed
     }
 --- response_body
 passed
+
+
+
+=== TEST 11: callback_path derives path from relative and absolute cas_callback_uri
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.cas-auth")
+            local h = plugin._test_helpers
+            local cases = {
+                {"/cas_callback",                          "/cas_callback"},
+                {"https://app.example.com/cas_callback",   "/cas_callback"},
+                {"http://app.example.com:8443/cb",         "/cb"},
+                {"https://app.example.com",                "/"},
+            }
+            for _, c in ipairs(cases) do
+                local got = h.callback_path(c[1])
+                if got ~= c[2] then
+                    ngx.say("FAIL ", tostring(c[1]), " expected ", tostring(c[2]),
+                            " got ", tostring(got))
+                    return
+                end
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 12: add route with an absolute cas_callback_uri
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+
+            local code, body = t('/apisix/admin/routes/cas-abs',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "methods": ["GET", "POST"],
+                        "host" : "127.0.0.1",
+                        "plugins": {
+                            "cas-auth": {
+                                "idp_uri": "http://127.0.0.1:8080/realms/test/protocol/cas",
+                                "cas_callback_uri": "https://app.example.com/cas_callback",
+                                "logout_uri": "/logout",
+                                "cookie": {
+                                    "secret": "0123456789abcdef0123456789abcdef"
+                                }
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/*"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 13: absolute cas_callback_uri keeps service URL fixed despite forged Host
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/uri"
+
+            local res, err = httpc:request_uri(uri, {
+                method = "GET",
+                headers = {
+                    ["Host"] = "attacker.example.net",
+                }
+            })
+            if not res then
+                ngx.log(ngx.ERR, err)
+                ngx.exit(500)
+            end
+            ngx.say(res.status)
+            ngx.say(res.headers['Location'])
+        }
+    }
+--- response_body_like
+^302
+.*service=https%3A%2F%2Fapp\.example\.com%2Fcas_callback.*$

--- a/t/plugin/cas-auth.t
+++ b/t/plugin/cas-auth.t
@@ -396,6 +396,8 @@ passed
                 {"https://app.example.com/cas_callback",   "/cas_callback"},
                 {"http://app.example.com:8443/cb",         "/cb"},
                 {"https://app.example.com",                "/"},
+                {"https://app.example.com/cb?from=cas",    "/cb"},
+                {"https://app.example.com/cb#frag",        "/cb"},
             }
             for _, c in ipairs(cases) do
                 local got = h.callback_path(c[1])
@@ -423,7 +425,6 @@ passed
                  ngx.HTTP_PUT,
                  [[{
                         "methods": ["GET", "POST"],
-                        "host" : "127.0.0.1",
                         "plugins": {
                             "cas-auth": {
                                 "idp_uri": "http://127.0.0.1:8080/realms/test/protocol/cas",


### PR DESCRIPTION
### Description

The `cas-auth` plugin assembles the CAS `service` parameter (the callback URL sent to the CAS identity provider) from the request scheme, `Host` header and port plus `cas_callback_uri`.

This PR lets operators configure `cas_callback_uri` as an absolute URL. When it is absolute (matches `^https?://`), it is used verbatim as the CAS `service` URL and the request-derived construction is skipped. The relative-path form keeps its existing behaviour, and `check_schema` logs a warning at config-load time when the relative form is used so operators are aware the service URL is derived from the request `Host` header.

The callback path matched against `ctx.var.uri` for incoming IdP callbacks is now derived from `cas_callback_uri`, so matching keeps working when an absolute URL is configured.

New cases in `t/plugin/cas-auth.t` cover the absolute-URL form, the relative-path form, and the path-derivation helper.

This change is backward compatible: existing relative-path configurations behave exactly as before.

#### Which issue(s) this PR fixes:

N/A

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible