### PR TITLE
ci: use prebuilt apisix runtime

### DIFF
--- a/ci/linux-install-openresty.sh
+++ b/ci/linux-install-openresty.sh
@@ -61,12 +61,19 @@ else
     sudo apt-get -y update --fix-missing
     sudo apt-get install -y build-essential gcc g++ cpanminus
 
+    if [ "$APISIX_RUNTIME" != "1.3.6" ]; then
+        echo "Please update the apisix-runtime-debug checksum for APISIX_RUNTIME=$APISIX_RUNTIME" >&2
+        exit 1
+    fi
+
     case "$ARCH" in
         x86_64|amd64)
             DEB_ARCH="amd64"
+            EXPECTED_SHA256="f3c3836270e4d71c7154bea3dd13005cacad5b489eacf9fab7b048907fa4d641"
             ;;
         arm64|aarch64)
             DEB_ARCH="arm64"
+            EXPECTED_SHA256="6f5ba1e4dee34f9c2593687b3e97dad53cbc1f2b90283961fd87eba62e4c9bc4"
             ;;
         *)
             echo "Unsupported architecture: $ARCH" >&2
@@ -78,6 +85,7 @@ else
     RELEASE_URL="https://github.com/api7/apisix-build-tools/releases/download/apisix-runtime%2F${APISIX_RUNTIME}/${DEB_NAME}"
 
     wget --no-verbose --tries=3 --retry-connrefused "$RELEASE_URL" -O "/tmp/$DEB_NAME"
+    echo "$EXPECTED_SHA256  /tmp/$DEB_NAME" | sha256sum -c -
     sudo apt-get install -y "/tmp/$DEB_NAME"
     rm -f "/tmp/$DEB_NAME"
 fi

--- a/ci/linux-install-openresty.sh
+++ b/ci/linux-install-openresty.sh
@@ -22,38 +22,64 @@ source ./ci/common.sh
 export_version_info
 
 ARCH=${ARCH:-`(uname -m | tr '[:upper:]' '[:lower:]')`}
-arch_path=""
-if [[ $ARCH == "arm64" ]] || [[ $ARCH == "aarch64" ]]; then
-    arch_path="arm64/"
-fi
-
-wget -qO - https://openresty.org/package/pubkey.gpg | sudo apt-key add -
-wget -qO - http://repos.apiseven.com/pubkey.gpg | sudo apt-key add -
-sudo apt-get -y update --fix-missing
-sudo apt-get -y install software-properties-common
-sudo add-apt-repository -y "deb https://openresty.org/package/${arch_path}ubuntu $(lsb_release -sc) main"
-sudo add-apt-repository -y "deb http://repos.apiseven.com/packages/${arch_path}debian bullseye main"
-
-sudo apt-get update
-sudo apt-get install -y openresty-pcre-dev openresty-zlib-dev build-essential gcc g++ cpanminus
 
 SSL_LIB_VERSION=${SSL_LIB_VERSION-openssl}
 ENABLE_FIPS=${ENABLE_FIPS:-"false"}
 
-if [ "$SSL_LIB_VERSION" == "tongsuo" ]; then
-    export openssl_prefix=/usr/local/tongsuo
-    export zlib_prefix=$OPENRESTY_PREFIX/zlib
-    export pcre_prefix=$OPENRESTY_PREFIX/pcre
+if [ "$SSL_LIB_VERSION" == "tongsuo" ] || [ "$ENABLE_FIPS" == "true" ]; then
+    arch_path=""
+    if [[ $ARCH == "arm64" ]] || [[ $ARCH == "aarch64" ]]; then
+        arch_path="arm64/"
+    fi
 
-    export cc_opt="-DNGX_LUA_ABORT_AT_PANIC -I${zlib_prefix}/include -I${pcre_prefix}/include -I${openssl_prefix}/include"
-    export ld_opt="-L${zlib_prefix}/lib -L${pcre_prefix}/lib -L${openssl_prefix}/lib64 -Wl,-rpath,${zlib_prefix}/lib:${pcre_prefix}/lib:${openssl_prefix}/lib64"
-fi
+    wget -qO - https://openresty.org/package/pubkey.gpg | sudo apt-key add -
+    wget -qO - http://repos.apiseven.com/pubkey.gpg | sudo apt-key add -
+    sudo apt-get -y update --fix-missing
+    sudo apt-get -y install software-properties-common
+    sudo add-apt-repository -y "deb https://openresty.org/package/${arch_path}ubuntu $(lsb_release -sc) main"
+    sudo add-apt-repository -y "deb http://repos.apiseven.com/packages/${arch_path}debian bullseye main"
 
-install_apisix_runtime
+    sudo apt-get update
+    sudo apt-get install -y openresty-pcre-dev openresty-zlib-dev build-essential gcc g++ cpanminus
 
-if [ ! "$ENABLE_FIPS" == "true" ]; then
-curl -o /usr/local/openresty/openssl3/ssl/openssl.cnf \
-    https://raw.githubusercontent.com/api7/apisix-build-tools/apisix-runtime/${APISIX_RUNTIME}/conf/openssl3/openssl.cnf
+    if [ "$SSL_LIB_VERSION" == "tongsuo" ]; then
+        export openssl_prefix=/usr/local/tongsuo
+        export zlib_prefix=$OPENRESTY_PREFIX/zlib
+        export pcre_prefix=$OPENRESTY_PREFIX/pcre
+
+        export cc_opt="-DNGX_LUA_ABORT_AT_PANIC -I${zlib_prefix}/include -I${pcre_prefix}/include -I${openssl_prefix}/include"
+        export ld_opt="-L${zlib_prefix}/lib -L${pcre_prefix}/lib -L${openssl_prefix}/lib64 -Wl,-rpath,${zlib_prefix}/lib:${pcre_prefix}/lib:${openssl_prefix}/lib64"
+    fi
+
+    install_apisix_runtime
+
+    if [ ! "$ENABLE_FIPS" == "true" ]; then
+        curl -o /usr/local/openresty/openssl3/ssl/openssl.cnf \
+            https://raw.githubusercontent.com/api7/apisix-build-tools/apisix-runtime/${APISIX_RUNTIME}/conf/openssl3/openssl.cnf
+    fi
+else
+    sudo apt-get -y update --fix-missing
+    sudo apt-get install -y build-essential gcc g++ cpanminus
+
+    case "$ARCH" in
+        x86_64|amd64)
+            DEB_ARCH="amd64"
+            ;;
+        arm64|aarch64)
+            DEB_ARCH="arm64"
+            ;;
+        *)
+            echo "Unsupported architecture: $ARCH" >&2
+            exit 1
+            ;;
+    esac
+
+    DEB_NAME="apisix-runtime-debug_${APISIX_RUNTIME}-0.debianbookworm-slim_${DEB_ARCH}.deb"
+    RELEASE_URL="https://github.com/api7/apisix-build-tools/releases/download/apisix-runtime%2F${APISIX_RUNTIME}/${DEB_NAME}"
+
+    wget --no-verbose --tries=3 --retry-connrefused "$RELEASE_URL" -O "/tmp/$DEB_NAME"
+    sudo apt-get install -y "/tmp/$DEB_NAME"
+    rm -f "/tmp/$DEB_NAME"
 fi
 
 # patch lua-resty-events

