### PR TITLE
fix(limit-count): redis-sentinel keepalive pools must not be shared across database/credentials

### DIFF
--- a/apisix-master-0.rockspec
+++ b/apisix-master-0.rockspec
@@ -32,7 +32,7 @@ description = {
 
 dependencies = {
     "lua-resty-ctxdump = 0.1-0",
-    "api7-lua-resty-redis-connector = 0.12.0",
+    "api7-lua-resty-redis-connector = 0.13.0",
     "lyaml = 6.2.8-1",
     "api7-lua-resty-dns-client = 7.1.1-0",
     "lua-resty-template = 2.0-1",

--- a/t/lib/test_redis.lua
+++ b/t/lib/test_redis.lua
@@ -23,7 +23,9 @@ local tonumber = tonumber
 
 local _M = {}
 
-local DEFAULT_PORTS = {6379, 5000, 5001, 5002, 5003, 5004, 5005, 5006}
+-- 6479 is the sentinel master used by the redis-sentinel policies; leftover
+-- counters there survive CI re-runs if it is not flushed
+local DEFAULT_PORTS = {6379, 6479, 5000, 5001, 5002, 5003, 5004, 5005, 5006}
 local DEFAULT_HOST = "127.0.0.1"
 
 local function log_warn(...)

--- a/t/plugin/limit-count-redis-sentinel.t
+++ b/t/plugin/limit-count-redis-sentinel.t
@@ -507,3 +507,118 @@ GET /hello
 --- error_code: 500
 --- error_log
 invalid username-password pair
+
+
+
+=== TEST 15: routes with different databases must not share connections
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            for i, db in ipairs({1, 2}) do
+                local code, body = t('/apisix/admin/routes/' .. i,
+                    ngx.HTTP_PUT,
+                    string.format([[{
+                        "uri": "/hello%s",
+                        "plugins": {
+                            "limit-count": {
+                                "count": 5,
+                                "time_window": 60,
+                                "rejected_code": 503,
+                                "key": "remote_addr",
+                                "policy": "redis-sentinel",
+                                "redis_sentinels": [
+                                     {"host": "127.0.0.1", "port": 26379}
+                                 ],
+                                 "redis_master_name": "mymaster",
+                                 "redis_role": "master",
+                                 "redis_database": %d
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        }
+                    }]], i == 1 and "" or "1", db)
+                    )
+                if code >= 300 then
+                    ngx.status = code
+                    ngx.say(body)
+                    return
+                end
+            end
+
+            ngx.sleep(0.5)
+
+            -- alternate requests between the two routes so that the second
+            -- route is served by a connection put into the keepalive pool
+            -- by the first one if the pool is wrongly shared
+            local http = require "resty.http"
+            local uris = {
+                "http://127.0.0.1:" .. ngx.var.server_port .. "/hello",
+                "http://127.0.0.1:" .. ngx.var.server_port .. "/hello1",
+            }
+            for i = 1, 2 do
+                for _, uri in ipairs(uris) do
+                    local httpc = http.new()
+                    local res, err = httpc:request_uri(uri)
+                    if not res then
+                        ngx.say("request failed: ", err)
+                        return
+                    end
+                    ngx.say(res.status, " remaining: ",
+                            res.headers["X-RateLimit-Remaining"] or "nil")
+                end
+            end
+
+            -- each database must contain only its own route's counter,
+            -- tracking exactly the 2 requests sent to that route
+            local redis = require "resty.redis"
+            for db = 1, 2 do
+                local red = redis:new()
+                red:set_timeout(1000)
+                local ok, err = red:connect("127.0.0.1", 6479)
+                if not ok then
+                    ngx.say("failed to connect: ", err)
+                    return
+                end
+                ok, err = red:select(db)
+                if not ok then
+                    ngx.say("failed to select db ", db, ": ", err)
+                    return
+                end
+                local keys, err = red:keys("plugin-limit-count*")
+                if not keys then
+                    ngx.say("failed to get keys: ", err)
+                    return
+                end
+                ngx.say("db ", db, " keys: ", #keys)
+                for _, key in ipairs(keys) do
+                    local counter, err = red:get(key)
+                    if err then
+                        ngx.say("failed to get counter of ", key, ": ", err)
+                        return
+                    end
+                    ngx.say("db ", db, " counter: ", counter)
+                    red:del(key)
+                end
+                red:close()
+            end
+
+            for i = 1, 2 do
+                t('/apisix/admin/routes/' .. i, ngx.HTTP_DELETE)
+            end
+        }
+    }
+--- timeout: 10
+--- response_body
+200 remaining: 4
+200 remaining: 4
+200 remaining: 3
+200 remaining: 3
+db 1 keys: 1
+db 1 counter: 2
+db 2 keys: 1
+db 2 counter: 2


### PR DESCRIPTION
### Description

Fixes #13454

Sentinel-mode counterpart of #13516. The `redis-sentinel` policy goes through api7-lua-resty-redis-connector, which skips AUTH/SELECT on connections reused from the keepalive pool while pooling by the default `host:port` key — so two routes pointing at the same sentinel-managed master with different `redis_database` or credentials cross-contaminate exactly like the plain-redis case: limit counters land in the wrong database.

This bumps the connector to 0.13.0 (api7/lua-resty-redis-connector#9), which derives the default pool name from everything the connection gets bound to at handshake time — resolved address, database, a credentials digest, and TLS options — while an explicit `connection_options.pool` still wins. Building the name from the resolved address keeps failover correct: a new master gets a new pool instead of reusing connections to the old one.

The regression test mirrors the plain-redis one: two routes on the same sentinel master with `redis_database` 1 and 2 must keep their counters in their own databases. Without the bump it fails with both keys landing in db 1. The test helper now also flushes the sentinel master (port 6479) so counters don't survive CI re-runs.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible