### PR TITLE
feat: add error-log-collect plugin

### DIFF
--- a/apisix/core/log.lua
+++ b/apisix/core/log.lua
@@ -26,14 +26,20 @@ local select = select
 local setmetatable = setmetatable
 local tostring = tostring
 local unpack = unpack
+local type = type
+local pcall = pcall
+local debug = debug
 -- avoid loading other module since core.log is the most foundational one
 local tab_clear = require("table.clear")
+local tab_insert = table.insert
 local ngx_errlog = require("ngx.errlog")
 local ngx_get_phase = ngx.get_phase
+local circular_queue = require("apisix.utils.circular-queue")
 
 
 local _M = {version = 0.4}
 
+local log_buffer = circular_queue:new(1000)
 
 local log_levels = {
     stderr = ngx.STDERR,
@@ -47,8 +53,72 @@ local log_levels = {
     debug  = ngx.DEBUG,
 }
 
-
 local cur_level
+
+local append_to_req_buffer_method
+do
+    local allowed_phases = {
+        rewrite = true,
+        access = true,
+        content = true,
+        header_filter = true,
+        body_filter = true,
+        log = true,
+        balancer = true,
+        ssl_certificate = true
+    }
+    local function append_to_req_buffer(...)
+        local ngx_ctx = ngx.ctx
+        local collecting = ngx_ctx.error_log_collecting
+        if collecting then
+            local api_ctx = ngx_ctx.api_ctx
+            local var = api_ctx and api_ctx.var or ngx.var
+            local request_id = var.apisix_request_id
+            local prefix = ngx.localtime() .. " " .. (request_id or "") .. " "
+            local info = debug.getinfo(4, "nSl")
+            -- unable to obtain function name for self:method(), so we use the file name instead.
+            local fn_name = (info.name and info.name .. "()")
+                            or (info.short_src and info.short_src:match("[^/\\]+$"))
+                            or "unknown"
+            local func_info = fn_name .. ":" .. info.currentline .. ": "
+            local strs = {prefix, func_info}
+            for i = 1, select('#', ...) do
+                local item = select(i, ...)
+                if type(item) == "table" then
+                    tab_insert(strs, "{...}")
+                else
+                    tab_insert(strs, tostring(item))
+                end
+            end
+            log_buffer:enqueue(strs)
+        end
+    end
+
+    -- to avoid stack overflow
+    local append = false
+    function append_to_req_buffer_method(...)
+        if not allowed_phases[ngx_get_phase()] then
+            return
+        end
+        if append then
+            return
+        end
+        append = true
+        local ok, err = pcall(append_to_req_buffer, ...)
+        append = false
+        if not ok then
+            ngx_log(ngx.ERR, "failed to append log to buffer: ", err)
+        end
+    end
+end
+
+function _M.reset_buffer(size)
+    log_buffer:reset(size)
+end
+
+function _M.get_buffer()
+    return log_buffer
+end
 
 local do_nothing = function() end
 
@@ -98,7 +168,7 @@ setmetatable(_M, {__index = function(self, cmd)
 
     if cur_level and (log_level > cur_level)
     then
-        method = do_nothing
+        method = append_to_req_buffer_method
     else
         method = function(...)
             return ngx_log(log_level, ...)

--- a/apisix/plugins/error-log-collect.lua
+++ b/apisix/plugins/error-log-collect.lua
@@ -1,0 +1,134 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+local core   = require("apisix.core")
+local expr   = require("resty.expr.v1")
+local ngx    = ngx
+local ngx_now = ngx.now
+local ngx_worker_id = ngx.worker.id
+local ngx_sleep = ngx.sleep
+local ngx_timer_at = ngx.timer.at
+local ipairs = ipairs
+local tab_concat = table.concat
+local tostring = tostring
+
+local lrucache = core.lrucache.new({
+    type = "plugin",
+})
+
+local math_random = math.random
+
+local plugin_name   = "error-log-collect"
+
+local schema = {
+    type = "object",
+    properties = {
+        vars = {
+            type = "array",
+            description = "an array of variables expressions;"
+                            .. " logs are collected only when all expressions evaluate to true",
+        },
+        sample_ratio = {
+            type = "number",
+            minimum = 0.00001,
+            maximum = 1,
+            default = 1,
+            description = "the probability of collecting logs for a request;"
+                            .. " 1 means all logs are collected",
+        },
+        buffer_max_size = {
+            type = "integer",
+            minimum = 1,
+            description = "log buffer capacity; when the number of logs exceeds this value,"
+                            .. " the oldest logs will be overwritten",
+            default = 1000,
+        },
+    },
+}
+
+local _M = {
+    version = 0.1,
+    priority = 12100000,
+    name = plugin_name,
+    schema = schema,
+}
+
+function _M.check_schema(conf)
+    if conf.vars then
+        local ok, err = expr.new(conf.vars)
+        if not ok then
+            return nil, "failed to validate the 'vars' expression: " .. err
+        end
+    end
+    return core.schema.check(schema, conf)
+end
+
+
+local function collect(conf, ctx)
+    local log_buffer = core.log.get_buffer()
+    if not log_buffer then
+        return
+    end
+
+    local elements = log_buffer:drain()
+    if #elements == 0 then
+        return
+    end
+    core.log.reset_buffer(conf.buffer_max_size)
+
+    ngx_timer_at(0, function()
+        local time = tostring(ngx_now() * 1000)
+        local worker_id = tostring(ngx_worker_id()) or ""
+        local prefix =  time .. "#" .. worker_id .. " [error-log-collect] "
+        core.log.info(prefix, "collecting ", #elements)
+        for idx, log_entry in ipairs(elements) do
+            if idx % 20 == 0 then
+                ngx_sleep(0)
+            end
+            core.log.error(prefix, tab_concat(log_entry))
+        end
+    end)
+end
+
+
+function _M.rewrite(conf, ctx)
+    if conf.sample_ratio ~= 1 then
+        local val = math_random()
+        if val >= conf.sample_ratio then
+            return
+        end
+    end
+    ngx.ctx.error_log_collecting = true
+end
+
+
+function _M.log(conf, ctx)
+    local matched = true
+    if conf.vars then
+        local e, err = core.lrucache.plugin_ctx(lrucache, ctx, nil, expr.new, conf.vars)
+        if not e then
+            core.log.error("failed to create expression: ", err)
+            return
+        end
+        matched = e:eval(ctx.var)
+    end
+    if matched then
+        collect(conf, ctx)
+    end
+end
+
+
+return _M

--- a/apisix/utils/circular-queue.lua
+++ b/apisix/utils/circular-queue.lua
@@ -1,0 +1,135 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+local setmetatable = setmetatable
+local tab_new = table.new
+local tab_insert = table.insert
+local tab_clear = table.clear
+
+local circular_queue = {}
+circular_queue.__index = circular_queue
+
+
+function circular_queue:new(_capacity)
+    _capacity = _capacity or 100
+    if _capacity < 1 then
+        _capacity = 1
+    end
+
+    local obj = {
+        _capacity = _capacity,
+        front = 1,
+        rear = 1,
+        data = tab_new(_capacity, 0),
+        size = 0,
+    }
+    setmetatable(obj, self)
+    return obj
+end
+
+
+function circular_queue:is_empty()
+    return self.size == 0
+end
+
+
+function circular_queue:is_full()
+    return self.size == self._capacity
+end
+
+
+function circular_queue:len()
+    return self.size
+end
+
+
+function circular_queue:capacity()
+    return self._capacity
+end
+
+
+function circular_queue:reset(new_capacity)
+    self:clear()
+    self._capacity = new_capacity or self._capacity
+    if self._capacity < 1 then
+        self._capacity = 1
+    end
+end
+
+
+function circular_queue:enqueue(element)
+    if self:is_full() then
+        self.front = self.front % self._capacity + 1
+    else
+        self.size = self.size + 1
+    end
+
+    self.data[self.rear] = element
+    self.rear = self.rear % self._capacity + 1
+end
+
+
+function circular_queue:dequeue()
+    if self:is_empty() then
+        return nil
+    end
+    local element = self.data[self.front]
+    self.data[self.front] = nil
+    self.front = self.front % self._capacity + 1
+    self.size = self.size - 1
+    return element
+end
+
+
+function circular_queue:peek()
+    if self:is_empty() then
+        return nil
+    end
+    return self.data[self.front]
+end
+
+
+function circular_queue:clear()
+    self.front = 1
+    self.rear = 1
+    self.size = 0
+    tab_clear(self.data)
+end
+
+
+function circular_queue:traverse()
+    local elements = {}
+    if self:is_empty() then
+        return elements
+    end
+    local idx = self.front
+    for i = 1, self.size do
+        tab_insert(elements, self.data[idx])
+        idx = idx % self._capacity + 1
+    end
+    return elements
+end
+
+
+function circular_queue:drain()
+    local elements = self:traverse()
+    self:clear()
+    return elements
+end
+
+
+return circular_queue

--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -516,6 +516,7 @@ plugins:                           # plugin list (sorted by priority)
   - opa                            # priority: 2001
   - authz-keycloak                 # priority: 2000
   - data-mask                      # priority: 1500
+  - error-log-collect              # priority: 12100000
   #- error-log-logger              # priority: 1091
   - proxy-cache                    # priority: 1085
   - body-transformer               # priority: 1080

--- a/t/plugin/error-log-collect.t
+++ b/t/plugin/error-log-collect.t
@@ -1,0 +1,314 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->extra_yaml_config) {
+        my $extra_yaml_config = <<_EOC_;
+plugins:
+    - error-log-collect
+_EOC_
+        $block->set_value("extra_yaml_config", $extra_yaml_config);
+    }
+
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: sanity
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.error-log-collect")
+            local ok, err = plugin.check_schema({
+                vars = {
+                    {"arg_debug", "==", "true"}
+                },
+                sample_ratio = 0.5,
+                buffer_max_size = 500
+            })
+            if not ok then
+                ngx.say(err)
+            else
+                ngx.say("done")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+
+
+
+=== TEST 2: invalid vars
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.error-log-collect")
+            local ok, err = plugin.check_schema({
+                vars = "invalid"
+            })
+            if not ok then
+                ngx.say(err)
+            else
+                ngx.say("done")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+failed to validate the 'vars' expression
+
+
+
+=== TEST 3: invalid sample_ratio
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.error-log-collect")
+            local ok, err = plugin.check_schema({
+                sample_ratio = 2
+            })
+            if not ok then
+                ngx.say(err)
+            else
+                ngx.say("done")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+invalid
+
+
+
+=== TEST 4: enable plugin
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "error-log-collect": {
+                            "sample_ratio": 1
+                        }
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        }
+                    },
+                    "uri": "/hello"
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 5: collect error logs
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/hello"
+            local res, err = httpc:request_uri(uri, {method = "GET"})
+            if not res then
+                ngx.say(err)
+                return
+            end
+            ngx.say(res.status)
+        }
+    }
+--- request
+GET /t
+--- response_body
+200
+--- error_log eval
+qr/\[error-log-collect\]/
+--- no_error_log eval
+qr/\[error\]/
+--- wait: 2
+
+
+
+=== TEST 6: collect with vars filter
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "error-log-collect": {
+                            "vars": [
+                                ["arg_debug", "==", "true"]
+                            ],
+                            "sample_ratio": 1
+                        }
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        }
+                    },
+                    "uri": "/hello"
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 7: verify vars filter works
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+
+            -- Request without debug param (should not collect)
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/hello"
+            local res, err = httpc:request_uri(uri, {method = "GET"})
+            if not res then
+                ngx.say(err)
+                return
+            end
+            ngx.say("without debug: ", res.status)
+
+            -- Request with debug param (should collect)
+            uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/hello?debug=true"
+            res, err = httpc:request_uri(uri, {method = "GET"})
+            if not res then
+                ngx.say(err)
+                return
+            end
+            ngx.say("with debug: ", res.status)
+        }
+    }
+--- request
+GET /t
+--- response_body
+without debug: 200
+with debug: 200
+--- error_log eval
+qr/\[error-log-collect\]/
+--- no_error_log eval
+qr/\[error\]/
+--- wait: 2
+
+
+
+=== TEST 8: sampling
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "error-log-collect": {
+                            "sample_ratio": 0.00001
+                        }
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        }
+                    },
+                    "uri": "/hello"
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 9: verify sampling works
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+
+            -- Send multiple requests (most should not be sampled)
+            for i = 1, 10 do
+                local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/hello"
+                local res, err = httpc:request_uri(uri, {method = "GET"})
+                if not res then
+                    ngx.say(err)
+                    return
+                end
+            end
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+--- error_log eval
+qr/\[error-log-collect\]/
+--- no_error_log eval
+qr/\[error\]/
+--- wait: 5


