### PR TITLE
fix(response-rewrite): do not empty body when base64 secret is invalid

### DIFF
--- a/apisix/plugins/response-rewrite.lua
+++ b/apisix/plugins/response-rewrite.lua
@@ -294,12 +294,21 @@ function _M.body_filter(conf, ctx)
     end
 
     if conf.body then
-        ngx.arg[2] = true
+        local body = conf.body
         if conf.body_base64 then
-            ngx.arg[1] = ngx.decode_base64(conf.body)
-        else
-            ngx.arg[1] = conf.body
+            body = ngx.decode_base64(conf.body)
+            if not body then
+                -- conf.body may be a resolved secret reference whose value is
+                -- not valid base64; the config-time check is skipped for secret
+                -- references, so guard here instead of silently emptying the body.
+                core.log.error("response-rewrite: body is configured with ",
+                               "body_base64 = true but its value is not valid ",
+                               "base64; leaving the response body unchanged")
+                return
+            end
         end
+        ngx.arg[2] = true
+        ngx.arg[1] = body
     end
 end
 

--- a/t/secret/central-secret-refs.t
+++ b/t/secret/central-secret-refs.t
@@ -18,6 +18,7 @@ BEGIN {
     $ENV{TEST_HOST} = "test.example.com";
     $ENV{TEST_URI} = "/hello";
     $ENV{TEST_HEADER_VALUE} = "from-env";
+    $ENV{TEST_NOT_BASE64} = "@@@ not valid base64 @@@";
 }
 
 use t::APISIX 'no_plan';
@@ -374,3 +375,54 @@ openid-connect has required field client_secret that must be a string.
     }
 --- response_body
 success
+
+
+
+=== TEST 13: response-rewrite body_base64 with a secret-ref resolving to non-base64
+The config-time base64 check is skipped for secret references, so this only
+fails at runtime; the response body must be left unchanged rather than emptied.
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/rr-b64-secret",
+                    "plugins": {
+                        "proxy-rewrite": {
+                            "uri": "/hello"
+                        },
+                        "response-rewrite": {
+                            "body": "$env://TEST_NOT_BASE64",
+                            "body_base64": true
+                        }
+                    },
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        }
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+                return ngx.say(body)
+            end
+            ngx.say("success")
+        }
+    }
+--- response_body
+success
+
+
+
+=== TEST 14: invalid base64 secret leaves the upstream body unchanged and logs an error
+--- request
+GET /rr-b64-secret
+--- response_body
+hello world
+--- error_log
+its value is not valid base64


### PR DESCRIPTION
### Description

With `body_base64 = true` and `body` set to a **secret reference** (`$env://...`, `$secret://...`), the config-time base64 validation is **skipped** because the value is unknown until runtime. If the resolved secret is not valid base64, `ngx.decode_base64` returned `nil` and the response body was **silently set to empty** — no log, hard to diagnose.

In `body_filter`, when base64 decoding fails, this now logs an error and **leaves the upstream response body unchanged** instead of emptying it, mirroring the existing failure handling in the `filters` path of the same plugin. The body is only overwritten on a successful decode.

### Tests

`t/secret/central-secret-refs.t` TEST 13/14: a route configured with `body = $env://TEST_NOT_BASE64` (resolves to a non-base64 value) and `body_base64 = true`; the request returns the unchanged upstream body and an error is logged.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (N/A — bugfix, no config/behavior doc change)
- [x] I have verified that this change is backward compatible