### PR TITLE
fix(admin): encrypt_fields get double-encrypted on every PATCH

### DIFF
--- a/apisix/admin/resource.lua
+++ b/apisix/admin/resource.lua
@@ -17,6 +17,7 @@
 local core = require("apisix.core")
 local utils = require("apisix.admin.utils")
 local apisix_ssl = require("apisix.ssl")
+local apisix_plugin = require("apisix.plugin")
 local apisix_consumer = require("apisix.consumer")
 local tbl_deepcopy = require("apisix.core.table").deepcopy
 local setmetatable = setmetatable
@@ -420,6 +421,13 @@ function _M:patch(id, conf, sub_path, args)
 
     local node_value = res_old.body.node.value
     local modified_index = res_old.body.node.modifiedIndex
+
+    -- the encrypt_fields of the stored plugin conf are ciphertext, decrypt
+    -- them before merging, otherwise the check_conf below will encrypt them
+    -- again, resulting in fields that are encrypted multiple times
+    if apisix_plugin.enable_gde() then
+        utils.decrypt_params(apisix_plugin.decrypt_conf, res_old.body)
+    end
 
     if sub_path and sub_path ~= "" then
         if self.name == "ssls" then

--- a/apisix/admin/resource.lua
+++ b/apisix/admin/resource.lua
@@ -461,12 +461,14 @@ function _M:patch(id, conf, sub_path, args)
         utils.inject_timestamp(node_value, nil, conf)
     end
 
-    core.log.info("new conf: ", core.json.delay_encode(node_value, true))
-
     local ok, err = self:check_conf(id, node_value, true, typ, true)
     if not ok then
         return 400, err
     end
+
+    -- log after check_conf so the encrypt_fields are encrypted again and
+    -- the plaintext values decrypted above don't leak into the log
+    core.log.info("new conf: ", core.json.delay_encode(node_value, true))
 
     local ttl = nil
     if args then

--- a/t/admin/routes4.t
+++ b/t/admin/routes4.t
@@ -795,3 +795,153 @@ passed
 --- error_code: 400
 --- response_body eval
 qr/\{"error_msg":"the property is forbidden:.*"\}/
+
+
+
+=== TEST 23: PATCH must not re-encrypt the encrypted plugin fields (full body)
+--- yaml_config
+apisix:
+    data_encryption:
+        enable_encrypt_fields: true
+        keyring:
+            - edd1c9f0985e76a2
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/hello",
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        }
+                    },
+                    "plugins": {
+                        "csrf": {
+                            "key": "userkey",
+                            "expires": 1000000000
+                        }
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            -- patch an unrelated field twice
+            for i = 1, 2 do
+                local code, body = t('/apisix/admin/routes/1',
+                    ngx.HTTP_PATCH,
+                    '{"desc": "patch ' .. i .. '"}'
+                )
+                if code >= 300 then
+                    ngx.status = code
+                    ngx.say(body)
+                    return
+                end
+            end
+
+            -- get plugin conf from admin api, the key is decrypted
+            local code, message, res = t('/apisix/admin/routes/1',
+                ngx.HTTP_GET
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(message)
+                return
+            end
+            res = json.decode(res)
+            ngx.say(res.value.plugins["csrf"].key)
+
+            -- get plugin conf from etcd, the key is encrypted exactly once
+            local etcd = require("apisix.core.etcd")
+            local res = assert(etcd.get('/routes/1'))
+            ngx.say(res.body.node.value.plugins["csrf"].key)
+        }
+    }
+--- response_body
+userkey
+mt39FazQccyMqt4ctoRV7w==
+
+
+
+=== TEST 24: PATCH must not re-encrypt the encrypted plugin fields (sub path)
+--- yaml_config
+apisix:
+    data_encryption:
+        enable_encrypt_fields: true
+        keyring:
+            - edd1c9f0985e76a2
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/hello",
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        }
+                    },
+                    "plugins": {
+                        "csrf": {
+                            "key": "userkey",
+                            "expires": 1000000000
+                        }
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            -- patch an unrelated field twice via sub path
+            for i = 1, 2 do
+                local code, body = t('/apisix/admin/routes/1/desc',
+                    ngx.HTTP_PATCH,
+                    '"patch ' .. i .. '"'
+                )
+                if code >= 300 then
+                    ngx.status = code
+                    ngx.say(body)
+                    return
+                end
+            end
+
+            -- get plugin conf from admin api, the key is decrypted
+            local code, message, res = t('/apisix/admin/routes/1',
+                ngx.HTTP_GET
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(message)
+                return
+            end
+            res = json.decode(res)
+            ngx.say(res.value.plugins["csrf"].key)
+
+            -- get plugin conf from etcd, the key is encrypted exactly once
+            local etcd = require("apisix.core.etcd")
+            local res = assert(etcd.get('/routes/1'))
+            ngx.say(res.body.node.value.plugins["csrf"].key)
+
+            t('/apisix/admin/routes/1', ngx.HTTP_DELETE)
+        }
+    }
+--- response_body
+userkey
+mt39FazQccyMqt4ctoRV7w==


### PR DESCRIPTION
### Description

When data encryption (`data_encryption.enable_encrypt_fields`, enabled by default since 3.10.0) is on, every Admin API PATCH request re-encrypts the plugin fields declared in `encrypt_fields`, even though the stored values are already ciphertext. The ciphertext grows with every PATCH, while the data plane decrypts exactly once, so plugins end up running with a corrupted secret. For example, after PATCHing an unrelated field on a route that uses `ai-proxy`, the gateway starts sending a garbled API key upstream and gets 401 responses.

Root cause: the PATCH handler in `apisix/admin/resource.lua` reads the raw resource from etcd (where `encrypt_fields` hold ciphertext), merges the patch into it, and then passes the merged value to `check_conf`, which unconditionally calls `encrypt_conf`. So the already-encrypted fields get wrapped in another encryption layer on every PATCH.

Fix: decrypt the stored plugin conf right after fetching it from etcd and before the merge, reusing the same decryption helpers the GET path uses (`utils.decrypt_params` + `plugin.decrypt_conf`). The merged value is then plaintext, and `check_conf` re-encrypts it exactly once on write. Both the whole-body PATCH and the sub-path PATCH variants are covered.

Affected resource types: all PATCH-able resources whose `check_conf` encrypts plugin fields — routes, services, plugin_configs, global_rules and consumer_groups. Consumers, credentials and plugin_metadata do not support PATCH. Upstream `tls.client_key` is not affected, since its encryption is guarded by a PEM-prefix check and is therefore already idempotent.

#### Which issue(s) this PR fixes:

Fixes #13351

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
