### PR TITLE
Support  for Redis Cluster ACL authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@ title: Changelog
 - chore: add ngx.flush after ngx.print [#12988](https://github.com/apache/apisix/pull/12988)
 
 ### Plugins
-
+- feat: support `redis_username` for Redis Cluster ACL authentication
 - feat: allow to use secrets in clickhouse-logger plugin [#12951](https://github.com/apache/apisix/pull/12951)
 - feat: added max/resp_body_bytes attr to logger plugins [#13034](https://github.com/apache/apisix/pull/13034)
 - feat(jwt): support more algorithms [#12944](https://github.com/apache/apisix/pull/12944)

--- a/apisix/utils/redis-schema.lua
+++ b/apisix/utils/redis-schema.lua
@@ -60,6 +60,9 @@ local policy_to_additional_properties = {
                     type = "string", minLength = 2, maxLength = 100
                 },
             },
+            redis_username = {
+                type = "string", minLength = 1,
+            },
             redis_password = {
                 type = "string", minLength = 0,
             },

--- a/apisix/utils/rediscluster.lua
+++ b/apisix/utils/rediscluster.lua
@@ -29,6 +29,7 @@ local function new_redis_cluster(conf, dict_name)
         connect_timeout = conf.redis_timeout,
         read_timeout = conf.redis_timeout,
         send_timeout = conf.redis_timeout,
+        username = conf.redis_username
         auth = conf.redis_password,
         dict_name = dict_name,
         connect_opts = {


### PR DESCRIPTION
This PR closes #13463 (alongside this PR for [resty-redis-cluster](https://github.com/steve0511/resty-redis-cluster) https://github.com/steve0511/resty-redis-cluster/pull/116 )