### PR TITLE
fix(jwt-auth): reject malformed JWT signature instead of erroring

### DIFF
--- a/apisix/plugins/jwt-auth/parser.lua
+++ b/apisix/plugins/jwt-auth/parser.lua
@@ -223,8 +223,26 @@ end
 
 
 function _M.verify_signature(self, key)
-    return alg_verify[self.header.alg](self.raw_header .. "." ..
-               self.raw_payload, base64_decode(self.signature), key)
+    local verifier = alg_verify[self.header.alg]
+    if not verifier then
+        return false, "unsupported algorithm: " .. tostring(self.header.alg)
+    end
+
+    local signature = base64_decode(self.signature)
+    if not signature then
+        return false, "failed to decode signature"
+    end
+
+    -- the per-algorithm verifiers assert on signature length and key validity,
+    -- so guard with pcall to turn a malformed token into a clean rejection
+    -- instead of letting the error propagate as a 500 response
+    local ok, verified = pcall(verifier, self.raw_header .. "." .. self.raw_payload,
+                               signature, key)
+    if not ok then
+        return false, verified
+    end
+
+    return verified
 end
 
 

--- a/apisix/plugins/jwt-auth/parser.lua
+++ b/apisix/plugins/jwt-auth/parser.lua
@@ -32,6 +32,7 @@ local ipairs = ipairs
 local type = type
 local error = error
 local pcall = pcall
+local tostring = tostring
 
 local default_claims = {
     "nbf",
@@ -236,13 +237,15 @@ function _M.verify_signature(self, key)
     -- the per-algorithm verifiers assert on signature length and key validity,
     -- so guard with pcall to turn a malformed token into a clean rejection
     -- instead of letting the error propagate as a 500 response
-    local ok, verified = pcall(verifier, self.raw_header .. "." .. self.raw_payload,
-                               signature, key)
+    local ok, verified, verify_err = pcall(verifier,
+        self.raw_header .. "." .. self.raw_payload, signature, key)
     if not ok then
+        -- verifier raised: `verified` holds the caught error message
         return false, verified
     end
 
-    return verified
+    -- preserve the verifier's own (verified, err) return contract
+    return verified, verify_err
 end
 
 

--- a/t/plugin/jwt-auth.t
+++ b/t/plugin/jwt-auth.t
@@ -1431,14 +1431,14 @@ failed to verify jwt: 'exp' claim expired at Tue, 23 Jul 2019 08:28:21 GMT
 
 
 
-=== TEST 59: malformed signature (wrong length) must be rejected, not crash
+=== TEST 59: malformed signatures must be rejected with 401, not crash with 500
 --- config
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            -- ES256 consumer; the per-algorithm verifier asserts the signature
-            -- is 64 bytes, so a malformed signature used to raise a Lua error
-            -- and surface as a 500 instead of a clean 401.
+            -- ES256 consumer: the per-algorithm verifier asserts the signature
+            -- length and decodes it from base64url, so a malformed signature
+            -- used to raise a Lua error and surface as a 500 instead of a 401.
             local code, body = t('/apisix/admin/consumers',
                 ngx.HTTP_PUT,
                 [[{
@@ -1471,44 +1471,22 @@ failed to verify jwt: 'exp' claim expired at Tue, 23 Jul 2019 08:28:21 GMT
                 )
             assert(code < 300, body)
 
-            -- valid ES256 header + payload (key claim = user-key-es256), but the
-            -- signature "YWJj" decodes to 3 bytes instead of the required 64
-            local token = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9"
+            -- valid ES256 header + payload (key claim = user-key-es256), with two
+            -- malformed signatures: "YWJj" decodes to 3 bytes (not the required
+            -- 64), and "@@@@" is not valid base64url so decoding returns nil
+            local header_payload = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9"
                 .. ".eyJrZXkiOiJ1c2VyLWtleS1lczI1NiIsIm5iZiI6MTcyNzI3NDk4M30"
-                .. ".YWJj"
-
-            code, body = t('/hello?jwt=' .. token, ngx.HTTP_GET)
-            ngx.status = code
-            ngx.print(body)
+            for _, sig in ipairs({"YWJj", "@@@@"}) do
+                local rc, rb = t('/hello?jwt=' .. header_payload .. "." .. sig,
+                                 ngx.HTTP_GET)
+                assert(rc == 401, "signature '" .. sig .. "' expected 401 but got "
+                       .. tostring(rc))
+                assert(string.find(rb, "failed to verify jwt", 1, true), rb)
+            end
+            ngx.say("passed")
         }
     }
---- error_code: 401
 --- response_body
-{"message":"failed to verify jwt"}
---- no_error_log
-[error]
-
-
-
-=== TEST 60: non-base64url signature must be rejected, not crash
---- config
-    location /t {
-        content_by_lua_block {
-            local t = require("lib.test_admin").test
-            -- reuse the ES256 consumer/route from the previous test; the
-            -- signature "@@@@" is not valid base64url, so decoding returns nil
-            -- and used to raise a Lua error when indexed for its length
-            local token = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9"
-                .. ".eyJrZXkiOiJ1c2VyLWtleS1lczI1NiIsIm5iZiI6MTcyNzI3NDk4M30"
-                .. ".@@@@"
-
-            local code, body = t('/hello?jwt=' .. token, ngx.HTTP_GET)
-            ngx.status = code
-            ngx.print(body)
-        }
-    }
---- error_code: 401
---- response_body
-{"message":"failed to verify jwt"}
+passed
 --- no_error_log
 [error]

--- a/t/plugin/jwt-auth.t
+++ b/t/plugin/jwt-auth.t
@@ -1428,3 +1428,87 @@ GET /hello?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1c2VyLWtleSIsImV4
 {"message":"failed to verify jwt"}
 --- error_log
 failed to verify jwt: 'exp' claim expired at Tue, 23 Jul 2019 08:28:21 GMT
+
+
+
+=== TEST 59: malformed signature (wrong length) must be rejected, not crash
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            -- ES256 consumer; the per-algorithm verifier asserts the signature
+            -- is 64 bytes, so a malformed signature used to raise a Lua error
+            -- and surface as a 500 instead of a clean 401.
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "kerouac",
+                    "plugins": {
+                        "jwt-auth": {
+                            "key": "user-key-es256",
+                            "algorithm": "ES256",
+                            "public_key": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEVs/o5+uQbTjL3chynL4wXgUg2R9\nq9UU8I5mEovUf86QZ7kOBIjJwqnzD1omageEHWwHdBO6B+dFabmdT9POxg==\n-----END PUBLIC KEY-----"
+                        }
+                    }
+                }]]
+                )
+            assert(code < 300, body)
+
+            code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "jwt-auth": {}
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+            assert(code < 300, body)
+
+            -- valid ES256 header + payload (key claim = user-key-es256), but the
+            -- signature "YWJj" decodes to 3 bytes instead of the required 64
+            local token = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9"
+                .. ".eyJrZXkiOiJ1c2VyLWtleS1lczI1NiIsIm5iZiI6MTcyNzI3NDk4M30"
+                .. ".YWJj"
+
+            code, body = t('/hello?jwt=' .. token, ngx.HTTP_GET)
+            ngx.status = code
+            ngx.print(body)
+        }
+    }
+--- error_code: 401
+--- response_body
+{"message":"failed to verify jwt"}
+--- no_error_log
+[error]
+
+
+
+=== TEST 60: non-base64url signature must be rejected, not crash
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            -- reuse the ES256 consumer/route from the previous test; the
+            -- signature "@@@@" is not valid base64url, so decoding returns nil
+            -- and used to raise a Lua error when indexed for its length
+            local token = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9"
+                .. ".eyJrZXkiOiJ1c2VyLWtleS1lczI1NiIsIm5iZiI6MTcyNzI3NDk4M30"
+                .. ".@@@@"
+
+            local code, body = t('/hello?jwt=' .. token, ngx.HTTP_GET)
+            ngx.status = code
+            ngx.print(body)
+        }
+    }
+--- error_code: 401
+--- response_body
+{"message":"failed to verify jwt"}
+--- no_error_log
+[error]


