### PR TITLE
fix(mcp-bridge): terminate backend process on client disconnect and bound concurrent sessions

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -404,6 +404,7 @@ http {
     {%end%}
 
     lua_socket_log_errors off;
+    lua_check_client_abort on;
 
     resolver {% for _, dns_addr in ipairs(dns_resolver or {}) do %} {*dns_addr*} {% end %} {% if dns_resolver_valid then %} valid={*dns_resolver_valid*}{% end %} ipv6={% if enable_ipv6 then %}on{% else %}off{% end %};
     resolver_timeout {*resolver_timeout*};

--- a/apisix/plugins/mcp-bridge.lua
+++ b/apisix/plugins/mcp-bridge.lua
@@ -44,6 +44,11 @@ local schema = {
             },
             minItems = 0,
         },
+        max_sessions = {
+            type = "integer",
+            minimum = 1,
+            default = 100,
+        },
     },
     required = {
         "command"

--- a/apisix/plugins/mcp/server.lua
+++ b/apisix/plugins/mcp/server.lua
@@ -89,11 +89,30 @@ function _M.start(self)
                 self.need_exit = true
                 break
             end
-            ngx_sleep(30)
+            -- wait up to the keepalive interval before the next ping, but wake
+            -- early when the session has been asked to stop (e.g. the client
+            -- disconnected) so the backend process is released promptly
+            local waited = 0
+            while waited < 30 do
+                if self.need_exit or worker_exiting() then
+                    break
+                end
+                ngx_sleep(0.5)
+                waited = waited + 0.5
+            end
         end
     end)
     thread_wait(ping)
     thread_kill(ping)
+end
+
+
+-- Ask the session loop to stop instead of waiting for the next keepalive write
+-- to fail. Only flips a flag, so it is safe to call from a client-abort handler
+-- (which runs in a separate light thread); the ping loop picks it up and the
+-- request returns to run its cleanup.
+function _M.stop(self)
+    self.need_exit = true
 end
 
 

--- a/apisix/plugins/mcp/server_wrapper.lua
+++ b/apisix/plugins/mcp/server_wrapper.lua
@@ -43,6 +43,14 @@ local function run_session(conf, opts, server)
     -- the next keepalive write to fail, so the backend process is released
     -- promptly. requires lua_check_client_abort to be enabled; degrade to the
     -- write-failure path if it is not.
+    --
+    -- NOTE: ngx.on_abort can only be registered once per request; this consumes
+    -- that single slot for the lifetime of the SSE request. That is safe here
+    -- because the SSE endpoint runs a dedicated long-lived request that does not
+    -- share its lifecycle with other plugins needing the abort hook. If the
+    -- registration fails (e.g. another handler already claimed it, or
+    -- lua_check_client_abort is off), we simply fall back to detecting the
+    -- disconnect on the next keepalive write.
     local ok, err = ngx_on_abort(function()
         server:stop()
     end)

--- a/apisix/plugins/mcp/server_wrapper.lua
+++ b/apisix/plugins/mcp/server_wrapper.lua
@@ -16,22 +16,39 @@
 --
 local ngx          = ngx
 local ngx_exit     = ngx.exit
+local ngx_on_abort = ngx.on_abort
 local re_match     = ngx.re.match
+local pcall        = pcall
 local core         = require("apisix.core")
 local mcp_server   = require("apisix.plugins.mcp.server")
+local session_limit = require("apisix.plugins.mcp.session_limit")
 
 local _M = {}
 
 local V241105_ENDPOINT_SSE     = "sse"
 local V241105_ENDPOINT_MESSAGE = "message"
 
+local DEFAULT_MAX_SESSIONS     = 100
 
-local function sse_handler(conf, ctx, opts)
+
+-- run the SSE session loop; only returns once the client disconnects (or the
+-- connection setup fails). kept separate so that the caller can always release
+-- the resources it reserved, even if the loop raises.
+local function run_session(conf, opts, server)
     -- send SSE headers and first chunk
     core.response.set_header("Content-Type", "text/event-stream")
     core.response.set_header("Cache-Control", "no-cache")
 
-    local server = opts.server
+    -- stop the session as soon as the client goes away rather than waiting for
+    -- the next keepalive write to fail, so the backend process is released
+    -- promptly. requires lua_check_client_abort to be enabled; degrade to the
+    -- write-failure path if it is not.
+    local ok, err = ngx_on_abort(function()
+        server:stop()
+    end)
+    if not ok then
+        core.log.warn("failed to register client abort handler: ", err)
+    end
 
     -- send endpoint event to advertise the message endpoint
     server.transport:send(conf.base_uri .. "/message?sessionId=" .. server.session_id, "endpoint")
@@ -50,10 +67,46 @@ local function sse_handler(conf, ctx, opts)
         end
         server:start() -- this is a sync call that only returns when the client disconnects
     end
+end
 
-    if opts.event_handler.on_disconnect then
-        opts.event_handler.on_disconnect({ server = server })
+
+local function sse_handler(conf, ctx, opts)
+    local server = opts.server
+
+    -- bound the number of concurrent sessions a worker will keep open, so a
+    -- route cannot be driven to spawn an unbounded number of backend processes
+    local max_sessions = conf.max_sessions or DEFAULT_MAX_SESSIONS
+    if not session_limit.acquire(max_sessions) then
+        core.log.warn("mcp session limit reached (", max_sessions,
+                      "), rejecting new SSE connection")
+        return core.response.exit(429,
+            { error_msg = "too many concurrent MCP sessions" })
+    end
+
+    local ok, code, body = pcall(run_session, conf, opts, server)
+
+    -- always release: tear down the backend process/broker state and free the
+    -- session slot regardless of how the loop ended. the teardown is itself
+    -- guarded so that a raising handler cannot skip session_limit.release() and
+    -- pin the worker at the ceiling.
+    local cleanup_ok, cleanup_err = pcall(function()
+        if opts.event_handler and opts.event_handler.on_disconnect then
+            opts.event_handler.on_disconnect({ server = server })
+        end
         server:close()
+    end)
+    session_limit.release()
+    if not cleanup_ok then
+        core.log.error("mcp session cleanup error: ", cleanup_err)
+    end
+
+    if not ok then
+        core.log.error("mcp session handler error: ", code)
+        return core.response.exit(500)
+    end
+
+    if code then
+        return code, body
     end
 
     ngx_exit(0) -- exit current phase, skip the upstream module

--- a/apisix/plugins/mcp/session_limit.lua
+++ b/apisix/plugins/mcp/session_limit.lua
@@ -1,0 +1,54 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+local type = type
+
+-- Tracks the number of live MCP SSE sessions handled by the current worker so
+-- that a single route cannot spawn an unbounded number of backend processes.
+local _M = {}
+
+
+local count = 0
+
+
+-- Try to reserve a slot for a new session. Returns true if the worker is below
+-- the configured ceiling, false otherwise. Every successful acquire() must be
+-- balanced by exactly one release(). A missing or non-numeric ceiling is treated
+-- as "no slot available" rather than raising, so a misconfigured or future call
+-- site fails closed instead of erroring.
+function _M.acquire(max)
+    if type(max) ~= "number" or count >= max then
+        return false
+    end
+    count = count + 1
+    return true
+end
+
+
+function _M.release()
+    if count > 0 then
+        count = count - 1
+    end
+end
+
+
+function _M.count()
+    return count
+end
+
+
+return _M

--- a/t/plugin/mcp-bridge.t
+++ b/t/plugin/mcp-bridge.t
@@ -57,3 +57,92 @@ property "command" is required
 property "command" validation failed: wrong type: expected string, got number
 done
 property "args" validation failed: wrong type: expected array, got string
+
+
+
+=== TEST 2: max_sessions schema validation
+--- config
+    location /t {
+        content_by_lua_block {
+            local test_cases = {
+                {command = "npx", max_sessions = 10},
+                {command = "npx", max_sessions = 0},
+                {command = "npx", max_sessions = "10"},
+            }
+            local plugin = require("apisix.plugins.mcp-bridge")
+
+            for _, case in ipairs(test_cases) do
+                local ok, err = plugin.check_schema(case)
+                ngx.say(ok and "done" or err)
+            end
+        }
+    }
+--- response_body
+done
+property "max_sessions" validation failed: expected 0 to be at least 1
+property "max_sessions" validation failed: wrong type: expected integer, got string
+
+
+
+=== TEST 3: session limit acquire/release bookkeeping
+--- config
+    location /t {
+        content_by_lua_block {
+            local session_limit = require("apisix.plugins.mcp.session_limit")
+
+            -- two slots available
+            ngx.say(session_limit.acquire(2)) -- true
+            ngx.say(session_limit.acquire(2)) -- true
+            ngx.say(session_limit.count())    -- 2
+            ngx.say(session_limit.acquire(2)) -- false, ceiling reached
+
+            -- releasing frees a slot for the next session
+            session_limit.release()
+            ngx.say(session_limit.count())    -- 1
+            ngx.say(session_limit.acquire(2)) -- true again
+
+            -- release never drops below zero
+            session_limit.release()
+            session_limit.release()
+            session_limit.release()
+            ngx.say(session_limit.count())    -- 0
+
+            -- a missing or non-numeric ceiling fails closed instead of raising
+            ngx.say(session_limit.acquire(nil))   -- false
+            ngx.say(session_limit.acquire("2"))   -- false
+            ngx.say(session_limit.count())        -- 0
+        }
+    }
+--- response_body
+true
+true
+2
+false
+1
+true
+0
+false
+false
+0
+
+
+
+=== TEST 4: SSE endpoint rejects new sessions once the ceiling is reached
+--- config
+    location /t {
+        content_by_lua_block {
+            local wrapper = require("apisix.plugins.mcp.server_wrapper")
+            local session_limit = require("apisix.plugins.mcp.session_limit")
+
+            -- occupy the single available slot so the next session is over the
+            -- ceiling and must be rejected by the handler
+            session_limit.acquire(1)
+
+            local conf = { base_uri = "", max_sessions = 1 }
+            local ctx = { var = { uri = "/sse" } }
+            wrapper.access(conf, ctx, { event_handler = {} })
+        }
+    }
+--- error_code: 429
+--- response_body
+{"error_msg":"too many concurrent MCP sessions"}


### PR DESCRIPTION
### Description

The `mcp-bridge` plugin spawns a backend process per SSE connection and relies on the SSE session loop returning to tear that process down. Today the loop only ends when a keepalive write fails, which can take up to two 30s ping cycles or, if writes keep being absorbed by the connection, may not happen at all. As a result a backend process started for a client that has already gone away can stay alive until the worker reloads. Separately, there is no ceiling on how many sessions a worker will keep open, so a route can keep spawning backend processes for as many connections as are opened.

This PR makes session teardown deterministic and bounds concurrency:

- Register an `ngx.on_abort` handler so a client disconnect stops the session promptly instead of waiting for the next keepalive write to fail.
- Make the ping loop wake early once the session has been asked to stop, so the backend process is released without waiting out the keepalive interval.
- Always run teardown (backend process + broker state) and free the session slot through a guarded path, regardless of how the loop ended.
- Add a per-worker concurrent-session ceiling via a new `max_sessions` config field (default `100`); connections beyond the ceiling get `429`.
- Enable `lua_check_client_abort` in the main `http` block so `on_abort` is usable.

The concurrent-session bookkeeping is factored into a small `apisix/plugins/mcp/session_limit.lua` module so it can be unit-tested.

#### Behaviour changes

- `lua_check_client_abort` is now enabled globally in the main `http` block. This means long-running Lua handler phases are terminated when the client disconnects. Proxied requests were already aborted by nginx in this case, so the practical effect is limited to Lua streaming handlers, which now stop work when the client goes away.
- New optional config field `max_sessions` (integer, default `100`). Existing configs keep working unchanged; the default applies when the field is omitted.

#### Which issue(s) this PR fixes:

Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
