### PR TITLE
fix(cas-auth): return 400 instead of 500 for SLO POST with empty body

### DIFF
--- a/apisix/plugins/cas-auth.lua
+++ b/apisix/plugins/cas-auth.lua
@@ -381,7 +381,7 @@ function _M.access(conf, ctx)
 
     if method == "POST" and uri == cas_callback_path then
         local data = core.request.get_body()
-        local ticket = data and data:match("<samlp:SessionIndex>(.*)</samlp:SessionIndex>")
+        local ticket = data and data:match("<samlp:SessionIndex>(.+)</samlp:SessionIndex>")
         if ticket == nil then
             return ngx.HTTP_BAD_REQUEST,
                 {message = "invalid logout request from IdP, no ticket"}

--- a/apisix/plugins/cas-auth.lua
+++ b/apisix/plugins/cas-auth.lua
@@ -381,7 +381,7 @@ function _M.access(conf, ctx)
 
     if method == "POST" and uri == cas_callback_path then
         local data = core.request.get_body()
-        local ticket = data:match("<samlp:SessionIndex>(.*)</samlp:SessionIndex>")
+        local ticket = data and data:match("<samlp:SessionIndex>(.*)</samlp:SessionIndex>")
         if ticket == nil then
             return ngx.HTTP_BAD_REQUEST,
                 {message = "invalid logout request from IdP, no ticket"}

--- a/t/plugin/cas-auth.t
+++ b/t/plugin/cas-auth.t
@@ -842,7 +842,7 @@ passed
 
 
 
-=== TEST 20: POST to CAS callback with empty body returns 400, not 500
+=== TEST 20: malformed SLO POST to callback returns 400, not 500
 --- config
     location /t {
         content_by_lua_block {
@@ -850,8 +850,8 @@ passed
             local httpc = http.new()
             local base = "http://127.0.0.1:" .. ngx.var.server_port
 
-            -- A malformed SLO POST (no body, hence no <samlp:SessionIndex>)
-            -- must fall through to a clean 400, not index a nil body and 500.
+            -- (1) no body at all: get_body() returns nil, which must not be
+            -- indexed (500) but fall through to a clean 400.
             local res, err = httpc:request_uri(base .. "/cas_callback", {
                 method = "POST",
                 headers = { ["Host"] = "127.0.0.20" },
@@ -861,6 +861,18 @@ passed
                 "expected 400 for empty-body SLO POST, got " .. res.status)
             assert(res.body and res.body:find("no ticket", 1, true),
                 "expected 'no ticket' message, got: " .. tostring(res.body))
+
+            -- (2) body present but SessionIndex empty: still a malformed
+            -- logout, must be 400 rather than passing an empty ticket through.
+            res, err = httpc:request_uri(base .. "/cas_callback", {
+                method = "POST",
+                headers = { ["Host"] = "127.0.0.20" },
+                body = "<samlp:SessionIndex></samlp:SessionIndex>",
+            })
+            assert(res, "request failed: " .. tostring(err))
+            assert(res.status == 400,
+                "expected 400 for empty SessionIndex, got " .. res.status)
+
             ngx.say("passed")
         }
     }

--- a/t/plugin/cas-auth.t
+++ b/t/plugin/cas-auth.t
@@ -797,3 +797,72 @@ passed
     }
 --- response_body
 passed
+
+
+
+=== TEST 19: add route for empty-body SLO callback test
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+
+            local code, body = t('/apisix/admin/routes/cas-slo',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "methods": ["GET", "POST"],
+                        "host": "127.0.0.20",
+                        "priority": 10,
+                        "plugins": {
+                            "cas-auth": {
+                                "idp_uri": "http://127.0.0.1:8080/realms/test/protocol/cas",
+                                "cas_callback_uri": "/cas_callback",
+                                "logout_uri": "/logout",
+                                "cookie": {
+                                    "secret": "0123456789abcdef0123456789abcdef",
+                                    "secure": false
+                                }
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {"127.0.0.1:1980": 1},
+                            "type": "roundrobin"
+                        },
+                        "uri": "/*"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 20: POST to CAS callback with empty body returns 400, not 500
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+            local base = "http://127.0.0.1:" .. ngx.var.server_port
+
+            -- A malformed SLO POST (no body, hence no <samlp:SessionIndex>)
+            -- must fall through to a clean 400, not index a nil body and 500.
+            local res, err = httpc:request_uri(base .. "/cas_callback", {
+                method = "POST",
+                headers = { ["Host"] = "127.0.0.20" },
+            })
+            assert(res, "request failed: " .. tostring(err))
+            assert(res.status == 400,
+                "expected 400 for empty-body SLO POST, got " .. res.status)
+            assert(res.body and res.body:find("no ticket", 1, true),
+                "expected 'no ticket' message, got: " .. tostring(res.body))
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed


### PR DESCRIPTION
A `POST` to the CAS callback path with an empty request body returns a 500 instead of a clean 400.

The single-logout branch in `cas-auth`'s `access` reads the body and immediately calls `:match` on it:

```lua
local data = core.request.get_body()
local ticket = data:match("<samlp:SessionIndex>(.*)</samlp:SessionIndex>")
```

`core.request.get_body()` returns `nil` when there's no body, so `data:match` raises `attempt to index local 'data' (a nil value)` and the request 500s — even though the very next line already handles the "no ticket" case with a 400, it's never reached.

Fix is a one-liner: guard the body before matching so a missing/empty body falls through to the existing 400 branch. A normal CAS ticket callback (a GET with `?ticket=`) is unaffected.

Added a test that POSTs to the callback with no body and asserts a 400 — it fails with 500 before the fix.
