### PR TITLE
chore: ignore stray files left in the repo root by local test runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,10 @@ t/node_modules/
 release/*
 
 
-
-# redis snapshot dumped by a locally running redis-server during tests
+# files produced when running the test suite locally; never commit these
+# redis snapshot from a locally run redis-server (limit-* tests)
 dump.rdb
+# redis persistence dirs from the docker-compose redis services (--appendonly yes)
+/data/
+# telemetry dumped by the otel collector during tests
+ci/pod/otelcol-contrib/data-otlp.json

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ t/node_modules/
 release/*
 
 
+
+# redis snapshot dumped by a locally running redis-server during tests
+dump.rdb


### PR DESCRIPTION
### Description

Running the test suite from the repo root leaves a few artifacts behind that are easy to sweep into a commit by accident — `dump.rdb` already slipped into #13516 twice before eclint caught it. This started as just ignoring `dump.rdb`, but the same thing happens with a couple of other test outputs, so let's cover them all at once:

- `dump.rdb` — RDB snapshot from a locally run `redis-server` (limit-count / limit-req / limit-conn tests).
- `data/` — redis persistence dirs (`data/master`, `data/slave1`) created by the docker-compose redis services in `ci/pod/docker-compose.plugin.yml`, which run with `--appendonly yes`. They land at the repo root because the Makefile runs compose with `--project-directory $(CURDIR)`.
- `ci/pod/otelcol-contrib/data-otlp.json` — telemetry the otel collector writes into the rw-mounted config dir during the opentelemetry tests (the tests `tail` this file to assert spans).

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible