### PR TITLE
test(jwe-decrypt): reindex test blocks to fix lint on master

### DIFF
--- a/t/plugin/jwe-decrypt.t
+++ b/t/plugin/jwe-decrypt.t
@@ -500,7 +500,7 @@ fo4XKdZ1xSrIZyms4q2BwPrW5lMpls9qqy5tiAk2esc=
 
 
 
-=== TEST 27: setup route protected by jwe-decrypt
+=== TEST 22: setup route protected by jwe-decrypt
 --- config
     location /t {
         content_by_lua_block {
@@ -553,7 +553,7 @@ done
 
 
 
-=== TEST 28: well-formed token whose ciphertext does not decrypt is rejected
+=== TEST 23: well-formed token whose ciphertext does not decrypt is rejected
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
### Description

After #13464 removed the server-side token generation test blocks from `t/plugin/jwe-decrypt.t`, the trailing tests were left numbered `TEST 27` / `TEST 28`. The `make lint` reindex check expects sequential numbering, so it currently fails on `master` (and on every PR branched from it):

```
=====bad style=====
reindex: t/plugin/jwe-decrypt.t:	done.
you need to run 'reindex' to fix them.
```

This renumbers the two blocks to `TEST 22` / `TEST 23` (the output of `utils/reindex`), fixing the lint failure. No test logic changes.

#### Which issue(s) this PR fixes:
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
