### PR TITLE
fix(plugin): ignore plugin_metadata of disabled or unknown plugins

### DIFF
--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -1183,10 +1183,37 @@ _M.encrypt_conf = encrypt_conf
 
 
 check_plugin_metadata = function(item)
-    local ok, err = check_single_plugin_schema(item.id, item,
+    local name = item.id
+    if type(name) ~= "string" then
+        core.log.warn("ignore invalid plugin_metadata entry: ",
+                      core.json.delay_encode(item))
+        return true
+    end
+
+    -- The plugin_metadata directory is watched in both the http and the
+    -- stream subsystems, but local_plugins_hash only holds the http plugins,
+    -- and they are only loaded in the http subsystem. Skip silently the
+    -- metadata of the plugins which are known to the deployment but missing
+    -- from local_plugins_hash (stream plugins, and http plugins when running
+    -- in the stream subsystem), instead of reporting them as disabled or
+    -- unknown.
+    if not local_plugins_hash[name] then
+        if stream_local_plugins_hash[name] then
+            return true
+        end
+
+        -- http plugins are never loaded in the stream subsystem, so consult
+        -- the configured plugin name list instead
+        if not is_http and local_conf
+           and core.table.array_find(local_conf.plugins, name) then
+            return true
+        end
+    end
+
+    local ok, err = check_single_plugin_schema(name, item,
                                                core.schema.TYPE_METADATA, true)
     if ok and enable_gde() then
-        decrypt_conf(item.id, item, core.schema.TYPE_METADATA)
+        decrypt_conf(name, item, core.schema.TYPE_METADATA)
     end
 
     return ok, err

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -970,15 +970,20 @@ end
 
 
 
-local function check_single_plugin_schema(name, plugin_conf, schema_type, skip_disabled_plugin)
+local function check_single_plugin_schema(name, plugin_conf, schema_type, skip_disabled_plugin,
+                                          ignore_disabled_plugin)
     if type(plugin_conf) ~= "table" then
         return false, "invalid plugin conf " ..
             core.json.encode(plugin_conf, true) ..
-            " for plugin [" .. name .. "]"
+            " for plugin [" .. tostring(name) .. "]"
     end
 
     local plugin_obj = local_plugins_hash[name]
     if not plugin_obj then
+        if ignore_disabled_plugin then
+            return true
+        end
+
         if skip_disabled_plugin then
             core.log.warn("skipping check schema for disabled or unknown plugin [",
                                     name, "]. Enable the plugin or modify configuration")
@@ -1183,37 +1188,15 @@ _M.encrypt_conf = encrypt_conf
 
 
 check_plugin_metadata = function(item)
-    local name = item.id
-    if type(name) ~= "string" then
-        core.log.warn("ignore invalid plugin_metadata entry: ",
-                      core.json.delay_encode(item))
-        return true
-    end
-
-    -- The plugin_metadata directory is watched in both the http and the
-    -- stream subsystems, but local_plugins_hash only holds the http plugins,
-    -- and they are only loaded in the http subsystem. Skip silently the
-    -- metadata of the plugins which are known to the deployment but missing
-    -- from local_plugins_hash (stream plugins, and http plugins when running
-    -- in the stream subsystem), instead of reporting them as disabled or
-    -- unknown.
-    if not local_plugins_hash[name] then
-        if stream_local_plugins_hash[name] then
-            return true
-        end
-
-        -- http plugins are never loaded in the stream subsystem, so consult
-        -- the configured plugin name list instead
-        if not is_http and local_conf
-           and core.table.array_find(local_conf.plugins, name) then
-            return true
-        end
-    end
-
-    local ok, err = check_single_plugin_schema(name, item,
-                                               core.schema.TYPE_METADATA, true)
+    -- A plugin_metadata entry takes no effect until its plugin is enabled,
+    -- so entries of disabled or unknown plugins are ignored silently. This
+    -- also covers the entries of the other subsystem's plugins: the
+    -- plugin_metadata directory is watched by both the http and the stream
+    -- subsystems, while each of them only loads its own plugins.
+    local ok, err = check_single_plugin_schema(item.id, item,
+                                               core.schema.TYPE_METADATA, false, true)
     if ok and enable_gde() then
-        decrypt_conf(name, item, core.schema.TYPE_METADATA)
+        decrypt_conf(item.id, item, core.schema.TYPE_METADATA)
     end
 
     return ok, err

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -1195,7 +1195,9 @@ check_plugin_metadata = function(item)
     -- subsystems, while each of them only loads its own plugins.
     local ok, err = check_single_plugin_schema(item.id, item,
                                                core.schema.TYPE_METADATA, false, true)
-    if ok and enable_gde() then
+    -- the schema of an unloaded plugin is unavailable, so decrypting its
+    -- metadata would only produce a "failed to get schema" warning
+    if ok and enable_gde() and local_plugins_hash[item.id] then
         decrypt_conf(item.id, item, core.schema.TYPE_METADATA)
     end
 

--- a/t/config-center-yaml/plugin-metadata.t
+++ b/t/config-center-yaml/plugin-metadata.t
@@ -87,3 +87,110 @@ plugin_metadata:
 GET /hello
 --- error_log
 failed to check item data of [plugin_metadata]
+
+
+
+=== TEST 3: metadata of plugins from the other subsystem should be skipped silently
+--- yaml_config
+apisix:
+    node_listen: 1984
+    proxy_mode: http&stream
+    stream_proxy:
+        tcp:
+            - 9100
+deployment:
+    role: data_plane
+    role_data_plane:
+        config_provider: yaml
+--- stream_enable
+--- apisix_yaml
+upstreams:
+  - id: 1
+    nodes:
+      "127.0.0.1:1980": 1
+    type: roundrobin
+routes:
+  -
+    uri: /hello
+    upstream_id: 1
+    plugins:
+        cors:
+            allow_origins_by_metadata:
+                - local
+plugin_metadata:
+  - id: cors
+    allow_origins:
+        local: "http://example.com"
+  - id: mqtt-proxy
+    log_format:
+        host: "$host"
+#END
+--- request
+GET /hello
+--- response_body
+hello world
+--- no_error_log
+disabled or unknown plugin
+
+
+
+=== TEST 4: metadata of a genuinely unknown plugin should still warn
+--- yaml_config
+apisix:
+    node_listen: 1984
+    proxy_mode: http&stream
+    stream_proxy:
+        tcp:
+            - 9100
+deployment:
+    role: data_plane
+    role_data_plane:
+        config_provider: yaml
+--- stream_enable
+--- apisix_yaml
+upstreams:
+  - id: 1
+    nodes:
+      "127.0.0.1:1980": 1
+    type: roundrobin
+routes:
+  -
+    uri: /hello
+    upstream_id: 1
+plugin_metadata:
+  - id: plugin-not-exist
+    log_format:
+        host: "$host"
+#END
+--- request
+GET /hello
+--- response_body
+hello world
+--- error_log
+disabled or unknown plugin [plugin-not-exist]
+
+
+
+=== TEST 5: metadata entry without id should be reported as invalid
+--- apisix_yaml
+upstreams:
+  - id: 1
+    nodes:
+      "127.0.0.1:1980": 1
+    type: roundrobin
+routes:
+  -
+    uri: /hello
+    upstream_id: 1
+plugin_metadata:
+  - log_format:
+        host: "$host"
+#END
+--- request
+GET /hello
+--- response_body
+hello world
+--- error_log
+ignore invalid plugin_metadata entry
+--- no_error_log
+disabled or unknown plugin

--- a/t/config-center-yaml/plugin-metadata.t
+++ b/t/config-center-yaml/plugin-metadata.t
@@ -134,19 +134,7 @@ disabled or unknown plugin
 
 
 
-=== TEST 4: metadata of a genuinely unknown plugin should still warn
---- yaml_config
-apisix:
-    node_listen: 1984
-    proxy_mode: http&stream
-    stream_proxy:
-        tcp:
-            - 9100
-deployment:
-    role: data_plane
-    role_data_plane:
-        config_provider: yaml
---- stream_enable
+=== TEST 4: metadata of a disabled or unknown plugin is ignored silently
 --- apisix_yaml
 upstreams:
   - id: 1
@@ -166,12 +154,13 @@ plugin_metadata:
 GET /hello
 --- response_body
 hello world
---- error_log
-disabled or unknown plugin [plugin-not-exist]
+--- no_error_log
+disabled or unknown plugin
+failed to check item data of [plugin_metadata]
 
 
 
-=== TEST 5: metadata entry without id should be reported as invalid
+=== TEST 5: metadata entry without id is ignored silently
 --- apisix_yaml
 upstreams:
   - id: 1
@@ -190,7 +179,6 @@ plugin_metadata:
 GET /hello
 --- response_body
 hello world
---- error_log
-ignore invalid plugin_metadata entry
 --- no_error_log
 disabled or unknown plugin
+failed to check item data of [plugin_metadata]

--- a/t/config-center-yaml/plugin-metadata.t
+++ b/t/config-center-yaml/plugin-metadata.t
@@ -135,6 +135,12 @@ disabled or unknown plugin
 
 
 === TEST 4: metadata of a disabled or unknown plugin is ignored silently
+--- extra_yaml_config
+apisix:
+    data_encryption:
+        enable_encrypt_fields: true
+        keyring:
+            - edd1c9f0985e76a2
 --- apisix_yaml
 upstreams:
   - id: 1
@@ -157,6 +163,7 @@ hello world
 --- no_error_log
 disabled or unknown plugin
 failed to check item data of [plugin_metadata]
+failed to get schema
 
 
 


### PR DESCRIPTION
### Description

Fixes #13305

After upgrading to 3.15.0, deployments running `proxy_mode: http&stream` get flooded with warnings on every config sync:

```
skipping check schema for disabled or unknown plugin [cors]. Enable the plugin or modify configuration
```

The `/plugin_metadata` directory is watched by both the http and the stream subsystems, while each subsystem only loads its own plugins — so http-plugin metadata is always "unknown" to stream workers (and vice versa). The warning itself was introduced by #12655; before that the skip was silent. Stale entries with a missing `id` additionally produce `disabled or unknown plugin [nil]`.

The warning brings no value for plugin_metadata in the first place: a metadata entry simply takes no effect until its plugin is enabled. This is unlike a disabled plugin configured on a route, where the plugin silently not running is confusing and worth warning about.

So instead of teaching the metadata checker about the other subsystem's plugin set, this PR adds an `ignore_disabled_plugin` flag to `check_single_plugin_schema`, checked before `skip_disabled_plugin`: when set, metadata of a disabled or unknown plugin is accepted silently. `check_plugin_metadata` is the only caller using it; the route/service/plugin_config validation paths keep their existing warning/rejection behavior unchanged.

Behavior change: metadata entries of disabled or genuinely unknown plugins (and entries with a missing `id`) no longer produce warnings in any subsystem — same silent-skip behavior as releases before 3.14.1.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
