### PR TITLE
fix(ai-proxy): don't abort Anthropic response on bad tool_call arguments

### DIFF
--- a/apisix/plugins/ai-protocols/converters/anthropic-messages-to-openai-chat.lua
+++ b/apisix/plugins/ai-protocols/converters/anthropic-messages-to-openai-chat.lua
@@ -650,8 +650,15 @@ function _M.convert_response(res_body, ctx)
             local input = {}
             if tc["function"] and type(tc["function"].arguments) == "string" then
                 local decoded, err = core.json.decode(tc["function"].arguments)
-                if decoded == nil then
-                    return nil, "invalid tool_call arguments: " .. (err or "decode error")
+                if type(decoded) ~= "table" then
+                    -- Upstream returned malformed or non-object tool_call
+                    -- arguments. Don't abort the whole response conversion --
+                    -- that would also drop already-collected text/thinking
+                    -- content; fall back to an empty object and log instead.
+                    core.log.warn("anthropic converter: failed to decode ",
+                                  "tool_call arguments, using empty input: ",
+                                  err or "not a JSON object")
+                    decoded = {}
                 end
                 input = decoded
             end

--- a/t/plugin/ai-proxy-anthropic.t
+++ b/t/plugin/ai-proxy-anthropic.t
@@ -1755,3 +1755,57 @@ X-AI-Fixture: anthropic/messages-streaming-with-cache.sse
 --- error_code: 200
 --- access_log eval
 qr/127\.0\.0\.1:1980 200 [\d.]+ \"\S+\" claude-3-5-sonnet-20241022 claude-3-5-sonnet-20241022 [\d.]+ 50 30 80 true false 0 \S* 200 100 0/
+
+
+
+=== TEST 52: malformed tool_call arguments fall back to empty input instead of aborting
+An OpenAI-compatible upstream may emit tool_call arguments that are not valid
+JSON (or not a JSON object). The converter must not abort the whole response --
+which would also drop already-collected text/thinking content -- but fall back
+to an empty input object and log a warning.
+--- config
+    location /t {
+        content_by_lua_block {
+            local converter = require("apisix.plugins.ai-protocols.converters.anthropic-messages-to-openai-chat")
+            local ctx = { var = { llm_model = "gpt-4o" } }
+
+            local res, err = converter.convert_response({
+                id = "msg_1",
+                choices = {{
+                    message = {
+                        content = "partial answer",
+                        tool_calls = {{
+                            id = "call_1",
+                            type = "function",
+                            ["function"] = { name = "do_it", arguments = "{not valid json" },
+                        }},
+                    },
+                    finish_reason = "tool_calls",
+                }},
+                usage = { prompt_tokens = 10, completion_tokens = 5 },
+            }, ctx)
+
+            assert(res ~= nil, "conversion must not abort: " .. tostring(err))
+
+            local has_text, has_tool = false, false
+            for _, c in ipairs(res.content) do
+                if c.type == "text" and c.text == "partial answer" then
+                    has_text = true
+                end
+                if c.type == "tool_use" then
+                    has_tool = true
+                    assert(type(c.input) == "table", "input is an object")
+                    assert(next(c.input) == nil, "input is an empty object")
+                    assert(c.name == "do_it", "tool name preserved")
+                end
+            end
+            assert(has_text, "already-collected text content preserved")
+            assert(has_tool, "tool_use block still emitted")
+
+            ngx.say("OK")
+        }
+    }
+--- response_body
+OK
+--- error_log
+failed to decode tool_call arguments

--- a/t/plugin/ai-proxy-anthropic.t
+++ b/t/plugin/ai-proxy-anthropic.t
@@ -1895,3 +1895,50 @@ to an empty input object and log a warning.
 OK
 --- error_log
 failed to decode tool_call arguments
+
+
+
+=== TEST 55: tool_call arguments that decode to non-object fall back to empty input
+Valid JSON that is not an object (number, string, boolean) should also trigger
+the empty-object fallback and log "not a JSON object".
+--- config
+    location /t {
+        content_by_lua_block {
+            local converter = require("apisix.plugins.ai-protocols.converters.anthropic-messages-to-openai-chat")
+            local ctx = { var = { llm_model = "gpt-4o" } }
+
+            local res, err = converter.convert_response({
+                id = "msg_1",
+                choices = {{
+                    message = {
+                        content = "answer",
+                        tool_calls = {{
+                            id = "call_1",
+                            type = "function",
+                            ["function"] = { name = "do_it", arguments = "123" },
+                        }},
+                    },
+                    finish_reason = "tool_calls",
+                }},
+                usage = { prompt_tokens = 10, completion_tokens = 5 },
+            }, ctx)
+
+            assert(res ~= nil, "conversion must not abort: " .. tostring(err))
+
+            local has_tool = false
+            for _, c in ipairs(res.content) do
+                if c.type == "tool_use" then
+                    has_tool = true
+                    assert(type(c.input) == "table", "input is an object")
+                    assert(next(c.input) == nil, "input is an empty object")
+                end
+            end
+            assert(has_tool, "tool_use block emitted")
+
+            ngx.say("OK")
+        }
+    }
+--- response_body
+OK
+--- error_log
+not a JSON object

--- a/t/plugin/ai-proxy-anthropic.t
+++ b/t/plugin/ai-proxy-anthropic.t
@@ -1925,14 +1925,18 @@ the empty-object fallback and log "not a JSON object".
 
             assert(res ~= nil, "conversion must not abort: " .. tostring(err))
 
-            local has_tool = false
+            local has_text, has_tool = false, false
             for _, c in ipairs(res.content) do
+                if c.type == "text" and c.text == "answer" then
+                    has_text = true
+                end
                 if c.type == "tool_use" then
                     has_tool = true
                     assert(type(c.input) == "table", "input is an object")
                     assert(next(c.input) == nil, "input is an empty object")
                 end
             end
+            assert(has_text, "already-collected text content preserved")
             assert(has_tool, "tool_use block emitted")
 
             ngx.say("OK")


### PR DESCRIPTION
### Description

In the Anthropic-messages → OpenAI-chat converter, when an OpenAI-compatible upstream returns `tool_call` arguments that are **not valid JSON** (or decode to a non-object such as a number/string), `convert_response` did `return nil, "invalid tool_call arguments: ..."`. This **aborts the entire non-streaming response conversion** and drops any already-collected text/thinking content — the client receives nothing instead of a partial-but-usable message.

This patch falls back to an empty input object (`{}`) and logs a warning, so the rest of the message (text, other tool calls) is still delivered. Anthropic's `tool_use.input` must be an object, so non-object decoded values are handled the same way as a decode failure.

Added `t/plugin/ai-proxy-anthropic.t` TEST 52 covering malformed `arguments`: conversion still returns, text content is preserved, `tool_use.input` is an empty object, and a warning is logged.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have verified that this change is backward compatible