### PR TITLE
fix(ai-proxy-multi): keep existing query string in health check path; cover construct_upstream mutation contract

### DIFF
--- a/apisix/plugins/ai-proxy-multi.lua
+++ b/apisix/plugins/ai-proxy-multi.lua
@@ -626,8 +626,10 @@ function _M.construct_upstream(instance)
             end
         end
         if auth.query then
-            checks.active.http_path = string.format("%s?%s",
-                    checks.active.http_path, core.string.encode_args(auth.query))
+            local http_path = checks.active.http_path or "/"
+            local sep = string.find(http_path, "?", 1, true) and "&" or "?"
+            checks.active.http_path = http_path .. sep ..
+                                      core.string.encode_args(auth.query)
         end
     end
     upstream.nodes = upstream_nodes

--- a/t/plugin/ai-proxy-multi-construct-upstream.t
+++ b/t/plugin/ai-proxy-multi-construct-upstream.t
@@ -1,0 +1,111 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+log_level("info");
+repeat_each(1);
+no_long_string();
+no_shuffle();
+no_root_location();
+
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+    my $user_yaml_config = <<_EOC_;
+plugins:
+  - ai-proxy-multi
+_EOC_
+    $block->set_value("extra_yaml_config", $user_yaml_config);
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: construct_upstream must not mutate the instance checks in place
+# The healthcheck manager calls construct_upstream once per second per
+# instance from its timers, always passing the cached route config. The
+# returned checks must carry the auth header/query, but the input table must
+# stay untouched: otherwise auth.query is appended to checks.active.http_path
+# again on every call, and the cached config no longer matches the config
+# delivered by the config center.
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ai-proxy-multi")
+            local instance = {
+                name = "ins",
+                provider = "openai",
+                weight = 1,
+                auth = {
+                    header = {
+                        Authorization = "Bearer token",
+                    },
+                    query = {
+                        api_key = "secret",
+                    },
+                },
+                options = {
+                    model = "gpt-4",
+                },
+                override = {
+                    endpoint = "http://127.0.0.1:16724",
+                },
+                checks = {
+                    active = {
+                        type = "http",
+                        http_path = "/status",
+                        healthy = {
+                            interval = 1,
+                            successes = 1,
+                        },
+                        unhealthy = {
+                            interval = 1,
+                            http_failures = 2,
+                        },
+                    },
+                },
+            }
+
+            for i = 1, 3 do
+                local upstream, err = plugin.construct_upstream(instance)
+                assert(upstream, err)
+                assert(upstream.checks.active.http_path == "/status?api_key=secret",
+                       "call " .. i .. ": unexpected http_path: "
+                       .. upstream.checks.active.http_path)
+                local req_headers = upstream.checks.active.req_headers
+                assert(#req_headers == 1 and req_headers[1] == "Authorization: Bearer token",
+                       "call " .. i .. ": unexpected req_headers: "
+                       .. require("cjson.safe").encode(req_headers))
+            end
+
+            assert(instance.checks.active.http_path == "/status",
+                   "instance checks.active.http_path mutated in place: "
+                   .. instance.checks.active.http_path)
+            assert(instance.checks.active.req_headers == nil,
+                   "instance checks.active.req_headers mutated in place")
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed

--- a/t/plugin/ai-proxy-multi-construct-upstream.t
+++ b/t/plugin/ai-proxy-multi-construct-upstream.t
@@ -109,3 +109,58 @@ __DATA__
     }
 --- response_body
 passed
+
+
+
+=== TEST 2: auth.query is appended with & when http_path already has a query string
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ai-proxy-multi")
+            local instance = {
+                name = "ins",
+                provider = "openai",
+                weight = 1,
+                auth = {
+                    query = {
+                        api_key = "secret",
+                    },
+                },
+                options = {
+                    model = "gpt-4",
+                },
+                override = {
+                    endpoint = "http://127.0.0.1:16724",
+                },
+                checks = {
+                    active = {
+                        type = "http",
+                        http_path = "/status?probe=ready",
+                        healthy = {
+                            interval = 1,
+                            successes = 1,
+                        },
+                        unhealthy = {
+                            interval = 1,
+                            http_failures = 2,
+                        },
+                    },
+                },
+            }
+
+            for i = 1, 2 do
+                local upstream, err = plugin.construct_upstream(instance)
+                assert(upstream, err)
+                local http_path = upstream.checks.active.http_path
+                assert(http_path == "/status?probe=ready&api_key=secret",
+                       "call " .. i .. ": unexpected http_path: " .. http_path)
+            end
+
+            assert(instance.checks.active.http_path == "/status?probe=ready",
+                   "instance checks.active.http_path mutated in place: "
+                   .. instance.checks.active.http_path)
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed


### PR DESCRIPTION
### Description

Two related changes to `construct_upstream` in ai-proxy-multi:

**Fix: `auth.query` broke health check paths that already contain a query string.** The code always joined `auth.query` onto `checks.active.http_path` with `?`, so a configured path like `/status?probe=ready` became `/status?probe=ready?api_key=...` and the active probe requested a wrong path (which can flip healthy instances to unhealthy). Now `&` is used when the path already contains `?`.

**Test: cover the no-mutation contract.** `construct_upstream` is invoked once per second per instance by the healthcheck manager timers, always against the cached route config. The checks table is cloned before applying `auth.header` / `auth.query`; without the clone, the auth query string would be appended to `checks.active.http_path` again on every call and the cached config would silently diverge from the config center. This contract had no coverage — the new test calls `construct_upstream` repeatedly and asserts the returned checks stay stable and the input instance table is not mutated.

Both test cases fail without their respective code behavior: TEST 1 fails if the deepcopy is removed (`call 2: unexpected http_path: /status?api_key=secret?api_key=secret`), TEST 2 fails without the separator fix (`call 1: unexpected http_path: /status?probe=ready?api_key=secret`).

### Which issue(s) this PR fixes:

N/A

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible