### PR TITLE
fix(workflow): log phase fails when access phase was short-circuited

### DIFF
--- a/apisix/plugins/workflow.lua
+++ b/apisix/plugins/workflow.lua
@@ -178,6 +178,14 @@ function _M.access(conf, ctx)
 end
 
 function _M.log(conf, ctx)
+    -- ctx._workflow_cache is created in the access phase, but the access
+    -- phase may be skipped, e.g. when a plugin of the route finishes the
+    -- request in the rewrite phase while the workflow plugin is configured
+    -- in a global rule
+    if not ctx._workflow_cache then
+        return
+    end
+
     for idx, rule in ipairs(conf.rules) do
         local match_result = ctx._workflow_cache[idx]
         if match_result then

--- a/t/plugin/workflow3.t
+++ b/t/plugin/workflow3.t
@@ -142,3 +142,107 @@ GET /test_concurrency
 503
 503
 503
+
+
+
+=== TEST 3: set up workflow with limit-conn in global rule, and a route with cors
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/global_rules/1',
+                 ngx.HTTP_PUT,
+                 json.encode({
+                    plugins = {
+                        workflow = {
+                            rules = {
+                                {
+                                    case = {
+                                        {"uri", "==", "/hello"}
+                                    },
+                                    actions = {
+                                        {
+                                            "limit-conn",
+                                            {
+                                                conn = 2,
+                                                burst = 1,
+                                                default_conn_delay = 0.1,
+                                                rejected_code = 503,
+                                                key = "remote_addr"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                 })
+            )
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 json.encode({
+                    uri = "/hello",
+                    plugins = {
+                        cors = {}
+                    },
+                    upstream = {
+                        nodes = {
+                            ["127.0.0.1:1980"] = 1
+                        },
+                        type = "roundrobin"
+                    }
+                 })
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 4: OPTIONS preflight finished by cors in rewrite phase, workflow log phase should not fail
+--- request
+OPTIONS /hello
+--- more_headers
+Origin: https://sub.domain.com
+Access-Control-Request-Method: GET
+--- error_code: 200
+--- no_error_log
+_workflow_cache
+
+
+
+=== TEST 5: clean up
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/global_rules/1', ngx.HTTP_DELETE)
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_DELETE)
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed


### PR DESCRIPTION
### Description

When the `workflow` plugin is configured in a global rule with a `limit-conn` action, and a route-level plugin finishes the request in the rewrite phase (e.g. `cors` answering an OPTIONS preflight with 200), every such request floods the error log with:

```
failed to run log_by_lua*: apisix/plugins/workflow.lua:182: attempt to index field '_workflow_cache' (a nil value)
```

The log handler introduced in #12465 assumes `ctx._workflow_cache` always exists, but it is only created in the access phase. Route plugins' rewrite phase runs before the global rule's access phase, so when rewrite short-circuits the request, `workflow.access` never runs while `workflow.log` still does (the log phase always runs global rules).

This PR returns early from `workflow.log` when `ctx._workflow_cache` is missing. This is safe: if the access phase never ran, no `limit-conn` counter was incremented, so there is nothing to clean up in the log phase.

#### Which issue(s) this PR fixes:

Fixes #13479

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
