### PR TITLE
fix(batch-requests): missing the port number error when APISIX listens on a unix socket

### DIFF
--- a/apisix/plugins/batch-requests.lua
+++ b/apisix/plugins/batch-requests.lua
@@ -20,6 +20,7 @@ local plugin    = require("apisix.plugin")
 local ngx       = ngx
 local ipairs    = ipairs
 local pairs     = pairs
+local type      = type
 local str_find  = core.string.find
 local str_lower = string.lower
 
@@ -224,6 +225,39 @@ local function set_common_query(data)
 end
 
 
+-- When the request is received on a unix domain socket, $server_port is an
+-- empty string, so we fall back to the first TCP port in `apisix.node_listen`.
+-- The value read from the local conf is not normalized by the CLI, so it can
+-- be a plain port number, or an array of port numbers or `{ip, port}` tables.
+local function get_loopback_port()
+    local server_port = ngx.var.server_port
+    if server_port and server_port ~= "" then
+        return server_port
+    end
+
+    local local_conf = core.config.local_conf()
+    local node_listen = core.table.try_read_attr(local_conf, "apisix", "node_listen")
+    if type(node_listen) == "number" then
+        return node_listen
+    end
+
+    if type(node_listen) == "table" then
+        for _, value in ipairs(node_listen) do
+            if type(value) == "number" then
+                return value
+            end
+
+            if type(value) == "table" then
+                -- the port defaults to 9080 if not set, see `apisix/cli/ops.lua`
+                return value.port or 9080
+            end
+        end
+    end
+
+    return nil
+end
+
+
 local function batch_requests(ctx)
     local metadata = plugin.plugin_metadata(plugin_name)
     core.log.info("metadata: ", core.json.delay_encode(metadata))
@@ -269,9 +303,17 @@ local function batch_requests(ctx)
         }
     end
 
+    local server_port = get_loopback_port()
+    if not server_port then
+        return 503, {
+            error_msg = "this APISIX instance doesn't listen on a TCP port, " ..
+                        "but the batch-requests plugin needs one to loop back requests"
+        }
+    end
+
     local httpc = http.new()
     httpc:set_timeout(data.timeout)
-    local ok, err = httpc:connect("127.0.0.1", ngx.var.server_port)
+    local ok, err = httpc:connect("127.0.0.1", server_port)
     if not ok then
         return 500, {error_msg = "connect to apisix failed: " .. err}
     end

--- a/t/plugin/batch-requests.t
+++ b/t/plugin/batch-requests.t
@@ -1194,3 +1194,78 @@ qr/property \\"path\\" is required/
 GET /t
 --- response_body
 passed
+
+
+
+=== TEST 31: aggregate requests arriving via a unix domain socket
+--- config
+    listen unix:$TEST_NGINX_HTML_DIR/apisix.sock;
+
+    location = /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local http = require("resty.http")
+            local httpc = http.new()
+            local ok, err = httpc:connect("unix:$TEST_NGINX_HTML_DIR/apisix.sock")
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            local res, err = httpc:request({
+                method = "POST",
+                path = "/apisix/batch-requests",
+                headers = {
+                    ["Host"] = "127.0.0.1",
+                    ["Content-Type"] = "application/json",
+                },
+                body = [=[{
+                    "pipeline":[
+                    {
+                        "path": "/uds-b"
+                    },{
+                        "path": "/uds-c",
+                        "method": "PUT"
+                    }]
+                }]=],
+            })
+            if not res then
+                ngx.say("request failed: ", err)
+                return
+            end
+
+            local body, err = res:read_body()
+            if not body then
+                ngx.say("failed to read response body: ", err)
+                return
+            end
+
+            if res.status ~= 200 then
+                ngx.status = res.status
+                ngx.print(body)
+                return
+            end
+
+            local data = json.decode(body)
+            for _, resp in ipairs(data) do
+                ngx.say(resp.status, " ", resp.body)
+            end
+        }
+    }
+
+    location = /uds-b {
+        content_by_lua_block {
+            ngx.print("B")
+        }
+    }
+    location = /uds-c {
+        content_by_lua_block {
+            ngx.status = 201
+            ngx.print("C")
+        }
+    }
+--- request
+GET /t
+--- response_body
+200 B
+201 C


### PR DESCRIPTION
### Description

When APISIX listens on a unix domain socket (e.g. behind a sidecar or local proxy via `nginx_config.http_server_configuration_snippet`), calling the batch-requests endpoint fails with:

```json
{"error_msg":"connect to apisix failed: missing the port number"}
```

The plugin loops the pipelined requests back to APISIX itself with `httpc:connect("127.0.0.1", ngx.var.server_port)`, but nginx's `$server_port` is an empty string when the inbound request arrived over a unix socket, so the connect fails.

This PR makes the loopback connect fall back to the first TCP port found in `apisix.node_listen` from the local config when `$server_port` is empty. Since the value in the local conf is not normalized by the CLI, both config forms are handled: a plain port number, and an array of port numbers or `{ip, port}` tables. If no TCP port can be resolved at all, the plugin now returns a clear 503 explaining that batch-requests needs a TCP listener to loop back requests.

This follows the direction explored in the PoC #11782 (falling back to `node_listen`). An alternative would be to connect back over the unix socket itself, but the listening socket path is not exposed through any nginx variable, so that is left as possible future work.

Added a regression test that injects an extra `listen unix:` listener into the test server and sends the batch-requests call over it: it fails with the `missing the port number` error before the fix and passes after.

#### Which issue(s) this PR fixes:

Fixes #11781

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
