### PR TITLE
docs: sign Digest header in hmac-auth body validation example

### DIFF
--- a/docs/en/latest/plugins/hmac-auth.md
+++ b/docs/en/latest/plugins/hmac-auth.md
@@ -887,6 +887,10 @@ body = '{"name": "world"}'          # example request body
 # skew to prolong the validity within the advised security boundary
 gmt_time = datetime.now(timezone.utc).strftime('%a, %d %b %Y %H:%M:%S GMT')
 
+# create the SHA-256 digest of the request body and base64 encode it
+body_digest = hashlib.sha256(body.encode('utf-8')).digest()
+body_digest_base64 = base64.b64encode(body_digest).decode('utf-8')
+
 # construct the signing string (ordered)
 # the date and any subsequent custom headers should be lowercased and separated by a
 # single space character, i.e. `<key>:<space><value>`
@@ -895,15 +899,12 @@ signing_string = (
     f"{key_id}\n"
     f"{request_method} {request_path}\n"
     f"date: {gmt_time}\n"
+    f"digest: SHA-256={body_digest_base64}\n"
 )
 
 # create signature
 signature = hmac.new(secret_key, signing_string.encode('utf-8'), hashlib.sha256).digest()
 signature_base64 = base64.b64encode(signature).decode('utf-8')
-
-# create the SHA-256 digest of the request body and base64 encode it
-body_digest = hashlib.sha256(body.encode('utf-8')).digest()
-body_digest_base64 = base64.b64encode(body_digest).decode('utf-8')
 
 # construct the request headers
 headers = {
@@ -911,7 +912,7 @@ headers = {
     "Digest": f"SHA-256={body_digest_base64}",
     "Authorization": (
         f'Signature keyId="{key_id}",algorithm="hmac-sha256",'
-        f'headers="@request-target date",'
+        f'headers="@request-target date digest",'
         f'signature="{signature_base64}"'
     )
 }
@@ -919,6 +920,10 @@ headers = {
 # print headers
 print(headers)
 ```
+
+:::note
+When `validate_request_body` is enabled, APISIX checks that the `Digest` header matches the request body. However, the body itself is not automatically included in the HMAC signature. To bind the request body to the authentication, you must include the `Digest` header in the signed headers list. The example below includes `digest` in the `headers` parameter (`headers="@request-target date digest"`). For stricter enforcement, you can also set the `signed_headers` plugin attribute to require the `digest` header for all requests.
+:::
 
 Run the script:
 
@@ -929,7 +934,7 @@ python3 hmac-sig-digest-header-gen.py
 You should see the request headers printed:
 
 ```text
-{'Date': 'Fri, 06 Sep 2024 09:16:16 GMT', 'Digest': 'SHA-256=78qzJuLwSpZ8HacsTdFCQJWxzPMOf8bYctRk2ySLpS8=', 'Authorization': 'Signature keyId="john-key",algorithm="hmac-sha256",headers="@request-target date",signature="rjS6NxOBKmzS8CZL05uLiAfE16hXdIpMD/L/HukOTYE="'}
+{'Date': 'Fri, 06 Sep 2024 09:16:16 GMT', 'Digest': 'SHA-256=78qzJuLwSpZ8HacsTdFCQJWxzPMOf8bYctRk2ySLpS8=', 'Authorization': 'Signature keyId="john-key",algorithm="hmac-sha256",headers="@request-target date digest",signature="rjS6NxOBKmzS8CZL05uLiAfE16hXdIpMD/L/HukOTYE="'}
 ```
 
 Using the headers generated, send a request to the Route:
@@ -938,7 +943,7 @@ Using the headers generated, send a request to the Route:
 curl "http://127.0.0.1:9080/post" -X POST \
   -H "Date: Fri, 06 Sep 2024 09:16:16 GMT" \
   -H "Digest: SHA-256=78qzJuLwSpZ8HacsTdFCQJWxzPMOf8bYctRk2ySLpS8=" \
-  -H 'Authorization: Signature keyId="john-key",algorithm="hmac-sha256",headers="@request-target date",signature="rjS6NxOBKmzS8CZL05uLiAfE16hXdIpMD/L/HukOTYE="' \
+  -H 'Authorization: Signature keyId="john-key",algorithm="hmac-sha256",headers="@request-target date digest",signature="rjS6NxOBKmzS8CZL05uLiAfE16hXdIpMD/L/HukOTYE="' \
   -d '{"name": "world"}'
 ```
 


### PR DESCRIPTION
Fixes #13395\n\n### What this PR does\n- Updates the Python example in the hmac-auth documentation to include the `Digest` header in the signed headers list.\n- Moves the digest computation earlier so the signature covers the body digest.\n\n### Why\nAs described in #13395, the existing example computes the Digest header but does not sign it, which can be misleading for users who expect end-to-end body integrity. This PR makes the example match the intended secure usage.\n\n### Testing\n- Ran the updated Python snippet to confirm the signature generation works.\n- The example remains a documentation-only change, so no runtime tests are required.