### PR DESCRIPTION
### Description

`jwt-auth`'s custom JWT parser (`apisix/plugins/jwt-auth/parser.lua`) replaced `resty.jwt` verification with per-algorithm verifiers. `verify_signature` looked up the verifier and passed the decoded signature without guarding either path:

```lua
function _M.verify_signature(self, key)
    return alg_verify[self.header.alg](self.raw_header .. "." ..
               self.raw_payload, base64_decode(self.signature), key)
end
```

The per-algorithm verifiers `assert` on signature length and key validity, and `base64_decode` returns `nil` for an invalid base64url signature. So a token with a **wrong-length signature** (`assert(#signature == 64, "Signature must be 64 bytes.")`) or a **non-base64url signature** (`#nil` -> "attempt to get length of a nil value") makes the verifier raise a Lua error. Since the caller invokes `verify_signature` without a guard, the error propagates and the request returns **500 instead of 401** for any route protected by `jwt-auth`. An unauthenticated client that knows a valid consumer key can repeatedly trigger these internal errors and error-log noise.

This makes `verify_signature` defensive: guard the algorithm lookup and the base64url decode, and run the verifier under `pcall` so a malformed token is cleanly rejected as an invalid signature instead of crashing the request.

#### Which issue(s) this PR fixes:

N/A (reported via a private security scan)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change (no user-facing behavior or config change; internal robustness fix only)
- [x] I have verified that this change is backward compatible