### PR TITLE
fix(limit-count): validate variable-resolved count/time_window bounds

### DIFF
--- a/apisix/plugins/limit-count/init.lua
+++ b/apisix/plugins/limit-count/init.lua
@@ -432,8 +432,13 @@ local function get_rules(ctx, conf)
 
     local rules = {}
     for index, rule in ipairs(conf.rules) do
-        -- an invalid count/time_window must reject, not silently skip the rule,
-        -- otherwise a client-controlled variable could disable rate limiting
+        -- a rule keyed on a var absent for this request just doesn't apply
+        local key, _, n_resolved = core.utils.resolve_var(rule.key, ctx.var)
+        if n_resolved == 0 then
+            goto CONTINUE
+        end
+        -- the rule applies, so an invalid count/time_window must reject, not
+        -- silently skip it, else a client-controlled var could disable limiting
         local count, err = resolve_var(ctx, rule.count)
         if err then
             return nil, err
@@ -441,11 +446,6 @@ local function get_rules(ctx, conf)
         local time_window, err2 = resolve_var(ctx, rule.time_window)
         if err2 then
             return nil, err2
-        end
-        -- a rule keyed on a var absent for this request just doesn't apply
-        local key, _, n_resolved = core.utils.resolve_var(rule.key, ctx.var)
-        if n_resolved == 0 then
-            goto CONTINUE
         end
         core.table.insert(rules, {
             count = count,

--- a/apisix/plugins/limit-count/init.lua
+++ b/apisix/plugins/limit-count/init.lua
@@ -389,9 +389,22 @@ local function resolve_var(ctx, value)
         if err then
             return nil, "could not resolve var for value: " .. original_value .. ", err: " .. err
         end
+        local resolved = value
         value = tonumber(value)
         if not value then
-            return nil, "resolved value is not a number: " .. tostring(value)
+            return nil, "resolved value is not a number: " .. tostring(resolved)
+        end
+        -- count/time_window must be positive integers, matching the schema
+        if value <= 0 then
+            return nil, "resolved value must be a positive number, got: " .. tostring(value)
+        end
+        if value ~= math_floor(value) then
+            return nil, "resolved value must be an integer, got: " .. tostring(value)
+        end
+        -- LuaJIT doubles lose integer precision above 2^53
+        if value > 9007199254740991 then
+            return nil, "resolved value exceeds safe integer range (2^53-1), got: "
+                        .. tostring(value)
         end
     end
     return value

--- a/apisix/plugins/limit-count/init.lua
+++ b/apisix/plugins/limit-count/init.lua
@@ -432,14 +432,17 @@ local function get_rules(ctx, conf)
 
     local rules = {}
     for index, rule in ipairs(conf.rules) do
+        -- an invalid count/time_window must reject, not silently skip the rule,
+        -- otherwise a client-controlled variable could disable rate limiting
         local count, err = resolve_var(ctx, rule.count)
         if err then
-            goto CONTINUE
+            return nil, err
         end
         local time_window, err2 = resolve_var(ctx, rule.time_window)
         if err2 then
-            goto CONTINUE
+            return nil, err2
         end
+        -- a rule keyed on a var absent for this request just doesn't apply
         local key, _, n_resolved = core.utils.resolve_var(rule.key, ctx.var)
         if n_resolved == 0 then
             goto CONTINUE

--- a/apisix/plugins/limit-count/init.lua
+++ b/apisix/plugins/limit-count/init.lua
@@ -389,10 +389,9 @@ local function resolve_var(ctx, value)
         if err then
             return nil, "could not resolve var for value: " .. original_value .. ", err: " .. err
         end
-        local resolved = value
         value = tonumber(value)
         if not value then
-            return nil, "resolved value is not a number: " .. tostring(resolved)
+            return nil, "resolved value is not a number"
         end
         -- count/time_window must be positive integers, matching the schema
         if value <= 0 then

--- a/t/plugin/limit-count-variable.t
+++ b/t/plugin/limit-count-variable.t
@@ -287,7 +287,7 @@ qr/\{\\x22rate_limiting_key\\x22:\\x22\/apisix\/routes\/1:\d+:test\.com\\x22,\\x
 
 
 
-=== TEST 9: reject out-of-bounds resolved count/time_window
+=== TEST 9: set up route with count/time_window from request variables
 --- config
     location /t {
         content_by_lua_block {
@@ -339,6 +339,36 @@ passed
                                                     headers = {["count"] = count}})
                 if res.status ~= 500 then
                     ngx.say("count=", count, " should be rejected with 500, got ", res.status)
+                    return
+                end
+            end
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- error_log
+resolved value must be a positive number
+resolved value must be an integer
+resolved value exceeds safe integer range
+
+
+
+=== TEST 11: a client-supplied 0/negative/fractional time_window is rejected, not bypassed
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require("resty.http")
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/hello"
+            local httpc = http.new()
+            for _, time_window in ipairs({"0", "-1", "1.5", "9999999999999999"}) do
+                local res = httpc:request_uri(uri, {method = "GET",
+                                                    headers = {["time_window"] = time_window}})
+                if res.status ~= 500 then
+                    ngx.say("time_window=", time_window, " should be rejected with 500, got ",
+                            res.status)
                     return
                 end
             end

--- a/t/plugin/limit-count-variable.t
+++ b/t/plugin/limit-count-variable.t
@@ -284,3 +284,72 @@ nginx_config:
 --- error_code: 200
 --- access_log eval
 qr/\{\\x22rate_limiting_key\\x22:\\x22\/apisix\/routes\/1:\d+:test\.com\\x22,\\x22rate_limiting_limit\\x22:2,\\x22rate_limiting_remaining\\x22:1,\\x22rate_limiting_reset\\x22:10}/
+
+
+
+=== TEST 9: reject out-of-bounds resolved count/time_window
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "methods": ["GET"],
+                        "plugins": {
+                            "limit-count": {
+                                "count": "${http_count ?? 2}",
+                                "time_window": "${http_time_window ?? 5}",
+                                "rejected_code": 503,
+                                "key_type": "var",
+                                "key": "remote_addr",
+                                "policy": "local"
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 10: a client-supplied 0/negative/fractional count is rejected, not bypassed
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require("resty.http")
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/hello"
+            local httpc = http.new()
+            for _, count in ipairs({"0", "-1", "1.5", "9999999999999999"}) do
+                local res = httpc:request_uri(uri, {method = "GET",
+                                                    headers = {["count"] = count}})
+                if res.status ~= 500 then
+                    ngx.say("count=", count, " should be rejected with 500, got ", res.status)
+                    return
+                end
+            end
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- error_log
+resolved value must be a positive number
+resolved value must be an integer
+resolved value exceeds safe integer range

--- a/t/plugin/limit-count-variable.t
+++ b/t/plugin/limit-count-variable.t
@@ -383,3 +383,72 @@ passed
 resolved value must be a positive number
 resolved value must be an integer
 resolved value exceeds safe integer range
+
+
+
+=== TEST 12: set up rules-mode route with count from a request variable
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "methods": ["GET"],
+                        "plugins": {
+                            "limit-count": {
+                                "rejected_code": 503,
+                                "rules": [
+                                    {
+                                        "key": "${http_user}",
+                                        "count": "${http_count ?? 2}",
+                                        "time_window": 60
+                                    }
+                                ]
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 13: rules-mode invalid count rejects, not silently skips the rule
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require("resty.http")
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/hello"
+            local httpc = http.new()
+            -- the rule's key resolves (user header present), so without bounds
+            -- validation a count of 0 would drop the rule and let the request pass
+            local res = httpc:request_uri(uri, {method = "GET",
+                                headers = {["user"] = "jack", ["count"] = "0"}})
+            if res.status ~= 500 then
+                ngx.say("invalid rule count should be rejected with 500, got ", res.status)
+                return
+            end
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- error_log
+resolved value must be a positive number


### PR DESCRIPTION
### Description

`limit-count` lets `count` and `time_window` be set from a request variable, e.g. `"count": "${http_count ?? 2}"`. At request time the resolved string was only coerced with `tonumber` and checked for being a number. It was never bounds-checked, so a client-supplied value of `0`, a negative, a fractional, or an out-of-range number bypassed the schema's `> 0` integer constraint:

- `0`/negative hit the limiter constructor's `assert(limit > 0 and window > 0)`, turning a client header into a request-time error.
- fractional/huge values skewed the limiter's math.

This mirrors the validation `limit-conn` already performs on its variable-resolved `conn`/`burst`: the resolved value must be a positive integer within the safe integer range (`2^53-1`). Invalid values are now rejected through the normal error path instead of reaching the limiter.

`limit-conn`'s identical gap was already fixed; this closes the same hole in `limit-count`.

#### Which issue(s) this PR fixes:

N/A (hardening; reported internally against the API7 fork)

### Compatibility

No valid configuration changes behavior: a request variable that resolves to a positive integer is handled exactly as before. There is one observable change at the out-of-spec edge:

- `0`/negative resolved values already errored at request time (via the limiter's `assert`); they now error through the normal path with a clearer message. Same client-visible outcome.
- fractional or out-of-range (`>2^53-1`) resolved values were previously **accepted and served** with skewed limiting math; they are now **rejected** (`rejected_code`/500). These values were never valid per the schema (`integer`, `> 0`) and produced incorrect limiting, so this is the correct behavior, but a client that was unknowingly sending such values and getting served will now be rejected.
- **rules mode**: previously a rule whose `count`/`time_window` resolved to an invalid value was silently skipped (`goto CONTINUE`), bypassing that rule's limit; it now rejects the request, the same as the non-rules path. A rule whose **key** does not resolve is still skipped, since such a rule legitimately does not apply to the request.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (docs already state `> 0`; behavior now matches)
- [x] I have verified that this change is backward compatible
