### PR TITLE
fix(brotli): don't log expected non-standard ETag at error level

### DIFF
--- a/apisix/plugins/brotli.lua
+++ b/apisix/plugins/brotli.lua
@@ -158,12 +158,15 @@ local function weak_etag_header()
         return
     end
 
-    local regex = [[^(W/)?"(.*)"$]]
+    local regex = [[^(W/)?"([^"]*)"$]]
     local matched, err = ngx.re.match(etag, regex, "jo")
-    if not matched or err then
-        -- not standard etag, no quote
+    if err then
+        core.log.error("failed to match etag: ", err)
+    end
+    if not matched then
+        -- non-standard etag (not quoted) or a match failure; it cannot be
+        -- weakened, so drop it
         core.response.set_header("Etag", nil)
-        core.log.error("no standard etag or regex match failed: ", err)
         return
     end
 

--- a/t/plugin/brotli.t
+++ b/t/plugin/brotli.t
@@ -833,8 +833,8 @@ Content-Encoding: br
 Vary:
 Etag:
 Content-Length:
---- error_log
-no standard etag or regex match failed:
+--- no_error_log
+[error]
 
 
 
@@ -888,3 +888,22 @@ Vary:
 Etag: W/"123456789"
 Last-Modified: Thu, 27 Nov 2025 00:32:33 GMT
 Content-Length:
+
+
+
+=== TEST 37: etag with embedded quotes is non-standard, clear it
+--- request
+POST /echo
+0123456789
+012345678
+--- more_headers
+Accept-Encoding: br
+Content-Type: text/html
+Etag: "12"34"
+--- response_headers
+Content-Encoding: br
+Vary:
+Etag:
+Content-Length:
+--- no_error_log
+[error]


### PR DESCRIPTION
### TL;DR

`brotli.lua` logged an **expected** non-quoted upstream ETag at `error` level (printing `... : nil`), spamming the error log.

### Cause

`weak_etag_header()` downgrades a strong `ETag` to a weak one (Brotli alters the body, so a strong validator no longer holds). When the upstream `ETag` is not a quoted string the regex simply does not match — an expected case — but the code logs it at `error` level with a nil `err`:

```lua
local matched, err = ngx.re.match(etag, regex, "jo")
if not matched or err then
    core.response.set_header("Etag", nil)
    core.log.error("no standard etag or regex match failed: ", err)  -- err is nil here
    return
end
```

### Fix

- Only log at `error` level when `ngx.re.match` actually returns an error; otherwise drop the ETag silently (behavior unchanged).
- Tighten the capture group from `(.*)` to `([^"]*)` so a malformed ETag containing internal quotes is treated as non-standard (and dropped) rather than weakened into another malformed value.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (N/A)
- [x] I have verified that the changes pass the existing tests
