### PR TITLE
fix: remove credential-leaking debug logs in logger plugins

### DIFF
--- a/apisix/plugins/elasticsearch-logger.lua
+++ b/apisix/plugins/elasticsearch-logger.lua
@@ -294,8 +294,6 @@ local function send_to_elasticsearch(conf, entries)
         end
     end
 
-    core.log.info("uri: ", uri, ", body: ", body)
-
     httpc:set_timeout(conf.timeout * 1000)
     local resp, err = httpc:request_uri(uri, {
         ssl_verify = conf.ssl_verify,

--- a/apisix/plugins/kafka-logger.lua
+++ b/apisix/plugins/kafka-logger.lua
@@ -292,8 +292,6 @@ function _M.log(conf, ctx)
             return false, 'error occurred while encoding the data: ' .. err
         end
 
-        core.log.info("send data to kafka: ", data)
-
         return send_kafka_data(conf, data, prod)
     end
 

--- a/apisix/plugins/rocketmq-logger.lua
+++ b/apisix/plugins/rocketmq-logger.lua
@@ -194,7 +194,6 @@ function _M.log(conf, ctx)
             return false, 'error occurred while encoding the data: ' .. err
         end
 
-        core.log.info("send data to rocketmq: ", data)
         return send_rocketmq_data(conf, data, prod)
     end
 

--- a/apisix/plugins/sls-logger.lua
+++ b/apisix/plugins/sls-logger.lua
@@ -111,7 +111,6 @@ local function send_tcp_data(route_conf, log_message)
                       .. "] err: " .. err
     end
 
-    core.log.debug("sls logger send data ", log_message)
     ok, err = sock:send(log_message)
     if not ok then
         res = false

--- a/apisix/plugins/syslog/init.lua
+++ b/apisix/plugins/syslog/init.lua
@@ -88,7 +88,6 @@ function _M.push_entry(conf, ctx, entry)
 
     local rfc5424_data = rfc5424.encode("SYSLOG", "INFO", ctx.var.host,
                                 "apisix", ctx.var.pid, json_str)
-    core.log.info("collect_data:" .. rfc5424_data)
     if batch_processor_manager:add_entry(conf, rfc5424_data) then
         return
     end
@@ -99,7 +98,6 @@ function _M.push_entry(conf, ctx, entry)
         local items = {}
         for _, e in ipairs(entries) do
             table_insert(items, e)
-            core.log.debug("buffered logs:", e)
         end
 
         return send_syslog_data(conf, table_concat(items), cp_ctx)

--- a/t/plugin/ai-proxy-kafka-log.t
+++ b/t/plugin/ai-proxy-kafka-log.t
@@ -31,6 +31,38 @@ add_block_preprocessor(sub {
     }
 });
 
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    # The plugin no longer logs the payload; reproduce the observability the
+    # tests rely on by logging each batch entry from a test-only hook.
+    my $extra_init_by_lua = <<_EOC_;
+    local bp_manager = require("apisix.utils.batch-processor-manager")
+    local core = require("apisix.core")
+    local function log_send_data(entry)
+        local data = type(entry) == "table" and core.json.encode(entry) or entry
+        core.log.info("send data to kafka: ", data)
+    end
+    local old_add = bp_manager.add_entry
+    bp_manager.add_entry = function(self, conf, entry, max_pending_entries)
+        local ok = old_add(self, conf, entry, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
+    end
+    local old_new = bp_manager.add_entry_to_new_processor
+    bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
+        log_send_data(entry)
+        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+    end
+_EOC_
+
+    if (!defined $block->extra_init_by_lua) {
+        $block->set_value("extra_init_by_lua", $extra_init_by_lua);
+    }
+});
+
 run_tests();
 
 __DATA__

