### PR TITLE
fix(ci): verify LuaRocks tarball checksum before install

### DIFF
--- a/utils/linux-install-luarocks.sh
+++ b/utils/linux-install-luarocks.sh
@@ -23,9 +23,14 @@ if [ -z ${OPENRESTY_PREFIX} ]; then
 fi
 
 LUAROCKS_VER=3.12.0
-wget -q https://github.com/luarocks/luarocks/archive/v"$LUAROCKS_VER".tar.gz
-tar -xf v"$LUAROCKS_VER".tar.gz
-rm -f v"$LUAROCKS_VER".tar.gz
+LUAROCKS_SHA256=745e3c5df2f955ecaf60ba1361cfc224564ef7ec210e9a784a3858ae853e9f7c
+LUAROCKS_TARBALL=v"$LUAROCKS_VER".tar.gz
+
+wget -q -O "$LUAROCKS_TARBALL" https://github.com/luarocks/luarocks/archive/"$LUAROCKS_TARBALL"
+echo "$LUAROCKS_SHA256  $LUAROCKS_TARBALL" | sha256sum -c -
+
+tar -xf "$LUAROCKS_TARBALL"
+rm -f "$LUAROCKS_TARBALL"
 cd luarocks-"$LUAROCKS_VER" || exit
 
 OR_BIN="$OPENRESTY_PREFIX/bin/openresty"


### PR DESCRIPTION
### Description

`utils/linux-install-luarocks.sh` downloads the LuaRocks source tarball with `wget` and immediately extracts and builds it without any integrity verification. This means a corrupted download or a compromised/MITM'd fetch would be built and installed silently.

This change hardens the install step against supply-chain tampering by pinning the expected SHA256 of the LuaRocks tarball and verifying it with `sha256sum -c -` before extraction. If the checksum does not match, the script fails fast instead of building untrusted code.

**How:**
- Pin `LUAROCKS_SHA256` for the already-pinned `LUAROCKS_VER=3.12.0`.
- Download to an explicit output path, then verify the checksum, then extract.

The expected hash `745e3c5df2f955ecaf60ba1361cfc224564ef7ec210e9a784a3858ae853e9f7c` was confirmed by downloading `https://github.com/luarocks/luarocks/archive/v3.12.0.tar.gz` and computing its SHA256.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/blob/master/CONTRIBUTING.md#submit-a-proposal) first)