--- a/t/plugin/uri-blocker.t
+++ b/t/plugin/uri-blocker.t
@@ -51,7 +51,7 @@ location /t {
 GET /t
 --- error_code: 400
 --- response_body
-{"error_msg":"failed to check the configuration of plugin uri-blocker err: pcre2_compile() failed: missing closing parenthesis in \".+(\""}
+{"error_msg":"failed to check the configuration of plugin uri-blocker err: pcre_compile() failed: missing ) in \".+(\""}
 
 
 
@@ -112,7 +112,7 @@ location /t {
 GET /t
 --- error_code: 400
 --- response_body
-{"error_msg":"failed to check the configuration of plugin uri-blocker err: pcre2_compile() failed: missing closing parenthesis in \"^b(\""}
+{"error_msg":"failed to check the configuration of plugin uri-blocker err: pcre_compile() failed: missing ) in \"^b(\""}
 
 
 

--- a/t/plugin/uri-blocker.t
+++ b/t/plugin/uri-blocker.t
@@ -50,8 +50,8 @@ location /t {
 --- request
 GET /t
 --- error_code: 400
---- response_body
-{"error_msg":"failed to check the configuration of plugin uri-blocker err: pcre2_compile() failed: missing closing parenthesis in \".+(\""}
+--- response_body_like
+.*failed to check the configuration of plugin uri-blocker err: pcre2?_compile\(\) failed: missing (closing parenthesis|\)) in \\"\.\+\(\\".*
 
 
 
@@ -111,8 +111,8 @@ location /t {
 --- request
 GET /t
 --- error_code: 400
---- response_body
-{"error_msg":"failed to check the configuration of plugin uri-blocker err: pcre2_compile() failed: missing closing parenthesis in \"^b(\""}
+--- response_body_like
+.*failed to check the configuration of plugin uri-blocker err: pcre2?_compile\(\) failed: missing (closing parenthesis|\)) in \\"\^b\(\\".*
 
 
 

--- a/t/plugin/uri-blocker.t
+++ b/t/plugin/uri-blocker.t
@@ -50,8 +50,8 @@ location /t {
 --- request
 GET /t
 --- error_code: 400
---- response_body_like
-.*failed to check the configuration of plugin uri-blocker err: pcre2?_compile\(\) failed: missing (closing parenthesis|\)) in \\"\.\+\(\\".*
+--- response_body
+{"error_msg":"failed to check the configuration of plugin uri-blocker err: pcre2_compile() failed: missing closing parenthesis in \".+(\""}
 
 
 
@@ -111,8 +111,8 @@ location /t {
 --- request
 GET /t
 --- error_code: 400
---- response_body_like
-.*failed to check the configuration of plugin uri-blocker err: pcre2?_compile\(\) failed: missing (closing parenthesis|\)) in \\"\^b\(\\".*
+--- response_body
+{"error_msg":"failed to check the configuration of plugin uri-blocker err: pcre2_compile() failed: missing closing parenthesis in \"^b(\""}
 
 
 


### PR DESCRIPTION
### Description

The Linux OpenResty CI setup currently builds `apisix-runtime` from source through `build-apisix-runtime.sh` during each job. That makes CI spend extra time rebuilding the same runtime that is already published as release artifacts.

This changes the default OpenSSL path in `ci/linux-install-openresty.sh` to install the prebuilt `apisix-runtime-debug` Debian package for the `APISIX_RUNTIME` version from `.requirements`. The package is verified with the expected SHA256 checksum before installation. The Tongsuo and FIPS paths still use the existing source build flow because they need custom runtime build options.

The `uri-blocker` regex error assertions are also updated to match the runtime used by the prebuilt package. The released APISIX runtime package and APISIX Docker image use PCRE1 (`libpcre.so.1`), so the expected error text should be `pcre_compile() failed: missing )`, which is consistent with the runtime that this CI path now installs.

For the `CI` workflow, comparing a recent master run that still source-builds the runtime with this PR run:

- `Linux Install` step: about 5m06s-5m19s before, about 1m09s-1m15s after.
- Workflow wall-clock: 41m58s before, 38m38s after.

The total workflow time still depends mostly on the test groups, but the repeated runtime installation work is reduced by about four minutes per `linux_openresty` job.

#### Which issue(s) this PR fixes:

None.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (not needed; CI-only change)
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
