### PR TITLE
test(openid-connect): stop logout tests from calling live IdPs

### DIFF
--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -501,6 +501,11 @@ end
 function _M._well_known_openid_configuration_with_end_session()
     local t = require("lib.test_admin")
     local openid_data = json_decode(t.read_file("t/plugin/openid-connect/configuration.json"))
+    if not openid_data then
+        ngx.status = 500
+        ngx.say("failed to decode openid discovery fixture")
+        return
+    end
     openid_data.end_session_endpoint = "https://samples.auth0.com/v2/logout"
     ngx.say(json_encode(openid_data))
 end

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -496,6 +496,15 @@ function _M._well_known_openid_configuration()
     ngx.say(openid_data)
 end
 
+-- Same discovery document but advertising an end_session_endpoint, so the
+-- openid-connect logout flow can be exercised without reaching a live provider.
+function _M._well_known_openid_configuration_with_end_session()
+    local t = require("lib.test_admin")
+    local openid_data = json_decode(t.read_file("t/plugin/openid-connect/configuration.json"))
+    openid_data.end_session_endpoint = "https://samples.auth0.com/v2/logout"
+    ngx.say(json_encode(openid_data))
+end
+
 function _M.google_logging_token()
     local args = ngx.req.get_uri_args()
     local args_token_type = args.token_type or "Bearer"

--- a/t/plugin/openid-connect.t
+++ b/t/plugin/openid-connect.t
@@ -1384,9 +1384,10 @@ x-userinfo: ey.*
                             "openid-connect": {
                                 "client_id": "kbyuFDidLLm280LIwVFiazOqjO3ty8KH",
                                 "client_secret": "60Op4HFM0I8ajz0WdiStAbziZ-VFQttXuxixHHs2R7r7-CW8GR79l-mmLqMhc-Sa",
-                                "discovery": "https://samples.auth0.com/.well-known/openid-configuration",
+                                "discovery": "http://127.0.0.1:1980/.well-known/openid-configuration",
                                 "redirect_uri": "https://iresty.com",
                                 "post_logout_redirect_uri": "https://iresty.com",
+                                "ssl_verify": false,
                                 "scope": "openid profile",
                                 "session": {
                                     "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
@@ -1414,8 +1415,7 @@ passed
 
 
 
-=== TEST 36: Check whether auth0 can redirect normally using post_logout_redirect_uri configuration
---- custom_trusted_cert: /etc/ssl/certs/ca-certificates.crt
+=== TEST 36: Redirect to post_logout_redirect_uri when provider has no end_session_endpoint
 --- config
     location /t {
         content_by_lua_block {
@@ -1424,9 +1424,9 @@ passed
             local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/logout"
             local res, err = httpc:request_uri(uri, {method = "GET"})
             ngx.status = res.status
-            local location = res.headers['Location']
-            if location and string.find(location, 'https://iresty.com') ~= -1 and
-                string.find(location, 'post_logout_redirect_uri=https://iresty.com') ~= -1 then
+            local location = ngx.unescape_uri(res.headers['Location'] or "")
+            if location:find('https://iresty.com', 1, true) and
+                location:find('post_logout_redirect_uri=https://iresty.com', 1, true) then
                 ngx.say(true)
             end
         }
@@ -1447,11 +1447,12 @@ true
                  ngx.HTTP_PUT,
                  [[{ "plugins": {
                             "openid-connect": {
-                                "client_id": "942299072001-vhduu1uljmdhhbbp7g22m3qsmo246a75.apps.googleusercontent.com",
-                                "client_secret": "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",
-                                "discovery": "https://accounts.google.com/.well-known/openid-configuration",
+                                "client_id": "kbyuFDidLLm280LIwVFiazOqjO3ty8KH",
+                                "client_secret": "60Op4HFM0I8ajz0WdiStAbziZ-VFQttXuxixHHs2R7r7-CW8GR79l-mmLqMhc-Sa",
+                                "discovery": "http://127.0.0.1:1980/.well-known/openid-configuration-with-end-session",
                                 "redirect_uri": "https://iresty.com",
                                 "post_logout_redirect_uri": "https://iresty.com",
+                                "ssl_verify": false,
                                 "scope": "openid profile",
                                 "session": {
                                     "secret": "jwcE5v3pM9VhqLxmxFOH9uZaLo8u7KQK"
@@ -1479,8 +1480,7 @@ passed
 
 
 
-=== TEST 38: Check whether google can redirect normally using post_logout_redirect_uri configuration
---- custom_trusted_cert: /etc/ssl/certs/ca-certificates.crt
+=== TEST 38: Redirect to end_session_endpoint with post_logout_redirect_uri when provider exposes it
 --- config
     location /t {
         content_by_lua_block {
@@ -1489,9 +1489,9 @@ passed
             local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/logout"
             local res, err = httpc:request_uri(uri, {method = "GET"})
             ngx.status = res.status
-            local location = res.headers['Location']
-            if location and string.find(location, 'https://iresty.com') ~= -1 and
-                string.find(location, 'post_logout_redirect_uri=https://iresty.com') ~= -1 then
+            local location = ngx.unescape_uri(res.headers['Location'] or "")
+            if location:find('https://samples.auth0.com/v2/logout', 1, true) and
+                location:find('post_logout_redirect_uri=https://iresty.com', 1, true) then
                 ngx.say(true)
             end
         }


### PR DESCRIPTION
### Description

`t/plugin/openid-connect.t` TEST 36 and TEST 38 fetch the OIDC discovery
document from the **live** `samples.auth0.com` / `accounts.google.com`
endpoints. On CI runners that cannot validate the upstream TLS certificate
this fails deterministically (it is environmental, reruns do not help):

```
accessing discovery url (https://samples.auth0.com/.well-known/openid-configuration)
failed: 20: unable to get local issuer certificate
... openid-connect exits with http status code 503
```

Example failure (linux_openresty `t/plugin/[l-z]*.t` bucket):
https://github.com/apache/apisix/actions/runs/28147860875/job/83374909107

This PR removes the external dependency by pointing both tests at the in-tree
mock discovery already served on `127.0.0.1:1980`, so the logout flow is
exercised entirely locally:

- **TEST 36** keeps using the existing discovery document (no
  `end_session_endpoint`) and covers the `redirect_after_logout_uri` path.
- **TEST 38** uses a new mock endpoint that advertises an
  `end_session_endpoint`, covering the `end_session_endpoint` path which was
  previously not tested at all.

It also fixes the assertions. The old checks used
`string.find(location, ...) ~= -1`, which is **always true** (`string.find`
returns `nil` or a number, never `-1`), so the redirect target was never
actually validated — and `string.find` was treating the expected value as a
Lua pattern. The assertions now unescape the `Location` header and match with
a plain-text `find`, so they verify the real redirect (including the
percent-encoded `post_logout_redirect_uri`).

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change (test-only change)
- [x] I have updated the documentation to reflect this change (n/a)
- [x] I have verified that this change is backward compatible (test-only change)