### PR TITLE
fix(loki-logger): resolve log labels per request to avoid label leakage

### DIFF
--- a/apisix/plugins/loki-logger.lua
+++ b/apisix/plugins/loki-logger.lua
@@ -245,7 +245,9 @@ function _M.log(conf, ctx)
     local labels = core.table.clone(conf.log_labels)
     for key, value in pairs(labels) do
         local new_val, err, n_resolved = core.utils.resolve_var(value, ctx.var)
-        if not err and n_resolved > 0 then
+        if err then
+            core.log.warn("failed to resolve label '", key, "' value '", value, "': ", err)
+        elseif n_resolved > 0 then
             labels[key] = new_val
         end
     end
@@ -265,9 +267,14 @@ function _M.log(conf, ctx)
         for _, entry in ipairs(entries) do
             local entry_labels = entry.loki_labels
             local log_time = entry.loki_log_time
-            -- clean logger internal fields before encoding the log line
+            -- remove logger internal fields so they don't leak into the encoded
+            -- log line, then restore them: the batch processor reuses the same
+            -- entry tables on retry, so they must survive a failed flush
             entry.loki_log_time = nil
             entry.loki_labels = nil
+            local line = core.json.encode(entry)
+            entry.loki_log_time = log_time
+            entry.loki_labels = entry_labels
 
             local key = gen_label_key(entry_labels)
             local stream = stream_by_key[key]
@@ -281,7 +288,7 @@ function _M.log(conf, ctx)
             end
 
             table_insert(stream.values, {
-                log_time, core.json.encode(entry)
+                log_time, line
             })
         end
 

--- a/apisix/plugins/loki-logger.lua
+++ b/apisix/plugins/loki-logger.lua
@@ -26,6 +26,8 @@ local ipairs       = ipairs
 local tostring     = tostring
 local math_random  = math.random
 local table_insert = table.insert
+local table_sort   = table.sort
+local table_concat = table.concat
 local ngx          = ngx
 local str_format   = core.string.format
 
@@ -153,6 +155,24 @@ function _M.check_schema(conf, schema_type)
 end
 
 
+-- build a stable, collision-resistant key for a resolved label set so entries
+-- sharing the exact same labels are grouped into a single Loki stream.
+local function gen_label_key(labels)
+    local keys = {}
+    for k in pairs(labels) do
+        keys[#keys + 1] = k
+    end
+    table_sort(keys)
+
+    local parts = new_tab(#keys, 0)
+    for i, k in ipairs(keys) do
+        parts[i] = k .. "=" .. labels[k]
+    end
+    -- NUL separator avoids collisions between distinct key/value boundaries
+    return table_concat(parts, "\0")
+end
+
+
 local function send_http_data(conf, log)
     local headers = conf.headers or {}
     headers = core.table.clone(headers)
@@ -218,41 +238,57 @@ function _M.log(conf, ctx)
     -- and then add 6 zeros by string concatenation
     entry.loki_log_time = tostring(ngx.req.start_time() * 1000) .. "000000"
 
-    if batch_processor_manager:add_entry(conf, entry, max_pending_entries) then
-        return
-    end
-
-    local labels = conf.log_labels
-
-    -- parsing possible variables in label value
+    -- resolve possible variables in label values per request and attach the
+    -- result to the entry. Clone first so the shared plugin conf is never
+    -- mutated, and resolve before the batch-processor early-return so every
+    -- entry carries its own labels (e.g. a per-request $service_name).
+    local labels = core.table.clone(conf.log_labels)
     for key, value in pairs(labels) do
         local new_val, err, n_resolved = core.utils.resolve_var(value, ctx.var)
         if not err and n_resolved > 0 then
             labels[key] = new_val
         end
     end
+    entry.loki_labels = labels
+
+    if batch_processor_manager:add_entry(conf, entry, max_pending_entries) then
+        return
+    end
 
     -- generate a function to be executed by the batch processor
     local func = function(entries)
-        -- build loki request data
-        local data = {
-            streams = {
-                {
-                    stream = labels,
+        -- group entries into Loki streams by their resolved label set so each
+        -- request is logged under its own labels instead of a single shared set
+        local streams = new_tab(1, 0)
+        local stream_by_key = {}
+
+        for _, entry in ipairs(entries) do
+            local entry_labels = entry.loki_labels
+            local log_time = entry.loki_log_time
+            -- clean logger internal fields before encoding the log line
+            entry.loki_log_time = nil
+            entry.loki_labels = nil
+
+            local key = gen_label_key(entry_labels)
+            local stream = stream_by_key[key]
+            if not stream then
+                stream = {
+                    stream = entry_labels,
                     values = new_tab(1, 0),
                 }
-            }
-        }
+                stream_by_key[key] = stream
+                table_insert(streams, stream)
+            end
 
-        -- add all entries to the batch
-        for _, entry in ipairs(entries) do
-            local log_time = entry.loki_log_time
-            entry.loki_log_time = nil -- clean logger internal field
-
-            table_insert(data.streams[1].values, {
+            table_insert(stream.values, {
                 log_time, core.json.encode(entry)
             })
         end
+
+        -- build loki request data
+        local data = {
+            streams = streams
+        }
 
         return send_http_data(conf, data)
     end

--- a/t/plugin/loki-logger.t
+++ b/t/plugin/loki-logger.t
@@ -472,14 +472,20 @@ passed
             local http = require("resty.http")
             local cjson = require("cjson")
 
-            -- both requests hit the same worker (worker_processes 1), so a buggy
+            -- all requests hit the same worker (worker_processes 1), so a buggy
             -- shared-conf / single-stream batch would freeze the first label and
-            -- stamp every line with it
-            for _, svc in ipairs({"svc-alpha", "svc-beta"}) do
+            -- stamp every line with it. the last request omits x-service-name
+            -- (boundary case): it must not inherit a prior request's label
+            local req_headers = {
+                { ["x-service-name"] = "svc-alpha" },
+                { ["x-service-name"] = "svc-beta" },
+                {},
+            }
+            for _, headers in ipairs(req_headers) do
                 local httpc = http.new()
                 local res, err = httpc:request_uri(
                     "http://127.0.0.1:" .. ngx.var.server_port .. "/hello",
-                    { headers = { ["x-service-name"] = svc } })
+                    { headers = headers })
                 assert(res, "request failed: " .. (err or ""))
                 assert(res.status == 200, "unexpected status: " .. res.status)
             end
@@ -499,8 +505,9 @@ passed
                 assert(err == nil, "fetch logs error: " .. (err or ""))
                 assert(data.status == "success",
                        "loki response error: " .. cjson.encode(data))
-                assert(#data.data.result > 0,
-                       "no log under label service=" .. svc .. ": " .. cjson.encode(data))
+                assert(#data.data.result == 1,
+                       "expected exactly one stream for service=" .. svc .. ": "
+                       .. cjson.encode(data))
 
                 local entry = data.data.result[1]
                 assert(entry.stream.service == svc,

--- a/t/plugin/loki-logger.t
+++ b/t/plugin/loki-logger.t
@@ -423,3 +423,100 @@ GET /hello
 hello world
 --- error_log
 go(): authorization: test1234
+
+
+
+=== TEST 17: setup route (per-request variable label)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "loki-logger": {
+                            "endpoint_addrs": ["http://127.0.0.1:3100"],
+                            "tenant_id": "tenant_1",
+                            "log_labels": {
+                                "service": "$http_x_service_name"
+                            },
+                            "batch_max_size": 1
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 18: hit route with first service name
+--- request
+GET /hello
+--- more_headers
+x-service-name: svc-alpha
+--- response_body
+hello world
+
+
+
+=== TEST 19: hit route with second service name (same route config)
+--- request
+GET /hello
+--- more_headers
+x-service-name: svc-beta
+--- response_body
+hello world
+
+
+
+=== TEST 20: each request is logged under its own resolved label
+--- config
+    location /t {
+        content_by_lua_block {
+            local cjson = require("cjson")
+            local loki = require("lib.grafana_loki")
+            local now = ngx.now() * 1000
+            local from = tostring(now - 10000) .. "000000"
+            local to = tostring(now) .. "000000"
+
+            -- both label values must resolve to their own stream; the second
+            -- request must NOT leak into the first request's frozen label set
+            for _, svc in ipairs({"svc-alpha", "svc-beta"}) do
+                local data, err = loki.fetch_logs_from_loki(from, to,
+                    { query = [[{service="]] .. svc .. [["} | json]] })
+
+                assert(err == nil, "fetch logs error: " .. (err or ""))
+                assert(data.status == "success",
+                       "loki response error: " .. cjson.encode(data))
+                assert(#data.data.result > 0,
+                       "no log under label service=" .. svc .. ": " .. cjson.encode(data))
+
+                local entry = data.data.result[1]
+                assert(entry.stream.service == svc,
+                       "expected stream service=" .. svc .. ": " .. cjson.encode(entry))
+                assert(entry.stream.request_headers_x_service_name == svc,
+                       "log line under service=" .. svc ..
+                       " belongs to another request: " .. cjson.encode(entry))
+            end
+
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed

--- a/t/plugin/loki-logger.t
+++ b/t/plugin/loki-logger.t
@@ -426,7 +426,7 @@ go(): authorization: test1234
 
 
 
-=== TEST 17: setup route (per-request variable label)
+=== TEST 17: setup route with a per-request variable label (same conf for all requests)
 --- config
     location /t {
         content_by_lua_block {
@@ -441,7 +441,7 @@ go(): authorization: test1234
                             "log_labels": {
                                 "service": "$http_x_service_name"
                             },
-                            "batch_max_size": 1
+                            "batch_max_size": 2
                         }
                     },
                     "upstream": {
@@ -465,38 +465,33 @@ passed
 
 
 
-=== TEST 18: hit route with first service name
---- request
-GET /hello
---- more_headers
-x-service-name: svc-alpha
---- response_body
-hello world
-
-
-
-=== TEST 19: hit route with second service name (same route config)
---- request
-GET /hello
---- more_headers
-x-service-name: svc-beta
---- response_body
-hello world
-
-
-
-=== TEST 20: each request is logged under its own resolved label
+=== TEST 18: two requests with different label values share one worker and must not leak
 --- config
     location /t {
         content_by_lua_block {
+            local http = require("resty.http")
             local cjson = require("cjson")
+
+            -- both requests hit the same worker (worker_processes 1), so a buggy
+            -- shared-conf / single-stream batch would freeze the first label and
+            -- stamp every line with it
+            for _, svc in ipairs({"svc-alpha", "svc-beta"}) do
+                local httpc = http.new()
+                local res, err = httpc:request_uri(
+                    "http://127.0.0.1:" .. ngx.var.server_port .. "/hello",
+                    { headers = { ["x-service-name"] = svc } })
+                assert(res, "request failed: " .. (err or ""))
+                assert(res.status == 200, "unexpected status: " .. res.status)
+            end
+
+            -- wait for the batch flush timer and Loki ingestion
+            ngx.sleep(2)
+
             local loki = require("lib.grafana_loki")
             local now = ngx.now() * 1000
             local from = tostring(now - 10000) .. "000000"
             local to = tostring(now) .. "000000"
 
-            -- both label values must resolve to their own stream; the second
-            -- request must NOT leak into the first request's frozen label set
             for _, svc in ipairs({"svc-alpha", "svc-beta"}) do
                 local data, err = loki.fetch_logs_from_loki(from, to,
                     { query = [[{service="]] .. svc .. [["} | json]] })


### PR DESCRIPTION
### Description

When `loki-logger` is configured with a dynamic label value (e.g. a global rule with `"log_labels": {"job": "apisix", "service_name": "$service_name"}`), the label leaked across services: one service's `service_name` got pinned onto every other service's logs, and the value froze after the first request.

Two defects combined:

1. **The shared plugin `conf.log_labels` was mutated in place.** While resolving variables, the resolved literal was written back into `conf.log_labels`. After the first request `"$service_name"` became a literal, and `core.utils.resolve_var` returns `n_resolved == 0` for a literal, so it was never re-resolved again, freezing the value.

2. **Labels were resolved once per batch processor and shared by all entries.** The resolution and the flush closure sat *after* the `batch_processor_manager:add_entry` early-return, so they ran only for the request that first created the processor. The closure built a single Loki stream and put every batched line into it under one label set.

This is worst with a **global rule**, which has exactly one `conf` (the batch processor is keyed by `plugin.conf_version(conf)`), so one shared processor per worker froze the label for all subsequent requests from any service.

### Fix

- **Clone** `conf.log_labels` before resolving, so the shared conf is never mutated.
- **Resolve per request, before the early-return**, and stamp the result onto the entry (`entry.loki_labels`), mirroring the existing `entry.loki_log_time`. The entry is the only channel through the batch processor.
- At flush time, **group entries into multiple Loki streams** keyed by their resolved label set, so each request is logged under its own labels. In Loki a stream is one unique label set, and the push payload supports multiple stream objects — the old code forced everything into one.
- The grouping key sorts label names and joins `key=value` pairs with a NUL separator (avoids relying on JSON key ordering).
- Internal fields (`loki_log_time`, `loki_labels`) are stripped from the entry before encoding the log line.

No schema change; pure runtime behavior.

### Tests

Added `t/plugin/loki-logger.t` TEST 17–20: one route with `log_labels.service = "$http_x_service_name"`, hit twice with different header values against the same conf, then assert Loki has a distinct stream per value and each line sits under its own label. Fails on the old frozen-label code, passes on the fix. These are integration tests needing a live Loki at `127.0.0.1:3100` (like the existing TEST 4/7/14).

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (no doc change needed — the documented behavior was already correct; this fix makes the implementation match it)
- [x] I have verified that the code passes lint (`luacheck`)