### PR TITLE
fix(ai-proxy): map upstream LLM timeouts to 504 instead of 500

### DIFF
--- a/apisix/plugins/ai-transport/http.lua
+++ b/apisix/plugins/ai-transport/http.lua
@@ -36,8 +36,10 @@ local rapidjson_null = rapidjson.null
 
 
 --- Map network errors to HTTP status codes.
+-- Cosocket timers report "timeout"; OS errno (ETIMEDOUT) and the resolver
+-- report "... timed out", so both spellings must be matched.
 function _M.handle_error(err)
-    if core.string.find(err, "timeout") then
+    if core.string.find(err, "timeout") or core.string.find(err, "timed out") then
         return 504
     end
     return 500

--- a/t/plugin/ai-transport-http.t
+++ b/t/plugin/ai-transport-http.t
@@ -288,3 +288,68 @@ failed to encode AI request body with rapidjson:
 {"messages":[{"content":"hi","role":"user"},{"content":"hello","role":"assistant"}],"model":"m"}
 --- no_error_log
 failed to encode AI request body with rapidjson:
+
+
+
+=== TEST 6: connect timeout ("Operation timed out") maps to 504
+--- config
+    location /t {
+        content_by_lua_block {
+            local orig_http = package.loaded["resty.http"]
+            local orig_transport = package.loaded["apisix.plugins.ai-transport.http"]
+
+            package.loaded["resty.http"] = {
+                new = function()
+                    return {
+                        set_timeout = function() end,
+                        connect = function() return nil, "Operation timed out" end,
+                    }
+                end,
+            }
+
+            package.loaded["apisix.plugins.ai-transport.http"] = nil
+            local transport = require("apisix.plugins.ai-transport.http")
+            local res, err = transport.request({
+                host = "127.0.0.1",
+                port = 80,
+                path = "/",
+                body = {model = "m"},
+            }, 1000)
+            ngx.say("err: ", err)
+            ngx.say("status: ", transport.handle_error(err))
+
+            package.loaded["resty.http"] = orig_http
+            package.loaded["apisix.plugins.ai-transport.http"] = orig_transport
+        }
+    }
+--- response_body
+err: connect: Operation timed out
+status: 504
+
+
+
+=== TEST 7: handle_error maps every timeout spelling to 504, others to 500
+--- config
+    location /t {
+        content_by_lua_block {
+            local transport = require("apisix.plugins.ai-transport.http")
+            local cases = {
+                "connect: timeout",
+                "connect: connection timed out",
+                "connect: operation timed out",
+                "connect: Operation timed out",
+                "request: connection refused",
+                "request: connection reset by peer",
+            }
+            for _, e in ipairs(cases) do
+                ngx.say(e, " => ", transport.handle_error(e))
+            end
+        }
+    }
+--- response_body
+connect: timeout => 504
+connect: connection timed out => 504
+connect: operation timed out => 504
+connect: Operation timed out => 504
+request: connection refused => 500
+request: connection reset by peer => 500


### PR DESCRIPTION
### Description

When an AI proxy request times out reaching the upstream LLM, the client receives `500 Internal Server Error` instead of `504 Gateway Timeout`.

`apisix/plugins/ai-transport/http.lua` maps errors to `504` only when the error string contains the contiguous substring `timeout`:

```lua
function _M.handle_error(err)
    if core.string.find(err, "timeout") then
        return 504
    end
    return 500
end
```

`core.string.find` is a plain-text search, and an OS connect timeout surfaces as `Operation timed out` / `Connection timed out`, which contains `timed out` (with a space), **not** the contiguous `timeout`. So it falls through to the default `500`.

#### Timeout error taxonomy

`handle_error` receives its error from `lua-resty-http` over OpenResty cosockets. lua-resty-http propagates the raw cosocket error unchanged (`return nil, err` in every connect/send/receive/body-reader path), so the only timeout spellings that can reach `handle_error` are produced by the cosocket layer and the nginx resolver:

| Scenario | Source | String reaching `handle_error` | matched by |
|---|---|---|:--:|
| connect / send / read / streaming-read deadline (the `set_timeout` value fires) | cosocket timer (`ngx_http_lua_socket_tcp.c`, `FT_TIMEOUT`) | `timeout` | `timeout` |
| kernel connect `ETIMEDOUT`, Linux | errno strerror (lowercased by ngx_lua) | `connection timed out` | `timed out` |
| kernel connect `ETIMEDOUT`, macOS/BSD | errno strerror (lowercased by ngx_lua) | `operation timed out` | `timed out` |
| DNS resolver timeout | `ngx_resolver_strerror` (hardcoded) | `Operation timed out` | `timed out` |

The complete timeout set collapses to exactly two substrings: `timeout` (cosocket timer) and `timed out` (errno / resolver). Matching both is **necessary** (the bare `timeout` case has no space; the `… timed out` cases have no contiguous `timeout`) and **sufficient**. Non-timeout errors (`connection refused`, `connection reset by peer`, `closed`) keep returning `500`.

### Fix

Match `timed out` in addition to `timeout`:

```lua
function _M.handle_error(err)
    if core.string.find(err, "timeout") or core.string.find(err, "timed out") then
        return 504
    end
    return 500
end
```

`handle_error` is the single status mapper behind all AI upstream failure paths (ai-proxy request/metric, ai-providers sidecar request and streaming read), so all of them now return `504` on timeout.

### Tests

Added two cases to `t/plugin/ai-transport-http.t`:

- a regression test that mocks `connect` returning `Operation timed out` and asserts the mapped status is `504`;
- a matrix over one representative per timeout class plus non-timeout controls.

Both fail before the change (the `… timed out` cases return `500`) and pass after.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (N/A — internal error-code mapping, no documented behavior change)
- [x] I have verified that this change is backward compatible (timeouts previously returned 500; they now return the more accurate 504)
