### PR TITLE
fix(opa): apply send_headers_upstream for headers absent from OPA response

### DIFF
--- a/apisix/plugins/opa.lua
+++ b/apisix/plugins/opa.lua
@@ -137,13 +137,17 @@ function _M.access(conf, ctx)
         end
 
         return status_code, reason
-    else if result.headers and conf.send_headers_upstream then
+    else if conf.send_headers_upstream then
+        local headers = result.headers or {}
+        -- set headers from the OPA response, clearing any client-supplied
+        -- values for configured headers not present in the OPA response
         for _, name in ipairs(conf.send_headers_upstream) do
-            local value = result.headers[name]
-            if value then
-                core.request.set_header(ctx, name, value)
-            end
+            local value = headers[name]
+            -- if value is nil, the client header's value will be removed if it exists
+            core.request.set_header(ctx, name, value)
         end
+        -- discard cached request headers so downstream readers observe the update
+        ctx.headers = nil
         end
     end
 end

--- a/t/plugin/opa3.t
+++ b/t/plugin/opa3.t
@@ -1,0 +1,84 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: setup route with send_headers_upstream
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "opa": {
+                                "host": "http://127.0.0.1:8181",
+                                "policy": "example",
+                                "send_headers_upstream": ["X-Foo"]
+                            },
+                            "serverless-post-function": {
+                                "phase": "access",
+                                "functions": [
+                                    "return function(conf, ctx) local core = require(\"apisix.core\"); core.response.exit(200, core.request.headers(ctx)); end"
+                                ]
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/echo"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 2: client-supplied send_headers_upstream entry is cleared when OPA response omits it
+--- request
+GET /echo
+--- more_headers
+X-Foo: client-value
+--- error_code: 200
+--- response_body_unlike eval
+qr/x-foo/


### PR DESCRIPTION
### Description

When the `opa` plugin is configured with `send_headers_upstream` and the OPA server returns `allow = true` without including one of the configured headers in its response (or without a `headers` field at all), the plugin previously left any incoming request value for that header in place on the upstream call. The intent of `send_headers_upstream` is that the upstream sees only the values OPA returns for those names; the prior behavior diverged from that.

This change iterates the configured list and calls `core.request.set_header(ctx, name, value)` for every name in `send_headers_upstream`. When OPA does not return that header, `value` is `nil` and the incoming request header is cleared. The condition no longer short-circuits on a missing `result.headers` field.

`t/plugin/opa3.t` covers the case where OPA returns `allow = true` with no `headers` field and a configured header is sent by the client: the upstream must not see the client-supplied value.

#### Which issue(s) this PR fixes:
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)