### PR TITLE
test: fix standalone content type narrowing

### DIFF
--- a/t/admin/standalone.spec.ts
+++ b/t/admin/standalone.spec.ts
@@ -181,12 +181,14 @@ const serviceWithInvalidUpstream = {
 
 let mockDigest = 1;
 
+const isYamlContentType = (contentType: unknown) =>
+  typeof contentType === 'string' && contentType.includes('application/yaml');
+
 describe('Admin - Standalone', () => {
   const client = axios.create(clientConfig);
   client.interceptors.response.use((response) => {
-    const contentType = response.headers['content-type'] || '';
     if (
-      contentType.includes('application/yaml') &&
+      isYamlContentType(response.headers['content-type']) &&
       typeof response.data === 'string' &&
       response.config.responseType !== 'text'
     )
@@ -648,9 +650,8 @@ describe('Admin - Standalone', () => {
 describe('Validate API - Standalone', () => {
   const client = axios.create(clientConfig);
   client.interceptors.response.use((response) => {
-    const contentType = response.headers['content-type'] || '';
     if (
-      contentType.includes('application/yaml') &&
+      isYamlContentType(response.headers['content-type']) &&
       typeof response.data === 'string' &&
       response.config.responseType !== 'text'
     )


### PR DESCRIPTION
fix https://github.com/apache/apisix/actions/runs/26734077339/job/78786801514
<img width="2458" height="932" alt="image" src="https://github.com/user-attachments/assets/b80f4908-df77-4afe-9176-46f19816b285" />


This fixes the standalone admin TypeScript test after axios exposes `response.headers['content-type']` as a wider union type. The test only needs the YAML branch when the header is a string, so this narrows the value before calling `includes`.

Tested with:

```
prove -Itest-nginx/lib -I. -r t/admin/standalone.t
```