### PR TITLE
change(auth): require configured jwt claims, harden empty claims_to_verify and key-auth anonymous fallback

### DIFF
--- a/apisix/plugins/jwt-auth/parser.lua
+++ b/apisix/plugins/jwt-auth/parser.lua
@@ -256,6 +256,9 @@ function _M.verify_claims(self, claims, conf)
     -- required: they must exist in the payload and be valid.
     for _, claim_name in ipairs(claims) do
         local claim = self.payload[claim_name]
+        if claim == nil then
+            return false, "claim " .. claim_name .. " is missing"
+        end
         local checker = claims_checker[claim_name]
         if type(claim) ~= checker.type then
             return false, "claim " .. claim_name .. " is not a " .. checker.type

--- a/apisix/plugins/jwt-auth/parser.lua
+++ b/apisix/plugins/jwt-auth/parser.lua
@@ -229,7 +229,11 @@ end
 
 
 function _M.verify_claims(self, claims, conf)
-    if not claims then
+    -- Treat an explicitly empty `claims_to_verify` array the same as unset and
+    -- fall back to the default claims (exp/nbf). An empty array is truthy in
+    -- Lua, so without the `#claims == 0` check the loop below would iterate over
+    -- nothing and silently accept expired tokens.
+    if not claims or #claims == 0 then
         claims = default_claims
     end
 

--- a/apisix/plugins/jwt-auth/parser.lua
+++ b/apisix/plugins/jwt-auth/parser.lua
@@ -229,25 +229,40 @@ end
 
 
 function _M.verify_claims(self, claims, conf)
-    -- Treat an explicitly empty `claims_to_verify` array the same as unset and
-    -- fall back to the default claims (exp/nbf). An empty array is truthy in
-    -- Lua, so without the `#claims == 0` check the loop below would iterate over
-    -- nothing and silently accept expired tokens.
+    -- When `claims_to_verify` is not configured (nil or an explicitly empty
+    -- array), fall back to the default claims (exp/nbf) and validate them only
+    -- if they are present in the payload. This closes the expired-token hole
+    -- while staying lenient for tokens that legitimately omit these claims.
+    -- An empty array must NOT skip validation, otherwise it reopens the bypass.
     if not claims or #claims == 0 then
-        claims = default_claims
+        for _, claim_name in ipairs(default_claims) do
+            local claim = self.payload[claim_name]
+            if claim ~= nil then
+                local checker = claims_checker[claim_name]
+                if type(claim) ~= checker.type then
+                    return false, "claim " .. claim_name .. " is not a " .. checker.type
+                end
+                local ok, err = checker.check(claim, conf)
+                if not ok then
+                    return false, err
+                end
+            end
+        end
+
+        return true
     end
 
+    -- When `claims_to_verify` is explicitly configured, the listed claims are
+    -- required: they must exist in the payload and be valid.
     for _, claim_name in ipairs(claims) do
         local claim = self.payload[claim_name]
-        if claim then
-            local checker = claims_checker[claim_name]
-            if type(claim) ~= checker.type then
-                return false, "claim " .. claim_name .. " is not a " .. checker.type
-            end
-            local ok, err = checker.check(claim, conf)
-            if not ok then
-                return false, err
-            end
+        local checker = claims_checker[claim_name]
+        if type(claim) ~= checker.type then
+            return false, "claim " .. claim_name .. " is not a " .. checker.type
+        end
+        local ok, err = checker.check(claim, conf)
+        if not ok then
+            return false, err
         end
     end
 

--- a/apisix/plugins/key-auth.lua
+++ b/apisix/plugins/key-auth.lua
@@ -108,6 +108,21 @@ function _M.rewrite(conf, ctx)
             core.response.set_header("WWW-Authenticate", "apikey realm=\"" .. conf.realm .. "\"")
             return 401, { message = err}
         end
