### PR TITLE
fix(balancer): separate keepalive pool by referenced client cert

### DIFF
--- a/apisix/balancer.lua
+++ b/apisix/balancer.lua
@@ -398,8 +398,12 @@ do
                 local sni = ctx.var.upstream_host
                 pool = pool .. "#" .. sni
 
+                -- separate the pool by client cert so referenced SSL objects
+                -- don't share a connection
                 if up_conf.tls and up_conf.tls.client_cert then
                     pool = pool .. "#" .. up_conf.tls.client_cert
+                elseif up_conf.tls and up_conf.tls.client_cert_id then
+                    pool = pool .. "#" .. up_conf.tls.client_cert_id
                 end
             end
             pool_opt.pool = pool

--- a/t/node/upstream-keepalive-pool.t
+++ b/t/node/upstream-keepalive-pool.t
@@ -805,3 +805,140 @@ grpcurl -import-path ./t/grpc_server_example/proto -proto helloworld.proto -plai
 {
   "message": "Hello apisix"
 }
+
+
+
+=== TEST 19: upstreams with different client cert referenced by id
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin")
+            local test = require("lib.test_admin").test
+            local json = require("toolkit.json")
+            local ssl_cert = t.read_file("t/certs/mtls_client.crt")
+            local ssl_key = t.read_file("t/certs/mtls_client.key")
+            local ssl_cert2 = t.read_file("t/certs/apisix.crt")
+            local ssl_key2 = t.read_file("t/certs/apisix.key")
+
+            local code, body = test('/apisix/admin/ssls/1',
+                ngx.HTTP_PUT,
+                json.encode({type = "client", cert = ssl_cert, key = ssl_key})
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.print(body)
+                return
+            end
+
+            local code, body = test('/apisix/admin/ssls/2',
+                ngx.HTTP_PUT,
+                json.encode({type = "client", cert = ssl_cert2, key = ssl_key2})
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.print(body)
+                return
+            end
+
+            local code, body = test('/apisix/admin/upstreams/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "scheme": "https",
+                    "type": "roundrobin",
+                    "nodes": {
+                        "127.0.0.1:1983": 1
+                    },
+                    "keepalive_pool": {
+                        "size": 4
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.print(body)
+                return
+            end
+
+            local code, body = test('/apisix/admin/upstreams/2',
+                ngx.HTTP_PUT,
+                json.encode({
+                    scheme = "https",
+                    type = "roundrobin",
+                    nodes = {["127.0.0.1:1983"] = 1},
+                    tls = {client_cert_id = 1},
+                    keepalive_pool = {size = 8}
+                })
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.print(body)
+                return
+            end
+
+            local code, body = test('/apisix/admin/upstreams/3',
+                ngx.HTTP_PUT,
+                json.encode({
+                    scheme = "https",
+                    type = "roundrobin",
+                    nodes = {["127.0.0.1:1983"] = 1},
+                    tls = {client_cert_id = 2},
+                    keepalive_pool = {size = 16}
+                })
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.print(body)
+                return
+            end
+
+            for i = 1, 3 do
+                local code, body = test('/apisix/admin/routes/' .. i,
+                    ngx.HTTP_PUT,
+                    [[{
+                        "uri":"/hello/]] .. i .. [[",
+                        "plugins": {
+                            "proxy-rewrite": {
+                                "uri": "/hello"
+                            }
+                        },
+                        "upstream_id": ]] .. i .. [[
+                    }]])
+                if code >= 300 then
+                    ngx.status = code
+                    ngx.print(body)
+                    return
+                end
+            end
+        }
+    }
+--- response_body
+
+
+
+=== TEST 20: hit
+--- upstream_server_config
+    ssl_client_certificate ../../certs/mtls_ca.crt;
+    ssl_verify_client on;
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port
+
+            for i = 1, 12 do
+                local idx = (i % 3) + 1
+                local httpc = http.new()
+                local res, err = httpc:request_uri(uri .. "/hello/" .. idx)
+                if not res then
+                    ngx.say(err)
+                    return
+                end
+
+                if idx == 2 then
+                    assert(res.status == 200)
+                else
+                    assert(res.status == 400)
+                end
+            end
+        }
+    }


### PR DESCRIPTION
### Description

When an HTTPS/GRPCS upstream sets its client certificate via `tls.client_cert_id` (referencing an SSL object) rather than an inline `tls.client_cert`, the keepalive connection pool name did not include any cert identifier.

The pool name only appended `tls.client_cert` (the inline PEM). For upstreams referencing certs by id, that field is empty, so two upstreams pointing at the same backend host/port/SNI but using different `client_cert_id`s collapsed into the same pool and could reuse each other's already-established TLS connections.

This change appends `tls.client_cert_id` to the pool name when an inline cert is not present, so connections established with different referenced client certs are kept in separate pools.

A regression test in `t/node/upstream-keepalive-pool.t` sets up two upstreams to the same backend with different `client_cert_id`s and asserts their connections are not shared (it fails before this change and passes after).

#### Which issue(s) this PR fixes:
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)