### PR TITLE
docs: add note about signing Digest header for body validation in hmac-auth

### DIFF
--- a/docs/en/latest/plugins/hmac-auth.md
+++ b/docs/en/latest/plugins/hmac-auth.md
@@ -868,6 +868,8 @@ kubectl apply -f hmac-auth-ic.yaml
 
 Generate a signature. You can use the below Python snippet or other stack of your choice:
 
+> **Note**: When `validate_request_body` is enabled, the plugin checks that the `Digest` header matches the request body. However, to ensure the body itself is bound to the HMAC signature (preventing an attacker from replacing both the body and the Digest header), you must also include the `Digest` header in the signed headers list. The example below demonstrates this by adding `digest` to the `headers` parameter in the `Authorization` header.
+
 ```python title="hmac-sig-digest-header-gen.py"
 import hmac
 import hashlib


### PR DESCRIPTION
Fix #13395

Add a note clarifying that when `validate_request_body` is enabled, the Digest header must be included in the signed headers list to ensure body integrity is bound to the HMAC signature. The existing example already demonstrates this by adding `digest` to the `headers` parameter; this PR just adds an explanatory note.

Changes:
- docs/en/latest/plugins/hmac-auth.md: Insert note before the body-validation code block.
