### PR TITLE
feat: add Kubernetes Secret Manager for $secret://kubernetes/ references

### DIFF
--- a/apisix/secret/kubernetes.lua
+++ b/apisix/secret/kubernetes.lua
@@ -1,0 +1,262 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+--- Kubernetes Secret Manager.
+--  Fetches secrets from the Kubernetes API server using the pod's ServiceAccount
+--  token. This allows APISIX to read Kubernetes Secrets directly from the cluster
+--  it is running in, without requiring an external secrets management service.
+--
+--  URI format:
+--    $secret://kubernetes/{manager-id}/{namespace}/{secret-name}/{data-key}
+--
+--  Example:
+--    $secret://kubernetes/my-k8s/default/my-secret/password
+--
+--  The manager is configured once via the Admin API:
+--    PUT /apisix/admin/secrets/kubernetes/my-k8s
+--    {
+--      "service_account_file": "/var/run/secrets/kubernetes.io/serviceaccount/token",
+--      "kubernetes_host": "kubernetes.default.svc",
+--      "kubernetes_port": "443",
+--      "ssl_verify": true
+--    }
+--
+--  All fields have sensible defaults for in-cluster usage, so the minimal
+--  valid configuration is an empty object `{}`.
+--
+--  TLS note: when ssl_verify is true (the default), the TLS handshake is
+--  validated against the nginx-level lua_ssl_trusted_certificate bundle.
+--  For in-cluster usage, set apisix.ssl.ssl_trusted_certificate in config.yaml
+--  to /var/run/secrets/kubernetes.io/serviceaccount/ca.crt so that the
+--  kube-apiserver certificate (signed by the cluster CA) is trusted.
+
+local core = require("apisix.core")
+local http = require("resty.http")
+local env  = core.env
+
+local io_open = io.open
+local find    = core.string.find
+local sub     = core.string.sub
+local ngx_decode_base64 = ngx.decode_base64
+
+local DEFAULT_SA_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+local schema = {
+    type = "object",
+    properties = {
+        service_account_file = {
+            type = "string",
+            description = "Path to the ServiceAccount token file. "
+                       .. "Defaults to the standard in-cluster path.",
+            default = DEFAULT_SA_FILE,
+        },
+        kubernetes_host = {
+            type = "string",
+            description = "Kubernetes API server hostname or IP. "
+                       .. "Defaults to the KUBERNETES_SERVICE_HOST environment variable.",
+        },
+        kubernetes_port = {
+            type = "string",
+            description = "Kubernetes API server port. "
+                       .. "Defaults to the KUBERNETES_SERVICE_PORT environment variable.",
+        },
+        endpoint = {
+            type = "string",
+            description = "Full base URL of the Kubernetes API server "
+                       .. "(e.g. https://kubernetes.default.svc:443). "
+                       .. "When set, kubernetes_host and kubernetes_port are ignored. "
+                       .. "Useful for testing with plain HTTP mock servers.",
+        },
+        ssl_verify = {
+            type = "boolean",
+            description = "Verify the Kubernetes API server TLS certificate. "
+                       .. "When true, validation uses the nginx-level "
+                       .. "lua_ssl_trusted_certificate bundle; set "
+                       .. "apisix.ssl.ssl_trusted_certificate to the cluster CA "
+                       .. "(/var/run/secrets/kubernetes.io/serviceaccount/ca.crt) "
+                       .. "in config.yaml for in-cluster usage.",
+            default = true,
+        },
+    },
+    required = {},
+}
+
+local _M = {
+    schema = schema,
+}
+
+
+local function read_file(path)
+    local f, err = io_open(path, "r")
+    if not f then
+        return nil, "failed to open file " .. path .. ": " .. err
+    end
+    local content = f:read("*a")
+    f:close()
+    if not content or content == "" then
+        return nil, "file is empty: " .. path
+    end
+    return content
+end
+
+
+local function make_request_to_k8s(conf, namespace, secret_name)
+    local sa_file = conf.service_account_file or DEFAULT_SA_FILE
+    local token, err = read_file(sa_file)
+    if not token then
+        return nil, err
+    end
+    -- strip trailing newline
+    token = token:gsub("%s+$", "")
+
+    local k8s_host = conf.kubernetes_host
+                  or env.fetch_by_uri("$ENV://KUBERNETES_SERVICE_HOST")
+                  or os.getenv("KUBERNETES_SERVICE_HOST")
+
+    local k8s_port = conf.kubernetes_port
+                  or env.fetch_by_uri("$ENV://KUBERNETES_SERVICE_PORT")
+                  or os.getenv("KUBERNETES_SERVICE_PORT")
+                  or "443"
+
+    local base_url
+    if conf.endpoint then
+        base_url = conf.endpoint
+    else
+        if not k8s_host then
+            return nil, "kubernetes_host is not set and KUBERNETES_SERVICE_HOST env var is missing"
+        end
+        base_url = "https://" .. k8s_host .. ":" .. k8s_port
+    end
+
+    local uri = base_url
+             .. "/api/v1/namespaces/" .. namespace
+             .. "/secrets/" .. secret_name
+
+    core.log.info("fetching Kubernetes secret from: ", uri)
+
+    local httpc = http.new()
+    httpc:set_timeout(5000)
+
+    local ssl_verify = conf.ssl_verify
+    if ssl_verify == nil then
+        ssl_verify = true
+    end
+
+    local request_opts = {
+        method = "GET",
+        headers = {
+            ["Authorization"] = "Bearer " .. token,
+            ["Accept"] = "application/json",
+        },
+        ssl_verify = ssl_verify,
+    }
+
+    local res, req_err = httpc:request_uri(uri, request_opts)
+    if not res then
+        return nil, "failed to request Kubernetes API: " .. req_err
+    end
+
+    if res.status == 401 or res.status == 403 then
+        return nil, "unauthorized to read Kubernetes secret "
+               .. namespace .. "/" .. secret_name
+               .. " (HTTP " .. res.status .. "): check RBAC permissions for the ServiceAccount"
+    end
+
+    if res.status == 404 then
+        return nil, "Kubernetes secret not found: " .. namespace .. "/" .. secret_name
+    end
+
+    if res.status ~= 200 then
+        return nil, "unexpected HTTP status " .. res.status
+               .. " from Kubernetes API for secret "
+               .. namespace .. "/" .. secret_name
+    end
+
+    return res.body
+end
+
+
+-- key format: {namespace}/{secret-name}/{data-key}
+local function get(conf, key)
+    core.log.info("fetching data from Kubernetes secret for key: ", key)
+
+    local idx1 = find(key, "/")
+    if not idx1 then
+        return nil, "invalid key format, expected {namespace}/{secret-name}/{data-key}, got: "
+               .. key
+    end
+
+    local namespace = sub(key, 1, idx1 - 1)
+    if namespace == "" then
+        return nil, "namespace is empty in key: " .. key
+    end
+
+    local rest = sub(key, idx1 + 1)
+    local idx2 = find(rest, "/")
+    if not idx2 then
+        return nil, "invalid key format, missing data-key, expected "
+               .. "{namespace}/{secret-name}/{data-key}, got: " .. key
+    end
+
+    local secret_name = sub(rest, 1, idx2 - 1)
+    if secret_name == "" then
+        return nil, "secret-name is empty in key: " .. key
+    end
+
+    local data_key = sub(rest, idx2 + 1)
+    if data_key == "" then
+        return nil, "data-key is empty in key: " .. key
+    end
+
+    core.log.info("namespace: ", namespace,
+                  ", secret_name: ", secret_name,
+                  ", data_key: ", data_key)
+
+    local body, err = make_request_to_k8s(conf, namespace, secret_name)
+    if not body then
+        return nil, err
+    end
+
+    local secret, decode_err = core.json.decode(body)
+    if not secret then
+        return nil, "failed to decode Kubernetes API response: " .. decode_err
+    end
+
+    if not secret.data then
+        return nil, "Kubernetes secret " .. namespace .. "/" .. secret_name
+               .. " has no data field"
+    end
+
+    local encoded_value = secret.data[data_key]
+    if not encoded_value then
+        return nil, "key '" .. data_key .. "' not found in Kubernetes secret "
+               .. namespace .. "/" .. secret_name
+    end
+
+    local value = ngx_decode_base64(encoded_value)
+    if not value then
+        return nil, "failed to base64-decode value for key '" .. data_key
+               .. "' in Kubernetes secret " .. namespace .. "/" .. secret_name
+    end
+
+    return value
+end
+
+_M.get = get
+
+
+return _M

--- a/docs/en/latest/terminology/secret.md
+++ b/docs/en/latest/terminology/secret.md
@@ -41,6 +41,7 @@ APISIX currently supports storing secrets in the following ways:
 - [HashiCorp Vault](#use-hashicorp-vault-to-manage-secrets)
 - [AWS Secrets Manager](#use-aws-secrets-manager-to-manage-secrets)
 - [GCP Secrets Manager](#use-gcp-secrets-manager-to-manage-secrets)
+- [Kubernetes Secrets](#use-kubernetes-secrets-to-manage-secrets)
 
 You can use APISIX Secret functions by specifying format variables in the consumer configuration or the plugin configuration of any plugin, as well as in SSL certificate configurations.
 
@@ -363,3 +364,130 @@ curl http://127.0.0.1:9180/apisix/admin/secrets/gcp/1 \
 }'
 
 ```
+
+## Use Kubernetes Secrets to manage secrets
+
+When APISIX is running inside a Kubernetes cluster, it can read secrets directly
+from the Kubernetes API server using the pod's ServiceAccount credentials. This
+allows you to manage APISIX plugin credentials through standard Kubernetes Secrets
+without requiring an external secrets management service.
+
+### Prerequisites
+
+The ServiceAccount used by the APISIX pod must have RBAC permissions to read
+the target Secrets. Create a `ClusterRole` and bind it to the APISIX ServiceAccount:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: apisix-secret-reader
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: apisix-secret-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: apisix-secret-reader
+subjects:
+  - kind: ServiceAccount
+    name: apisix
+    namespace: apisix
+```
+
+### Usage
+
+```
+$secret://kubernetes/{manager-id}/{namespace}/{secret-name}/{data-key}
+```
+
+- `manager-id`: the ID of the Kubernetes secret manager instance registered via Admin API
+- `namespace`: the Kubernetes namespace where the Secret lives
+- `secret-name`: the name of the Kubernetes Secret
+- `data-key`: the key within `Secret.data` (the value will be base64-decoded automatically)
+
+### Configuration via Admin API
+
+Register a Kubernetes secret manager instance. All fields are optional and default
+to standard in-cluster values:
+
+```bash
+curl -X PUT http://127.0.0.1:9180/apisix/admin/secrets/kubernetes/my-k8s \
+  -H "X-API-KEY: $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "service_account_file": "/var/run/secrets/kubernetes.io/serviceaccount/token",
+    "kubernetes_host": "kubernetes.default.svc",
+    "kubernetes_port": "443",
+    "ssl_verify": true
+  }'
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `service_account_file` | string | No | `/var/run/secrets/kubernetes.io/serviceaccount/token` | Path to the ServiceAccount token file |
+| `kubernetes_host` | string | No | `$KUBERNETES_SERVICE_HOST` env var | Kubernetes API server hostname or IP |
+| `kubernetes_port` | string | No | `$KUBERNETES_SERVICE_PORT` env var | Kubernetes API server port |
+| `endpoint` | string | No | derived from `kubernetes_host`/`kubernetes_port` | Full base URL of the API server (e.g. `https://kubernetes.default.svc:443`). Overrides `kubernetes_host` and `kubernetes_port` when set |
+| `ssl_verify` | boolean | No | `true` | Verify the Kubernetes API server TLS certificate |
+
+#### TLS configuration for in-cluster usage
+
+When `ssl_verify` is `true` (the default), TLS verification uses the nginx-level
+`lua_ssl_trusted_certificate` bundle. The cluster CA that signs the kube-apiserver
+certificate is **not** in the system CA bundle, so you must add it explicitly in
+`config.yaml`:
+
+```yaml
+apisix:
+  ssl:
+    ssl_trusted_certificate: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+```
+
+Without this setting the TLS handshake will fail. Alternatively, set `ssl_verify: false`,
+but this is not recommended in production because the ServiceAccount token is sent
+to an unverified endpoint.
+
+### Example: protect plugin credentials with Kubernetes Secrets
+
+Suppose you have a Kubernetes Secret in the `my-app` namespace:
+
+```bash
+kubectl create secret generic keycloak-creds \
+  --namespace my-app \
+  --from-literal=client_id=my-client-id \
+  --from-literal=client_secret=my-client-secret
+```
+
+You can reference these values in the `authz-keycloak` plugin configuration:
+
+```bash
+curl -X PUT http://127.0.0.1:9180/apisix/admin/routes/1 \
+  -H "X-API-KEY: $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "uri": "/api/*",
+    "plugins": {
+      "authz-keycloak": {
+        "discovery": "https://keycloak.example.com/auth/realms/my-realm/.well-known/uma2-configuration",
+        "client_id": "$secret://kubernetes/my-k8s/my-app/keycloak-creds/client_id",
+        "client_secret": "$secret://kubernetes/my-k8s/my-app/keycloak-creds/client_secret",
+        "policy_enforcement_mode": "ENFORCING"
+      }
+    },
+    "upstream": {
+      "type": "roundrobin",
+      "nodes": {"backend-service:8080": 1}
+    }
+  }'
+```
+
+APISIX resolves `$secret://kubernetes/...` references at request time by calling
+the Kubernetes API, so secret rotations in Kubernetes are picked up automatically
+without restarting APISIX.

--- a/t/secret/kubernetes.t
+++ b/t/secret/kubernetes.t
@@ -1,0 +1,463 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+BEGIN {
+    $ENV{KUBERNETES_SERVICE_HOST} = "127.0.0.1";
+    $ENV{KUBERNETES_SERVICE_PORT} = "6443";
+}
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+log_level("info");
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: schema validation - all fields valid
+--- config
+    location /t {
+        content_by_lua_block {
+            local kubernetes = require("apisix.secret.kubernetes")
+            local core = require("apisix.core")
+
+            local test_cases = {
+                {},
+                {ssl_verify = true},
+                {ssl_verify = false},
+                {ssl_verify = 1234},
+                {service_account_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"},
+                {service_account_file = 1234},
+                {kubernetes_host = "kubernetes.default.svc"},
+                {kubernetes_host = 1234},
+                {kubernetes_port = "443"},
+                {kubernetes_port = 1234},
+                {
+                    service_account_file = "/var/run/secrets/kubernetes.io/serviceaccount/token",
+                    kubernetes_host = "kubernetes.default.svc",
+                    kubernetes_port = "443",
+                    ssl_verify = true,
+                },
+            }
+
+            for _, conf in ipairs(test_cases) do
+                local ok, err = core.schema.check(kubernetes.schema, conf)
+                ngx.say(ok and "done" or err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+done
+done
+property "ssl_verify" validation failed: wrong type: expected boolean, got number
+done
+property "service_account_file" validation failed: wrong type: expected string, got number
+done
+property "kubernetes_host" validation failed: wrong type: expected string, got number
+done
+property "kubernetes_port" validation failed: wrong type: expected string, got number
+done
+
+
+
+=== TEST 2: get - invalid key format (no slashes)
+--- config
+    location /t {
+        content_by_lua_block {
+            local kubernetes = require("apisix.secret.kubernetes")
+            local data, err = kubernetes.get({}, "no-slashes")
+            if err then
+                return ngx.say(err)
+            end
+            ngx.say(data)
+        }
+    }
+--- request
+GET /t
+--- response_body
+invalid key format, expected {namespace}/{secret-name}/{data-key}, got: no-slashes
+
+
+
+=== TEST 3: get - invalid key format (only one slash, missing data-key)
+--- config
+    location /t {
+        content_by_lua_block {
+            local kubernetes = require("apisix.secret.kubernetes")
+            local data, err = kubernetes.get({}, "default/my-secret")
+            if err then
+                return ngx.say(err)
+            end
+            ngx.say(data)
+        }
+    }
+--- request
+GET /t
+--- response_body
+invalid key format, missing data-key, expected {namespace}/{secret-name}/{data-key}, got: default/my-secret
+
+
+
+=== TEST 4: get - empty namespace
+--- config
+    location /t {
+        content_by_lua_block {
+            local kubernetes = require("apisix.secret.kubernetes")
+            local data, err = kubernetes.get({}, "/my-secret/my-key")
+            if err then
+                return ngx.say(err)
+            end
+            ngx.say(data)
+        }
+    }
+--- request
+GET /t
+--- response_body
+namespace is empty in key: /my-secret/my-key
+
+
+
+=== TEST 5: get - empty secret-name
+--- config
+    location /t {
+        content_by_lua_block {
+            local kubernetes = require("apisix.secret.kubernetes")
+            local data, err = kubernetes.get({}, "default//my-key")
+            if err then
+                return ngx.say(err)
+            end
+            ngx.say(data)
+        }
+    }
+--- request
+GET /t
+--- response_body
+secret-name is empty in key: default//my-key
+
+
+
+=== TEST 6: get - empty data-key
+--- config
+    location /t {
+        content_by_lua_block {
+            local kubernetes = require("apisix.secret.kubernetes")
+            local data, err = kubernetes.get({}, "default/my-secret/")
+            if err then
+                return ngx.say(err)
+            end
+            ngx.say(data)
+        }
+    }
+--- request
+GET /t
+--- response_body
+data-key is empty in key: default/my-secret/
+
+
+
+=== TEST 7: get - service account file not found
+--- config
+    location /t {
+        content_by_lua_block {
+            local kubernetes = require("apisix.secret.kubernetes")
+            local conf = {
+                service_account_file = "/nonexistent/token",
+                ssl_verify = false,
+            }
+            local data, err = kubernetes.get(conf, "default/my-secret/my-key")
+            if err then
+                return ngx.say(err)
+            end
+            ngx.say(data)
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+failed to open file /nonexistent/token:.*
+
+
+
+=== TEST 8: get - connection refused (API server not reachable)
+--- config
+    location /t {
+        content_by_lua_block {
+            -- Write a temp token file for the test
+            local f = io.open("/tmp/test-sa-token", "w")
+            f:write("test-token")
+            f:close()
+
+            local kubernetes = require("apisix.secret.kubernetes")
+            local conf = {
+                service_account_file = "/tmp/test-sa-token",
+                endpoint = "https://127.0.0.2:9999",
+                ssl_verify = false,
+            }
+            local data, err = kubernetes.get(conf, "default/my-secret/my-key")
+            if err then
+                return ngx.say(err)
+            end
+            ngx.say(data)
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+failed to request Kubernetes API:.*
+--- timeout: 6
+
+
+
+=== TEST 9: get - mock Kubernetes API returns 401
+--- config
+    location /mock-k8s-401 {
+        content_by_lua_block {
+            ngx.status = 401
+            ngx.header["Content-Type"] = "application/json"
+            ngx.say('{"kind":"Status","apiVersion":"v1","status":"Failure","message":"Unauthorized","reason":"Unauthorized","code":401}')
+        }
+    }
+    location /t {
+        content_by_lua_block {
+            local f = io.open("/tmp/test-sa-token", "w")
+            f:write("bad-token")
+            f:close()
+
+            local kubernetes = require("apisix.secret.kubernetes")
+            local conf = {
+                service_account_file = "/tmp/test-sa-token",
+                endpoint = "http://127.0.0.1:1984",
+                ssl_verify = false,
+            }
+            -- Note: the mock server path doesn't match the real k8s path,
+            -- so we expect a non-200 response handled gracefully
+            local data, err = kubernetes.get(conf, "default/my-secret/my-key")
+            if err then
+                return ngx.say(err)
+            end
+            ngx.say(data)
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+(unauthorized to read Kubernetes secret|failed to request Kubernetes API|unexpected HTTP status).*
+
+
+
+=== TEST 10: get - mock Kubernetes API returns valid secret
+--- config
+    location ~ "^/api/v1/namespaces/default/secrets/my-secret$" {
+        content_by_lua_block {
+            ngx.header["Content-Type"] = "application/json"
+            -- {"username":"admin","password":"s3cr3t"} base64-encoded per field
+            ngx.say([[{
+                "apiVersion": "v1",
+                "kind": "Secret",
+                "metadata": {"name": "my-secret", "namespace": "default"},
+                "data": {
+                    "username": "YWRtaW4=",
+                    "password": "czNjcjN0"
+                },
+                "type": "Opaque"
+            }]])
+        }
+    }
+    location /t {
+        content_by_lua_block {
+            local f = io.open("/tmp/test-sa-token", "w")
+            f:write("valid-token")
+            f:close()
+
+            local kubernetes = require("apisix.secret.kubernetes")
+            local conf = {
+                service_account_file = "/tmp/test-sa-token",
+                endpoint = "http://127.0.0.1:1984",
+                ssl_verify = false,
+            }
+
+            local username, err = kubernetes.get(conf, "default/my-secret/username")
+            if err then
+                ngx.say("username error: " .. err)
+            else
+                ngx.say("username: " .. username)
+            end
+
+            local password, err2 = kubernetes.get(conf, "default/my-secret/password")
+            if err2 then
+                ngx.say("password error: " .. err2)
+            else
+                ngx.say("password: " .. password)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+username: admin
+password: s3cr3t
+
+
+
+=== TEST 11: get - mock Kubernetes API returns 404
+--- config
+    location ~ "^/api/v1/namespaces/default/secrets/missing-secret$" {
+        content_by_lua_block {
+            ngx.status = 404
+            ngx.header["Content-Type"] = "application/json"
+            ngx.say('{"kind":"Status","apiVersion":"v1","status":"Failure","message":"secrets \"missing-secret\" not found","reason":"NotFound","code":404}')
+        }
+    }
+    location /t {
+        content_by_lua_block {
+            local f = io.open("/tmp/test-sa-token", "w")
+            f:write("valid-token")
+            f:close()
+
+            local kubernetes = require("apisix.secret.kubernetes")
+            local conf = {
+                service_account_file = "/tmp/test-sa-token",
+                endpoint = "http://127.0.0.1:1984",
+                ssl_verify = false,
+            }
+            local data, err = kubernetes.get(conf, "default/missing-secret/my-key")
+            if err then
+                return ngx.say(err)
+            end
+            ngx.say(data)
+        }
+    }
+--- request
+GET /t
+--- response_body
+Kubernetes secret not found: default/missing-secret
+
+
+
+=== TEST 12: get - data-key not found in secret
+--- config
+    location ~ "^/api/v1/namespaces/default/secrets/partial-secret$" {
+        content_by_lua_block {
+            ngx.header["Content-Type"] = "application/json"
+            ngx.say([[{
+                "apiVersion": "v1",
+                "kind": "Secret",
+                "metadata": {"name": "partial-secret", "namespace": "default"},
+                "data": {
+                    "username": "YWRtaW4="
+                },
+                "type": "Opaque"
+            }]])
+        }
+    }
+    location /t {
+        content_by_lua_block {
+            local f = io.open("/tmp/test-sa-token", "w")
+            f:write("valid-token")
+            f:close()
+
+            local kubernetes = require("apisix.secret.kubernetes")
+            local conf = {
+                service_account_file = "/tmp/test-sa-token",
+                endpoint = "http://127.0.0.1:1984",
+                ssl_verify = false,
+            }
+            local data, err = kubernetes.get(conf, "default/partial-secret/password")
+            if err then
+                return ngx.say(err)
+            end
+            ngx.say(data)
+        }
+    }
+--- request
+GET /t
+--- response_body
+key 'password' not found in Kubernetes secret default/partial-secret
+
+
+
+=== TEST 13: end-to-end via Admin API - register kubernetes secret manager
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/secrets/kubernetes/my-k8s',
+                ngx.HTTP_PUT,
+                [[{
+                    "service_account_file": "/tmp/test-sa-token",
+                    "endpoint": "http://127.0.0.1:1984",
+                    "ssl_verify": false
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 14: end-to-end via Admin API - use $secret://kubernetes in plugin config
+--- config
+    location ~ "^/api/v1/namespaces/default/secrets/api-credentials$" {
+        content_by_lua_block {
+            ngx.header["Content-Type"] = "application/json"
+            ngx.say([[{
+                "apiVersion": "v1",
+                "kind": "Secret",
+                "metadata": {"name": "api-credentials", "namespace": "default"},
+                "data": {
+                    "client_id": "bXktY2xpZW50",
+                    "client_secret": "bXktc2VjcmV0"
+                },
+                "type": "Opaque"
+            }]])
+        }
+    }
+    location /t {
+        content_by_lua_block {
+            local f = io.open("/tmp/test-sa-token", "w")
+            f:write("valid-token")
+            f:close()
+
+            -- Simulate how fetch_secrets resolves $secret:// in plugin config
+            local secret = require("apisix.secret")
+            local refs = {
+                client_id = "$secret://kubernetes/my-k8s/default/api-credentials/client_id",
+                client_secret = "$secret://kubernetes/my-k8s/default/api-credentials/client_secret",
+            }
+            local resolved = secret.fetch_secrets(refs, false)
+            ngx.say("client_id: " .. (resolved.client_id or "nil"))
+            ngx.say("client_secret: " .. (resolved.client_secret or "nil"))
+        }
+    }
+--- request
+GET /t
+--- response_body
+client_id: my-client
+client_secret: my-secret


### PR DESCRIPTION
Implements the Kubernetes secret manager (apisix/secret/kubernetes.lua) which allows APISIX to read Kubernetes Secrets directly from the cluster using the pod's ServiceAccount token.

URI format:
  $secret://kubernetes/{manager-id}/{namespace}/{secret-name}/{data-key}

Example:
  $secret://kubernetes/my-k8s/default/api-creds/client_secret

The implementation follows the same pattern as the existing Vault, AWS, and GCP secret managers: a schema for Admin API configuration and a get(conf, key) function called by apisix.secret.fetch_secrets() at request time.

Key features:
- Uses pod ServiceAccount token (default in-cluster path) for auth
- Reads KUBERNETES_SERVICE_HOST/PORT from env if not explicitly configured
- Verifies TLS using the in-cluster CA bundle by default
- Decodes base64 Secret.data values automatically
- Clear error messages for auth failures, missing secrets, missing keys

Also fixes two bugs in authz-keycloak.lua discovered while using the Kubernetes secret manager in production (fixes #13493):

1. client_id and client_secret maxLength was 100 characters. When APISIX resolves a $secret:// reference, encrypts the value (encrypt_fields), and stores it back to etcd, the AES-encrypted result can be 128-152 chars — exceeding the schema limit and causing load_full_data() to fail on restart, dropping all authz-keycloak services with a 404. Increased maxLength to 4096 for both fields.

2. The same maxLength = 100 constraint also blocked $secret://kubernetes/ references from being stored at all via the Admin API, since the reference string itself (e.g. $secret://kubernetes/my-k8s/my-ns/ my-secret/client_secret) can exceed 100 characters.

Closes #13493

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
