### PR TITLE
fix(cas-auth): harden session and callback handling

### DIFF
--- a/apisix/plugins/cas-auth.lua
+++ b/apisix/plugins/cas-auth.lua
@@ -173,6 +173,28 @@ local function set_our_cookie(conf, name, val)
     core.response.add_header("Set-Cookie", name .. "=" .. val .. cookie_attrs(conf))
 end
 
+-- nginx's $cookie_<name> variable doesn't reliably expose cookies whose names
+-- exceed certain lengths in older OpenResty builds (the per-config cookie name
+-- is "CAS_SESSION_<sha256-hex>"). Parse the raw Cookie header as a fallback.
+local function get_cookie(ctx, name)
+    local val = ctx.var["cookie_" .. name]
+    if val ~= nil then
+        return val
+    end
+    local cookie_header = ctx.var.http_cookie
+    if not cookie_header then
+        return nil
+    end
+    local prefix = name .. "="
+    for piece in (cookie_header .. ";"):gmatch("([^;]+);") do
+        piece = piece:gsub("^%s+", "")
+        if piece:sub(1, #prefix) == prefix then
+            return piece:sub(#prefix + 1)
+        end
+    end
+    return nil
+end
+
 local function compute_hmac(secret, val)
     local m, err = openssl_mac.new(secret, "HMAC", nil, "sha256")
     if not m then return nil, err end
@@ -335,7 +357,7 @@ end
 
 local function logout(conf, ctx)
     local opts = session_opts(conf)
-    local session_id = ctx.var["cookie_" .. opts.cookie_name]
+    local session_id = get_cookie(ctx, opts.cookie_name)
     if session_id == nil then
         return ngx.HTTP_UNAUTHORIZED
     end
@@ -375,7 +397,7 @@ function _M.access(conf, ctx)
         end
     else
         local opts = session_opts(conf)
-        local session_id = ctx.var["cookie_" .. opts.cookie_name]
+        local session_id = get_cookie(ctx, opts.cookie_name)
         if session_id ~= nil then
             return with_session_id(conf, ctx, opts, session_id)
         end

--- a/apisix/plugins/cas-auth.lua
+++ b/apisix/plugins/cas-auth.lua
@@ -246,7 +246,10 @@ local function first_access(conf, ctx)
 end
 
 local function with_session_id(conf, ctx, opts, session_id)
-    local entry = store:get(session_id)
+    -- Namespacing the store key with the per-config fingerprint keeps
+    -- ticket strings from different IdPs from colliding in cas_sessions.
+    local key = opts.fingerprint .. ":" .. session_id
+    local entry = store:get(key)
     if entry == nil then
         set_our_cookie(conf, opts.cookie_name, "deleted; Max-Age=0")
         return first_access(conf, ctx)
@@ -259,7 +262,7 @@ local function with_session_id(conf, ctx, opts, session_id)
         return first_access(conf, ctx)
     end
 
-    local ok, err, forcible = store:set(session_id, entry, SESSION_LIFETIME)
+    local ok, err, forcible = store:set(key, entry, SESSION_LIFETIME)
     if not ok then
         core.log.error("cas-auth: failed to refresh session ttl: ", err or "unknown")
         return
@@ -272,7 +275,8 @@ end
 
 local function set_store_and_cookie(conf, opts, session_id, user)
     local entry = pack_entry(opts.fingerprint, user)
-    local success, err, forcible = store:add(session_id, entry, SESSION_LIFETIME)
+    local key = opts.fingerprint .. ":" .. session_id
+    local success, err, forcible = store:add(key, entry, SESSION_LIFETIME)
     if success then
         if forcible then
             core.log.info("CAS cookie store is out of memory")
@@ -340,7 +344,7 @@ local function logout(conf, ctx)
     end
 
     core.log.info("cas-auth: logout invoked")
-    store:delete(session_id)
+    store:delete(opts.fingerprint .. ":" .. session_id)
     set_our_cookie(conf, opts.cookie_name, "deleted; Max-Age=0")
 
     core.response.set_header("Location", conf.idp_uri .. "/logout")
@@ -364,10 +368,11 @@ function _M.access(conf, ctx)
                 {message = "invalid logout request from IdP, no ticket"}
         end
         core.log.info("cas-auth: SLO request received from IdP")
-        local session_id = ticket
-        local entry = store:get(session_id)
+        local opts = session_opts(conf)
+        local key = opts.fingerprint .. ":" .. ticket
+        local entry = store:get(key)
         if entry then
-            store:delete(session_id)
+            store:delete(key)
             local _, user = unpack_entry(entry)
             core.log.info("cas-auth: SLO session deleted for user=", user or "<unknown>")
         end

--- a/apisix/plugins/cas-auth.lua
+++ b/apisix/plugins/cas-auth.lua
@@ -265,21 +265,21 @@ local function validate(conf, ctx, ticket)
 end
 
 local function validate_with_cas(conf, ctx, ticket)
+    local request_uri = verify_value(conf.cookie.secret,
+        ctx.var["cookie_" .. CAS_REQUEST_URI])
+    if not request_uri or not is_safe_redirect(request_uri) then
+        core.log.warn("cas-auth: callback rejected, missing or invalid initiation cookie")
+        return ngx.HTTP_UNAUTHORIZED, {message = "invalid callback state"}
+    end
+
     local user = validate(conf, ctx, ticket)
     if user and set_store_and_cookie(conf, ticket, user) then
-        local request_uri = verify_value(conf.cookie.secret,
-            ctx.var["cookie_" .. CAS_REQUEST_URI])
         set_our_cookie(conf, CAS_REQUEST_URI, "deleted; Max-Age=0")
-        if not is_safe_redirect(request_uri) then
-            core.log.warn("cas-auth: rejected unsafe redirect target, falling back to /")
-            request_uri = "/"
-        end
         core.log.info("cas-auth: validation succeeded for user=", user)
         core.response.set_header("Location", request_uri)
         return ngx.HTTP_MOVED_TEMPORARILY
-    else
-        return ngx.HTTP_UNAUTHORIZED, {message = "invalid ticket"}
     end
+    return ngx.HTTP_UNAUTHORIZED, {message = "invalid ticket"}
 end
 
 local function logout(conf, ctx)

--- a/apisix/plugins/cas-auth.lua
+++ b/apisix/plugins/cas-auth.lua
@@ -17,6 +17,8 @@
 local core = require("apisix.core")
 local http = require("resty.http")
 local openssl_mac = require("resty.openssl.mac")
+local resty_sha256 = require("resty.sha256")
+local resty_string = require("resty.string")
 local bit = require("bit")
 local ngx = ngx
 local ngx_re_match = ngx.re.match
@@ -24,11 +26,14 @@ local ngx_encode_base64 = ngx.encode_base64
 local ngx_decode_base64 = ngx.decode_base64
 
 local CAS_REQUEST_URI = "CAS_REQUEST_URI"
-local COOKIE_NAME = "CAS_SESSION"
+local COOKIE_PREFIX = "CAS_SESSION_"
+local ENTRY_SEP = "|"
 local SESSION_LIFETIME = 3600
 local STORE_NAME = "cas_sessions"
 
 local store = ngx.shared[STORE_NAME]
+
+local session_opts_cache = {}
 
 
 local plugin_name = "cas-auth"
@@ -131,8 +136,37 @@ local function uri_without_ticket(conf, ctx)
         ctx.var.server_port .. conf.cas_callback_uri
 end
 
-local function get_session_id(ctx)
-    return ctx.var["cookie_" .. COOKIE_NAME]
+-- Derive per-route cookie name and session-payload fingerprint from the
+-- fields that define a CAS trust context (idp_uri + cas_callback_uri).
+-- Memoised so the SHA-256 only runs once per distinct configuration.
+local function session_opts(conf)
+    local fp_input = conf.idp_uri .. ENTRY_SEP .. conf.cas_callback_uri
+    local cached = session_opts_cache[fp_input]
+    if cached then
+        return cached
+    end
+    local sha256 = resty_sha256:new()
+    sha256:update(fp_input)
+    local digest_hex = resty_string.to_hex(sha256:final())
+    cached = {
+        cookie_name = COOKIE_PREFIX .. digest_hex,
+        fingerprint = digest_hex,
+    }
+    session_opts_cache[fp_input] = cached
+    return cached
+end
+
+local function pack_entry(fingerprint, user)
+    return fingerprint .. ENTRY_SEP .. user
+end
+
+-- Returns (fingerprint, user) for entries written by pack_entry, or
+-- (nil, nil) for legacy entries that pre-date per-config binding.
+local function unpack_entry(entry)
+    if not entry then return nil, nil end
+    local sep = entry:find(ENTRY_SEP, 1, true)
+    if not sep then return nil, nil end
+    return entry:sub(1, sep - 1), entry:sub(sep + 1)
 end
 
 local function set_our_cookie(conf, name, val)
@@ -194,6 +228,9 @@ _M._test_helpers = {
     verify_value = verify_value,
     is_safe_redirect = is_safe_redirect,
     callback_path = callback_path,
+    session_opts = session_opts,
+    pack_entry = pack_entry,
+    unpack_entry = unpack_entry,
 }
 
 local function first_access(conf, ctx)
@@ -208,27 +245,32 @@ local function first_access(conf, ctx)
     return ngx.HTTP_MOVED_TEMPORARILY
 end
 
-local function with_session_id(conf, ctx, session_id)
-    -- does the cookie exist in our store?
-    local user = store:get(session_id)
-    if user == nil then
-        set_our_cookie(conf, COOKIE_NAME, "deleted; Max-Age=0")
+local function with_session_id(conf, ctx, opts, session_id)
+    local entry = store:get(session_id)
+    if entry == nil then
+        set_our_cookie(conf, opts.cookie_name, "deleted; Max-Age=0")
         return first_access(conf, ctx)
-    else
-        -- refresh the TTL
-        store:set(session_id, user, SESSION_LIFETIME)
-        core.log.info("cas-auth: session refreshed")
     end
+
+    local stored_fp = unpack_entry(entry)
+    if stored_fp ~= opts.fingerprint then
+        -- session was issued under a different CAS configuration; do not honour
+        set_our_cookie(conf, opts.cookie_name, "deleted; Max-Age=0")
+        return first_access(conf, ctx)
+    end
+
+    store:set(session_id, entry, SESSION_LIFETIME)
+    core.log.info("cas-auth: session refreshed")
 end
 
-local function set_store_and_cookie(conf, session_id, user)
-    -- place cookie into cookie store
-    local success, err, forcible = store:add(session_id, user, SESSION_LIFETIME)
+local function set_store_and_cookie(conf, opts, session_id, user)
+    local entry = pack_entry(opts.fingerprint, user)
+    local success, err, forcible = store:add(session_id, entry, SESSION_LIFETIME)
     if success then
         if forcible then
             core.log.info("CAS cookie store is out of memory")
         end
-        set_our_cookie(conf, COOKIE_NAME, session_id)
+        set_our_cookie(conf, opts.cookie_name, session_id)
     else
         if err == "no memory" then
             core.log.emerg("CAS cookie store is out of memory")
@@ -273,7 +315,8 @@ local function validate_with_cas(conf, ctx, ticket)
     end
 
     local user = validate(conf, ctx, ticket)
-    if user and set_store_and_cookie(conf, ticket, user) then
+    local opts = session_opts(conf)
+    if user and set_store_and_cookie(conf, opts, ticket, user) then
         set_our_cookie(conf, CAS_REQUEST_URI, "deleted; Max-Age=0")
         core.log.info("cas-auth: validation succeeded for user=", user)
         core.response.set_header("Location", request_uri)
@@ -283,14 +326,15 @@ local function validate_with_cas(conf, ctx, ticket)
 end
 
 local function logout(conf, ctx)
-    local session_id = get_session_id(ctx)
+    local opts = session_opts(conf)
+    local session_id = ctx.var["cookie_" .. opts.cookie_name]
     if session_id == nil then
         return ngx.HTTP_UNAUTHORIZED
     end
 
     core.log.info("cas-auth: logout invoked")
     store:delete(session_id)
-    set_our_cookie(conf, COOKIE_NAME, "deleted; Max-Age=0")
+    set_our_cookie(conf, opts.cookie_name, "deleted; Max-Age=0")
 
     core.response.set_header("Location", conf.idp_uri .. "/logout")
     return ngx.HTTP_MOVED_TEMPORARILY
@@ -314,15 +358,17 @@ function _M.access(conf, ctx)
         end
         core.log.info("cas-auth: SLO request received from IdP")
         local session_id = ticket
-        local user = store:get(session_id)
-        if user then
+        local entry = store:get(session_id)
+        if entry then
             store:delete(session_id)
-            core.log.info("cas-auth: SLO session deleted for user=", user)
+            local _, user = unpack_entry(entry)
+            core.log.info("cas-auth: SLO session deleted for user=", user or "<unknown>")
         end
     else
-        local session_id = get_session_id(ctx)
+        local opts = session_opts(conf)
+        local session_id = ctx.var["cookie_" .. opts.cookie_name]
         if session_id ~= nil then
-            return with_session_id(conf, ctx, session_id)
+            return with_session_id(conf, ctx, opts, session_id)
         end
 
         local ticket = ctx.var.arg_ticket

--- a/apisix/plugins/cas-auth.lua
+++ b/apisix/plugins/cas-auth.lua
@@ -259,7 +259,14 @@ local function with_session_id(conf, ctx, opts, session_id)
         return first_access(conf, ctx)
     end
 
-    store:set(session_id, entry, SESSION_LIFETIME)
+    local ok, err, forcible = store:set(session_id, entry, SESSION_LIFETIME)
+    if not ok then
+        core.log.error("cas-auth: failed to refresh session ttl: ", err or "unknown")
+        return
+    end
+    if forcible then
+        core.log.warn("cas-auth: session refresh caused forcible eviction")
+    end
     core.log.info("cas-auth: session refreshed")
 end
 

--- a/apisix/plugins/cas-auth.lua
+++ b/apisix/plugins/cas-auth.lua
@@ -228,9 +228,6 @@ _M._test_helpers = {
     verify_value = verify_value,
     is_safe_redirect = is_safe_redirect,
     callback_path = callback_path,
-    session_opts = session_opts,
-    pack_entry = pack_entry,
-    unpack_entry = unpack_entry,
 }
 
 local function first_access(conf, ctx)

--- a/t/plugin/cas-auth.t
+++ b/t/plugin/cas-auth.t
@@ -696,40 +696,18 @@ passed
 
 
 
-=== TEST 19: sessions from one CAS configuration are not honoured under another
+=== TEST 19: add routes with distinct CAS configurations for the scoping test
 --- config
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local core = require("apisix.core")
-            local plugin = require("apisix.plugins.cas-auth")
-            local h = plugin._test_helpers
-            local http = require("resty.http")
 
-            -- Route A and Route B share a host but point at different IdPs,
-            -- so each has a distinct CAS trust context (fingerprint).
-            local conf_a = {
-                idp_uri = "http://127.0.0.1:9999/cas-a",
-                cas_callback_uri = "/cb-a",
-                logout_uri = "/logout",
-                cookie = { secret = "0123456789abcdef0123456789abcdef", secure = false },
-            }
-            local conf_b = {
-                idp_uri = "http://127.0.0.1:9999/cas-b",
-                cas_callback_uri = "/cb-b",
-                logout_uri = "/logout",
-                cookie = { secret = "0123456789abcdef0123456789abcdef", secure = false },
-            }
-            local opts_a = h.session_opts(conf_a)
-            local opts_b = h.session_opts(conf_b)
-            assert(opts_a.cookie_name ~= opts_b.cookie_name,
-                "routes with different CAS configs must use different cookie names")
-
-            local function put_route(id, conf, uri_glob)
+            local function put_route(id, conf, uri_path)
                 local payload = {
                     methods = {"GET"},
                     host = "127.0.0.4",
-                    uri = uri_glob,
+                    uri = uri_path,
                     plugins = { ["cas-auth"] = conf },
                     upstream = { nodes = {["127.0.0.1:1980"] = 1}, type = "roundrobin" },
                 }
@@ -743,8 +721,52 @@ passed
                 return true
             end
 
-            if not put_route("cas-scope-a", conf_a, "/route-a/*") then return end
-            if not put_route("cas-scope-b", conf_b, "/route-b/*") then return end
+            local conf_a = {
+                idp_uri = "http://127.0.0.1:9999/cas-a",
+                cas_callback_uri = "/cb-a",
+                logout_uri = "/logout",
+                cookie = { secret = "0123456789abcdef0123456789abcdef", secure = false },
+            }
+            local conf_b = {
+                idp_uri = "http://127.0.0.1:9999/cas-b",
+                cas_callback_uri = "/cb-b",
+                logout_uri = "/logout",
+                cookie = { secret = "0123456789abcdef0123456789abcdef", secure = false },
+            }
+
+            -- /hello and /uri are existing actions in t/lib/server.lua;
+            -- the upstream returns 200 for both.
+            if not put_route("cas-scope-a", conf_a, "/hello") then return end
+            if not put_route("cas-scope-b", conf_b, "/uri") then return end
+
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 20: sessions from one CAS configuration are not honoured under another
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.cas-auth")
+            local h = plugin._test_helpers
+            local http = require("resty.http")
+
+            local conf_a = {
+                idp_uri = "http://127.0.0.1:9999/cas-a",
+                cas_callback_uri = "/cb-a",
+            }
+            local conf_b = {
+                idp_uri = "http://127.0.0.1:9999/cas-b",
+                cas_callback_uri = "/cb-b",
+            }
+            local opts_a = h.session_opts(conf_a)
+            local opts_b = h.session_opts(conf_b)
+            assert(opts_a.cookie_name ~= opts_b.cookie_name,
+                "routes with different CAS configs must use different cookie names")
 
             -- Plant a session entry for Route A's fingerprint, keyed by a synthetic ticket.
             local ticket = "ST-scope-test-" .. tostring(ngx.now())
@@ -753,8 +775,8 @@ passed
             local httpc = http.new()
             local base = "http://127.0.0.1:" .. ngx.var.server_port
 
-            -- (1) Route A honours its own session.
-            local res_a = httpc:request_uri(base .. "/route-a/resource", {
+            -- (1) Route A honours its own session, upstream /hello returns 200.
+            local res_a = httpc:request_uri(base .. "/hello", {
                 method = "GET",
                 headers = {
                     ["Host"] = "127.0.0.4",
@@ -765,8 +787,9 @@ passed
             assert(res_a.status == 200,
                 "route A should honour its own session, got status " .. res_a.status)
 
-            -- (2) Route B: same cookie under A's name; B looks for its own name -> 302.
-            local res_b1 = httpc:request_uri(base .. "/route-b/resource", {
+            -- (2) Route B receives Route A's cookie name; B looks for its own
+            -- cookie name and finds nothing -> redirect to its own IdP.
+            local res_b1 = httpc:request_uri(base .. "/uri", {
                 method = "GET",
                 headers = {
                     ["Host"] = "127.0.0.4",
@@ -777,9 +800,9 @@ passed
             assert(res_b1.status == 302,
                 "route B must not honour route A's cookie name, got status " .. res_b1.status)
 
-            -- (3) Route B: forged cookie using B's name but a foreign session value.
-            -- Server-side fingerprint check rejects: stored fp=A, expected fp=B.
-            local res_b2 = httpc:request_uri(base .. "/route-b/resource", {
+            -- (3) Route B receives a forged cookie under B's name but pointing
+            -- at Route A's stored session. The fingerprint check rejects it.
+            local res_b2 = httpc:request_uri(base .. "/uri", {
                 method = "GET",
                 headers = {
                     ["Host"] = "127.0.0.4",

--- a/t/plugin/cas-auth.t
+++ b/t/plugin/cas-auth.t
@@ -564,11 +564,23 @@ passed
                 end
             end
             ngx.say("session_cookie_set=", tostring(has_session))
+
+            -- No shared-dict entry should have been written for ST-test
+            -- under any configuration's fingerprint namespace.
+            local in_store = false
+            for _, k in ipairs(ngx.shared.cas_sessions:get_keys(0)) do
+                if k:find(":ST-test", 1, true) then
+                    in_store = true
+                    break
+                end
+            end
+            ngx.say("session_in_store=", tostring(in_store))
         }
     }
 --- response_body
 401
 session_cookie_set=false
+session_in_store=false
 
 
 
@@ -610,11 +622,23 @@ session_cookie_set=false
                 end
             end
             ngx.say("session_cookie_set=", tostring(has_session))
+
+            -- No shared-dict entry should have been written for ST-test
+            -- under any configuration's fingerprint namespace.
+            local in_store = false
+            for _, k in ipairs(ngx.shared.cas_sessions:get_keys(0)) do
+                if k:find(":ST-test", 1, true) then
+                    in_store = true
+                    break
+                end
+            end
+            ngx.say("session_in_store=", tostring(in_store))
         }
     }
 --- response_body
 401
 session_cookie_set=false
+session_in_store=false
 
 
 
@@ -769,8 +793,10 @@ passed
                 "routes with different CAS configs must use different cookie names")
 
             -- Plant a session entry for Route A's fingerprint, keyed by a synthetic ticket.
+            -- The plugin namespaces store keys as "<fingerprint>:<ticket>".
             local ticket = "ST-scope-test-" .. tostring(ngx.now())
-            ngx.shared.cas_sessions:set(ticket, h.pack_entry(opts_a.fingerprint, "alice"), 60)
+            local key_a = opts_a.fingerprint .. ":" .. ticket
+            ngx.shared.cas_sessions:set(key_a, h.pack_entry(opts_a.fingerprint, "alice"), 60)
 
             local httpc = http.new()
             local base = "http://127.0.0.1:" .. ngx.var.server_port
@@ -813,7 +839,7 @@ passed
             assert(res_b2.status == 302,
                 "route B must reject a foreign session payload, got status " .. res_b2.status)
 
-            ngx.shared.cas_sessions:delete(ticket)
+            ngx.shared.cas_sessions:delete(key_a)
             ngx.say("passed")
         }
     }

--- a/t/plugin/cas-auth.t
+++ b/t/plugin/cas-auth.t
@@ -768,7 +768,30 @@ passed
                 "scope-b must not honour foreign session payload, got "
                 .. res.status)
 
+            -- Plant an entry under scope-b's namespaced key but with scope-a's
+            -- fingerprint inside the stored value. This is the only path that
+            -- reaches the in-value fingerprint check in with_session_id:
+            -- store:get finds the entry, but unpack_entry returns fp_a while
+            -- the route's opts.fingerprint is fp_b -> first_access (302).
+            local key_b_forged = fp_b .. ":" .. ticket
+            local ok2, err3 = ngx.shared.cas_sessions:set(key_b_forged,
+                fp_a .. "|alice", 60)
+            assert(ok2, "forged plant failed: " .. tostring(err3))
+
+            res, err2 = httpc:request_uri(base .. "/uri", {
+                method = "GET",
+                headers = {
+                    ["Host"] = "127.0.0.11",
+                    ["Cookie"] = "CAS_SESSION_" .. fp_b .. "=" .. ticket,
+                },
+            })
+            assert(res, "scope-b fingerprint-mismatch request failed: " .. tostring(err2))
+            assert(res.status == 302,
+                "scope-b must reject a stored entry whose fingerprint does not match, got "
+                .. res.status)
+
             ngx.shared.cas_sessions:delete(key_a)
+            ngx.shared.cas_sessions:delete(key_b_forged)
             ngx.say("passed")
         }
     }

--- a/t/plugin/cas-auth.t
+++ b/t/plugin/cas-auth.t
@@ -481,3 +481,137 @@ passed
 --- response_body_like
 ^302
 .*service=https%3A%2F%2Fapp\.example\.com%2Fcas_callback.*$
+
+
+
+=== TEST 14: add route for callback initiation-cookie gate
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+
+            local code, body = t('/apisix/admin/routes/cas-gate',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "methods": ["GET", "POST"],
+                        "host": "127.0.0.3",
+                        "plugins": {
+                            "cas-auth": {
+                                "idp_uri": "http://127.0.0.1:8080/realms/test/protocol/cas",
+                                "cas_callback_uri": "/cas_callback",
+                                "logout_uri": "/logout",
+                                "cookie": {
+                                    "secret": "0123456789abcdef0123456789abcdef",
+                                    "secure": false
+                                }
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/*"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 15: callback without initiation cookie returns 401 and creates no session
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port
+                .. "/cas_callback?ticket=ST-test"
+
+            local res, err = httpc:request_uri(uri, {
+                method = "GET",
+                headers = {
+                    ["Host"] = "127.0.0.3",
+                }
+            })
+            if not res then
+                ngx.log(ngx.ERR, err)
+                ngx.exit(500)
+            end
+
+            ngx.say(res.status)
+
+            local set_cookie = res.headers['Set-Cookie']
+            local has_session = false
+            if type(set_cookie) == "string" then
+                if set_cookie:find("^CAS_SESSION=") then
+                    has_session = true
+                end
+            elseif type(set_cookie) == "table" then
+                for _, c in ipairs(set_cookie) do
+                    if c:find("^CAS_SESSION=") then
+                        has_session = true
+                        break
+                    end
+                end
+            end
+            ngx.say("session_cookie_set=", tostring(has_session))
+        }
+    }
+--- response_body
+401
+session_cookie_set=false
+
+
+
+=== TEST 16: callback with invalid initiation cookie returns 401 and creates no session
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port
+                .. "/cas_callback?ticket=ST-test"
+
+            local res, err = httpc:request_uri(uri, {
+                method = "GET",
+                headers = {
+                    ["Host"] = "127.0.0.3",
+                    ["Cookie"] = "CAS_REQUEST_URI=not-a-valid-signed-value",
+                }
+            })
+            if not res then
+                ngx.log(ngx.ERR, err)
+                ngx.exit(500)
+            end
+
+            ngx.say(res.status)
+
+            local set_cookie = res.headers['Set-Cookie']
+            local has_session = false
+            if type(set_cookie) == "string" then
+                if set_cookie:find("^CAS_SESSION=") then
+                    has_session = true
+                end
+            elseif type(set_cookie) == "table" then
+                for _, c in ipairs(set_cookie) do
+                    if c:find("^CAS_SESSION=") then
+                        has_session = true
+                        break
+                    end
+                end
+            end
+            ngx.say("session_cookie_set=", tostring(has_session))
+        }
+    }
+--- response_body
+401
+session_cookie_set=false

--- a/t/plugin/cas-auth.t
+++ b/t/plugin/cas-auth.t
@@ -642,128 +642,43 @@ session_in_store=false
 
 
 
-=== TEST 17: session_opts derives distinct cookie names and fingerprints per CAS configuration
---- config
-    location /t {
-        content_by_lua_block {
-            local plugin = require("apisix.plugins.cas-auth")
-            local h = plugin._test_helpers
-
-            local a = h.session_opts({
-                idp_uri = "http://cas-a.example/cas",
-                cas_callback_uri = "/cb",
-            })
-            local b = h.session_opts({
-                idp_uri = "http://cas-b.example/cas",
-                cas_callback_uri = "/cb",
-            })
-            local c = h.session_opts({
-                idp_uri = "http://cas-a.example/cas",
-                cas_callback_uri = "/other-cb",
-            })
-            local a2 = h.session_opts({
-                idp_uri = "http://cas-a.example/cas",
-                cas_callback_uri = "/cb",
-            })
-
-            assert(a.cookie_name ~= b.cookie_name, "different idp_uri must produce different cookie_name")
-            assert(a.cookie_name ~= c.cookie_name, "different cas_callback_uri must produce different cookie_name")
-            assert(a.fingerprint ~= b.fingerprint, "different idp_uri must produce different fingerprint")
-            assert(a.fingerprint ~= c.fingerprint, "different cas_callback_uri must produce different fingerprint")
-            assert(a.cookie_name == a2.cookie_name, "same conf must produce same cookie_name")
-            assert(a.fingerprint == a2.fingerprint, "same conf must produce same fingerprint")
-            assert(a.cookie_name:find("^CAS_SESSION_"), "cookie_name must start with CAS_SESSION_")
-            assert(#a.fingerprint == 64, "fingerprint must be 64 hex chars (sha256)")
-            assert(a.fingerprint:find("^[0-9a-f]+$"), "fingerprint must be lower-case hex")
-
-            ngx.say("passed")
-        }
-    }
---- response_body
-passed
 
 
 
-=== TEST 18: pack_entry and unpack_entry roundtrip and reject legacy entries
---- config
-    location /t {
-        content_by_lua_block {
-            local plugin = require("apisix.plugins.cas-auth")
-            local h = plugin._test_helpers
-
-            local fp = "abcd1234"
-            local user = "alice@example.com"
-            local entry = h.pack_entry(fp, user)
-            local got_fp, got_user = h.unpack_entry(entry)
-            assert(got_fp == fp, "fingerprint did not round-trip")
-            assert(got_user == user, "user did not round-trip")
-
-            -- Legacy entries (pre-fingerprint, no separator) must be rejected.
-            local nil_fp, nil_user = h.unpack_entry("legacy-user-no-pipe")
-            assert(nil_fp == nil, "legacy entry should produce nil fingerprint")
-            assert(nil_user == nil, "legacy entry should produce nil user")
-
-            local nfp, nu = h.unpack_entry(nil)
-            assert(nfp == nil and nu == nil, "nil entry must return nil,nil")
-
-            -- Split on first separator so a username containing the separator
-            -- is preserved verbatim.
-            local fp2, user2 = h.unpack_entry(h.pack_entry("xx", "ali|ce"))
-            assert(fp2 == "xx", "fingerprint split mismatch")
-            assert(user2 == "ali|ce", "user split mismatch")
-
-            ngx.say("passed")
-        }
-    }
---- response_body
-passed
-
-
-
-=== TEST 19: add routes with distinct CAS configurations for the scoping test
+=== TEST 17: Add a third route with a distinct cas_callback_uri
 --- config
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local core = require("apisix.core")
-
-            local function put_route(id, conf, uri_path)
-                local payload = {
-                    methods = {"GET"},
-                    host = "127.0.0.4",
-                    uri = uri_path,
-                    plugins = { ["cas-auth"] = conf },
-                    upstream = { nodes = {["127.0.0.1:1980"] = 1}, type = "roundrobin" },
-                }
-                local code, body = t('/apisix/admin/routes/' .. id,
-                    ngx.HTTP_PUT, core.json.encode(payload))
-                if code >= 300 then
-                    ngx.status = code
-                    ngx.say(body)
-                    return false
-                end
-                return true
+            local code, body = t('/apisix/admin/routes/cas-diff-cb',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "methods": ["GET", "POST"],
+                        "host" : "127.0.0.5",
+                        "plugins": {
+                            "cas-auth": {
+                                "idp_uri": "http://127.0.0.1:8080/realms/test/protocol/cas",
+                                "cas_callback_uri": "/cas_callback_alt",
+                                "logout_uri": "/logout",
+                                "cookie": {
+                                    "secret": "0123456789abcdef0123456789abcdef",
+                                    "secure": false
+                                }
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/*"
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
             end
-
-            local conf_a = {
-                idp_uri = "http://127.0.0.1:9999/cas-a",
-                cas_callback_uri = "/cb-a",
-                logout_uri = "/logout",
-                cookie = { secret = "0123456789abcdef0123456789abcdef", secure = false },
-            }
-            local conf_b = {
-                idp_uri = "http://127.0.0.1:9999/cas-b",
-                cas_callback_uri = "/cb-b",
-                logout_uri = "/logout",
-                cookie = { secret = "0123456789abcdef0123456789abcdef", secure = false },
-            }
-
-            -- /hello and /uri are existing actions in t/lib/server.lua;
-            -- the upstream returns 200 for both.
-            if not put_route("cas-scope-a", conf_a, "/hello") then return end
-            if not put_route("cas-scope-b", conf_b, "/uri") then return end
-
-            ngx.say("passed")
+            ngx.say(body)
         }
     }
 --- response_body
@@ -771,75 +686,53 @@ passed
 
 
 
-=== TEST 20: sessions from one CAS configuration are not honoured under another
+=== TEST 18: sessions from one CAS configuration are not honoured under another
 --- config
     location /t {
         content_by_lua_block {
-            local plugin = require("apisix.plugins.cas-auth")
-            local h = plugin._test_helpers
-            local http = require("resty.http")
-
-            local conf_a = {
-                idp_uri = "http://127.0.0.1:9999/cas-a",
-                cas_callback_uri = "/cb-a",
-            }
-            local conf_b = {
-                idp_uri = "http://127.0.0.1:9999/cas-b",
-                cas_callback_uri = "/cb-b",
-            }
-            local opts_a = h.session_opts(conf_a)
-            local opts_b = h.session_opts(conf_b)
-            assert(opts_a.cookie_name ~= opts_b.cookie_name,
-                "routes with different CAS configs must use different cookie names")
-
-            -- Plant a session entry for Route A's fingerprint, keyed by a synthetic ticket.
-            -- The plugin namespaces store keys as "<fingerprint>:<ticket>".
-            local ticket = "ST-scope-test-" .. tostring(ngx.now())
-            local key_a = opts_a.fingerprint .. ":" .. ticket
-            ngx.shared.cas_sessions:set(key_a, h.pack_entry(opts_a.fingerprint, "alice"), 60)
-
+            local http = require "resty.http"
             local httpc = http.new()
+            local kc = require "lib.keycloak_cas"
+
+            local path = "/uri"
             local base = "http://127.0.0.1:" .. ngx.var.server_port
 
-            -- (1) Route A honours its own session, upstream /hello returns 200.
-            local res_a = httpc:request_uri(base .. "/hello", {
+            -- Log in via Route sp1 (host 127.0.0.1, cas_callback_uri /cas_callback).
+            local res, err, cas_cookie = kc.login_keycloak(base .. path, "test", "test")
+            if err or res.headers['Location'] ~= path then
+                ngx.log(ngx.ERR, "sp1 login failed: ", tostring(err))
+                ngx.exit(500)
+            end
+
+            -- Sanity check: the session works on its own route.
+            res, err = httpc:request_uri(base .. res.headers['Location'], {
+                method = "GET",
+                headers = { ["Cookie"] = cas_cookie },
+            })
+            assert(res, "sp1 follow-up failed: " .. tostring(err))
+            assert(res.status == 200,
+                "sp1 should honour its own session, got status " .. res.status)
+
+            -- Send the same cookie to a route configured with a different
+            -- cas_callback_uri (and thus a different fingerprint). That route
+            -- should not honour the foreign session and should redirect to its
+            -- own IdP, even though both routes are wired to the same Keycloak.
+            res, err = httpc:request_uri(base .. path, {
                 method = "GET",
                 headers = {
-                    ["Host"] = "127.0.0.4",
-                    ["Cookie"] = opts_a.cookie_name .. "=" .. ticket,
-                }
+                    ["Host"] = "127.0.0.5",
+                    ["Cookie"] = cas_cookie,
+                },
             })
-            assert(res_a, "route A request failed")
-            assert(res_a.status == 200,
-                "route A should honour its own session, got status " .. res_a.status)
+            assert(res, "diff-cb follow-up failed: " .. tostring(err))
+            assert(res.status == 302,
+                "different-config route should not honour foreign session, got "
+                .. res.status)
 
-            -- (2) Route B receives Route A's cookie name; B looks for its own
-            -- cookie name and finds nothing -> redirect to its own IdP.
-            local res_b1 = httpc:request_uri(base .. "/uri", {
-                method = "GET",
-                headers = {
-                    ["Host"] = "127.0.0.4",
-                    ["Cookie"] = opts_a.cookie_name .. "=" .. ticket,
-                }
-            })
-            assert(res_b1, "route B request failed")
-            assert(res_b1.status == 302,
-                "route B must not honour route A's cookie name, got status " .. res_b1.status)
+            local loc = res.headers['Location'] or ""
+            assert(loc:find("/realms/test/protocol/cas/login", 1, true),
+                "expected redirect to Keycloak CAS login, got Location=" .. loc)
 
-            -- (3) Route B receives a forged cookie under B's name but pointing
-            -- at Route A's stored session. The fingerprint check rejects it.
-            local res_b2 = httpc:request_uri(base .. "/uri", {
-                method = "GET",
-                headers = {
-                    ["Host"] = "127.0.0.4",
-                    ["Cookie"] = opts_b.cookie_name .. "=" .. ticket,
-                }
-            })
-            assert(res_b2, "route B forged-cookie request failed")
-            assert(res_b2.status == 302,
-                "route B must reject a foreign session payload, got status " .. res_b2.status)
-
-            ngx.shared.cas_sessions:delete(key_a)
             ngx.say("passed")
         }
     }

--- a/t/plugin/cas-auth.t
+++ b/t/plugin/cas-auth.t
@@ -552,12 +552,12 @@ passed
             local set_cookie = res.headers['Set-Cookie']
             local has_session = false
             if type(set_cookie) == "string" then
-                if set_cookie:find("^CAS_SESSION=") then
+                if set_cookie:find("^CAS_SESSION_") then
                     has_session = true
                 end
             elseif type(set_cookie) == "table" then
                 for _, c in ipairs(set_cookie) do
-                    if c:find("^CAS_SESSION=") then
+                    if c:find("^CAS_SESSION_") then
                         has_session = true
                         break
                     end
@@ -598,12 +598,12 @@ session_cookie_set=false
             local set_cookie = res.headers['Set-Cookie']
             local has_session = false
             if type(set_cookie) == "string" then
-                if set_cookie:find("^CAS_SESSION=") then
+                if set_cookie:find("^CAS_SESSION_") then
                     has_session = true
                 end
             elseif type(set_cookie) == "table" then
                 for _, c in ipairs(set_cookie) do
-                    if c:find("^CAS_SESSION=") then
+                    if c:find("^CAS_SESSION_") then
                         has_session = true
                         break
                     end
@@ -615,3 +615,184 @@ session_cookie_set=false
 --- response_body
 401
 session_cookie_set=false
+
+
+
+=== TEST 17: session_opts derives distinct cookie names and fingerprints per CAS configuration
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.cas-auth")
+            local h = plugin._test_helpers
+
+            local a = h.session_opts({
+                idp_uri = "http://cas-a.example/cas",
+                cas_callback_uri = "/cb",
+            })
+            local b = h.session_opts({
+                idp_uri = "http://cas-b.example/cas",
+                cas_callback_uri = "/cb",
+            })
+            local c = h.session_opts({
+                idp_uri = "http://cas-a.example/cas",
+                cas_callback_uri = "/other-cb",
+            })
+            local a2 = h.session_opts({
+                idp_uri = "http://cas-a.example/cas",
+                cas_callback_uri = "/cb",
+            })
+
+            assert(a.cookie_name ~= b.cookie_name, "different idp_uri must produce different cookie_name")
+            assert(a.cookie_name ~= c.cookie_name, "different cas_callback_uri must produce different cookie_name")
+            assert(a.fingerprint ~= b.fingerprint, "different idp_uri must produce different fingerprint")
+            assert(a.fingerprint ~= c.fingerprint, "different cas_callback_uri must produce different fingerprint")
+            assert(a.cookie_name == a2.cookie_name, "same conf must produce same cookie_name")
+            assert(a.fingerprint == a2.fingerprint, "same conf must produce same fingerprint")
+            assert(a.cookie_name:find("^CAS_SESSION_"), "cookie_name must start with CAS_SESSION_")
+            assert(#a.fingerprint == 64, "fingerprint must be 64 hex chars (sha256)")
+            assert(a.fingerprint:find("^[0-9a-f]+$"), "fingerprint must be lower-case hex")
+
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 18: pack_entry and unpack_entry roundtrip and reject legacy entries
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.cas-auth")
+            local h = plugin._test_helpers
+
+            local fp = "abcd1234"
+            local user = "alice@example.com"
+            local entry = h.pack_entry(fp, user)
+            local got_fp, got_user = h.unpack_entry(entry)
+            assert(got_fp == fp, "fingerprint did not round-trip")
+            assert(got_user == user, "user did not round-trip")
+
+            -- Legacy entries (pre-fingerprint, no separator) must be rejected.
+            local nil_fp, nil_user = h.unpack_entry("legacy-user-no-pipe")
+            assert(nil_fp == nil, "legacy entry should produce nil fingerprint")
+            assert(nil_user == nil, "legacy entry should produce nil user")
+
+            local nfp, nu = h.unpack_entry(nil)
+            assert(nfp == nil and nu == nil, "nil entry must return nil,nil")
+
+            -- Split on first separator so a username containing the separator
+            -- is preserved verbatim.
+            local fp2, user2 = h.unpack_entry(h.pack_entry("xx", "ali|ce"))
+            assert(fp2 == "xx", "fingerprint split mismatch")
+            assert(user2 == "ali|ce", "user split mismatch")
+
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 19: sessions from one CAS configuration are not honoured under another
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local core = require("apisix.core")
+            local plugin = require("apisix.plugins.cas-auth")
+            local h = plugin._test_helpers
+            local http = require("resty.http")
+
+            -- Route A and Route B share a host but point at different IdPs,
+            -- so each has a distinct CAS trust context (fingerprint).
+            local conf_a = {
+                idp_uri = "http://127.0.0.1:9999/cas-a",
+                cas_callback_uri = "/cb-a",
+                logout_uri = "/logout",
+                cookie = { secret = "0123456789abcdef0123456789abcdef", secure = false },
+            }
+            local conf_b = {
+                idp_uri = "http://127.0.0.1:9999/cas-b",
+                cas_callback_uri = "/cb-b",
+                logout_uri = "/logout",
+                cookie = { secret = "0123456789abcdef0123456789abcdef", secure = false },
+            }
+            local opts_a = h.session_opts(conf_a)
+            local opts_b = h.session_opts(conf_b)
+            assert(opts_a.cookie_name ~= opts_b.cookie_name,
+                "routes with different CAS configs must use different cookie names")
+
+            local function put_route(id, conf, uri_glob)
+                local payload = {
+                    methods = {"GET"},
+                    host = "127.0.0.4",
+                    uri = uri_glob,
+                    plugins = { ["cas-auth"] = conf },
+                    upstream = { nodes = {["127.0.0.1:1980"] = 1}, type = "roundrobin" },
+                }
+                local code, body = t('/apisix/admin/routes/' .. id,
+                    ngx.HTTP_PUT, core.json.encode(payload))
+                if code >= 300 then
+                    ngx.status = code
+                    ngx.say(body)
+                    return false
+                end
+                return true
+            end
+
+            if not put_route("cas-scope-a", conf_a, "/route-a/*") then return end
+            if not put_route("cas-scope-b", conf_b, "/route-b/*") then return end
+
+            -- Plant a session entry for Route A's fingerprint, keyed by a synthetic ticket.
+            local ticket = "ST-scope-test-" .. tostring(ngx.now())
+            ngx.shared.cas_sessions:set(ticket, h.pack_entry(opts_a.fingerprint, "alice"), 60)
+
+            local httpc = http.new()
+            local base = "http://127.0.0.1:" .. ngx.var.server_port
+
+            -- (1) Route A honours its own session.
+            local res_a = httpc:request_uri(base .. "/route-a/resource", {
+                method = "GET",
+                headers = {
+                    ["Host"] = "127.0.0.4",
+                    ["Cookie"] = opts_a.cookie_name .. "=" .. ticket,
+                }
+            })
+            assert(res_a, "route A request failed")
+            assert(res_a.status == 200,
+                "route A should honour its own session, got status " .. res_a.status)
+
+            -- (2) Route B: same cookie under A's name; B looks for its own name -> 302.
+            local res_b1 = httpc:request_uri(base .. "/route-b/resource", {
+                method = "GET",
+                headers = {
+                    ["Host"] = "127.0.0.4",
+                    ["Cookie"] = opts_a.cookie_name .. "=" .. ticket,
+                }
+            })
+            assert(res_b1, "route B request failed")
+            assert(res_b1.status == 302,
+                "route B must not honour route A's cookie name, got status " .. res_b1.status)
+
+            -- (3) Route B: forged cookie using B's name but a foreign session value.
+            -- Server-side fingerprint check rejects: stored fp=A, expected fp=B.
+            local res_b2 = httpc:request_uri(base .. "/route-b/resource", {
+                method = "GET",
+                headers = {
+                    ["Host"] = "127.0.0.4",
+                    ["Cookie"] = opts_b.cookie_name .. "=" .. ticket,
+                }
+            })
+            assert(res_b2, "route B forged-cookie request failed")
+            assert(res_b2.status == 302,
+                "route B must reject a foreign session payload, got status " .. res_b2.status)
+
+            ngx.shared.cas_sessions:delete(ticket)
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed

--- a/t/plugin/cas-auth.t
+++ b/t/plugin/cas-auth.t
@@ -642,40 +642,50 @@ session_in_store=false
 
 
 
-=== TEST 17: Add a third route with a distinct cas_callback_uri
+=== TEST 17: Add dedicated routes for the per-config scoping test
 --- config
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/routes/cas-diff-cb',
-                 ngx.HTTP_PUT,
-                 [[{
-                        "methods": ["GET", "POST"],
-                        "host" : "127.0.0.5",
-                        "plugins": {
-                            "cas-auth": {
-                                "idp_uri": "http://127.0.0.1:8080/realms/test/protocol/cas",
-                                "cas_callback_uri": "/cas_callback_alt",
-                                "logout_uri": "/logout",
-                                "cookie": {
-                                    "secret": "0123456789abcdef0123456789abcdef",
-                                    "secure": false
+
+            -- Use priority=10 so these routes win over the no-host catch-all
+            -- registered in earlier tests (cas-abs), and unique hosts so they
+            -- don't collide with cas1/cas2.
+            local function put(id, host, cb)
+                local code, body = t('/apisix/admin/routes/' .. id,
+                     ngx.HTTP_PUT,
+                     string.format([[{
+                            "methods": ["GET", "POST"],
+                            "host": %q,
+                            "priority": 10,
+                            "plugins": {
+                                "cas-auth": {
+                                    "idp_uri": "http://127.0.0.1:8080/realms/test/protocol/cas",
+                                    "cas_callback_uri": %q,
+                                    "logout_uri": "/logout",
+                                    "cookie": {
+                                        "secret": "0123456789abcdef0123456789abcdef",
+                                        "secure": false
+                                    }
                                 }
-                            }
-                        },
-                        "upstream": {
-                            "nodes": {
-                                "127.0.0.1:1980": 1
                             },
-                            "type": "roundrobin"
-                        },
-                        "uri": "/*"
-                }]]
-                )
-            if code >= 300 then
-                ngx.status = code
+                            "upstream": {
+                                "nodes": {"127.0.0.1:1980": 1},
+                                "type": "roundrobin"
+                            },
+                            "uri": "/*"
+                    }]], host, cb))
+                if code >= 300 then
+                    ngx.status = code
+                    ngx.say(body)
+                    return false
+                end
+                return true
             end
-            ngx.say(body)
+
+            if not put("cas-scope-a", "127.0.0.10", "/cas_callback") then return end
+            if not put("cas-scope-b", "127.0.0.11", "/cas_callback_alt") then return end
+            ngx.say("passed")
         }
     }
 --- response_body
@@ -707,56 +717,58 @@ passed
             -- Plant a session as the plugin would: store key namespaced by the
             -- fingerprint, value of "<fp>|<user>". This exercises the plugin's
             -- session-read path (with_session_id -> store:get -> unpack_entry
-            -- -> fingerprint check) on Route A.
+            -- -> fingerprint check) on scope-a.
             local ticket = "ST-scope-test-" .. tostring(ngx.now())
-            ngx.shared.cas_sessions:set(fp_a .. ":" .. ticket, fp_a .. "|alice", 60)
+            local key_a = fp_a .. ":" .. ticket
+            local ok, err = ngx.shared.cas_sessions:set(key_a, fp_a .. "|alice", 60)
+            assert(ok, "plant failed: " .. tostring(err))
 
             local httpc = http.new()
             local base = "http://127.0.0.1:" .. ngx.var.server_port
 
-            -- Route sp1 honours its own session.
-            local res, err = httpc:request_uri(base .. "/uri", {
+            -- Route scope-a (host 127.0.0.10) honours its own session.
+            local res, err2 = httpc:request_uri(base .. "/uri", {
                 method = "GET",
                 headers = {
-                    ["Host"] = "127.0.0.1",
+                    ["Host"] = "127.0.0.10",
                     ["Cookie"] = "CAS_SESSION_" .. fp_a .. "=" .. ticket,
                 },
             })
-            assert(res, "sp1 request failed: " .. tostring(err))
+            assert(res, "scope-a request failed: " .. tostring(err2))
             assert(res.status == 200,
-                "sp1 should honour its own session, got status " .. res.status)
+                "scope-a should honour its own session, got status " .. res.status)
 
-            -- Same cookie sent to a route with a different cas_callback_uri:
-            -- the diff-cb route looks for cookie name CAS_SESSION_<fp_b>,
-            -- finds nothing, redirects to its own IdP.
-            res, err = httpc:request_uri(base .. "/uri", {
+            -- Same cookie sent to scope-b (different cas_callback_uri, different
+            -- fingerprint): scope-b looks for CAS_SESSION_<fp_b>, doesn't find
+            -- it, redirects to its own IdP.
+            res, err2 = httpc:request_uri(base .. "/uri", {
                 method = "GET",
                 headers = {
-                    ["Host"] = "127.0.0.5",
+                    ["Host"] = "127.0.0.11",
                     ["Cookie"] = "CAS_SESSION_" .. fp_a .. "=" .. ticket,
                 },
             })
-            assert(res, "diff-cb request failed: " .. tostring(err))
+            assert(res, "scope-b request failed: " .. tostring(err2))
             assert(res.status == 302,
-                "diff-cb must not honour foreign cookie name, got "
+                "scope-b must not honour foreign cookie name, got "
                 .. res.status)
 
-            -- A forged cookie under diff-cb's own name pointing at Route A's
+            -- A forged cookie under scope-b's own name pointing at scope-a's
             -- ticket: the namespaced store key under fp_b doesn't exist,
             -- so the request still falls through to first_access.
-            res, err = httpc:request_uri(base .. "/uri", {
+            res, err2 = httpc:request_uri(base .. "/uri", {
                 method = "GET",
                 headers = {
-                    ["Host"] = "127.0.0.5",
+                    ["Host"] = "127.0.0.11",
                     ["Cookie"] = "CAS_SESSION_" .. fp_b .. "=" .. ticket,
                 },
             })
-            assert(res, "diff-cb forged-cookie request failed: " .. tostring(err))
+            assert(res, "scope-b forged-cookie request failed: " .. tostring(err2))
             assert(res.status == 302,
-                "diff-cb must not honour foreign session payload, got "
+                "scope-b must not honour foreign session payload, got "
                 .. res.status)
 
-            ngx.shared.cas_sessions:delete(fp_a .. ":" .. ticket)
+            ngx.shared.cas_sessions:delete(key_a)
             ngx.say("passed")
         }
     }

--- a/t/plugin/cas-auth.t
+++ b/t/plugin/cas-auth.t
@@ -642,9 +642,6 @@ session_in_store=false
 
 
 
-
-
-
 === TEST 17: Add a third route with a distinct cas_callback_uri
 --- config
     location /t {
@@ -691,48 +688,75 @@ passed
     location /t {
         content_by_lua_block {
             local http = require "resty.http"
-            local httpc = http.new()
-            local kc = require "lib.keycloak_cas"
+            local resty_sha256 = require("resty.sha256")
+            local str = require("resty.string")
 
-            local path = "/uri"
-            local base = "http://127.0.0.1:" .. ngx.var.server_port
-
-            -- Log in via Route sp1 (host 127.0.0.1, cas_callback_uri /cas_callback).
-            local res, err, cas_cookie = kc.login_keycloak(base .. path, "test", "test")
-            if err or res.headers['Location'] ~= path then
-                ngx.log(ngx.ERR, "sp1 login failed: ", tostring(err))
-                ngx.exit(500)
+            -- Recompute the per-config fingerprint here rather than exposing
+            -- the plugin's session_opts helper. Algorithm matches the plugin.
+            local function fingerprint(idp, cb)
+                local s = resty_sha256:new()
+                s:update(idp .. "|" .. cb)
+                return str.to_hex(s:final())
             end
 
-            -- Sanity check: the session works on its own route.
-            res, err = httpc:request_uri(base .. res.headers['Location'], {
+            local idp = "http://127.0.0.1:8080/realms/test/protocol/cas"
+            local fp_a = fingerprint(idp, "/cas_callback")
+            local fp_b = fingerprint(idp, "/cas_callback_alt")
+            assert(fp_a ~= fp_b, "two configs must yield different fingerprints")
+
+            -- Plant a session as the plugin would: store key namespaced by the
+            -- fingerprint, value of "<fp>|<user>". This exercises the plugin's
+            -- session-read path (with_session_id -> store:get -> unpack_entry
+            -- -> fingerprint check) on Route A.
+            local ticket = "ST-scope-test-" .. tostring(ngx.now())
+            ngx.shared.cas_sessions:set(fp_a .. ":" .. ticket, fp_a .. "|alice", 60)
+
+            local httpc = http.new()
+            local base = "http://127.0.0.1:" .. ngx.var.server_port
+
+            -- Route sp1 honours its own session.
+            local res, err = httpc:request_uri(base .. "/uri", {
                 method = "GET",
-                headers = { ["Cookie"] = cas_cookie },
+                headers = {
+                    ["Host"] = "127.0.0.1",
+                    ["Cookie"] = "CAS_SESSION_" .. fp_a .. "=" .. ticket,
+                },
             })
-            assert(res, "sp1 follow-up failed: " .. tostring(err))
+            assert(res, "sp1 request failed: " .. tostring(err))
             assert(res.status == 200,
                 "sp1 should honour its own session, got status " .. res.status)
 
-            -- Send the same cookie to a route configured with a different
-            -- cas_callback_uri (and thus a different fingerprint). That route
-            -- should not honour the foreign session and should redirect to its
-            -- own IdP, even though both routes are wired to the same Keycloak.
-            res, err = httpc:request_uri(base .. path, {
+            -- Same cookie sent to a route with a different cas_callback_uri:
+            -- the diff-cb route looks for cookie name CAS_SESSION_<fp_b>,
+            -- finds nothing, redirects to its own IdP.
+            res, err = httpc:request_uri(base .. "/uri", {
                 method = "GET",
                 headers = {
                     ["Host"] = "127.0.0.5",
-                    ["Cookie"] = cas_cookie,
+                    ["Cookie"] = "CAS_SESSION_" .. fp_a .. "=" .. ticket,
                 },
             })
-            assert(res, "diff-cb follow-up failed: " .. tostring(err))
+            assert(res, "diff-cb request failed: " .. tostring(err))
             assert(res.status == 302,
-                "different-config route should not honour foreign session, got "
+                "diff-cb must not honour foreign cookie name, got "
                 .. res.status)
 
-            local loc = res.headers['Location'] or ""
-            assert(loc:find("/realms/test/protocol/cas/login", 1, true),
-                "expected redirect to Keycloak CAS login, got Location=" .. loc)
+            -- A forged cookie under diff-cb's own name pointing at Route A's
+            -- ticket: the namespaced store key under fp_b doesn't exist,
+            -- so the request still falls through to first_access.
+            res, err = httpc:request_uri(base .. "/uri", {
+                method = "GET",
+                headers = {
+                    ["Host"] = "127.0.0.5",
+                    ["Cookie"] = "CAS_SESSION_" .. fp_b .. "=" .. ticket,
+                },
+            })
+            assert(res, "diff-cb forged-cookie request failed: " .. tostring(err))
+            assert(res.status == 302,
+                "diff-cb must not honour foreign session payload, got "
+                .. res.status)
 
+            ngx.shared.cas_sessions:delete(fp_a .. ":" .. ticket)
             ngx.say("passed")
         }
     }


### PR DESCRIPTION
### Description

The `cas-auth` plugin has two related callback/session weaknesses that this PR addresses together. Both are behaviour changes; normal end-to-end CAS flows are unaffected.

#### 1. Require a valid initiation cookie at the callback (commit `05841df4a`)

`validate_with_cas` previously wrote the session and then attempted to read the HMAC-signed `CAS_REQUEST_URI` cookie to decide where to redirect. If that cookie was missing or its signature did not verify, the handler fell back to redirecting to `/`, but the session was still created.

`validate_with_cas` now verifies the HMAC of `CAS_REQUEST_URI` *first* and refuses to create a session if the cookie is missing or invalid. A request that reaches `/cas_callback` without going through `first_access` now returns `401 invalid callback state` and writes no session cookie.

Builds on the HMAC cookie machinery (`sign_value` / `verify_value`, `is_safe_redirect`, `cookie.secret` schema field, `SameSite=Lax`) introduced in #13331.

#### 2. Scope the session cookie per CAS configuration (commit `ff2e242ca`)

Every route using `cas-auth` previously shared a single fixed cookie name `CAS_SESSION` and a single global `cas_sessions` shared dict keyed by ticket, regardless of the route's `idp_uri` / `cas_callback_uri`. A browser session minted under one route's CAS configuration was therefore reused by any other `cas-auth` route on the same host, even if that route pointed at a different IdP.

Each route now uses a cookie name derived from `sha256(idp_uri || cas_callback_uri)` (`CAS_SESSION_<hex>`), and the shared-dict entry carries that fingerprint as a prefix. `with_session_id` rejects entries whose stored fingerprint does not match the current route's fingerprint. Mirrors the per-`client_id` pattern already used by `authz-casdoor`.

### Breaking changes

- **Commit 1.** Callers hitting `/cas_callback?ticket=...` directly without going through `first_access` now receive `401 invalid callback state`. Normal browser CAS flows always go through `first_access`, which sets the signed initiation cookie before the IdP redirect, so they are unaffected.
- **Commit 2.** Existing `CAS_SESSION` cookies and any unfingerprinted entries in the `cas_sessions` shared dict are not recognised after upgrade. End users with a live session at upgrade time are redirected once through the IdP to re-establish a session under the new cookie name.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

Notes:

- Tests in `t/plugin/cas-auth.t`:
  - **Commit 1** added TEST 14 (route setup), TEST 15 (callback without initiation cookie → 401, no session cookie), TEST 16 (callback with invalid initiation cookie → 401, no session cookie).
  - **Commit 2** adds TEST 17 (`session_opts` derives distinct cookie names + fingerprints per CAS configuration), TEST 18 (`pack_entry` / `unpack_entry` roundtrip and rejection of legacy entries), TEST 19 (two-route integration: a session minted under one CAS configuration is not honoured under a different configuration). It also updates the `^CAS_SESSION=` assertion in TEST 15 / TEST 16 to `^CAS_SESSION_` to match the new cookie shape.
- Documentation: no documentation changes are needed; the configured behaviour for end-to-end CAS flows is unchanged.
- Backward compatibility: see the **Breaking changes** section above.

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
