### PR TITLE
test(xrpc): fix first-run failures in redis.t and prometheus.t

### DIFF
--- a/t/xrpc/prometheus.t
+++ b/t/xrpc/prometheus.t
@@ -145,9 +145,17 @@ passed
                 ngx.say("failed to get animals: ", err)
                 return
             end
+
+            -- metrics are accumulated in a per-worker counter and flushed to
+            -- the shared dict by an ngx.timer.every(1, ...); exiting workers
+            -- run no timers, so wait for the flush before this block ends and
+            -- the HUP reload retires the stream worker, or the deltas are
+            -- lost and TEST 3 sees no redis metrics at all
+            ngx.sleep(2)
         }
     }
 --- response_body
+--- timeout: 5
 --- stream_conf_enable
 
 

--- a/t/xrpc/prometheus.t
+++ b/t/xrpc/prometheus.t
@@ -146,11 +146,12 @@ passed
                 return
             end
 
-            -- metrics are accumulated in a per-worker counter and flushed to
-            -- the shared dict by an ngx.timer.every(1, ...); exiting workers
-            -- run no timers, so wait for the flush before this block ends and
-            -- the HUP reload retires the stream worker, or the deltas are
-            -- lost and TEST 3 sees no redis metrics at all
+            -- metrics are accumulated in a per-worker counter and flushed
+            -- to the shared dict by an ngx.timer.every(1, ...); once this
+            -- block ends, the only remaining flush is the premature timer
+            -- run when the HUP reload retires the stream worker, which races
+            -- with (and can lose to) the next block's scrape. Wait for a
+            -- regular flush before the block ends instead.
             ngx.sleep(2)
         }
     }

--- a/t/xrpc/redis.t
+++ b/t/xrpc/redis.t
@@ -242,7 +242,12 @@ hget animals: bark
                     local begin = tonumber(results[3])
                     for j = 1, 4 do
                         local incred = results[3 + j]
-                        if incred ~= results[2 + j] + 1 then
+                        -- on a fresh redis the first pipeline's GET returns
+                        -- ngx.null (the counter doesn't exist yet), skip the
+                        -- comparison for it instead of doing arithmetic on a
+                        -- userdata value
+                        local prev = tonumber(results[2 + j])
+                        if prev and incred ~= prev + 1 then
                             ngx.log(ngx.ERR, cjson.encode(results))
                         end
                     end


### PR DESCRIPTION
### Description

Both `t/xrpc/redis.t` TEST 5 and `t/xrpc/prometheus.t` TEST 3 fail on a fresh environment; in CI this is usually masked by the flaky-test rerun (the first attempt seeds redis / flushes the metrics), but it wastes a rerun on most jobs and sometimes fails both attempts (e.g. https://github.com/apache/apisix/actions/runs/27267853544/job/80529410463).

**redis.t TEST 5**: redis executes each pipeline as one contiguous batch, so on a fresh redis the first pipeline's `GET counter` always runs before any `INCR` and returns ngx.null; `results[2 + j] + 1` then aborts the user thread with `attempt to perform arithmetic on a userdata value`, which trips the `no_error_log` check. Reproducible 100% locally with a flushed redis. Fix: skip the consecutive-increment comparison when the previous value is not a number.

**prometheus.t TEST 3**: the metrics scrape contains no `apisix_redis_commands_*` lines. Metrics are accumulated in a per-worker resty counter and flushed to the shared dict by `ngx.timer.every(1, ...)` (prometheus_resty_counter). When TEST 2 ends right after the redis commands, the only remaining flush is the premature timer run that fires while the HUP reload (`TEST_NGINX_USE_HUP=1`) retires the old stream worker — and that races with, and can lose to, TEST 3's scrape (in the failing CI run the deltas arrived after TEST 3 but before TEST 5, which passed). Also reproducible locally. Fix: sleep past the sync interval so a regular flush happens while the block is still running.

Verified locally: both files fail on master with a flushed redis and pass with this change across repeated fresh runs.

### Which issue(s) this PR fixes:

N/A

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible