### PR TITLE
docs(hmac-auth): sign Digest header in body validation example (#13395)

### DIFF
--- a/docs/en/latest/plugins/hmac-auth.md
+++ b/docs/en/latest/plugins/hmac-auth.md
@@ -895,6 +895,7 @@ signing_string = (
     f"{key_id}\n"
     f"{request_method} {request_path}\n"
     f"date: {gmt_time}\n"
+    f"digest: SHA-256={body_digest_base64}\n"
 )
 
 # create signature
@@ -911,7 +912,7 @@ headers = {
     "Digest": f"SHA-256={body_digest_base64}",
     "Authorization": (
         f'Signature keyId="{key_id}",algorithm="hmac-sha256",'
-        f'headers="@request-target date",'
+        f'headers="@request-target date digest",'
         f'signature="{signature_base64}"'
     )
 }


### PR DESCRIPTION
### Description\n\nThis PR improves the body validation example in the hmac-auth plugin documentation.\n\n**Issue:** #13395\n\n**Changes:**\n- Include the Digest header in the signing string construction\n- Add `digest` to the signed headers list in Authorization header\n- Ensure the request body digest is covered by the HMAC signature, demonstrating complete body integrity validation\n\n**Testing:**\n- Verified the updated Python example generates the correct HMAC signature\n- Confirmed with the example cURL command that requests are properly authenticated\n\n### Related\n\nFixes #13395