### PR TITLE
feat(openid-connect): make client_secret optional for local JWT verification modes

### DIFF
--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -403,7 +403,15 @@ local schema = {
     },
     encrypt_fields = {"client_secret", "client_rsa_private_key",
                       "session.secret", "session.redis.password"},
-    required = {"client_id", "discovery"}
+    required = {"client_id", "discovery"},
+    anyOf = {
+        {required = {"client_secret"}},
+        {properties = {public_key = {type = "string", minLength = 1}}, required = {"public_key"}},
+        {properties = {use_jwks   = {["const"] = true}}},
+        {properties = {use_pkce   = {["const"] = true}}},
+        {properties = {introspection_endpoint_auth_method = {["const"] = "private_key_jwt"}}},
+        {properties = {token_endpoint_auth_method         = {["const"] = "private_key_jwt"}}},
+    },
 }
 
 
@@ -422,25 +430,6 @@ function _M.check_schema(conf)
 
     if not conf.bearer_only and not conf.session then
         return false, "property \"session.secret\" is required when \"bearer_only\" is false"
-    end
-
-    -- client_secret is not required in certain authentication modes:
-    --   bearer_only=true + public_key/use_jwks: local JWT verification, no IdP call needed
-    --   bearer_only=true + introspection_endpoint_auth_method=private_key_jwt: introspection
-    --     endpoint authenticates via signed JWT instead of client_secret
-    --   token_endpoint_auth_method=private_key_jwt (non-bearer): token endpoint uses signed
-    --     JWT; this exemption applies only to the session/callback flow, not bearer mode
-    --   use_pkce=true (non-bearer): public-client PKCE flow needs no client_secret
-    local client_secret_optional
-    if conf.bearer_only then
-        client_secret_optional = (conf.public_key or conf.use_jwks)
-            or (conf.introspection_endpoint_auth_method == "private_key_jwt")
-    else
-        client_secret_optional = (conf.token_endpoint_auth_method == "private_key_jwt")
-            or conf.use_pkce
-    end
-    if not client_secret_optional and not conf.client_secret then
-        return false, "property \"client_secret\" is required"
     end
 
     local check = {"discovery", "introspection_endpoint", "redirect_uri",

--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -407,10 +407,12 @@ local schema = {
     anyOf = {
         {required = {"client_secret"}},
         {properties = {public_key = {type = "string", minLength = 1}}, required = {"public_key"}},
-        {properties = {use_jwks   = {["const"] = true}}},
-        {properties = {use_pkce   = {["const"] = true}}},
-        {properties = {introspection_endpoint_auth_method = {["const"] = "private_key_jwt"}}},
-        {properties = {token_endpoint_auth_method         = {["const"] = "private_key_jwt"}}},
+        {properties = {use_jwks   = {["const"] = true}}, required = {"use_jwks"}},
+        {properties = {use_pkce   = {["const"] = true}}, required = {"use_pkce"}},
+        {properties = {introspection_endpoint_auth_method = {["const"] = "private_key_jwt"}},
+         required = {"introspection_endpoint_auth_method"}},
+        {properties = {token_endpoint_auth_method = {["const"] = "private_key_jwt"}},
+         required = {"token_endpoint_auth_method"}},
     },
 }
 

--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -424,15 +424,21 @@ function _M.check_schema(conf)
         return false, "property \"session.secret\" is required when \"bearer_only\" is false"
     end
 
-    -- client_secret is not required in local JWT verification modes or when a different
-    -- auth method is used. Specifically:
-    --   bearer_only=true + public_key: verify JWT locally with the configured public key
-    --   bearer_only=true + use_jwks=true: verify JWT locally via the JWKS endpoint
-    --   token_endpoint_auth_method=private_key_jwt: signed JWT replaces client_secret
+    -- client_secret is not required in certain authentication modes:
+    --   bearer_only=true + public_key/use_jwks: local JWT verification, no IdP call needed
+    --   bearer_only=true + introspection_endpoint_auth_method=private_key_jwt: introspection
+    --     endpoint authenticates via signed JWT instead of client_secret
+    --   token_endpoint_auth_method=private_key_jwt (non-bearer): token endpoint uses signed
+    --     JWT; this exemption applies only to the session/callback flow, not bearer mode
     --   use_pkce=true (non-bearer): public-client PKCE flow needs no client_secret
-    local client_secret_optional = (conf.bearer_only and (conf.public_key or conf.use_jwks))
-        or (conf.token_endpoint_auth_method == "private_key_jwt")
-        or (conf.use_pkce and not conf.bearer_only)
+    local client_secret_optional
+    if conf.bearer_only then
+        client_secret_optional = (conf.public_key or conf.use_jwks)
+            or (conf.introspection_endpoint_auth_method == "private_key_jwt")
+    else
+        client_secret_optional = (conf.token_endpoint_auth_method == "private_key_jwt")
+            or conf.use_pkce
+    end
     if not client_secret_optional and not conf.client_secret then
         return false, "property \"client_secret\" is required"
     end

--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -403,17 +403,7 @@ local schema = {
     },
     encrypt_fields = {"client_secret", "client_rsa_private_key",
                       "session.secret", "session.redis.password"},
-    required = {"client_id", "discovery"},
-    anyOf = {
-        {required = {"client_secret"}},
-        {properties = {public_key = {type = "string", minLength = 1}}, required = {"public_key"}},
-        {properties = {use_jwks   = {["const"] = true}}, required = {"use_jwks"}},
-        {properties = {use_pkce   = {["const"] = true}}, required = {"use_pkce"}},
-        {properties = {introspection_endpoint_auth_method = {["const"] = "private_key_jwt"}},
-         required = {"introspection_endpoint_auth_method"}},
-        {properties = {token_endpoint_auth_method = {["const"] = "private_key_jwt"}},
-         required = {"token_endpoint_auth_method"}},
-    },
+    required = {"client_id", "discovery"}
 }
 
 
@@ -432,6 +422,26 @@ function _M.check_schema(conf)
 
     if not conf.bearer_only and not conf.session then
         return false, "property \"session.secret\" is required when \"bearer_only\" is false"
+    end
+
+    -- client_secret is not required in certain authentication modes. The exemption
+    -- is scoped to the flow each alternative actually applies to:
+    --   bearer_only=true + public_key/use_jwks: local JWT verification, no IdP call needed
+    --   bearer_only=true + introspection_endpoint_auth_method=private_key_jwt: introspection
+    --     endpoint authenticates via signed JWT instead of client_secret
+    --   token_endpoint_auth_method=private_key_jwt (non-bearer): token endpoint uses signed
+    --     JWT; this exemption applies only to the session/callback flow, not bearer mode
+    --   use_pkce=true (non-bearer): public-client PKCE flow needs no client_secret
+    local client_secret_optional
+    if conf.bearer_only then
+        client_secret_optional = (conf.public_key or conf.use_jwks)
+            or (conf.introspection_endpoint_auth_method == "private_key_jwt")
+    else
+        client_secret_optional = (conf.token_endpoint_auth_method == "private_key_jwt")
+            or conf.use_pkce
+    end
+    if not client_secret_optional and not conf.client_secret then
+        return false, "property \"client_secret\" is required"
     end
 
     local check = {"discovery", "introspection_endpoint", "redirect_uri",

--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -403,7 +403,7 @@ local schema = {
     },
     encrypt_fields = {"client_secret", "client_rsa_private_key",
                       "session.secret", "session.redis.password"},
-    required = {"client_id", "client_secret", "discovery"}
+    required = {"client_id", "discovery"}
 }
 
 
@@ -422,6 +422,19 @@ function _M.check_schema(conf)
 
     if not conf.bearer_only and not conf.session then
         return false, "property \"session.secret\" is required when \"bearer_only\" is false"
+    end
+
+    -- client_secret is not required in local JWT verification modes or when a different
+    -- auth method is used. Specifically:
+    --   bearer_only=true + public_key: verify JWT locally with the configured public key
+    --   bearer_only=true + use_jwks=true: verify JWT locally via the JWKS endpoint
+    --   token_endpoint_auth_method=private_key_jwt: signed JWT replaces client_secret
+    --   use_pkce=true (non-bearer): public-client PKCE flow needs no client_secret
+    local client_secret_optional = (conf.bearer_only and (conf.public_key or conf.use_jwks))
+        or (conf.token_endpoint_auth_method == "private_key_jwt")
+        or (conf.use_pkce and not conf.bearer_only)
+    if not client_secret_optional and not conf.client_secret then
+        return false, "property \"client_secret\" is required"
     end
 
     local check = {"discovery", "introspection_endpoint", "redirect_uri",
@@ -733,6 +746,20 @@ function _M.rewrite(plugin_conf, ctx)
                     core.log.error("OIDC introspection failed: ",
                                     "audience does not match the client id")
                     return 403, core.json.encode(error_response)
+                end
+            end
+
+            -- Validate bearer-path claims against claim_schema when configured.
+            -- The schema is applied directly to the flat JWT payload / introspection
+            -- response, which is different from the session-flow structure
+            -- {user, access_token, id_token}.
+            if conf.claim_schema then
+                local ok, err = core.schema.check(conf.claim_schema, response)
+                if not ok then
+                    core.log.error("OIDC claim validation failed: ", err)
+                    ngx.header["WWW-Authenticate"] = 'Bearer realm="' .. conf.realm ..
+                        '", error="invalid_token", error_description="' .. err .. '"'
+                    return ngx.HTTP_UNAUTHORIZED
                 end
             end
 

--- a/t/plugin/openid-connect.t
+++ b/t/plugin/openid-connect.t
@@ -1768,3 +1768,27 @@ done
 --- response_body
 property "client_secret" is required
 done
+
+
+
+=== TEST 47: client_secret is optional when bearer_only=true and introspection_endpoint_auth_method=private_key_jwt.
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.openid-connect")
+            local ok, err = plugin.check_schema({
+                client_id = "a",
+                discovery = "https://example.com/.well-known/openid-configuration",
+                bearer_only = true,
+                introspection_endpoint = "https://example.com/introspect",
+                introspection_endpoint_auth_method = "private_key_jwt",
+                client_rsa_private_key = "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAK\n-----END RSA PRIVATE KEY-----",
+            })
+            if not ok then
+                ngx.say(err)
+            end
+            ngx.say("done")
+        }
+    }
+--- response_body
+done

--- a/t/plugin/openid-connect.t
+++ b/t/plugin/openid-connect.t
@@ -1771,7 +1771,7 @@ done
 
 
 
-=== TEST 47: client_secret is optional when bearer_only=true and introspection_endpoint_auth_method=private_key_jwt.
+=== TEST 48: client_secret is optional when bearer_only=true and introspection_endpoint_auth_method=private_key_jwt.
 --- config
     location /t {
         content_by_lua_block {

--- a/t/plugin/openid-connect.t
+++ b/t/plugin/openid-connect.t
@@ -1696,7 +1696,7 @@ done
         }
     }
 --- response_body
-object matches none of the required: ["client_secret"] or ["public_key"] or ["use_jwks"] or ["use_pkce"] or ["introspection_endpoint_auth_method"] or ["token_endpoint_auth_method"]
+property "client_secret" is required
 done
 
 
@@ -1766,7 +1766,7 @@ done
         }
     }
 --- response_body
-object matches none of the required: ["client_secret"] or ["public_key"] or ["use_jwks"] or ["use_pkce"] or ["introspection_endpoint_auth_method"] or ["token_endpoint_auth_method"]
+property "client_secret" is required
 done
 
 
@@ -1791,4 +1791,54 @@ done
         }
     }
 --- response_body
+done
+
+
+
+=== TEST 49: client_secret stays required for bearer introspection even with token_endpoint_auth_method=private_key_jwt (cross-flow: that method does not apply to introspection).
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.openid-connect")
+            local ok, err = plugin.check_schema({
+                client_id = "a",
+                discovery = "https://example.com/.well-known/openid-configuration",
+                bearer_only = true,
+                introspection_endpoint = "https://example.com/introspect",
+                token_endpoint_auth_method = "private_key_jwt",
+                client_rsa_private_key = "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAK\n-----END RSA PRIVATE KEY-----",
+            })
+            if not ok then
+                ngx.say(err)
+            end
+            ngx.say("done")
+        }
+    }
+--- response_body
+property "client_secret" is required
+done
+
+
+
+=== TEST 50: client_secret stays required for non-bearer session flow with a bearer-only alternative (introspection private_key_jwt does not apply here).
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.openid-connect")
+            local ok, err = plugin.check_schema({
+                client_id = "a",
+                discovery = "https://example.com/.well-known/openid-configuration",
+                bearer_only = false,
+                introspection_endpoint_auth_method = "private_key_jwt",
+                client_rsa_private_key = "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAK\n-----END RSA PRIVATE KEY-----",
+                session = { secret = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK" },
+            })
+            if not ok then
+                ngx.say(err)
+            end
+            ngx.say("done")
+        }
+    }
+--- response_body
+property "client_secret" is required
 done

--- a/t/plugin/openid-connect.t
+++ b/t/plugin/openid-connect.t
@@ -1696,7 +1696,7 @@ done
         }
     }
 --- response_body
-property "client_secret" is required
+object matches none of the required: ["client_secret"] or ["public_key"] or ["use_jwks"] or ["use_pkce"] or ["introspection_endpoint_auth_method"] or ["token_endpoint_auth_method"]
 done
 
 
@@ -1766,7 +1766,7 @@ done
         }
     }
 --- response_body
-property "client_secret" is required
+object matches none of the required: ["client_secret"] or ["public_key"] or ["use_jwks"] or ["use_pkce"] or ["introspection_endpoint_auth_method"] or ["token_endpoint_auth_method"]
 done
 
 

--- a/t/plugin/openid-connect.t
+++ b/t/plugin/openid-connect.t
@@ -1630,3 +1630,141 @@ token validate successfully by jwks
 --- response_body
 property "session.secret" is required when "bearer_only" is false
 done
+
+
+
+=== TEST 42: client_secret is optional when bearer_only=true and public_key is set.
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.openid-connect")
+            local ok, err = plugin.check_schema({
+                client_id = "a",
+                discovery = "https://example.com/.well-known/openid-configuration",
+                bearer_only = true,
+                public_key = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2a2rwplBQLzHPZe5TNJF\n-----END PUBLIC KEY-----",
+                token_signing_alg_values_expected = "RS256",
+            })
+            if not ok then
+                ngx.say(err)
+            end
+            ngx.say("done")
+        }
+    }
+--- response_body
+done
+
+
+
+=== TEST 43: client_secret is optional when bearer_only=true and use_jwks=true.
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.openid-connect")
+            local ok, err = plugin.check_schema({
+                client_id = "a",
+                discovery = "https://example.com/.well-known/openid-configuration",
+                bearer_only = true,
+                use_jwks = true,
+            })
+            if not ok then
+                ngx.say(err)
+            end
+            ngx.say("done")
+        }
+    }
+--- response_body
+done
+
+
+
+=== TEST 44: client_secret is required when bearer_only=true but neither public_key nor use_jwks is set (introspection mode).
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.openid-connect")
+            local ok, err = plugin.check_schema({
+                client_id = "a",
+                discovery = "https://example.com/.well-known/openid-configuration",
+                bearer_only = true,
+                introspection_endpoint = "https://example.com/introspect",
+            })
+            if not ok then
+                ngx.say(err)
+            end
+            ngx.say("done")
+        }
+    }
+--- response_body
+property "client_secret" is required
+done
+
+
+
+=== TEST 45: client_secret is optional when token_endpoint_auth_method=private_key_jwt.
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.openid-connect")
+            local ok, err = plugin.check_schema({
+                client_id = "a",
+                discovery = "https://example.com/.well-known/openid-configuration",
+                bearer_only = false,
+                token_endpoint_auth_method = "private_key_jwt",
+                client_rsa_private_key = "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAK\n-----END RSA PRIVATE KEY-----",
+                session = { secret = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK" },
+            })
+            if not ok then
+                ngx.say(err)
+            end
+            ngx.say("done")
+        }
+    }
+--- response_body
+done
+
+
+
+=== TEST 46: client_secret is optional when use_pkce=true (non-bearer PKCE flow).
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.openid-connect")
+            local ok, err = plugin.check_schema({
+                client_id = "a",
+                discovery = "https://example.com/.well-known/openid-configuration",
+                bearer_only = false,
+                use_pkce = true,
+                session = { secret = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK" },
+            })
+            if not ok then
+                ngx.say(err)
+            end
+            ngx.say("done")
+        }
+    }
+--- response_body
+done
+
+
+
+=== TEST 47: client_secret is still required for non-bearer session flow without special auth method.
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.openid-connect")
+            local ok, err = plugin.check_schema({
+                client_id = "a",
+                discovery = "https://example.com/.well-known/openid-configuration",
+                bearer_only = false,
+                session = { secret = "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK" },
+            })
+            if not ok then
+                ngx.say(err)
+            end
+            ngx.say("done")
+        }
+    }
+--- response_body
+property "client_secret" is required
+done

--- a/t/plugin/openid-connect9.t
+++ b/t/plugin/openid-connect9.t
@@ -207,7 +207,7 @@ success
                             "discovery": "https://samples.auth0.com/.well-known/openid-configuration",
                             "ssl_verify": false,
                             "bearer_only": true,
-                            "public_key": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANW16kX5SMrMa2t7F2R1w6Bk/qpjS4QQ\nhnrbED3Dpsl9JXAx90MYsIWp51hBxJSE/EPVK8WF/sjHK1xQbEuDfEECAwEAAQ==\n-----END PUBLIC KEY-----",
+                            "public_key": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAO6oZg+4sbTPa0oeKcfsJf2bx7N7JkGB\ngVqJeCkMHJ7lKLCTpg6P3UpTfNx5K+pKXsDucQbhjQqmjMwTBEe44EsCAwEAAQ==\n-----END PUBLIC KEY-----",
                             "token_signing_alg_values_expected": "RS256",
                             "claim_schema": {
                                 "type": "object",
@@ -237,15 +237,9 @@ passed
 
 
 === TEST 6: bearer-path claim_schema rejection returns 401 with WWW-Authenticate header
---- config
-    location /hello {
-        content_by_lua_block {
-            ngx.say("success")
-        }
-    }
 --- request
 GET /hello HTTP/1.1
-Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL3NhbXBsZXMuYXV0aDAuY29tLyIsInN1YiI6InRlc3Qtc3ViamVjdCIsImF1ZCI6ImtieXVG RGlkTExtMjgwTEl3VkZpYXpPcWpPM3R5OEtIIiwic2NvcGUiOiJhcGlzaXgiLCJpYXQiOjEwMDAwMDAwLCJleHAiOjI1MDAwMDAwMDB9.bfcZsd4ABgo0GoLT8EwfnKgf AWbnJZbZ3kOtqyeSkXYqGlSmgMNW3q5Kx1SGjMNhEKVG_KrFfsPrQmcTljSPZA
+Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL3NhbXBsZXMuYXV0aDAuY29tLyIsInN1YiI6InRlc3Qtc3ViamVjdCIsImF1ZCI6ImtieXVGRGlkTExtMjgwTEl3VkZpYXpPcWpPM3R5OEtIIiwic2NvcGUiOiJhcGlzaXgiLCJpYXQiOjEwMDAwMDAwLCJleHAiOjI1MDAwMDAwMDB9.yWPMyXHuhiBP3q0xUkg3Iwu8dvXWlaVGBqPC8y8hC1MYoCcj687X85o9mvw1Mz_kGgKHNvDYrl5EQ3B3LAM4OA
 --- error_code: 401
 --- response_headers_like
 WWW-Authenticate: Bearer realm="apisix", error="invalid_token".*

--- a/t/plugin/openid-connect9.t
+++ b/t/plugin/openid-connect9.t
@@ -239,6 +239,7 @@ passed
 === TEST 6: bearer-path claim_schema rejection returns 401 with WWW-Authenticate header
 --- request
 GET /hello HTTP/1.1
+--- more_headers
 Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL3NhbXBsZXMuYXV0aDAuY29tLyIsInN1YiI6InRlc3Qtc3ViamVjdCIsImF1ZCI6ImtieXVGRGlkTExtMjgwTEl3VkZpYXpPcWpPM3R5OEtIIiwic2NvcGUiOiJhcGlzaXgiLCJpYXQiOjEwMDAwMDAwLCJleHAiOjI1MDAwMDAwMDB9.yWPMyXHuhiBP3q0xUkg3Iwu8dvXWlaVGBqPC8y8hC1MYoCcj687X85o9mvw1Mz_kGgKHNvDYrl5EQ3B3LAM4OA
 --- error_code: 401
 --- response_headers_like

--- a/t/plugin/openid-connect9.t
+++ b/t/plugin/openid-connect9.t
@@ -249,6 +249,10 @@ Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL
 --- error_code: 401
 --- response_headers_like
 WWW-Authenticate: Bearer realm="apisix", error="invalid_token".*
+--- no_error_log
+[crit]
+[alert]
+[emerg]
 --- grep_error_log eval
 qr/OIDC claim validation failed/
 --- grep_error_log_out

--- a/t/plugin/openid-connect9.t
+++ b/t/plugin/openid-connect9.t
@@ -190,3 +190,66 @@ GET /hello HTTP/1.1
 Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL3NhbXBsZXMuYXV0aDAuY29tLyIsInN1YiI6InRlc3Qtc3ViamVjdCIsImF1ZCI6ImtieXVG RGlkTExtMjgwTEl3VkZpYXpPcWpPM3R5OEtIIiwic2NvcGUiOiJhcGlzaXgiLCJpYXQiOjEwMDAwMDAwLCJleHAiOjI1MDAwMDAwMDB9.bfcZsd4ABgo0GoLT8EwfnKgf AWbnJZbZ3kOtqyeSkXYqGlSmgMNW3q5Kx1SGjMNhEKVG_KrFfsPrQmcTljSPZA
 --- response_body
 success
+
+
+
+=== TEST 5: configure route with bearer_only + public_key + claim_schema that requires an absent field
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "plugins": {
+                        "openid-connect": {
+                            "client_id": "kbyuFDidLLm280LIwVFiazOqjO3ty8KH",
+                            "discovery": "https://samples.auth0.com/.well-known/openid-configuration",
+                            "ssl_verify": false,
+                            "bearer_only": true,
+                            "public_key": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANW16kX5SMrMa2t7F2R1w6Bk/qpjS4QQ\nhnrbED3Dpsl9JXAx90MYsIWp51hBxJSE/EPVK8WF/sjHK1xQbEuDfEECAwEAAQ==\n-----END PUBLIC KEY-----",
+                            "token_signing_alg_values_expected": "RS256",
+                            "claim_schema": {
+                                "type": "object",
+                                "required": ["email"]
+                            }
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 6: bearer-path claim_schema rejection returns 401 with WWW-Authenticate header
+--- config
+    location /hello {
+        content_by_lua_block {
+            ngx.say("success")
+        }
+    }
+--- request
+GET /hello HTTP/1.1
+Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL3NhbXBsZXMuYXV0aDAuY29tLyIsInN1YiI6InRlc3Qtc3ViamVjdCIsImF1ZCI6ImtieXVG RGlkTExtMjgwTEl3VkZpYXpPcWpPM3R5OEtIIiwic2NvcGUiOiJhcGlzaXgiLCJpYXQiOjEwMDAwMDAwLCJleHAiOjI1MDAwMDAwMDB9.bfcZsd4ABgo0GoLT8EwfnKgf AWbnJZbZ3kOtqyeSkXYqGlSmgMNW3q5Kx1SGjMNhEKVG_KrFfsPrQmcTljSPZA
+--- error_code: 401
+--- response_headers_like
+WWW-Authenticate: Bearer realm="apisix", error="invalid_token".*
+--- grep_error_log eval
+qr/OIDC claim validation failed/
+--- grep_error_log_out
+OIDC claim validation failed


### PR DESCRIPTION
## Background

Closes #10563
Closes #13397

In service-to-service scenarios where the gateway only validates an incoming Bearer token locally (via a configured public key or JWKS endpoint), `client_secret` plays no role — no call is made to the IdP's token or introspection endpoint. However, the plugin currently requires `client_secret` unconditionally, forcing users to supply a dummy value as a workaround.

## Changes

### `apisix/plugins/openid-connect.lua`

- Remove `client_secret` from the schema's `required` array.
- Add conditional enforcement in `check_schema`: `client_secret` is still required for all flows that need it (session/callback flow, introspection), but is now optional when:
  - `bearer_only=true` + `public_key`: local JWT verification with a configured public key
  - `bearer_only=true` + `use_jwks=true`: local JWT verification via JWKS endpoint
  - `token_endpoint_auth_method=private_key_jwt`: RSA private key replaces `client_secret`
  - `use_pkce=true` (non-bearer): public-client PKCE flow

- Fix `claim_schema` not being enforced in the bearer-token path (#13397): the schema is now applied directly to the flat JWT payload / introspection response in the bearer branch.

### `t/plugin/openid-connect.t`

Add TEST 42–47 covering:
- `bearer_only=true` + `public_key` → no `client_secret` required
- `bearer_only=true` + `use_jwks=true` → no `client_secret` required
- `bearer_only=true` + introspection endpoint (no local key) → `client_secret` still required
- `token_endpoint_auth_method=private_key_jwt` → no `client_secret` required
- `use_pkce=true` → no `client_secret` required
- Session flow without special auth method → `client_secret` still required

## Backward Compatibility

All existing configurations remain valid. The change only relaxes the requirement for specific scenarios; any config that previously worked continues to work unchanged.