### PR TITLE
fix: remove stale HTTP/2 body guard

### DIFF
--- a/apisix/core/request.lua
+++ b/apisix/core/request.lua
@@ -296,15 +296,6 @@ function _M.get_body(max_size, ctx)
         end
     end
 
-    -- check content-length header for http2/http3
-    do
-        local var = ctx and ctx.var or ngx.var
-        local content_length = tonumber(var.http_content_length)
-        if (var.server_protocol == "HTTP/2.0" or var.server_protocol == "HTTP/3.0")
-            and not content_length then
-            return nil, "HTTP2/HTTP3 request without a Content-Length header"
-        end
-    end
     req_read_body()
 
     local req_body = req_get_body_data()

--- a/t/plugin/azure-functions.t
+++ b/t/plugin/azure-functions.t
@@ -189,8 +189,6 @@ X-Extra-Header: MUST
 --- http2
 --- request
 GET /azure
---- more_headers
-Content-Length: 0
 --- response_body
 faas invoked
 
@@ -210,8 +208,6 @@ server: APISIX/2.10.2
 --- http2
 --- request
 HEAD /azure
---- more_headers
-Content-Length: 0
 --- response_headers
 Connection:
 Upgrade:
@@ -498,13 +494,3 @@ invocation /api successful
     }
 --- response_body
 passed
-
-
-
-=== TEST 15: http2 failed to check response body and headers
---- http2
---- request
-GET /azure
---- error_code: 400
---- error_log
-HTTP2/HTTP3 request without a Content-Length header,


### PR DESCRIPTION
### Description

`core.request.get_body()` still rejects HTTP/2 and HTTP/3 requests without a `Content-Length` header, but that guard was added for an older lua-nginx-module behavior that has since been reverted upstream.

Current lua-nginx-module no longer rejects `ngx.req.read_body()` for HTTP/2 or HTTP/3 requests without `Content-Length`, so APISIX should not reject those requests at its own request helper layer. This also matches the discussion in #11362, where the reported behavior was already stale for newer OpenResty releases.

This removes the stale guard and drops the test-only `Content-Length: 0` headers that were added for it.

#### Which issue(s) this PR fixes:

Fixes #11362

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (not needed; this removes an internal stale guard and there is no documented config/API change)
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)



Fixes #13237
