### PR TITLE
docs: fix misleading 'types of Plugin' wording in lifecycle diagram

### DIFF
--- a/docs/en/latest/architecture-design/apisix.md
+++ b/docs/en/latest/architecture-design/apisix.md
@@ -46,6 +46,6 @@ The diagram below shows how APISIX handles an incoming request and applies corre
 
 ## Plugin hierarchy
 
-The chart below shows the order in which different types of Plugin are applied to a request:
+The chart below shows the order in which different Plugin phases are applied to a request:
 
 ![flow-plugin-internal](https://raw.githubusercontent.com/apache/apisix/master/docs/assets/images/flow-plugin-internal.png)


### PR DESCRIPTION
## Summary

Fix misleading wording in the Plugin hierarchy section. The diagram shows plugin execution **phases**, not "types" of plugins.

## Changes

- `docs/en/latest/architecture-design/apisix.md`: Changed "different types of Plugin" to "different Plugin phases" to accurately describe what the diagram shows.

## Context

- Phases (init, rewrite, access, etc.) are lifecycle stages
- Each plugin implements callbacks for the phases it needs
- The diagram shows the order of phase execution, not plugin categories

Fixes #13166

## Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible