### PR TITLE
fix(elasticsearch-logger): guard os.date against invalid index template

### DIFF
--- a/apisix/plugins/elasticsearch-logger.lua
+++ b/apisix/plugins/elasticsearch-logger.lua
@@ -24,6 +24,8 @@ local ngx_re          = ngx.re
 local str_format      = core.string.format
 local math_random     = math.random
 local os_date         = os.date
+local pcall           = pcall
+local type            = type
 local pairs           = pairs
 
 local plugin_name = "elasticsearch-logger"
@@ -204,8 +206,12 @@ end
 
 local function replace_time(m)
     local time_format = m[1]
-    local time = os_date(time_format)
-    if not time then
+    -- os.date returns a *table* (not a string) for the "*t"/"!*t" formats, and
+    -- on non-LuaJIT runtimes can raise on a bad strftime escape. Either way the
+    -- result would be stringified into a garbage index name, so require a
+    -- string and fall back to an empty replacement otherwise.
+    local ok, time = pcall(os_date, time_format)
+    if not ok or type(time) ~= "string" then
         core.log.error("failed to parse time format: ", time_format)
         return ""
     end

--- a/t/plugin/elasticsearch-logger2.t
+++ b/t/plugin/elasticsearch-logger2.t
@@ -464,3 +464,27 @@ qr/body: \{"index":\{"_index":"services-myservice-\d\d\d\d\.\d\d\.\d\d"\}\}/
 --- no_error_log
 failed to parse time format
 --- timeout: 5
+
+
+
+=== TEST 10: non-string time format (os.date "*t" returns a table) falls back
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.elasticsearch-logger")
+            -- "*t"/"!*t" make os.date return a table instead of a string;
+            -- replace_time must reject it rather than stringify a garbage index.
+            for _, fmt in ipairs({"*t", "!*t"}) do
+                local new = plugin._resolve_index_vars("prefix{" .. fmt .. "}suffix")
+                if new ~= "prefixsuffix" then
+                    ngx.say("error: " .. new)
+                    return
+                end
+            end
+            ngx.say("ok")
+        }
+    }
+--- response_body
+ok
+--- error_log
+failed to parse time format


### PR DESCRIPTION
### TL;DR

Dynamic Elasticsearch index names containing `{*t}` / `{!*t}` produced a garbage index like `services-table: 0x7f...` instead of being rejected.

### Cause

The `index` field supports `{time_format}` placeholders passed straight to `os.date`. The existing `if not time` guard assumes bad input returns `nil`, but on LuaJIT/OpenResty it never does:

- `{*t}` / `{!*t}` make `os.date` return a **table**, not a string. It then flows into `ngx.re.gsub`, which stringifies it into the index name.

### Fix

Require `os.date` to return a string before using it; otherwise log `failed to parse time format` and fall back to an empty replacement. Wrapped in `pcall` for defense-in-depth on non-LuaJIT runtimes (where `os.date` *can* raise on a bad escape).

```lua
local ok, time = pcall(os_date, time_format)
if not ok or type(time) ~= "string" then
    core.log.error("failed to parse time format: ", time_format)
    return ""
end
```

### Test

`t/plugin/elasticsearch-logger2.t` TEST 10: `prefix{*t}suffix` (and `{!*t}`) now resolves to `prefixsuffix` with a `failed to parse time format` log, instead of embedding a `table: 0x...` address.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (N/A)
- [x] I have verified that the changes pass the existing tests