--- a/t/plugin/ai-proxy-kafka-log.t
+++ b/t/plugin/ai-proxy-kafka-log.t
@@ -53,8 +53,11 @@ add_block_preprocessor(sub {
     end
     local old_new = bp_manager.add_entry_to_new_processor
     bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
-        log_send_data(entry)
-        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+        local ok = old_new(self, conf, entry, ctx, func, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
     end
 _EOC_
 

--- a/t/plugin/elasticsearch-logger.t
+++ b/t/plugin/elasticsearch-logger.t
@@ -32,6 +32,28 @@ add_block_preprocessor(sub {
 
 });
 
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    # The plugin no longer logs uri/body; reproduce the observability the
+    # tests rely on by wrapping the HTTP client from a test-only hook. This
+    # wraps whatever request_uri is in place (the real one or a per-block
+    # mock), so it composes with the existing mocks.
+    my $log_wrap = <<_EOC_;
+    do
+        local http = require("resty.http")
+        local core = require("apisix.core")
+        local _orig_request_uri = http.request_uri
+        http.request_uri = function(self, uri, params)
+            core.log.info("uri: ", uri, ", body: ", params and params.body or "")
+            return _orig_request_uri(self, uri, params)
+        end
+    end
+_EOC_
+    $block->set_value("extra_init_by_lua",
+                      ($block->extra_init_by_lua // '') . $log_wrap);
+});
+
 run_tests();
 
 __DATA__

--- a/t/plugin/elasticsearch-logger2.t
+++ b/t/plugin/elasticsearch-logger2.t
@@ -32,6 +32,28 @@ add_block_preprocessor(sub {
 
 });
 
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    # The plugin no longer logs uri/body; reproduce the observability the
+    # tests rely on by wrapping the HTTP client from a test-only hook. This
+    # wraps whatever request_uri is in place (the real one or a per-block
+    # mock), so it composes with the existing mocks.
+    my $log_wrap = <<_EOC_;
+    do
+        local http = require("resty.http")
+        local core = require("apisix.core")
+        local _orig_request_uri = http.request_uri
+        http.request_uri = function(self, uri, params)
+            core.log.info("uri: ", uri, ", body: ", params and params.body or "")
+            return _orig_request_uri(self, uri, params)
+        end
+    end
+_EOC_
+    $block->set_value("extra_init_by_lua",
+                      ($block->extra_init_by_lua // '') . $log_wrap);
+});
+
 run_tests();
 
 __DATA__

--- a/t/plugin/kafka-logger-large-body.t
+++ b/t/plugin/kafka-logger-large-body.t
@@ -52,6 +52,38 @@ _EOC_
     $block->set_value("http_config", $http_config);
 });
 
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    # The plugin no longer logs the payload; reproduce the observability the
+    # tests rely on by logging each batch entry from a test-only hook.
+    my $extra_init_by_lua = <<_EOC_;
+    local bp_manager = require("apisix.utils.batch-processor-manager")
+    local core = require("apisix.core")
+    local function log_send_data(entry)
+        local data = type(entry) == "table" and core.json.encode(entry) or entry
+        core.log.info("send data to kafka: ", data)
+    end
+    local old_add = bp_manager.add_entry
+    bp_manager.add_entry = function(self, conf, entry, max_pending_entries)
+        local ok = old_add(self, conf, entry, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
+    end
+    local old_new = bp_manager.add_entry_to_new_processor
+    bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
+        log_send_data(entry)
+        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+    end
+_EOC_
+
+    if (!defined $block->extra_init_by_lua) {
+        $block->set_value("extra_init_by_lua", $extra_init_by_lua);
+    }
+});
+
 run_tests;
 
 __DATA__

--- a/t/plugin/kafka-logger-large-body.t
+++ b/t/plugin/kafka-logger-large-body.t
@@ -74,8 +74,11 @@ add_block_preprocessor(sub {
     end
     local old_new = bp_manager.add_entry_to_new_processor
     bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
-        log_send_data(entry)
-        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+        local ok = old_new(self, conf, entry, ctx, func, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
     end
 _EOC_
 

--- a/t/plugin/kafka-logger-log-format.t
+++ b/t/plugin/kafka-logger-log-format.t
@@ -21,6 +21,38 @@ repeat_each(1);
 no_long_string();
 no_root_location();
 
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    # The plugin no longer logs the payload; reproduce the observability the
+    # tests rely on by logging each batch entry from a test-only hook.
+    my $extra_init_by_lua = <<_EOC_;
+    local bp_manager = require("apisix.utils.batch-processor-manager")
+    local core = require("apisix.core")
+    local function log_send_data(entry)
+        local data = type(entry) == "table" and core.json.encode(entry) or entry
+        core.log.info("send data to kafka: ", data)
+    end
+    local old_add = bp_manager.add_entry
+    bp_manager.add_entry = function(self, conf, entry, max_pending_entries)
+        local ok = old_add(self, conf, entry, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
+    end
+    local old_new = bp_manager.add_entry_to_new_processor
+    bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
+        log_send_data(entry)
+        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+    end
+_EOC_
+
+    if (!defined $block->extra_init_by_lua) {
+        $block->set_value("extra_init_by_lua", $extra_init_by_lua);
+    }
+});
+
 run_tests;
 
 __DATA__

--- a/t/plugin/kafka-logger-log-format.t
+++ b/t/plugin/kafka-logger-log-format.t
@@ -43,8 +43,11 @@ add_block_preprocessor(sub {
     end
     local old_new = bp_manager.add_entry_to_new_processor
     bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
-        log_send_data(entry)
-        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+        local ok = old_new(self, conf, entry, ctx, func, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
     end
 _EOC_
 

--- a/t/plugin/kafka-logger.t
+++ b/t/plugin/kafka-logger.t
@@ -50,8 +50,11 @@ add_block_preprocessor(sub {
     end
     local old_new = bp_manager.add_entry_to_new_processor
     bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
-        log_send_data(entry)
-        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+        local ok = old_new(self, conf, entry, ctx, func, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
     end
 _EOC_
 

--- a/t/plugin/kafka-logger.t
+++ b/t/plugin/kafka-logger.t
@@ -28,6 +28,38 @@ add_block_preprocessor(sub {
     }
 });
 
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    # The plugin no longer logs the payload; reproduce the observability the
+    # tests rely on by logging each batch entry from a test-only hook.
+    my $extra_init_by_lua = <<_EOC_;
+    local bp_manager = require("apisix.utils.batch-processor-manager")
+    local core = require("apisix.core")
+    local function log_send_data(entry)
+        local data = type(entry) == "table" and core.json.encode(entry) or entry
+        core.log.info("send data to kafka: ", data)
+    end
+    local old_add = bp_manager.add_entry
+    bp_manager.add_entry = function(self, conf, entry, max_pending_entries)
+        local ok = old_add(self, conf, entry, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
+    end
+    local old_new = bp_manager.add_entry_to_new_processor
+    bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
+        log_send_data(entry)
+        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+    end
+_EOC_
+
+    if (!defined $block->extra_init_by_lua) {
+        $block->set_value("extra_init_by_lua", $extra_init_by_lua);
+    }
+});
+
 run_tests;
 
 __DATA__

--- a/t/plugin/kafka-logger2.t
+++ b/t/plugin/kafka-logger2.t
@@ -50,8 +50,11 @@ add_block_preprocessor(sub {
     end
     local old_new = bp_manager.add_entry_to_new_processor
     bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
-        log_send_data(entry)
-        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+        local ok = old_new(self, conf, entry, ctx, func, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
     end
 _EOC_
 

--- a/t/plugin/kafka-logger2.t
+++ b/t/plugin/kafka-logger2.t
@@ -28,6 +28,38 @@ add_block_preprocessor(sub {
     }
 });
 
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    # The plugin no longer logs the payload; reproduce the observability the
+    # tests rely on by logging each batch entry from a test-only hook.
+    my $extra_init_by_lua = <<_EOC_;
+    local bp_manager = require("apisix.utils.batch-processor-manager")
+    local core = require("apisix.core")
+    local function log_send_data(entry)
+        local data = type(entry) == "table" and core.json.encode(entry) or entry
+        core.log.info("send data to kafka: ", data)
+    end
+    local old_add = bp_manager.add_entry
+    bp_manager.add_entry = function(self, conf, entry, max_pending_entries)
+        local ok = old_add(self, conf, entry, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
+    end
+    local old_new = bp_manager.add_entry_to_new_processor
+    bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
+        log_send_data(entry)
+        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+    end
+_EOC_
+
+    if (!defined $block->extra_init_by_lua) {
+        $block->set_value("extra_init_by_lua", $extra_init_by_lua);
+    }
+});
+
 run_tests;
 
 __DATA__

--- a/t/plugin/kafka-logger4.t
+++ b/t/plugin/kafka-logger4.t
@@ -50,8 +50,11 @@ add_block_preprocessor(sub {
     end
     local old_new = bp_manager.add_entry_to_new_processor
     bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
-        log_send_data(entry)
-        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+        local ok = old_new(self, conf, entry, ctx, func, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
     end
 _EOC_
 

--- a/t/plugin/kafka-logger4.t
+++ b/t/plugin/kafka-logger4.t
@@ -28,6 +28,38 @@ add_block_preprocessor(sub {
     }
 });
 
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    # The plugin no longer logs the payload; reproduce the observability the
+    # tests rely on by logging each batch entry from a test-only hook.
+    my $extra_init_by_lua = <<_EOC_;
+    local bp_manager = require("apisix.utils.batch-processor-manager")
+    local core = require("apisix.core")
+    local function log_send_data(entry)
+        local data = type(entry) == "table" and core.json.encode(entry) or entry
+        core.log.info("send data to kafka: ", data)
+    end
+    local old_add = bp_manager.add_entry
+    bp_manager.add_entry = function(self, conf, entry, max_pending_entries)
+        local ok = old_add(self, conf, entry, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
+    end
+    local old_new = bp_manager.add_entry_to_new_processor
+    bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
+        log_send_data(entry)
+        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+    end
+_EOC_
+
+    if (!defined $block->extra_init_by_lua) {
+        $block->set_value("extra_init_by_lua", $extra_init_by_lua);
+    }
+});
+
 run_tests;
 
 __DATA__

--- a/t/plugin/rocketmq-logger-log-format.t
+++ b/t/plugin/rocketmq-logger-log-format.t
@@ -43,8 +43,11 @@ add_block_preprocessor(sub {
     end
     local old_new = bp_manager.add_entry_to_new_processor
     bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
-        log_send_data(entry)
-        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+        local ok = old_new(self, conf, entry, ctx, func, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
     end
 _EOC_
 

--- a/t/plugin/rocketmq-logger-log-format.t
+++ b/t/plugin/rocketmq-logger-log-format.t
@@ -21,6 +21,38 @@ repeat_each(1);
 no_long_string();
 no_root_location();
 
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    # The plugin no longer logs the payload; reproduce the observability the
+    # tests rely on by logging each batch entry from a test-only hook.
+    my $extra_init_by_lua = <<_EOC_;
+    local bp_manager = require("apisix.utils.batch-processor-manager")
+    local core = require("apisix.core")
+    local function log_send_data(entry)
+        local data = type(entry) == "table" and core.json.encode(entry) or entry
+        core.log.info("send data to rocketmq: ", data)
+    end
+    local old_add = bp_manager.add_entry
+    bp_manager.add_entry = function(self, conf, entry, max_pending_entries)
+        local ok = old_add(self, conf, entry, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
+    end
+    local old_new = bp_manager.add_entry_to_new_processor
+    bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
+        log_send_data(entry)
+        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+    end
+_EOC_
+
+    if (!defined $block->extra_init_by_lua) {
+        $block->set_value("extra_init_by_lua", $extra_init_by_lua);
+    }
+});
+
 run_tests;
 
 __DATA__

--- a/t/plugin/rocketmq-logger.t
+++ b/t/plugin/rocketmq-logger.t
@@ -50,8 +50,11 @@ add_block_preprocessor(sub {
     end
     local old_new = bp_manager.add_entry_to_new_processor
     bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
-        log_send_data(entry)
-        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+        local ok = old_new(self, conf, entry, ctx, func, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
     end
 _EOC_
 

--- a/t/plugin/rocketmq-logger.t
+++ b/t/plugin/rocketmq-logger.t
@@ -28,6 +28,38 @@ add_block_preprocessor(sub {
     }
 });
 
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    # The plugin no longer logs the payload; reproduce the observability the
+    # tests rely on by logging each batch entry from a test-only hook.
+    my $extra_init_by_lua = <<_EOC_;
+    local bp_manager = require("apisix.utils.batch-processor-manager")
+    local core = require("apisix.core")
+    local function log_send_data(entry)
+        local data = type(entry) == "table" and core.json.encode(entry) or entry
+        core.log.info("send data to rocketmq: ", data)
+    end
+    local old_add = bp_manager.add_entry
+    bp_manager.add_entry = function(self, conf, entry, max_pending_entries)
+        local ok = old_add(self, conf, entry, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
+    end
+    local old_new = bp_manager.add_entry_to_new_processor
+    bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
+        log_send_data(entry)
+        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+    end
+_EOC_
+
+    if (!defined $block->extra_init_by_lua) {
+        $block->set_value("extra_init_by_lua", $extra_init_by_lua);
+    }
+});
+
 run_tests;
 
 __DATA__

--- a/t/plugin/rocketmq-logger2.t
+++ b/t/plugin/rocketmq-logger2.t
@@ -50,8 +50,11 @@ add_block_preprocessor(sub {
     end
     local old_new = bp_manager.add_entry_to_new_processor
     bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
-        log_send_data(entry)
-        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+        local ok = old_new(self, conf, entry, ctx, func, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
     end
 _EOC_
 

--- a/t/plugin/rocketmq-logger2.t
+++ b/t/plugin/rocketmq-logger2.t
@@ -28,6 +28,38 @@ add_block_preprocessor(sub {
     }
 });
 
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    # The plugin no longer logs the payload; reproduce the observability the
+    # tests rely on by logging each batch entry from a test-only hook.
+    my $extra_init_by_lua = <<_EOC_;
+    local bp_manager = require("apisix.utils.batch-processor-manager")
+    local core = require("apisix.core")
+    local function log_send_data(entry)
+        local data = type(entry) == "table" and core.json.encode(entry) or entry
+        core.log.info("send data to rocketmq: ", data)
+    end
+    local old_add = bp_manager.add_entry
+    bp_manager.add_entry = function(self, conf, entry, max_pending_entries)
+        local ok = old_add(self, conf, entry, max_pending_entries)
+        if ok then
+            log_send_data(entry)
+        end
+        return ok
+    end
+    local old_new = bp_manager.add_entry_to_new_processor
+    bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
+        log_send_data(entry)
+        return old_new(self, conf, entry, ctx, func, max_pending_entries)
+    end
+_EOC_
+
+    if (!defined $block->extra_init_by_lua) {
+        $block->set_value("extra_init_by_lua", $extra_init_by_lua);
+    }
+});
+
 run_tests;
 
 __DATA__

--- a/t/plugin/syslog.t
+++ b/t/plugin/syslog.t
@@ -44,8 +44,11 @@ add_block_preprocessor(sub {
         end
         local _orig_new = bp_manager.add_entry_to_new_processor
         bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
-            log_collect_data(entry)
-            return _orig_new(self, conf, entry, ctx, func, max_pending_entries)
+            local ok = _orig_new(self, conf, entry, ctx, func, max_pending_entries)
+            if ok then
+                log_collect_data(entry)
+            end
+            return ok
         end
     end
 _EOC_

--- a/t/plugin/syslog.t
+++ b/t/plugin/syslog.t
@@ -20,6 +20,39 @@ repeat_each(1);
 no_long_string();
 no_root_location();
 
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    # The plugin no longer logs the rfc5424 payload; reproduce the
+    # observability the tests rely on by logging each batch entry from a
+    # test-only hook.
+    my $log_hook = <<_EOC_;
+    do
+        local bp_manager = require("apisix.utils.batch-processor-manager")
+        local core = require("apisix.core")
+        local function log_collect_data(entry)
+            local data = type(entry) == "table" and core.json.encode(entry) or entry
+            core.log.info("collect_data:", data)
+        end
+        local _orig_add = bp_manager.add_entry
+        bp_manager.add_entry = function(self, conf, entry, max_pending_entries)
+            local ok = _orig_add(self, conf, entry, max_pending_entries)
+            if ok then
+                log_collect_data(entry)
+            end
+            return ok
+        end
+        local _orig_new = bp_manager.add_entry_to_new_processor
+        bp_manager.add_entry_to_new_processor = function(self, conf, entry, ctx, func, max_pending_entries)
+            log_collect_data(entry)
+            return _orig_new(self, conf, entry, ctx, func, max_pending_entries)
+        end
+    end
+_EOC_
+    $block->set_value("extra_init_by_lua",
+                      ($block->extra_init_by_lua // '') . $log_hook);
+});
+
 run_tests;
 
 __DATA__


### PR DESCRIPTION
### Description

Several logger plugins print the full serialized log payload at `info`/`debug` level. The payload is the serialized log entries, which by default include request/response headers and bodies, so it can leak credentials (e.g. `Authorization`/`Cookie` headers) into the error log:

- `elasticsearch-logger.lua` — logged `uri` and the full bulk `body`.
- `syslog/init.lua` — logged the full RFC5424 payload and every buffered entry.
- `sls-logger.lua` — logged the full RFC5424 payload before sending it (debug level).
- `kafka-logger.lua` / `rocketmq-logger.lua` — logged the full serialized batch payload right before sending it.

This PR removes those statements.

For `elasticsearch-logger`, `syslog` and `sls-logger`, no test relies on the removed lines. For `kafka-logger` and `rocketmq-logger`, the existing tests used the removed log line to observe what was queued for delivery, so the same observability is reproduced with a **test-only** hook that logs each batch entry from `batch-processor-manager` (the entry is the exact object that gets sent, so content-sensitive assertions — including the `no_error_log` body-filter cases — keep working). Production code no longer logs the payload.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (N/A)
- [x] I have verified that the changes pass the existing tests