### PR TITLE
fix(opentelemetry): recreate tracer object after plugin metadata changed

### DIFF
--- a/apisix/plugins/opentelemetry.lua
+++ b/apisix/plugins/opentelemetry.lua
@@ -341,7 +341,8 @@ function _M.rewrite(conf, api_ctx)
     local plugin_info = metadata.value
     local vars = api_ctx.var
 
-    local tracer, err = core.lrucache.plugin_ctx(lrucache, api_ctx, nil,
+    -- key the cache on modifiedIndex so the tracer is rebuilt when metadata changes
+    local tracer, err = core.lrucache.plugin_ctx(lrucache, api_ctx, metadata.modifiedIndex,
                                                 create_tracer_obj, conf, plugin_info)
     if not tracer then
         core.log.error("failed to fetch tracer object: ", err)

--- a/apisix/plugins/opentelemetry.lua
+++ b/apisix/plugins/opentelemetry.lua
@@ -450,7 +450,8 @@ local function inject_core_spans(root_span_ctx, api_ctx, conf)
         additional_attributes = conf.additional_attributes,
         additional_header_prefix_attributes = conf.additional_header_prefix_attributes
     }
-    local tracer, err = core.lrucache.plugin_ctx(lrucache, api_ctx, nil,
+    -- key the cache on modifiedIndex so the tracer is rebuilt when metadata changes
+    local tracer, err = core.lrucache.plugin_ctx(lrucache, api_ctx, metadata.modifiedIndex,
                                                 create_tracer_obj, inject_conf, plugin_info)
     if not tracer then
         core.log.error("failed to fetch tracer object: ", err)

--- a/t/plugin/opentelemetry.t
+++ b/t/plugin/opentelemetry.t
@@ -644,3 +644,59 @@ opentracing
 tail -n 1 ci/pod/otelcol-contrib/data-otlp.json
 --- response_body eval
 qr/.*x-injected-by-plugin.*test-value.*/
+
+
+
+=== TEST 29: updating plugin_metadata rebuilds the cached tracer on a warm worker
+--- config
+    location /setup_first {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local plugin = require("apisix.plugin")
+            t('/apisix/admin/plugin_metadata/opentelemetry', ngx.HTTP_PUT,
+                [[{"batch_span_processor":{"max_export_batch_size":1,"inactive_timeout":0.5},"collector":{"address":"127.0.0.1:4318"},"resource":{"service.name":"otel-meta-change-first"}}]])
+            t('/apisix/admin/routes/1', ngx.HTTP_PUT,
+                [[{"plugins":{"opentelemetry":{"sampler":{"name":"always_on"}}},"upstream":{"nodes":{"127.0.0.1:1980":1},"type":"roundrobin"},"uri":"/opentracing"}]])
+            -- wait until this worker sees the metadata so the warm-up span uses it
+            for _ = 1, 50 do
+                local m = plugin.plugin_metadata("opentelemetry")
+                if m and m.value and m.value.resource
+                    and m.value.resource["service.name"] == "otel-meta-change-first" then
+                    break
+                end
+                ngx.sleep(0.1)
+            end
+            ngx.say("ok")
+        }
+    }
+    location /setup_second {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local plugin = require("apisix.plugin")
+            t('/apisix/admin/plugin_metadata/opentelemetry', ngx.HTTP_PUT,
+                [[{"batch_span_processor":{"max_export_batch_size":1,"inactive_timeout":0.5},"collector":{"address":"127.0.0.1:4318"},"resource":{"service.name":"otel-meta-change-second"}}]])
+            -- wait until this worker sees the updated metadata before the next span
+            for _ = 1, 50 do
+                local m = plugin.plugin_metadata("opentelemetry")
+                if m and m.value and m.value.resource
+                    and m.value.resource["service.name"] == "otel-meta-change-second" then
+                    break
+                end
+                ngx.sleep(0.1)
+            end
+            ngx.say("ok")
+        }
+    }
+--- pipelined_requests eval
+["GET /setup_first", "GET /opentracing", "GET /setup_second", "GET /opentracing"]
+--- response_body eval
+["ok\n", "opentracing\n", "ok\n", "opentracing\n"]
+--- wait: 3
+
+
+
+=== TEST 30: last exported span must carry the updated service.name, not the stale one
+--- exec
+tail -n 1 ci/pod/otelcol-contrib/data-otlp.json
+--- response_body eval
+qr/otel-meta-change-second/


### PR DESCRIPTION
### Description

The `opentelemetry` plugin caches the tracer object per route via `core.lrucache.plugin_ctx`, but passed `nil` as the cache version key in `_M.rewrite`. The tracer bakes in everything sourced from `plugin_metadata` (collector address, `request_timeout`/`request_headers`, `trace_id_source`, sampler, and resource attributes). With a `nil` version key the cache entry is never invalidated, so after an operator updates the `opentelemetry` plugin_metadata at runtime (e.g. points to a new OTLP collector or flips `trace_id_source`), the worker keeps serving the stale cached tracer. Spans keep going to the old endpoint until the per-conf cache entry is evicted or the worker recycles.

This passes `metadata.modifiedIndex` as the lrucache version key so the tracer is rebuilt whenever the plugin_metadata changes. `api_ctx.conf_version` (the existing version) only tracks the route/service, not plugin_metadata, so a metadata-only change does not invalidate the entry on its own.

Fixes the stale-tracer behavior on plugin_metadata change.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (N/A, behavior-internal)
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/blob/master/CONTRIBUTING.md#submit-a-proposal) first)