### PR DESCRIPTION
## Description

Add `error-log-collect` plugin that collects error logs generated during request processing and re-logs them with request context (request ID, timestamp, worker ID).

## Features

- **Filter by variable expressions**: Use `vars` to collect logs only for specific requests
- **Sampling support**: Use `sample_ratio` to reduce overhead in production
- **Configurable buffer size**: Use `buffer_max_size` to control memory usage
- **Circular queue**: Prevents unbounded memory growth by overwriting old entries

## Changes

1. **New file: `apisix/utils/circular-queue.lua`**
   - Circular queue data structure for buffering error logs

2. **Modified: `apisix/core/log.lua`**
   - Add buffer functionality (`reset_buffer`, `get_buffer`)
   - Intercept log calls when `ngx.ctx.error_log_collecting` is true

3. **New file: `apisix/plugins/error-log-collect.lua`**
   - The plugin itself with schema validation

4. **New file: `t/plugin/error-log-collect.t`**
   - Test cases for the plugin

5. **Modified: `conf/config.yaml.example`**
   - Enable the plugin in the plugins list

## Usage Example

```yaml
plugins:
  - error-log-collect

routes:
  - uri: /api/*
    plugins:
      error-log-collect:
        vars:
          - - arg_debug
            - "=="
            - "true"
        sample_ratio: 0.1
        buffer_max_size: 500
```

## How It Works

1. During the `rewrite` phase, the plugin sets `ngx.ctx.error_log_collecting = true` on the request context (with sampling)
2. When `core.log` is called during request processing, if the flag is set and the log level is above the current filter level, the log message is buffered in a circular queue
3. During the `log` phase, the plugin drains the buffer and re-logs all collected error messages with context information (timestamp, worker ID, request ID)

## Testing

```bash
prove -r t/plugin/error-log-collect.t
```
