### PR TITLE
fix(xrpc): stream routes with xRPC protocols fail check_schema in HTTP workers when admin is disabled

### DIFF
--- a/apisix/stream/xrpc.lua
+++ b/apisix/stream/xrpc.lua
@@ -56,8 +56,11 @@ function _M.init()
         return
     end
 
-    if is_http and not local_conf.apisix.enable_admin then
-        -- we need to register xRPC protocols in HTTP only when Admin API is enabled
+    if is_http and not local_conf.apisix.enable_admin and
+        not local_conf.apisix.stream_proxy then
+        -- we need to register xRPC protocols in HTTP only when Admin API is enabled,
+        -- or when stream_proxy is configured, as the stream router initialized in
+        -- HTTP workers needs them to check the schema of stream routes
         return
     end
 

--- a/t/config-center-yaml/stream-route.t
+++ b/t/config-center-yaml/stream-route.t
@@ -35,10 +35,12 @@ _EOC_
 
     $block->set_value("yaml_config", $yaml_config);
 
-    $block->set_value("stream_enable", 1);
+    if (!defined $block->stream_conf_enable) {
+        $block->set_value("stream_enable", 1);
 
-    if (!$block->stream_request) {
-        $block->set_value("stream_request", "mmm");
+        if (!$block->stream_request) {
+            $block->set_value("stream_request", "mmm");
+        }
     }
 
     if (!$block->error_log && !$block->no_error_log) {
@@ -125,3 +127,79 @@ upstreams:
 "\x10\x0f\x00\x04\x4d\x51\x54\x54\x04\x02\x00\x3c\x00\x03\x66\x6f\x6f"
 --- stream_response
 hello world
+
+
+
+=== TEST 5: xRPC protocol works when stream_proxy is enabled and Admin API is disabled
+--- yaml_config
+apisix:
+    node_listen: 1984
+    enable_admin: false
+    stream_proxy:
+        tcp:
+            - 9100
+xrpc:
+    protocols:
+        - name: pingpong
+deployment:
+    role: data_plane
+    role_data_plane:
+        config_provider: yaml
+--- apisix_yaml
+stream_routes:
+  - server_addr: 127.0.0.1
+    server_port: 1985
+    id: 1
+    protocol:
+      name: pingpong
+    upstream:
+      nodes:
+        "127.0.0.1:1995": 1
+      type: roundrobin
+#END
+--- stream_conf_enable
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.req.read_body()
+            local sock = ngx.socket.tcp()
+            sock:settimeout(1000)
+            local ok, err = sock:connect("127.0.0.1", 1985)
+            if not ok then
+                ngx.log(ngx.ERR, "failed to connect: ", err)
+                return ngx.exit(503)
+            end
+
+            local bytes, err = sock:send(ngx.req.get_body_data())
+            if not bytes then
+                ngx.log(ngx.ERR, "send stream request error: ", err)
+                return ngx.exit(503)
+            end
+            while true do
+                local data, err = sock:receiveany(4096)
+                if not data then
+                    sock:close()
+                    break
+                end
+                ngx.print(data)
+            end
+        }
+    }
+--- stream_upstream_code
+            local sock = ngx.req.socket(true)
+            sock:settimeout(10)
+            while true do
+                local data = sock:receiveany(4096)
+                if not data then
+                    return
+                end
+                sock:send(data)
+            end
+--- request eval
+"POST /t
+pp\x02\x00\x00\x00\x00\x00\x00\x03ABC"
+--- response_body eval
+"pp\x02\x00\x00\x00\x00\x00\x00\x03ABC"
+--- no_error_log
+unknown protocol
+[error]

--- a/t/config-center-yaml/stream-route.t
+++ b/t/config-center-yaml/stream-route.t
@@ -203,3 +203,4 @@ pp\x02\x00\x00\x00\x00\x00\x00\x03ABC"
 --- no_error_log
 unknown protocol
 [error]
+[alert]


### PR DESCRIPTION
### Description

Since 3.16.0, stream routes that use an xRPC protocol are rejected by the HTTP workers' schema check when the Admin API is disabled (e.g. `role: data_plane` with the yaml/json config provider), and the error below is logged on every config load:

```
failed to check item data of [stream_routes] err:unknown protocol [redis]
```

This is a regression from #12996: `router.http_init_worker()` now initializes the stream router in HTTP workers whenever `apisix.stream_proxy` is configured, so the stream route checker (which calls `xrpc.check_schema()`) also runs there. But `xrpc.init()` still skips registering protocol schemas in the HTTP subsystem when the Admin API is disabled, leaving the protocol registry empty in those workers and causing every xRPC stream route to be dropped from their view.

The fix extends the guard in `xrpc.init()` to also register protocol schemas when `stream_proxy` is configured, mirroring the condition #12996 added in `router.lua`.

Same direction as the self-closed #13327 by @herwinz.

#### Which issue(s) this PR fixes:

Fixes #13325

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
