### PR TITLE
docs: update plugin examples for ingress controller 2.1.0 release

### DIFF
--- a/docs/en/latest/plugins/basic-auth.md
+++ b/docs/en/latest/plugins/basic-auth.md
@@ -938,7 +938,149 @@ adc sync -f adc.yaml
 
 <TabItem value="aic">
 
-Consumer custom labels are currently not supported when configuring resources through the Ingress Controller, and the `X-Consumer-Custom-Id` header is not included in requests. At the moment, this example cannot be completed with the Ingress Controller.
+Create a Consumer with `basic-auth` Credential and a Route with `basic-auth` Plugin enabled:
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="basic-auth-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: johndoe
+  labels:
+    custom_id: "495aec6a"
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: basic-auth
+      name: primary-key
+      config:
+        username: johndoe
+        password: john-key
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: basic-auth-plugin-config
+spec:
+  plugins:
+    - name: basic-auth
+      config:
+        _meta:
+          disable: false
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: basic-auth-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: basic-auth-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f basic-auth-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="basic-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: johndoe
+  labels:
+    custom_id: "495aec6a"
+spec:
+  ingressClassName: apisix
+  authParameter:
+    basicAuth:
+      value:
+        username: johndoe
+        password: john-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: basic-auth-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: basic-auth-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: basic-auth
+          enable: true
+          config:
+            _meta:
+              disable: false
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f basic-auth-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
 
 </TabItem>
 
@@ -964,7 +1106,7 @@ You should see an `HTTP/1.1 200 OK` response similar to the following:
     "Host": "127.0.0.1",
     "User-Agent": "curl/8.6.0",
     "X-Amzn-Trace-Id": "Root=1-66ea8d64-33df89052ae198a706e18c2a",
-    "X-Consumer-Username": "johndoe",
+    "X-Consumer-Username": "aic_johndoe",
     "X-Credential-Identifier": "cred-john-basic-auth",
     "X-Consumer-Custom-Id": "495aec6a",
     "X-Forwarded-Host": "127.0.0.1"
@@ -1225,7 +1367,83 @@ kubectl apply -f basic-auth-ic.yaml
 
 <TabItem value="apisix-ingress-controller">
 
-The ApisixConsumer CRD currently does not support configuring plugins on consumers, except for the authentication plugins allowed in `authParameter`. This example cannot be completed with APISIX CRDs.
+Configure Consumers with different rate limits and a Route that accepts anonymous users:
+
+```yaml title="basic-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: johndoe
+spec:
+  ingressClassName: apisix
+  authParameter:
+    basicAuth:
+      value:
+        username: johndoe
+        password: john-key
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 3
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: anonymous
+spec:
+  ingressClassName: apisix
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 1
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: basic-auth-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: basic-auth-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: basic-auth
+          enable: true
+          config:
+            anonymous_consumer: aic_anonymous
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f basic-auth-ic.yaml
+```
 
 </TabItem>
 

--- a/docs/en/latest/plugins/hmac-auth.md
+++ b/docs/en/latest/plugins/hmac-auth.md
@@ -194,8 +194,6 @@ adc sync -f adc.yaml
 
 <TabItem value="aic">
 
-Consumer custom labels are currently not supported when configuring resources through the Ingress Controller. As a result, the `X-Consumer-Custom-Id` header will not be included in requests.
-
 <Tabs
 groupId="k8s-api"
 defaultValue="gateway-api"
@@ -212,6 +210,8 @@ kind: Consumer
 metadata:
   namespace: aic
   name: john
+  labels:
+    custom_id: "495aec6a"
 spec:
   gatewayRef:
     name: apisix
@@ -284,6 +284,8 @@ kind: ApisixConsumer
 metadata:
   namespace: aic
   name: john
+  labels:
+    custom_id: "495aec6a"
 spec:
   ingressClassName: apisix
   authParameter:
@@ -418,7 +420,7 @@ You should see an `HTTP/1.1 200 OK` response similar to the following:
     "Host": "127.0.0.1",
     "User-Agent": "curl/8.6.0",
     "X-Amzn-Trace-Id": "Root=1-66d96513-2e52d4f35c9b6a2772d667ea",
-    "X-Consumer-Username": "john",
+    "X-Consumer-Username": "aic_john",
     "X-Credential-Identifier": "cred-john-hmac-auth",
     "X-Consumer-Custom-Id": "495aec6a",
     "X-Forwarded-Host": "127.0.0.1"
@@ -1602,7 +1604,83 @@ kubectl apply -f hmac-auth-ic.yaml
 
 <TabItem value="apisix-crd">
 
-The ApisixConsumer CRD currently does not support configuring plugins on consumers, except for the authentication plugins allowed in `authParameter`. This example cannot be completed with APISIX CRDs.
+```yaml title="hmac-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: john
+spec:
+  ingressClassName: apisix
+  authParameter:
+    hmacAuth:
+      value:
+        key_id: john-key
+        secret_key: john-secret-key
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 3
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: anonymous
+spec:
+  ingressClassName: apisix
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 1
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: hmac-auth-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: hmac-auth-route
+      match:
+        paths:
+          - /get
+        methods:
+          - GET
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: hmac-auth
+          enable: true
+          config:
+            anonymous_consumer: aic_anonymous
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f hmac-auth-ic.yaml
+```
 
 </TabItem>
 

--- a/docs/en/latest/plugins/jwt-auth.md
+++ b/docs/en/latest/plugins/jwt-auth.md
@@ -274,7 +274,60 @@ kubectl apply -f jwt-auth-ic.yaml
 
 <TabItem value="apisix-ingress-controller">
 
-The ApisixConsumer CRD has a known issue where `private_key` is incorrectly required during the configuration. This issue will be addressed in a future release. At the moment, the example cannot be completed with APISIX CRDs.
+Create a consumer with `jwt-auth` credential and a route with `jwt-auth` plugin enabled as such:
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  ingressClassName: apisix
+  authParameter:
+    jwtAuth:
+      value:
+        key: jack-key
+        secret: jack-hs256-secret-that-is-very-long
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: jwt-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: jwt-route
+      match:
+        paths:
+          - /headers
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: jwt-auth
+          enable: true
+          config:
+            _meta:
+              disable: false
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
 
 </TabItem>
 
@@ -535,7 +588,63 @@ kubectl apply -f jwt-auth-ic.yaml
 
 <TabItem value="apisix-ingress-controller">
 
-The ApisixConsumer CRD has a known issue where `private_key` is incorrectly required during the configuration. This issue will be addressed in a future release. At the moment, the example cannot be completed with APISIX CRDs.
+Create a consumer with `jwt-auth` credential and a route with `jwt-auth` plugin configured as such:
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  ingressClassName: apisix
+  authParameter:
+    jwtAuth:
+      value:
+        key: jack-key
+        secret: jack-hs256-secret-that-is-very-long
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: jwt-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: jwt-route
+      match:
+        paths:
+          - /get
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: jwt-auth
+          enable: true
+          config:
+            _meta:
+              disable: false
+              header: jwt-auth-header
+              query: jwt-query
+              cookie: jwt-cookie
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
 
 </TabItem>
 
@@ -1194,7 +1303,70 @@ kubectl apply -f jwt-auth-ic.yaml
 
 <TabItem value="apisix-ingress-controller">
 
-The ApisixConsumer CRD has a known issue where `private_key` is incorrectly required during the configuration. This issue will be addressed in a future release. At the moment, the example cannot be completed with APISIX CRDs.
+Create a consumer with `jwt-auth` credential using RS256 algorithm and a route with `jwt-auth` plugin enabled as such:
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  ingressClassName: apisix
+  authParameter:
+    jwtAuth:
+      value:
+        key: jack-key
+        algorithm: RS256
+        public_key: |
+          -----BEGIN PUBLIC KEY-----
+          MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoTxe7ZPycrEP0SK4OBA2
+          0OUQsDN9gSFSHVvx/t++nZNrFxzZnV6q6/TRsihNXUIgwaOu5icFlIcxPL9Mf9UJ
+          a5/XCQExp1TxpuSmjkhIFAJ/x5zXrC8SGTztP3SjkhYnQO9PKVXI6ljwgakVCfpl
+          umuTYqI+ev7e45NdK8gJoJxPp8bPMdf8/nHfLXZuqhO/btrDg1x+j7frDNrEw+6B
+          CK2SsuypmYN+LwHfaH4Of7MQFk3LNIxyBz0mdbsKJBzp360rbWnQeauWtDymZxLT
+          ATRNBVyl3nCNsURRTkc7eyknLaDt2N5xTIoUGHTUFYSdE68QWmukYMVGcEHEEPkp
+          aQIDAQAB
+          -----END PUBLIC KEY-----
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: jwt-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: jwt-route
+      match:
+        paths:
+          - /headers
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: jwt-auth
+          enable: true
+          config:
+            _meta:
+              disable: false
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
 
 </TabItem>
 
@@ -1319,7 +1491,149 @@ adc sync -f adc.yaml
 
 <TabItem value="ingress">
 
-Consumer custom labels are currently not supported when configuring resources through the Ingress Controller, and the `X-Consumer-Custom-Id` header is not included in requests. At the moment, this example cannot be completed with the Ingress Controller.
+Create a consumer with `jwt-auth` credential and a route with `jwt-auth` plugin enabled:
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: jack
+  labels:
+    custom_id: "495aec6a"
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: jwt-auth
+      name: primary-cred
+      config:
+        key: jack-key
+        secret: jack-hs256-secret-that-is-very-long
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: jwt-auth-plugin-config
+spec:
+  plugins:
+    - name: jwt-auth
+      config:
+        _meta:
+          disable: false
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: jwt-auth-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: jwt-auth-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jack
+  labels:
+    custom_id: "495aec6a"
+spec:
+  ingressClassName: apisix
+  authParameter:
+    jwtAuth:
+      value:
+        key: jack-key
+        secret: jack-hs256-secret-that-is-very-long
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: jwt-auth-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: jwt-auth-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: jwt-auth
+          enable: true
+          config:
+            _meta:
+              disable: false
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
 
 </TabItem>
 
@@ -1363,7 +1677,7 @@ You should see an `HTTP/1.1 200 OK` response similar to the following:
     "User-Agent": "curl/8.6.0",
     "X-Amzn-Trace-Id": "Root=1-6873b19d-329331db76e5e7194c942b47",
     "X-Consumer-Custom-Id": "495aec6a",
-    "X-Consumer-Username": "jack",
+    "X-Consumer-Username": "aic_jack",
     "X-Credential-Identifier": "cred-jack-jwt-auth",
     "X-Forwarded-Host": "127.0.0.1"
   }
@@ -1617,7 +1931,83 @@ kubectl apply -f jwt-auth-ic.yaml
 
 <TabItem value="apisix-ingress-controller">
 
-The ApisixConsumer CRD currently does not support configuring plugins on Consumers, except for the authentication plugins allowed in `authParameter`. This example cannot be completed with APISIX CRDs.
+Configure consumers with different rate limits and a route that accepts anonymous users:
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  ingressClassName: apisix
+  authParameter:
+    jwtAuth:
+      value:
+        key: jack-key
+        secret: jack-hs256-secret-that-is-very-long
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 3
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: anonymous
+spec:
+  ingressClassName: apisix
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 1
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: jwt-auth-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: jwt-auth-route
+      match:
+        paths:
+          - /headers
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: jwt-auth
+          enable: true
+          config:
+            anonymous_consumer: aic_anonymous
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
 
 </TabItem>
 

--- a/docs/en/latest/plugins/key-auth.md
+++ b/docs/en/latest/plugins/key-auth.md
@@ -1187,7 +1187,147 @@ adc sync -f adc.yaml
 
 <TabItem value="aic">
 
-Consumer custom labels are currently not supported when configuring resources through the Ingress Controller, and the `X-Consumer-Custom-Id` header is not included in requests. At the moment, this example cannot be completed with the Ingress Controller.
+Create a Consumer with `key-auth` Credential and a Route with `key-auth` Plugin enabled:
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="key-auth-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: jack
+  labels:
+    custom_id: "495aec6a"
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: primary-key
+      config:
+        key: jack-key
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: key-auth-plugin-config
+spec:
+  plugins:
+    - name: key-auth
+      config:
+        _meta:
+          disable: false
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: key-auth-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: key-auth-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f key-auth-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="key-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jack
+  labels:
+    custom_id: "495aec6a"
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: jack-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: key-auth-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: key-auth-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: key-auth
+          enable: true
+          config:
+            _meta:
+              disable: false
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f key-auth-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
 
 </TabItem>
 
@@ -1214,7 +1354,7 @@ You should see an `HTTP/1.1 200 OK` response similar to the following:
     "Host": "127.0.0.1",
     "User-Agent": "curl/8.6.0",
     "X-Amzn-Trace-Id": "Root=1-66ea8d64-33df89052ae198a706e18c2a",
-    "X-Consumer-Username": "jack",
+    "X-Consumer-Username": "aic_jack",
     "X-Credential-Identifier": "cred-jack-key-auth",
     "X-Consumer-Custom-Id": "495aec6a",
     "X-Forwarded-Host": "127.0.0.1"
@@ -1472,7 +1612,82 @@ kubectl apply -f key-auth-ic.yaml
 
 <TabItem value="apisix-ingress-controller">
 
-The ApisixConsumer CRD currently does not support configuring plugins on consumers, except for the authentication plugins allowed in `authParameter`. This example cannot be completed with APISIX CRDs.
+Configure Consumers with different rate limits and a Route that accepts anonymous users:
+
+```yaml title="key-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: jack-key
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 3
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: anonymous
+spec:
+  ingressClassName: apisix
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 1
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: key-auth-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: key-auth-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: key-auth
+          enable: true
+          config:
+            anonymous_consumer: aic_anonymous
+```
+
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f key-auth-ic.yaml
+```
 
 </TabItem>
 

--- a/docs/en/latest/plugins/limit-count.md
+++ b/docs/en/latest/plugins/limit-count.md
@@ -1624,11 +1624,82 @@ kubectl apply -f limit-count-ic.yaml
 
 <TabItem value="apisix-crd">
 
-:::important[note]
+Configure consumers with different rate limits and a route that accepts anonymous users:
 
-The ApisixConsumer CRD currently does not support configuring plugins on consumers, except for the authentication plugins allowed in `authParameter`. This example cannot be completed with APISIX CRDs.
+```yaml title="limit-count-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: john
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: john-key
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 3
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: anonymous
+spec:
+  ingressClassName: apisix
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 1
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: key-auth-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: key-auth-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: key-auth
+          enable: true
+          config:
+            anonymous_consumer: aic_anonymous
+```
 
-:::
+Apply the configuration to your cluster:
+
+```shell
+kubectl apply -f limit-count-ic.yaml
+```
 
 </TabItem>
 

--- a/docs/zh/latest/plugins/basic-auth.md
+++ b/docs/zh/latest/plugins/basic-auth.md
@@ -938,7 +938,149 @@ adc sync -f adc.yaml
 
 <TabItem value="aic">
 
-通过 Ingress Controller 配置资源时，目前不支持消费者自定义标签，请求中不会包含 `X-Consumer-Custom-Id` 标头。暂时无法通过 Ingress Controller 完成此示例。
+创建带有 `basic-auth` 凭据的消费者，并启用 `basic-auth` 插件的路由：
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="basic-auth-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: johndoe
+  labels:
+    custom_id: "495aec6a"
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: basic-auth
+      name: primary-key
+      config:
+        username: johndoe
+        password: john-key
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: basic-auth-plugin-config
+spec:
+  plugins:
+    - name: basic-auth
+      config:
+        _meta:
+          disable: false
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: basic-auth-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: basic-auth-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f basic-auth-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="basic-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: johndoe
+  labels:
+    custom_id: "495aec6a"
+spec:
+  ingressClassName: apisix
+  authParameter:
+    basicAuth:
+      value:
+        username: johndoe
+        password: john-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: basic-auth-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: basic-auth-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: basic-auth
+          enable: true
+          config:
+            _meta:
+              disable: false
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f basic-auth-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
 
 </TabItem>
 
@@ -964,7 +1106,7 @@ curl -i "http://127.0.0.1:9080/anything" -u johndoe:john-key
     "Host": "127.0.0.1",
     "User-Agent": "curl/8.6.0",
     "X-Amzn-Trace-Id": "Root=1-66ea8d64-33df89052ae198a706e18c2a",
-    "X-Consumer-Username": "johndoe",
+    "X-Consumer-Username": "aic_johndoe",
     "X-Credential-Identifier": "cred-john-basic-auth",
     "X-Consumer-Custom-Id": "495aec6a",
     "X-Forwarded-Host": "127.0.0.1"
@@ -1225,7 +1367,83 @@ kubectl apply -f basic-auth-ic.yaml
 
 <TabItem value="apisix-ingress-controller">
 
-ApisixConsumer CRD 目前不支持在消费者上配置插件（`authParameter` 中允许的身份验证插件除外）。此示例无法通过 APISIX CRD 完成。
+配置具有不同速率限制的消费者和接受匿名用户的路由：
+
+```yaml title="basic-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: johndoe
+spec:
+  ingressClassName: apisix
+  authParameter:
+    basicAuth:
+      value:
+        username: johndoe
+        password: john-key
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 3
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: anonymous
+spec:
+  ingressClassName: apisix
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 1
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: basic-auth-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: basic-auth-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: basic-auth
+          enable: true
+          config:
+            anonymous_consumer: aic_anonymous  # namespace_consumername
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f basic-auth-ic.yaml
+```
 
 </TabItem>
 

--- a/docs/zh/latest/plugins/hmac-auth.md
+++ b/docs/zh/latest/plugins/hmac-auth.md
@@ -195,8 +195,6 @@ adc sync -f adc.yaml
 
 <TabItem value="aic">
 
-通过 Ingress Controller 配置资源时，目前不支持 Consumer 自定义标签。因此，`X-Consumer-Custom-Id` 标头不会包含在请求中。
-
 <Tabs
 groupId="k8s-api"
 defaultValue="gateway-api"
@@ -213,6 +211,8 @@ kind: Consumer
 metadata:
   namespace: aic
   name: john
+  labels:
+    custom_id: "495aec6a"
 spec:
   gatewayRef:
     name: apisix
@@ -285,6 +285,8 @@ kind: ApisixConsumer
 metadata:
   namespace: aic
   name: john
+  labels:
+    custom_id: "495aec6a"
 spec:
   ingressClassName: apisix
   authParameter:
@@ -419,7 +421,7 @@ curl -X GET "http://127.0.0.1:9080/get" \
     "Host": "127.0.0.1",
     "User-Agent": "curl/8.6.0",
     "X-Amzn-Trace-Id": "Root=1-66d96513-2e52d4f35c9b6a2772d667ea",
-    "X-Consumer-Username": "john",
+    "X-Consumer-Username": "aic_john",
     "X-Credential-Identifier": "cred-john-hmac-auth",
     "X-Consumer-Custom-Id": "495aec6a",
     "X-Forwarded-Host": "127.0.0.1"
@@ -1602,7 +1604,85 @@ kubectl apply -f hmac-auth-ic.yaml
 
 <TabItem value="apisix-crd">
 
-ApisixConsumer CRD 目前不支持在 Consumer 上配置插件，`authParameter` 中允许的认证插件除外。此示例无法通过 APISIX CRD 完成。
+配置具有不同速率限制的 Consumer 以及接受匿名用户的 Route：
+
+```yaml title="hmac-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: john
+spec:
+  ingressClassName: apisix
+  authParameter:
+    hmacAuth:
+      value:
+        key_id: john-key
+        secret_key: john-secret-key
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 3
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: anonymous
+spec:
+  ingressClassName: apisix
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 1
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: hmac-auth-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: hmac-auth-route
+      match:
+        paths:
+          - /get
+        methods:
+          - GET
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: hmac-auth
+          enable: true
+          config:
+            anonymous_consumer: aic_anonymous  # namespace_consumername
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f hmac-auth-ic.yaml
+```
 
 </TabItem>
 

--- a/docs/zh/latest/plugins/jwt-auth.md
+++ b/docs/zh/latest/plugins/jwt-auth.md
@@ -274,7 +274,60 @@ kubectl apply -f jwt-auth-ic.yaml
 
 <TabItem value="apisix-ingress-controller">
 
-ApisixConsumer CRD 存在一个已知问题，配置时会错误地要求提供 `private_key`。该问题将在后续版本中修复。目前，此示例无法通过 APISIX CRD 完成。
+创建带有 `jwt-auth` 凭据的消费者，并启用 `jwt-auth` 插件的路由：
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  ingressClassName: apisix
+  authParameter:
+    jwtAuth:
+      value:
+        key: jack-key
+        secret: jack-hs256-secret-that-is-very-long
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: jwt-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: jwt-route
+      match:
+        paths:
+          - /headers
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: jwt-auth
+          enable: true
+          config:
+            _meta:
+              disable: false
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
 
 </TabItem>
 
@@ -535,7 +588,63 @@ kubectl apply -f jwt-auth-ic.yaml
 
 <TabItem value="apisix-ingress-controller">
 
-ApisixConsumer CRD 存在一个已知问题，配置时会错误地要求提供 `private_key`。该问题将在后续版本中修复。目前，此示例无法通过 APISIX CRD 完成。
+创建带有 `jwt-auth` 凭据的消费者，并按如下方式配置启用 `jwt-auth` 插件的路由：
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  ingressClassName: apisix
+  authParameter:
+    jwtAuth:
+      value:
+        key: jack-key
+        secret: jack-hs256-secret-that-is-very-long
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: jwt-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: jwt-route
+      match:
+        paths:
+          - /get
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: jwt-auth
+          enable: true
+          config:
+            _meta:
+              disable: false
+              header: jwt-auth-header
+              query: jwt-query
+              cookie: jwt-cookie
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
 
 </TabItem>
 
@@ -1194,7 +1303,70 @@ kubectl apply -f jwt-auth-ic.yaml
 
 <TabItem value="apisix-ingress-controller">
 
-ApisixConsumer CRD 存在一个已知问题，配置时会错误地要求提供 `private_key`。该问题将在后续版本中修复。目前，此示例无法通过 APISIX CRD 完成。
+创建使用 RS256 算法的 `jwt-auth` 凭据的消费者，并按如下方式配置启用 `jwt-auth` 插件的路由：
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  ingressClassName: apisix
+  authParameter:
+    jwtAuth:
+      value:
+        key: jack-key
+        algorithm: RS256
+        public_key: |
+          -----BEGIN PUBLIC KEY-----
+          MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoTxe7ZPycrEP0SK4OBA2
+          0OUQsDN9gSFSHVvx/t++nZNrFxzZnV6q6/TRsihNXUIgwaOu5icFlIcxPL9Mf9UJ
+          a5/XCQExp1TxpuSmjkhIFAJ/x5zXrC8SGTztP3SjkhYnQO9PKVXI6ljwgakVCfpl
+          umuTYqI+ev7e45NdK8gJoJxPp8bPMdf8/nHfLXZuqhO/btrDg1x+j7frDNrEw+6B
+          CK2SsuypmYN+LwHfaH4Of7MQFk3LNIxyBz0mdbsKJBzp360rbWnQeauWtDymZxLT
+          ATRNBVyl3nCNsURRTkc7eyknLaDt2N5xTIoUGHTUFYSdE68QWmukYMVGcEHEEPkp
+          aQIDAQAB
+          -----END PUBLIC KEY-----
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: jwt-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: jwt-route
+      match:
+        paths:
+          - /headers
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: jwt-auth
+          enable: true
+          config:
+            _meta:
+              disable: false
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
 
 </TabItem>
 
@@ -1320,7 +1492,149 @@ adc sync -f adc.yaml
 
 <TabItem value="ingress">
 
-通过 Ingress Controller 配置资源时，目前不支持消费者自定义标签，请求中也不会包含 `X-Consumer-Custom-Id` 请求头。目前，此示例无法通过 Ingress Controller 完成。
+创建带有 `jwt-auth` 凭据的消费者，并启用 `jwt-auth` 插件的路由：
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: jack
+  labels:
+    custom_id: "495aec6a"
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: jwt-auth
+      name: primary-cred
+      config:
+        key: jack-key
+        secret: jack-hs256-secret-that-is-very-long
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: jwt-auth-plugin-config
+spec:
+  plugins:
+    - name: jwt-auth
+      config:
+        _meta:
+          disable: false
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: jwt-auth-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: jwt-auth-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jack
+  labels:
+    custom_id: "495aec6a"
+spec:
+  ingressClassName: apisix
+  authParameter:
+    jwtAuth:
+      value:
+        key: jack-key
+        secret: jack-hs256-secret-that-is-very-long
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: jwt-auth-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: jwt-auth-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: jwt-auth
+          enable: true
+          config:
+            _meta:
+              disable: false
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
 
 </TabItem>
 
@@ -1364,7 +1678,7 @@ curl -i "http://127.0.0.1:9080/headers" -H "Authorization: ${jwt_token}"
     "User-Agent": "curl/8.6.0",
     "X-Amzn-Trace-Id": "Root=1-6873b19d-329331db76e5e7194c942b47",
     "X-Consumer-Custom-Id": "495aec6a",
-    "X-Consumer-Username": "jack",
+    "X-Consumer-Username": "aic_jack",
     "X-Credential-Identifier": "cred-jack-jwt-auth",
     "X-Forwarded-Host": "127.0.0.1"
   }
@@ -1618,7 +1932,83 @@ kubectl apply -f jwt-auth-ic.yaml
 
 <TabItem value="apisix-ingress-controller">
 
-ApisixConsumer CRD 目前不支持在消费者上配置插件（`authParameter` 中允许的认证插件除外）。此示例无法通过 APISIX CRD 完成。
+配置具有不同限速策略的消费者和允许匿名用户的路由：
+
+```yaml title="jwt-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  ingressClassName: apisix
+  authParameter:
+    jwtAuth:
+      value:
+        key: jack-key
+        secret: jack-hs256-secret-that-is-very-long
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 3
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: anonymous
+spec:
+  ingressClassName: apisix
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 1
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: jwt-auth-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: jwt-auth-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: jwt-auth
+          enable: true
+          config:
+            anonymous_consumer: aic_anonymous  # namespace_consumername
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f jwt-auth-ic.yaml
+```
 
 </TabItem>
 

--- a/docs/zh/latest/plugins/key-auth.md
+++ b/docs/zh/latest/plugins/key-auth.md
@@ -1187,7 +1187,147 @@ adc sync -f adc.yaml
 
 <TabItem value="aic">
 
-通过 Ingress Controller 配置资源时，目前不支持消费者自定义标签，请求中不会包含 `X-Consumer-Custom-Id` 标头。暂时无法通过 Ingress Controller 完成此示例。
+创建带有 `key-auth` 凭据的消费者，并启用 `key-auth` 插件的路由：
+
+<Tabs
+groupId="k8s-api"
+defaultValue="gateway-api"
+values={[
+{label: 'Gateway API', value: 'gateway-api'},
+{label: 'APISIX CRD', value: 'apisix-crd'}
+]}>
+
+<TabItem value="gateway-api">
+
+```yaml title="key-auth-ic.yaml"
+apiVersion: apisix.apache.org/v1alpha1
+kind: Consumer
+metadata:
+  namespace: aic
+  name: jack
+  labels:
+    custom_id: "495aec6a"
+spec:
+  gatewayRef:
+    name: apisix
+  credentials:
+    - type: key-auth
+      name: primary-key
+      config:
+        key: jack-key
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+---
+apiVersion: apisix.apache.org/v1alpha1
+kind: PluginConfig
+metadata:
+  namespace: aic
+  name: key-auth-plugin-config
+spec:
+  plugins:
+    - name: key-auth
+      config:
+        _meta:
+          disable: false
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  namespace: aic
+  name: key-auth-route
+spec:
+  parentRefs:
+    - name: apisix
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /anything
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: apisix.apache.org
+            kind: PluginConfig
+            name: key-auth-plugin-config
+      backendRefs:
+        - name: httpbin-external-domain
+          port: 80
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f key-auth-ic.yaml
+```
+
+</TabItem>
+
+<TabItem value="apisix-crd">
+
+```yaml title="key-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jack
+  labels:
+    custom_id: "495aec6a"
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: jack-key
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: key-auth-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: key-auth-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: key-auth
+          enable: true
+          config:
+            _meta:
+              disable: false
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f key-auth-ic.yaml
+```
+
+</TabItem>
+
+</Tabs>
 
 </TabItem>
 
@@ -1214,7 +1354,7 @@ curl -i "http://127.0.0.1:9080/anything?apikey=jack-key"
     "Host": "127.0.0.1",
     "User-Agent": "curl/8.6.0",
     "X-Amzn-Trace-Id": "Root=1-66ea8d64-33df89052ae198a706e18c2a",
-    "X-Consumer-Username": "jack",
+    "X-Consumer-Username": "aic_jack",
     "X-Credential-Identifier": "cred-jack-key-auth",
     "X-Consumer-Custom-Id": "495aec6a",
     "X-Forwarded-Host": "127.0.0.1"
@@ -1472,7 +1612,82 @@ kubectl apply -f key-auth-ic.yaml
 
 <TabItem value="apisix-ingress-controller">
 
-ApisixConsumer CRD 目前不支持在消费者上配置插件（`authParameter` 中允许的身份验证插件除外）。此示例无法通过 APISIX CRD 完成。
+配置具有不同速率限制的消费者和接受匿名用户的路由：
+
+```yaml title="key-auth-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: jack
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: jack-key
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 3
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: anonymous
+spec:
+  ingressClassName: apisix
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 1
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: key-auth-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: key-auth-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: key-auth
+          enable: true
+          config:
+            anonymous_consumer: aic_anonymous  # namespace_consumername
+```
+
+将配置应用到集群：
+
+```shell
+kubectl apply -f key-auth-ic.yaml
+```
 
 </TabItem>
 

--- a/docs/zh/latest/plugins/limit-count.md
+++ b/docs/zh/latest/plugins/limit-count.md
@@ -1625,11 +1625,82 @@ kubectl apply -f limit-count-ic.yaml
 
 <TabItem value="apisix-crd">
 
-:::important[note]
+配置具有不同速率限制的消费者和接受匿名用户的路由：
 
-ApisixConsumer CRD 目前不支持在消费者上配置插件，除了 `authParameter` 中允许的认证插件。此示例无法使用 APISIX CRD 完成。
+```yaml title="limit-count-ic.yaml"
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: john
+spec:
+  ingressClassName: apisix
+  authParameter:
+    keyAuth:
+      value:
+        key: john-key
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 3
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixConsumer
+metadata:
+  namespace: aic
+  name: anonymous
+spec:
+  ingressClassName: apisix
+  plugins:
+    - name: limit-count
+      enable: true
+      config:
+        count: 1
+        time_window: 30
+        rejected_code: 429
+        policy: local
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixUpstream
+metadata:
+  namespace: aic
+  name: httpbin-external-domain
+spec:
+  ingressClassName: apisix
+  externalNodes:
+    - type: Domain
+      name: httpbin.org
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  namespace: aic
+  name: key-auth-route
+spec:
+  ingressClassName: apisix
+  http:
+    - name: key-auth-route
+      match:
+        paths:
+          - /anything
+      upstreams:
+        - name: httpbin-external-domain
+      plugins:
+        - name: key-auth
+          enable: true
+          config:
+            anonymous_consumer: aic_anonymous  # namespace_consumername
+```
 
-:::
+将配置应用到集群：
+
+```shell
+kubectl apply -f limit-count-ic.yaml
+```
 
 </TabItem>
 


### PR DESCRIPTION
## Summary
Update plugin docs to match released APISIX Ingress Controller behavior.

Updated in this PR:
- replace stale custom consumer label notes with working Ingress Controller examples in `basic-auth`, `key-auth`, `jwt-auth`, and `hmac-auth`
- replace stale `ApisixConsumer` consumer-plugin limitation notes with working APISIX CRD examples in `basic-auth`, `key-auth`, `jwt-auth`, `hmac-auth`, and `limit-count`
- update example response snippets to use the namespaced consumer usernames returned by Ingress Controller flows

## Validation
- re-verified custom consumer label propagation in APISIX CRD examples
- re-verified consumer-scoped plugin behavior on `ApisixConsumer` for anonymous-consumer rate-limit flows
- reused the same verified Ingress Controller manifest patterns already checked in the parallel API7/APISIX ingress-controller docs refresh work
