### PR TITLE
fix(cas-auth): stop SLO callback POST from being proxied upstream

### DIFF
--- a/apisix/plugins/cas-auth.lua
+++ b/apisix/plugins/cas-auth.lua
@@ -395,6 +395,8 @@ function _M.access(conf, ctx)
             local _, user = unpack_entry(entry)
             core.log.info("cas-auth: SLO session deleted for user=", user or "<unknown>")
         end
+        -- SLO callback ends here; never proxy the IdP's logout POST upstream
+        return ngx.HTTP_OK
     else
         local opts = session_opts(conf)
         local session_id = get_cookie(ctx, opts.cookie_name)

--- a/docs/en/latest/plugins/cas-auth.md
+++ b/docs/en/latest/plugins/cas-auth.md
@@ -98,6 +98,8 @@ Once this is done, the user is redirected to the original URL they wanted to vis
 
 Later, the user could visit `logout_uri` to start logout process. The user would be redirected to `idp_uri` to do logout.
 
+The IdP may also send a single logout (SLO) `POST` request to `cas_callback_uri`. The Plugin handles such requests itself (invalidating the matching session) and never forwards them to the upstream.
+
 Note that, `cas_callback_uri` and `logout_uri` should be
 either full qualified address (e.g. `http://127.0.0.1:9080/anything/logout`),
 or path only (e.g. `/anything/logout`), but it is recommended to be path only to keep consistent.

--- a/t/plugin/cas-auth.t
+++ b/t/plugin/cas-auth.t
@@ -878,3 +878,74 @@ passed
     }
 --- response_body
 passed
+
+
+
+=== TEST 21: add route whose upstream is a closed port for the SLO fall-through test
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+
+            local code, body = t('/apisix/admin/routes/cas-slo-noproxy',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "methods": ["GET", "POST"],
+                        "host": "127.0.0.21",
+                        "priority": 10,
+                        "plugins": {
+                            "cas-auth": {
+                                "idp_uri": "http://127.0.0.1:8080/realms/test/protocol/cas",
+                                "cas_callback_uri": "/cas_callback",
+                                "logout_uri": "/logout",
+                                "cookie": {
+                                    "secret": "0123456789abcdef0123456789abcdef",
+                                    "secure": false
+                                }
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {"127.0.0.1:1": 1},
+                            "type": "roundrobin"
+                        },
+                        "uri": "/*"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 22: well-formed SLO POST stops at the plugin and is never proxied upstream
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+            local base = "http://127.0.0.1:" .. ngx.var.server_port
+
+            -- A POST carrying a valid SessionIndex must be terminated by the
+            -- plugin (200), not fall through to the upstream. The upstream is a
+            -- closed port, so any fall-through would surface as a 502.
+            local res, err = httpc:request_uri(base .. "/cas_callback", {
+                method = "POST",
+                headers = { ["Host"] = "127.0.0.21" },
+                body = "<samlp:SessionIndex>ST-no-such-session</samlp:SessionIndex>",
+            })
+            assert(res, "request failed: " .. tostring(err))
+            assert(res.status == 200,
+                "expected 200 from plugin, got " .. res.status ..
+                " (non-200 means the SLO POST was proxied upstream)")
+
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed


### PR DESCRIPTION
### Description

The `cas-auth` plugin protects routes and also captures the configured `cas_callback_uri` so it can handle the IdP's single-logout (SLO) `POST` callback.

In `_M.access`, the SLO `POST` branch parses the SAML `SessionIndex`, optionally deletes the matching session, and then **falls through** the function. Because the branch has no terminating `return`, `_M.access` returns `nil`, which APISIX treats as "continue the phase chain", so the IdP's logout `POST` is proxied to the upstream unauthenticated.

This patch ends the SLO branch with an explicit `return ngx.HTTP_OK` after the logout bookkeeping, so the callback `POST` is fully handled by the plugin and never reaches the upstream.

### Fixes

- `apisix/plugins/cas-auth.lua`: terminate the SLO `POST` branch with `200`.
- `t/plugin/cas-auth.t`: regression test sending a well-formed SLO `POST` to a route whose upstream is a closed port; it must return `200` from the plugin rather than a `502` from a fall-through proxy attempt.
- `docs/en/latest/plugins/cas-auth.md`: document that SLO `POST` callbacks are handled by the plugin and not forwarded upstream.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible