### PR TITLE
docs: add missing traffic-split stream plugin to config.yaml.example

### DIFF
--- a/conf/config.yaml.example
+++ b/conf/config.yaml.example
@@ -595,6 +595,7 @@ stream_plugins:                    # stream plugin list (sorted by priority)
   - ip-restriction                 # priority: 3000
   - limit-conn                     # priority: 1003
   - mqtt-proxy                     # priority: 1000
+  - traffic-split                  # priority: 966
   #- prometheus                    # priority: 500
   - syslog                         # priority: 401
   # <- recommend to use priority (0, 100) for your custom plugins


### PR DESCRIPTION
The example configuration file (conf/config.yaml.example) was missing the traffic-split plugin under the stream_plugins section. 

## Changes
1. conf/config.yaml.example: Added - traffic-split # priority: 966 to the stream_plugins list.
2. Preserved the file's descending priority order by inserting it between mqtt-proxy (1000) and prometheus (500).
3. Files Modified => `conf/config.yaml.example`
4. Verified the YAML syntax using PyYAML to ensure no indentation or formatting regressions were introduced.
