### PR TITLE
feat(opentelemetry): Supports injecting custom attributes into open t…

### DIFF
--- a/apisix/plugins/opentelemetry.lua
+++ b/apisix/plugins/opentelemetry.lua
@@ -184,6 +184,11 @@ local schema = {
                 type = "string",
                 minLength = 1,
             }
+        },
+        additional_custom_attributes = {
+            type = "object",
+            description = "custom attributes string kv map",
+            additionalProperties = {type = "string"},
         }
     }
 }
@@ -501,6 +506,21 @@ function _M.log(conf, api_ctx)
                 conf.additional_header_prefix_attributes,
                 core.request.headers(api_ctx),
                 true
+            )
+        end
+
+        if conf.additional_custom_attributes then
+            -- get keys
+            local custom_keys = {}
+            for key,_ in pairs(conf.additional_custom_attributes) do
+                table.insert(custom_keys, key)
+            end
+            -- inject attributes
+            inject_attributes(
+                    attributes,
+                    custom_keys,
+                    conf.additional_custom_attributes,
+                    false
             )
         end
 

--- a/docs/en/latest/plugins/opentelemetry.md
+++ b/docs/en/latest/plugins/opentelemetry.md
@@ -90,6 +90,7 @@ curl http://127.0.0.1:9180/apisix/admin/plugin_metadata/opentelemetry -H "X-API-
 | sampler.options.root.options.fraction | number        | False    | 0            | [0, 1]       | Root sampling ratio when the sampling strategy is `trace_id_ratio`. |
 | additional_attributes                 | array[string] | False    | -            | -            | Additional attributes appended to the trace span. Support [built-in variables](https://apisix.apache.org/docs/apisix/apisix-variable/) in values. |
 | additional_header_prefix_attributes   | array[string] | False    | -            | -            | Headers or header prefixes appended to the trace span's attributes. For example, use `x-my-header"` or `x-my-headers-*` to include all headers with the prefix `x-my-headers-`. |
+| additional_custom_attributes          | object        | False    | -            | -            | Custom attributes string key-value map appended to the trace span. Both keys and values must be strings. For example, `{"custom.key1": "value1", "custom.key2": "value2"}`. |
 
 ## Examples
 

--- a/docs/zh/latest/plugins/opentelemetry.md
+++ b/docs/zh/latest/plugins/opentelemetry.md
@@ -89,6 +89,7 @@ curl http://127.0.0.1:9180/apisix/admin/plugin_metadata/opentelemetry -H "X-API-
 | sampler.options.root.options.fraction | number        | 否       | 0            | [0, 1]       | `trace_id_ratio` root 采样策略的百分比|
 | additional_attributes                 | array[string] | 否       | -            | -            | 追加到 trace span 的额外属性，支持内置 NGINX 或 [APISIX 变量](https://apisix.apache.org/docs/apisix/apisix-variable/)。|
 | additional_header_prefix_attributes   | array[string] | 否       | -            | -            | 附加到跟踪范围属性的标头或标头前缀。例如，使用 `x-my-header"` 或 `x-my-headers-*` 来包含带有前缀 `x-my-headers-` 的所有标头。 |
+| additional_custom_attributes          | object        | 否       | -            | -            | 追加到 trace span 的自定义属性字符串键值映射。键和值都必须为字符串类型。例如，`{"custom.key1": "value1", "custom.key2": "value2"}`。 |
 
 ## 示例
 

--- a/t/plugin/opentelemetry.t
+++ b/t/plugin/opentelemetry.t
@@ -644,3 +644,63 @@ opentracing
 tail -n 1 ci/pod/otelcol-contrib/data-otlp.json
 --- response_body eval
 qr/.*x-injected-by-plugin.*test-value.*/
+
+
+
+=== TEST 29: set additional_custom_attributes
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "name": "route_name",
+                    "plugins": {
+                        "opentelemetry": {
+                            "sampler": {
+                                "name": "always_on"
+                            },
+                            "additional_custom_attributes": {
+                                "custom.attr1": "custom_value_1",
+                                "custom.attr2": "custom_value_2"
+                            }
+                        }
+                    },
+                    "uri": "/opentracing",
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+
+
+
+=== TEST 30: trigger opentelemetry with additional_custom_attributes
+--- request
+GET /opentracing
+--- more_headers
+X-Request-Id: 01010101010101010101010101010104
+--- wait: 2
+--- response_body
+opentracing
+
+
+
+=== TEST 31: check custom attributes in span
+--- exec
+tail -n 1 ci/pod/otelcol-contrib/data-otlp.json
+--- response_body eval
+qr/.*custom\.attr1.*custom_value_1.*custom\.attr2.*custom_value_2.*/


### PR DESCRIPTION
### Description

This PR adds support for injecting user-defined custom attributes into OpenTelemetry spans. Currently, the OpenTelemetry plugin only allows a fixed set of attributes. With this change, users can configure an `additional_custom_attributes` map (key-value pairs with string values) in the plugin configuration. These attributes are then merged into the span's attribute list using the existing `inject_attributes` helper.

The main changes are in `apisix/plugins/opentelemetry.lua`:

- Added schema definition for `additional_custom_attributes` as an object with string values.
- In the span creation logic, if `conf.additional_custom_attributes` is present, the keys are collected and passed to `inject_attributes` to populate the span attributes.

This enhancement allows users to attach arbitrary metadata (e.g., user ID, region, version) to traces without modifying the plugin code.

#### Which issue(s) this PR fixes:
Fixes # (no existing issue; this is a feature enhancement)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)