+        -- Strip credentials before falling back to the anonymous consumer when
+        -- hide_credentials is enabled. find_consumer() only strips on the
+        -- successful-auth path, so without this an invalid credential would be
+        -- forwarded upstream during anonymous fallback. A request may carry the
+        -- credential in both the header and the query string, so clean up both.
+        if conf.hide_credentials then
+            if core.request.header(ctx, conf.header) then
+                core.request.set_header(ctx, conf.header, nil)
+            end
+            local args = core.request.get_uri_args(ctx) or {}
+            if args[conf.query] then
+                args[conf.query] = nil
+                core.request.set_uri_args(ctx, args)
+            end
+        end
         consumer, consumer_conf, err = consumer_mod.get_anonymous_consumer(conf.anonymous_consumer)
         if not consumer then
             err = "key-auth failed to authenticate the request, code: 401. error: " .. err

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -413,6 +413,22 @@ function _M.print_uri_detailed()
     ngx.say("ngx.var.request_uri: ", ngx.var.request_uri)
 end
 
+-- echo back exactly what the upstream received: the full request URI (with
+-- query string) and every request header. Lets tests assert on what was
+-- actually proxied upstream instead of scanning the error log.
+function _M.print_request_received()
+    ngx.say("request_uri: ", ngx.var.request_uri)
+    local headers = ngx.req.get_headers()
+    local keys = {}
+    for k in pairs(headers) do
+        keys[#keys + 1] = k
+    end
+    table.sort(keys)
+    for _, k in ipairs(keys) do
+        ngx.say(k, ": ", headers[k])
+    end
+end
+
 function _M.headers()
     local args = ngx.req.get_uri_args()
     for name, val in pairs(args) do

--- a/t/plugin/jwt-auth-more-algo.t
+++ b/t/plugin/jwt-auth-more-algo.t
@@ -325,13 +325,18 @@ passed
 
 
 
-=== TEST 13: verify success with expired token
+=== TEST 13: configured claim (nbf) missing from token -> rejected
+# claims_to_verify lists nbf, but this token only carries exp. A claim that is
+# explicitly configured is required, so the missing nbf is rejected.
 --- request
 GET /hello
 --- more_headers
 Authorization: eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTU2Mzg3MDUwMX0.SJNbFYR1qlIOD7D8aItkB9hYxdhc0d_JGaLgVjOCDOAHd8CSJuHp_R6YQniRDq8S
---- response_body
-hello world
+--- error_code: 401
+--- response_body eval
+qr/failed to verify jwt/
+--- error_log
+claim nbf is not a number
 
 
 

--- a/t/plugin/jwt-auth-more-algo.t
+++ b/t/plugin/jwt-auth-more-algo.t
@@ -368,6 +368,33 @@ hello world
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
+
+            -- TEST 12 left claims_to_verify=["nbf"] on this route. Now that
+            -- configured claims are required, that stale requirement would reject
+            -- the EdDSA token in TEST 17 (which carries exp but no nbf). This test
+            -- group targets signature verification, so restore a clean jwt-auth
+            -- config on the route first.
+            local code = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "jwt-auth": {}
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say("failed to reset route")
+                return
+            end
+
             local code, body = t('/apisix/admin/consumers',
                 ngx.HTTP_PUT,
                 [[{

--- a/t/plugin/jwt-auth-more-algo.t
+++ b/t/plugin/jwt-auth-more-algo.t
@@ -336,7 +336,7 @@ Authorization: eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4
 --- response_body eval
 qr/failed to verify jwt/
 --- error_log
-claim nbf is not a number
+claim nbf is missing
 
 
 

--- a/t/plugin/jwt-auth.t
+++ b/t/plugin/jwt-auth.t
@@ -1301,3 +1301,130 @@ passed
 {"message":"failed to verify jwt"}
 --- error_log
 failed to verify jwt: algorithm mismatch, expected RS256
+
+
+
+=== TEST 53: add consumer for default-claims verification
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack",
+                    "plugins": {
+                        "jwt-auth": {
+                            "key": "user-key",
+                            "secret": "my-secret-key"
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 54: enable jwt-auth WITHOUT claims_to_verify (default exp/nbf path)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "jwt-auth": {}
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 55: expired token with no claims_to_verify configured -> rejected
+--- request
+GET /hello?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTU2Mzg3MDUwMX0.pPNVvh-TQsdDzorRwa-uuiLYiEBODscp9wv0cwD6c68
+--- error_code: 401
+--- response_body
+{"message":"failed to verify jwt"}
+--- error_log
+failed to verify jwt: 'exp' claim expired at Tue, 23 Jul 2019 08:28:21 GMT
+
+
+
+=== TEST 56: token without exp claim and no claims_to_verify configured -> accepted
+--- request
+GET /hello?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSJ9._7aoTZdzQDT0r9swHTcHb3nsujexcGjSTU-LRzTRVyY
+--- response_body
+hello world
+--- no_error_log
+[error]
+
+
+
+=== TEST 57: enable jwt-auth with an explicit empty claims_to_verify array
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "jwt-auth": {
+                            "claims_to_verify": []
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 58: expired token with an explicit empty claims_to_verify -> still rejected
+--- request
+GET /hello?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4cCI6MTU2Mzg3MDUwMX0.pPNVvh-TQsdDzorRwa-uuiLYiEBODscp9wv0cwD6c68
+--- error_code: 401
+--- response_body
+{"message":"failed to verify jwt"}
+--- error_log
+failed to verify jwt: 'exp' claim expired at Tue, 23 Jul 2019 08:28:21 GMT

--- a/t/plugin/key-auth-anonymous-consumer.t
+++ b/t/plugin/key-auth-anonymous-consumer.t
@@ -224,57 +224,12 @@ failed to get anonymous consumer not-found-anonymous
 
 
 
-=== TEST 8: enable key-auth on /echo with anonymous consumer and hide_credentials
---- config
-    location /t {
-        content_by_lua_block {
-            local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/routes/1',
-                ngx.HTTP_PUT,
-                [[{
-                    "plugins": {
-                        "key-auth": {
-                            "anonymous_consumer": "anonymous",
-                            "hide_credentials": true
-                        }
-                    },
-                    "upstream": {
-                        "nodes": {
-                            "127.0.0.1:1980": 1
-                        },
-                        "type": "roundrobin"
-                    },
-                    "uri": "/echo"
-                }]]
-            )
-
-            if code >= 300 then
-                ngx.status = code
-            end
-            ngx.say(body)
-        }
-    }
---- request
-GET /t
---- response_body
-passed
-
-
-
-=== TEST 9: invalid key in header falls back to anonymous, invalid key not forwarded upstream
---- request
-GET /echo
---- more_headers
-apikey: invalid-key
---- response_headers
-!apikey
-x-consumer-username: anonymous
---- no_error_log
-invalid-key
-
-
-
-=== TEST 10: invalid key in query string falls back to anonymous, invalid key not forwarded upstream
+=== TEST 8: enable key-auth with anonymous consumer and hide_credentials
+# Route to an upstream that echoes back the request URI (with query string) and
+# every request header it received, so the tests can assert on what is actually
+# proxied upstream. Scanning the error log is unreliable here: nginx always logs
+# the original client request line, which still contains the credential even
+# after it is stripped from the upstream request.
 --- config
     location /t {
         content_by_lua_block {
@@ -295,9 +250,10 @@ invalid-key
                         },
                         "type": "roundrobin"
                     },
-                    "uri": "/echo"
+                    "uri": "/print_request_received"
                 }]]
             )
+
             if code >= 300 then
                 ngx.status = code
             end
@@ -311,25 +267,31 @@ passed
 
 
 
-=== TEST 11: verify invalid key query arg is stripped on anonymous fallback
+=== TEST 9: invalid key in header falls back to anonymous, credential not forwarded upstream
+# The upstream body must contain the anonymous marker (X-Consumer-Username:
+# anonymous, injected by apisix) AND must not contain the credential anywhere,
+# proving the invalid key was stripped before the request was proxied upstream.
 --- request
-GET /echo?auth=invalid-key
---- response_args
-!auth
---- response_headers
-x-consumer-username: anonymous
-
-
-
-=== TEST 12: invalid key in BOTH header and query -> both stripped on anonymous fallback
---- request
-GET /echo?auth=invalid-key
+GET /print_request_received
 --- more_headers
 apikey: invalid-key
---- response_args
-!auth
---- response_headers
-!apikey
-x-consumer-username: anonymous
---- no_error_log
-invalid-key
+--- response_body_like eval
+qr/(?s)^(?!.*invalid-key).*x-consumer-username: anonymous/
+
+
+
+=== TEST 10: invalid key in query falls back to anonymous, credential not forwarded upstream
+--- request
+GET /print_request_received?auth=invalid-key
+--- response_body_like eval
+qr/(?s)^(?!.*invalid-key).*x-consumer-username: anonymous/
+
+
+
+=== TEST 11: invalid key in BOTH header and query -> neither forwarded upstream
+--- request
+GET /print_request_received?auth=invalid-key
+--- more_headers
+apikey: invalid-key
+--- response_body_like eval
+qr/(?s)^(?!.*invalid-key).*x-consumer-username: anonymous/

--- a/t/plugin/key-auth-anonymous-consumer.t
+++ b/t/plugin/key-auth-anonymous-consumer.t
@@ -221,3 +221,115 @@ GET /hello
 failed to get anonymous consumer not-found-anonymous
 --- response_body
 {"message":"Invalid user authorization"}
+
+
+
+=== TEST 8: enable key-auth on /echo with anonymous consumer and hide_credentials
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "key-auth": {
+                            "anonymous_consumer": "anonymous",
+                            "hide_credentials": true
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/echo"
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 9: invalid key in header falls back to anonymous, invalid key not forwarded upstream
+--- request
+GET /echo
+--- more_headers
+apikey: invalid-key
+--- response_headers
+!apikey
+x-consumer-username: anonymous
+--- no_error_log
+invalid-key
+
+
+
+=== TEST 10: invalid key in query string falls back to anonymous, invalid key not forwarded upstream
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "key-auth": {
+                            "query": "auth",
+                            "anonymous_consumer": "anonymous",
+                            "hide_credentials": true
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/echo"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 11: verify invalid key query arg is stripped on anonymous fallback
+--- request
+GET /echo?auth=invalid-key
+--- response_args
+!auth
+--- response_headers
+x-consumer-username: anonymous
+
+
+
+=== TEST 12: invalid key in BOTH header and query -> both stripped on anonymous fallback
+--- request
+GET /echo?auth=invalid-key
+--- more_headers
+apikey: invalid-key
+--- response_args
+!auth
+--- response_headers
+!apikey
+x-consumer-username: anonymous
+--- no_error_log
+invalid-key


### PR DESCRIPTION
### Description

This PR contains hardening fixes in the auth plugins, each with tests.

**1. `jwt-auth`: treat an empty `claims_to_verify` array as unset**

`verify_claims()` falls back to the default claims (`exp`/`nbf`) when `claims_to_verify` is not configured. The guard used `if not claims then`, but an explicitly empty array (`"claims_to_verify": []`) is truthy in Lua, so it skipped the fallback and the validation loop iterated over nothing, meaning an expired token was accepted when `claims_to_verify` was set to `[]`. The schema allows an empty array (no `minItems`), so this configuration is reachable.

The guard now treats an empty array the same as an unset value (`if not claims or #claims == 0 then`), restoring the default `exp`/`nbf` checks. Behaviour for tokens that legitimately omit `exp`/`nbf` is unchanged (they are validated only if present).

**2. `jwt-auth`: require explicitly configured claims to be present (behavior change)**

Previously `verify_claims()` validated a configured claim only if it was present in the token (`if claim then ...`), so a route with e.g. `claims_to_verify: ["exp"]` would still accept a token that omitted `exp`. With this change, when `claims_to_verify` is explicitly configured the listed claims are **required**: a token missing a configured claim is rejected. The default path (no `claims_to_verify`, or an empty array) is unchanged and still validates `exp`/`nbf` only if present.

> [!WARNING]
> This is a behavior change. A route configured with `claims_to_verify: ["exp"]` (or any claim) will now reject a token that omits that claim, where it was previously accepted. It only affects routes that explicitly set `claims_to_verify`; the default behavior is unchanged. `jwt-auth-more-algo.t` TEST 13 is updated to reflect this (a token missing the configured `nbf` claim is now rejected). Happy to discuss on the dev mailing list if preferred.

**3. `key-auth`: strip credentials on anonymous-consumer fallback**

When a request carried an invalid API key and key-auth fell back to the configured `anonymous_consumer`, the (invalid) credential was still forwarded upstream even with `hide_credentials` enabled: `find_consumer()` only strips credentials on the successful-auth path. The fix strips the credential before falling back to the anonymous consumer when `hide_credentials` is true. Since a request can carry the key in both the header and the query string, both are cleaned up.

#### Which issue(s) this PR fixes:
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (item 2 is an intentional behavior change for explicitly-configured `claims_to_verify`; called out above)
