### PR TITLE
fix(nacos): declare nacos-stream shared dict in the stream subsystem

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -149,6 +149,7 @@ stream {
     lua_shared_dict lrucache-lock-stream {* stream.lua_shared_dict["lrucache-lock-stream"] *};
     lua_shared_dict etcd-cluster-health-check-stream {* stream.lua_shared_dict["etcd-cluster-health-check-stream"] *};
     lua_shared_dict worker-events-stream {* stream.lua_shared_dict["worker-events-stream"] *};
+    lua_shared_dict nacos-stream 10m;
 
     {% if enabled_discoveries["tars"] then %}
     lua_shared_dict tars-stream {* stream.lua_shared_dict["tars-stream"] *};

--- a/t/cli/test_discovery_nacos_stream.sh
+++ b/t/cli/test_discovery_nacos_stream.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+. ./t/cli/common.sh
+
+# stream is only fully supported on the customed apisix-nginx-module build
+exit_if_not_customed_nginx
+
+# Nacos discovery picks its shared dict by subsystem (discovery/nacos/init.lua):
+#     local dict_name = is_http and "nacos" or "nacos-stream"
+# and init_worker() raises 'lua_shared_dict "nacos-stream" not configured' when
+# the dict is missing. The `nacos-stream` dict must therefore be declared in the
+# stream block, otherwise enabling nacos discovery with the stream subsystem on
+# aborts the stream worker at startup.
+echo '
+apisix:
+    proxy_mode: stream
+    enable_admin: false
+    stream_proxy:
+        tcp:
+            - addr: 9100
+discovery:
+    nacos:
+        host:
+            - "http://127.0.0.1:8848"
+' > conf/config.yaml
+
+make run
+# wait until the stream worker accepts connections, which only happens after
+# init_worker has run -- avoids a race where the log is grepped too early
+wait_for_tcp 127.0.0.1 9100
+make stop
+
+# guard against a false pass if nginx never started for an unrelated reason
+if grep -q "\[emerg\]" logs/error.log; then
+    echo "failed: nginx did not start"
+    cat logs/error.log
+    exit 1
+fi
+
+if grep -q 'lua_shared_dict "nacos-stream" not configured' logs/error.log; then
+    echo "failed: nacos-stream shared dict is not declared in the stream subsystem"
+    exit 1
+fi
+
+echo "passed: nacos discovery initializes in the stream subsystem"


### PR DESCRIPTION
### TL;DR

Enabling nacos discovery while the **stream** subsystem is on crashes the stream worker at startup: `lua_shared_dict "nacos-stream" not configured`.

### Cause

nacos selects its shared dict by subsystem (`nacos` for http, `nacos-stream` for stream), but `nacos-stream` is declared **nowhere**. `init_worker()` errors out before any network call:

```
init_worker_by_lua error: .../nacos/init.lua:284: lua_shared_dict "nacos-stream" not configured
```

Introduced by the refactor in #13201.

### Fix

Declare `nacos-stream` in the `stream` block of `ngx_tpl.lua`, mirroring the unconditional `nacos` dict in the http block.

### Test

`t/cli/test_discovery_nacos_stream.sh`: starts APISIX with `proxy_mode: stream` + nacos discovery and asserts the stream worker initializes without the error (no nacos server needed — the dict check runs before any network call). Verified locally: passes with the fix, fails (exit 1, with the exact error above) without it.

The bug was missed because it lives in the production `ngx_tpl.lua` template + the stream `init_worker`, which the Test::Nginx `.t` suite bypasses (it uses its own nginx config); only the `t/cli` tests exercise the real generated config.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (N/A)
- [x] I have verified that the changes pass the existing tests
