### PR TITLE
fix(consul): one invalid node should not discard the remaining nodes of the service

### DIFF
--- a/apisix/discovery/consul/client.lua
+++ b/apisix/discovery/consul/client.lua
@@ -394,7 +394,9 @@ function _M.fetch_services_from_server(consul_server, options)
             local nodes_uniq = {}
             for _, node in ipairs(result.body) do
                 if not node.Service then
-                    goto CONTINUE
+                    log.warn("invalid consul service entry without Service field, ",
+                        "skip it: ", json_delay_encode(node))
+                    goto CONTINUE_NODE
                 end
 
                 local svc_address, svc_port = node.Service.Address, node.Service.Port
@@ -422,6 +424,7 @@ function _M.fetch_services_from_server(consul_server, options)
                     core.table.insert(nodes, n)
                     nodes_uniq[service_id] = true
                 end
+                :: CONTINUE_NODE ::
             end
 
             if nodes then

--- a/t/discovery/consul-malformed-node.t
+++ b/t/discovery/consul-malformed-node.t
@@ -112,7 +112,7 @@ run_tests();
 
 __DATA__
 
-=== TEST 1: one malformed catalog entry should not discard the remaining valid nodes
+=== TEST 1: one malformed health service entry should not discard the remaining valid nodes
 --- yaml_config eval: $::yaml_config
 --- apisix_yaml
 routes:

--- a/t/discovery/consul-malformed-node.t
+++ b/t/discovery/consul-malformed-node.t
@@ -1,0 +1,157 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+log_level('info');
+no_root_location();
+no_shuffle();
+
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    # mock consul server: /v1/health/service/service_a returns one malformed
+    # entry (without the Service field) followed by two valid entries
+    my $http_config = $block->http_config // <<_EOC_;
+
+    server {
+        listen 18506;
+
+        location /v1/catalog/services {
+            content_by_lua_block {
+                ngx.header["X-Consul-Index"] = "1"
+                ngx.header.content_type = "application/json"
+                ngx.say('{"service_a":[]}')
+            }
+        }
+
+        location /v1/health/state/any {
+            content_by_lua_block {
+                ngx.header["X-Consul-Index"] = "1"
+                ngx.header.content_type = "application/json"
+                ngx.say('[]')
+            }
+        }
+
+        location /v1/health/service/service_a {
+            content_by_lua_block {
+                ngx.header["X-Consul-Index"] = "1"
+                ngx.header.content_type = "application/json"
+                ngx.say('['
+                    .. '{"Node":{"Node":"reclaimed-node","Address":"127.0.0.1"},"Checks":[]},'
+                    .. '{"Node":{"Node":"node1","Address":"127.0.0.1"},'
+                    .. '"Service":{"ID":"service_a1","Service":"service_a",'
+                    .. '"Address":"127.0.0.1","Port":30511},"Checks":[]},'
+                    .. '{"Node":{"Node":"node2","Address":"127.0.0.1"},'
+                    .. '"Service":{"ID":"service_a2","Service":"service_a",'
+                    .. '"Address":"127.0.0.1","Port":30512},"Checks":[]}'
+                    .. ']')
+            }
+        }
+    }
+
+    server {
+        listen 30511;
+
+        location /hello {
+            content_by_lua_block {
+                ngx.say("server 1")
+            }
+        }
+    }
+    server {
+        listen 30512;
+
+        location /hello {
+            content_by_lua_block {
+                ngx.say("server 2")
+            }
+        }
+    }
+_EOC_
+
+    $block->set_value("http_config", $http_config);
+});
+
+our $yaml_config = <<_EOC_;
+apisix:
+  node_listen: 1984
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+discovery:
+  consul:
+    servers:
+      - "http://127.0.0.1:18506"
+    timeout:
+      connect: 1000
+      read: 1000
+      wait: 60
+    weight: 1
+    fetch_interval: 1
+    keepalive: true
+_EOC_
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: one malformed catalog entry should not discard the remaining valid nodes
+--- yaml_config eval: $::yaml_config
+--- apisix_yaml
+routes:
+  -
+    uri: /hello
+    upstream:
+      service_name: service_a
+      discovery_type: consul
+      type: roundrobin
+#END
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.sleep(2)
+
+            local http = require("resty.http")
+            local bodies = {}
+            for i = 1, 2 do
+                local httpc = http.new()
+                local res, err = httpc:request_uri("http://127.0.0.1:1984/hello")
+                if not res then
+                    ngx.say("request failed: ", err)
+                    return
+                end
+                if res.status ~= 200 then
+                    ngx.say("unexpected status: ", res.status)
+                    return
+                end
+                table.insert(bodies, res.body)
+            end
+            table.sort(bodies)
+            ngx.print(table.concat(bodies))
+        }
+    }
+--- timeout: 5
+--- request
+GET /t
+--- response_body
+server 1
+server 2
+--- error_log
+invalid consul service entry without Service field


### PR DESCRIPTION
### Description

A single malformed entry in the consul health API response (an entry without the `Service` field, e.g. from an agent on a reclaimed cloud instance) currently wipes out the whole service. The per-node check in `fetch_services_from_server()` does `goto CONTINUE`, but the `::CONTINUE::` label sits outside the node loop, so one bad entry skips all the remaining nodes, the sort, and the `up_services[key] = nodes` assignment. If the malformed entry comes first, the service ends up with no nodes, `update_all_services()` deletes it from the shared dict, and requests start failing with "no valid upstream node".

The fix makes the skip local to the node loop (`goto CONTINUE_NODE` with the label at the end of the loop body) and logs a warning for the skipped entry. After the change, a malformed entry only drops that one node and the remaining healthy nodes keep serving traffic.

Added a regression test (`t/discovery/consul-malformed-node.t`) with a mock consul server returning one malformed entry followed by two valid ones; it fails without the fix and passes with it.

#### Which issue(s) this PR fixes:

Fixes #12937

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
