### PR TITLE
fix(proxy-mirror): keep the original method path when mirroring gRPC requests

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -794,6 +794,7 @@ http {
         location / {
             set $upstream_mirror_host        '';
             set $upstream_mirror_uri         '';
+            set $upstream_mirror_grpc_path   '';
             set $upstream_upgrade            '';
             set $upstream_connection         '';
 
@@ -1046,6 +1047,7 @@ http {
             grpc_send_timeout {* proxy_mirror_timeouts.send *};
                 {% end %}
             {% end %}
+            rewrite ^ $upstream_mirror_grpc_path break;
             grpc_pass $upstream_mirror_host;
         }
         {% end %}

--- a/apisix/core/ctx.lua
+++ b/apisix/core/ctx.lua
@@ -207,6 +207,7 @@ do
 
         upstream_mirror_host       = true,
         upstream_mirror_uri        = true,
+        upstream_mirror_grpc_path  = true,
 
         upstream_cache_zone        = true,
         upstream_cache_zone_info   = true,

--- a/apisix/plugins/proxy-mirror.lua
+++ b/apisix/plugins/proxy-mirror.lua
@@ -16,6 +16,7 @@
 --
 local core          = require("apisix.core")
 local url           = require("net.url")
+local ngx           = ngx
 
 local math_random = math.random
 local has_mod, apisix_ngx_client = pcall(require, "resty.apisix.client")
@@ -127,6 +128,20 @@ function _M.rewrite(conf, ctx)
         end
     end
 
+end
+
+
+-- The :path of the mirrored gRPC request is taken from the subrequest URI rewritten
+-- in the proxy_mirror_grpc location, since grpc_pass cannot carry a URI. It must be
+-- captured after all access phase plugins (e.g. grpc-web) have rewritten the URI,
+-- which is too late for the rewrite phase above.
+function _M.before_proxy(conf, ctx)
+    if not ctx.enable_mirror then
+        return
+    end
+
+    -- read the var directly as ctx.var.uri may be cached before the rewrite
+    ctx.var.upstream_mirror_grpc_path = ngx.var.uri
 end
 
 

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -889,6 +889,7 @@ _EOC_
         location / {
             set \$upstream_mirror_host        '';
             set \$upstream_mirror_uri         '';
+            set \$upstream_mirror_grpc_path   '';
             set \$upstream_upgrade            '';
             set \$upstream_connection         '';
 
@@ -1004,6 +1005,7 @@ _EOC_
     }
 
     $config .= <<_EOC_;
+            rewrite ^ \$upstream_mirror_grpc_path break;
             grpc_pass \$upstream_mirror_host;
         }
 _EOC_

--- a/t/plugin/proxy-mirror3.t
+++ b/t/plugin/proxy-mirror3.t
@@ -35,6 +35,28 @@ _EOC_
 
     $block->set_value("yaml_config", $yaml_config);
 
+    # a h2c server that records the mirrored gRPC request
+    my $http_config = $block->http_config // <<_EOC_;
+    server {
+        listen 19797;
+        http2 on;
+        location / {
+            content_by_lua_block {
+                ngx.req.read_body()
+                local body = ngx.req.get_body_data()
+                ngx.log(ngx.WARN, "grpc mirror server got request: path=",
+                        ngx.var.request_uri,
+                        " content_type=", ngx.var.http_content_type or "",
+                        " body_len=", body and #body or 0)
+                ngx.header["Content-Type"] = "application/grpc"
+                ngx.exit(200)
+            }
+        }
+    }
+_EOC_
+
+    $block->set_value("http_config", $http_config);
+
     if (!$block->request) {
         $block->set_value("request", "POST /hello");
     }
@@ -45,7 +67,6 @@ run_tests;
 __DATA__
 
 === TEST 1: grpc mirror
---- log_level: debug
 --- http2
 --- apisix_yaml
 routes:
@@ -68,9 +89,40 @@ routes:
 #END
 --- exec
 grpcurl -import-path ./t/grpc_server_example/proto -proto helloworld.proto -plaintext -d '{"name":"apisix"}' 127.0.0.1:1984 helloworld.Greeter.SayHello
+sleep 0.5
 --- response_body
 {
   "message": "Hello apisix"
 }
---- error_log eval
-qr/Connection refused\) while connecting to upstream/
+--- error_log
+grpc mirror server got request: path=/helloworld.Greeter/SayHello content_type=application/grpc body_len=13
+
+
+
+=== TEST 2: grpc mirror keeps the URI rewritten by access phase plugins (grpc-web)
+--- apisix_yaml
+routes:
+  -
+    id: 1
+    uris:
+        - /grpc/web/*
+    plugins:
+        grpc-web: {}
+        proxy-mirror:
+            host: grpc://127.0.0.1:19797
+            sample_ratio: 1
+    upstream:
+      scheme: grpc
+      nodes:
+        "127.0.0.1:10051": 1
+      type: roundrobin
+#END
+--- exec
+printf '\000\000\000\000\010\012\006apisix' | curl -s -o /dev/null -w "code=%{http_code}" -X POST \
+    -H 'Content-Type: application/grpc-web+proto' --data-binary @- \
+    http://127.0.0.1:1984/grpc/web/helloworld.Greeter/SayHello
+sleep 0.5
+--- response_body chomp
+code=200
+--- error_log
+grpc mirror server got request: path=/helloworld.Greeter/SayHello content_type=application/grpc body_len=13


### PR DESCRIPTION
### Description

Fixes #13498

When `proxy-mirror` mirrors to a `grpc://` host, the mirrored request was sent with `:path = /proxy_mirror_grpc` (the internal mirror location name) instead of the real gRPC method path, so the mirror backend rejects every call with `UNIMPLEMENTED`. The cause is that `grpc_pass` cannot carry a URI (unlike the HTTP mirror location, which uses `proxy_pass $upstream_mirror_uri`), so the grpc module builds `:path` from the mirror subrequest's own URI.

The fix captures the request path into a new `$upstream_mirror_grpc_path` variable and rewrites the mirror subrequest URI with it in the `proxy_mirror_grpc` location before `grpc_pass`. The capture happens in the `before_proxy` phase rather than rewrite, because access phase plugins (e.g. `grpc-web`) may rewrite the URI after `proxy-mirror`'s rewrite phase has run; `before_proxy` runs after all of them, so the mirrored `:path` always matches what the main upstream receives. `path` / `path_concat_mode` stay not applicable to gRPC mirroring, as already documented.

The existing grpc mirror test from #9388 only asserted `Connection refused` against a closed port, so it could not catch this. It is reworked to mirror into a local h2c server that records the received request, asserting the `:path`, `content-type` and body length of the mirrored request; a second case covers the combination with `grpc-web`. Both fail before this fix (the mirror target receives `path=/proxy_mirror_grpc`) and pass after.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
