### PR TITLE
fix(core.request): stale entry kept in cached headers when set_header uses a different case

### DIFF
--- a/apisix/core/request.lua
+++ b/apisix/core/request.lua
@@ -161,14 +161,18 @@ local function modify_header(ctx, header_name, header_value, override)
         -- we can only update part of the cache instead of invalidating the whole
         a6_request.clear_request_header()
         if ctx and ctx.headers then
-            if override or not ctx.headers[header_name] then
-                ctx.headers[header_name] = header_value
+            -- the cached table from ngx.req.get_headers() stores keys in
+            -- lower case, so normalize the key to avoid leaving a stale
+            -- entry when the passed name uses a different case
+            local cache_key = str_lower(header_name)
+            if override or not ctx.headers[cache_key] then
+                ctx.headers[cache_key] = header_value
             else
-                local values = ctx.headers[header_name]
+                local values = ctx.headers[cache_key]
                 if type(values) == "table" then
                     table_insert(values, header_value)
                 else
-                    ctx.headers[header_name] = {values, header_value}
+                    ctx.headers[cache_key] = {values, header_value}
                 end
             end
         end

--- a/t/core/request.t
+++ b/t/core/request.t
@@ -542,3 +542,38 @@ same table: true
 decode_count: 1
 after set_body model: claude
 decode_count: 2
+
+
+
+=== TEST 18: set_header with a different case should not leave a stale entry in the cached headers
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            ngx.ctx.api_ctx = {}
+            local ctx = ngx.ctx.api_ctx
+
+            -- warm the headers cache
+            core.request.headers(ctx)
+
+            core.request.set_header(ctx, "X-Mixed-Case", "new")
+
+            local count = 0
+            local value
+            for k, v in pairs(core.request.headers(ctx)) do
+                if string.lower(k) == "x-mixed-case" then
+                    count = count + 1
+                    value = v
+                end
+            end
+            ngx.say("count: ", count)
+            ngx.say("value: ", value)
+            ngx.say("header: ", core.request.header(ctx, "X-Mixed-Case"))
+        }
+    }
+--- more_headers
+x-mixed-case: old
+--- response_body
+count: 1
+value: new
+header: new


### PR DESCRIPTION
### Description

When `core.request.set_header(ctx, name, value)` is called with a header name whose case differs from the cached key, the stale entry stays in the cached headers table alongside the new one. For example, after an ext-plugin rewrites the `Authorization` header in the request phase, `ext-plugin-post-resp` passes `core.request.headers(ctx)` to lua-resty-http, which iterates the table with `pairs()` and sends **both** the old and the new value upstream — and the upstream typically picks the old one (first header wins).

The cached table returned by `ngx.req.get_headers()` stores keys in lower case and only has an `__index` metamethod that normalizes lookups; there is no `__newindex`. So the partial cache update in `modify_header` (`ctx.headers[header_name] = header_value`) rawsets a new mixed-case key (e.g. `Authorization`) while the stale lower-case entry (`authorization`) keeps its old value. The bug affects any consumer that iterates the cached table; lookups via `core.request.header()` happen to return the new value because the rawget hits the mixed-case key first.

The fix normalizes the cache key to lower case before updating, matching how `ngx.req.get_headers()` stores keys, in both the `set_header` and `add_header` branches. Note that the `'_' → '-'` mapping in the metamethod's `__index` applies only to lookups, not to storage (a fresh `get_headers()` returns `lowcase_key` as-is), so lower-casing alone mirrors a refetch exactly.

#### Which issue(s) this PR fixes:

Fixes #13015

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
