### PR TITLE
chore(jwe-decrypt): fix lint caused by test numbering

### DIFF
--- a/t/plugin/jwe-decrypt.t
+++ b/t/plugin/jwe-decrypt.t
@@ -488,7 +488,7 @@ fo4XKdZ1xSrIZyms4q2BwPrW5lMpls9qqy5tiAk2esc=
 
 
 
-=== TEST 21:  verify in upstream header
+=== TEST 21: verify in upstream header
 --- request
 GET /headers
 --- more_headers
@@ -500,7 +500,7 @@ fo4XKdZ1xSrIZyms4q2BwPrW5lMpls9qqy5tiAk2esc=
 
 
 
-=== TEST 27: setup route protected by jwe-decrypt
+=== TEST 22: setup route protected by jwe-decrypt
 --- config
     location /t {
         content_by_lua_block {
@@ -553,7 +553,7 @@ done
 
 
 
-=== TEST 28: well-formed token whose ciphertext does not decrypt is rejected
+=== TEST 23: well-formed token whose ciphertext does not decrypt is rejected
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
### Description
Fix broken CI lint caused by test numbering issues in `t/plugin/jwe-decrypt.t`.

<img width="695" height="385" alt="image" src="https://github.com/user-attachments/assets/3a8f0127-4246-46c0-8f75-a36db870555f" />


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
