### PR TITLE
fix(resource): add plugin_configs support for fetch_latest_conf, fix ai-proxy-multi plugin with multi instance not support plugin_config_id

### DIFF
--- a/apisix/resource.lua
+++ b/apisix/resource.lua
@@ -59,6 +59,8 @@ local function fetch_latest_conf(resource_path)
         key = "/services"
     elseif resource_type == "stream_routes" then
         key = "/stream_routes"
+    elseif resource_type == "plugin_configs" then
+        key = "/stream_routes"
     else
         log.error("unsupported resource type: ", resource_type)
         return nil

--- a/apisix/resource.lua
+++ b/apisix/resource.lua
@@ -59,6 +59,8 @@ local function fetch_latest_conf(resource_path)
         key = "/services"
     elseif resource_type == "stream_routes" then
         key = "/stream_routes"
+    elseif resource_type == "plugin_configs" then
+        key = "/plugin_configs"
     else
         log.error("unsupported resource type: ", resource_type)
         return nil


### PR DESCRIPTION
When the ai-proxy-multi plugin uses plugin_config_id to reference a PluginConfig containing multiple instances, APISIX returns a 503 error: "fetch_latest_conf(): unsupported resource type: plugin_configs".

Root cause:
- pick_target() in ai-proxy-multi.lua calls resource.fetch_latest_conf() to fetch the parent configuration for load balancing and health checking.
- When referencing via plugin_config_id, the _meta.parent.resource_key is set to "/plugin_configs/<id>".
- resource.fetch_latest_conf() previously only supported upstreams, routes, services, and stream_routes, causing it to reject "plugin_configs".

Why single instance works:
- Single instance scenarios bypass pick_target() entirely since no load balancing is needed, so resource.fetch_latest_conf() is never invoked.

Fix:
- #13456 
- Add "plugin_configs" to the supported resource types in resource.lua.

Verification:
- Single instance + plugin_config_id: 200 (unchanged)
- Multi-instance + plugin_config_id: 503 -> 200 (fixed)
- Multi-instance + embedded plugins: 200 (unchanged)


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
