### PR TITLE
feat: encrypt redis_password and sentinel_password in limit-count/limit-req/limit-conn

### DIFF
--- a/apisix/plugins/limit-conn.lua
+++ b/apisix/plugins/limit-conn.lua
@@ -103,7 +103,8 @@ local schema = {
             },
         },
         ["then"] = redis_schema.limit_conn_redis_cluster_schema,
-    }
+    },
+    encrypt_fields = {"redis_password"},
 }
 
 local _M = {

--- a/apisix/plugins/limit-count/init.lua
+++ b/apisix/plugins/limit-count/init.lua
@@ -220,7 +220,8 @@ local schema = {
             },
             ["then"] = policy_to_additional_properties["redis-sentinel"],
         }
-    }
+    },
+    encrypt_fields = {"redis_password", "sentinel_password"},
 }
 
 local schema_copy = core.table.deepcopy(schema)

--- a/apisix/plugins/limit-req.lua
+++ b/apisix/plugins/limit-req.lua
@@ -83,7 +83,8 @@ local schema = {
             },
         },
         ["then"] = policy_to_additional_properties["redis-cluster"],
-    }
+    },
+    encrypt_fields = {"redis_password"},
 }
 
 

--- a/docs/en/latest/plugins/limit-conn.md
+++ b/docs/en/latest/plugins/limit-conn.md
@@ -71,6 +71,8 @@ The `limit-conn` Plugin limits the rate of requests by the number of concurrent 
 | rules.burst | integer or string | True | | >= 0 or [lua-resty-expr](https://github.com/api7/lua-resty-expr) | The number of excessive concurrent requests allowed to be delayed. Requests exceeding `conn + burst` will be rejected immediately. This parameter also supports the string data type and allows the use of built-in variables prefixed with a dollar sign (`$`). |
 | rules.key | string | True | | | The key to count requests by. If the configured key does not exist, the rule will not be executed. The `key` is interpreted as a combination of variables. All variables should be prefixed by dollar signs (`$`). |
 
+NOTE: `encrypt_fields = {"redis_password"}` is also defined in the schema, which means that the field will be stored encrypted in etcd. See [encrypted storage fields](../plugin-develop.md#encrypted-storage-fields).
+
 ## Examples
 
 The examples below demonstrate how you can configure `limit-conn` in different scenarios.

--- a/docs/en/latest/plugins/limit-count.md
+++ b/docs/en/latest/plugins/limit-count.md
@@ -86,6 +86,8 @@ You may see the following rate limiting headers in the response:
 | sentinel_username       | string            | False                                     |               |                            | The username for Redis Sentinel if Sentinel ACL is enabled. |
 | sentinel_password       | string            | False                                     |               |                            | The password for Redis Sentinel if Sentinel ACL is enabled. |
 
+NOTE: `encrypt_fields = {"redis_password", "sentinel_password"}` is also defined in the schema, which means that the fields will be stored encrypted in etcd. See [encrypted storage fields](../plugin-develop.md#encrypted-storage-fields).
+
 ## Examples
 
 The examples below demonstrate how you can configure `limit-count` in different scenarios.

--- a/docs/en/latest/plugins/limit-req.md
+++ b/docs/en/latest/plugins/limit-req.md
@@ -73,6 +73,8 @@ The `limit-req` Plugin supports two modes of rate limiting:
 | redis_cluster_ssl | boolean | False | false | | If true, use SSL to connect to Redis cluster when `policy` is `redis-cluster`. |
 | redis_cluster_ssl_verify | boolean | False | false | | If true, verify the server SSL certificate when `policy` is `redis-cluster`. |
 
+NOTE: `encrypt_fields = {"redis_password"}` is also defined in the schema, which means that the field will be stored encrypted in etcd. See [encrypted storage fields](../plugin-develop.md#encrypted-storage-fields).
+
 ## Examples
 
 The examples below demonstrate how you can configure `limit-req` in different scenarios.

--- a/docs/zh/latest/plugins/limit-conn.md
+++ b/docs/zh/latest/plugins/limit-conn.md
@@ -71,6 +71,8 @@ import TabItem from '@theme/TabItem';
 | rules.burst | integer 或 string | 是 | | >= 0 或 [lua-resty-expr](https://github.com/api7/lua-resty-expr) | 允许延迟的过多并发请求数。超过 `conn + burst` 的请求将被立即拒绝。该参数也支持 string 数据类型，并允许使用以美元符号（`$`）为前缀的内置变量。|
 | rules.key | string | 是 | | | 用于计数请求的键。如果配置的键不存在，则不会执行该规则。`key` 被解释为变量的组合。所有变量都应以美元符号（`$`）为前缀。|
 
+注意：schema 中还定义了 `encrypt_fields = {"redis_password"}`，这意味着该字段将会被加密存储在 etcd 中。具体参考[加密存储字段](../plugin-develop.md#加密存储字段)。
+
 ## 示例
 
 以下示例演示了如何在不同场景中配置 `limit-conn`。

--- a/docs/zh/latest/plugins/limit-count.md
+++ b/docs/zh/latest/plugins/limit-count.md
@@ -87,6 +87,8 @@ import TabItem from '@theme/TabItem';
 | sentinel_username | string | 否 | | | 如果启用了 Sentinel ACL，则为 Sentinel 用户名。 |
 | sentinel_password | string | 否 | | | 如果启用了 Sentinel ACL，则为 Sentinel 密码。 |
 
+注意：schema 中还定义了 `encrypt_fields = {"redis_password", "sentinel_password"}`，这意味着这些字段将会被加密存储在 etcd 中。具体参考[加密存储字段](../plugin-develop.md#加密存储字段)。
+
 ## 示例
 
 下面的示例演示了如何在不同情况下配置 `limit-count` 。

--- a/docs/zh/latest/plugins/limit-req.md
+++ b/docs/zh/latest/plugins/limit-req.md
@@ -73,6 +73,8 @@ import TabItem from '@theme/TabItem';
 | redis_cluster_ssl | boolean | 否 | false | | 如果为 `true`，当 `policy` 为 `redis-cluster` 时，使用 SSL 连接 Redis 集群。|
 | redis_cluster_ssl_verify | boolean | 否 | false | | 如果为 `true`，当 `policy` 为 `redis-cluster` 时，验证服务器 SSL 证书。|
 
+注意：schema 中还定义了 `encrypt_fields = {"redis_password"}`，这意味着该字段将会被加密存储在 etcd 中。具体参考[加密存储字段](../plugin-develop.md#加密存储字段)。
+
 ## 示例
 
 以下示例演示了如何在不同场景中配置 `limit-req`。

--- a/t/node/data_encrypt.t
+++ b/t/node/data_encrypt.t
@@ -573,3 +573,173 @@ apisix:
     }
 --- response_body
 ["bar","test"]
+
+
+
+=== TEST 14: limit-count redis_password is encrypted in etcd
+--- yaml_config
+apisix:
+    data_encryption:
+        enable_encrypt_fields: true
+        keyring:
+            - edd1c9f0985e76a2
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "limit-count": {
+                            "count": 1,
+                            "time_window": 60,
+                            "policy": "redis",
+                            "redis_host": "127.0.0.1",
+                            "redis_password": "foobar"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {"127.0.0.1:1980": 1},
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            ngx.sleep(0.1)
+
+            -- admin API returns the decrypted value
+            local code, message, res = t('/apisix/admin/routes/1', ngx.HTTP_GET)
+            res = json.decode(res)
+            ngx.say(res.value.plugins["limit-count"].redis_password)
+
+            -- etcd stores the encrypted value
+            local etcd = require("apisix.core.etcd")
+            local res = assert(etcd.get('/routes/1'))
+            local stored = res.body.node.value.plugins["limit-count"].redis_password
+            ngx.say(stored == "foobar" and "plaintext" or "encrypted")
+        }
+    }
+--- response_body
+foobar
+encrypted
+
+
+
+=== TEST 15: limit-req redis_password is encrypted in etcd
+--- yaml_config
+apisix:
+    data_encryption:
+        enable_encrypt_fields: true
+        keyring:
+            - edd1c9f0985e76a2
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "limit-req": {
+                            "rate": 1,
+                            "burst": 0,
+                            "key": "remote_addr",
+                            "policy": "redis",
+                            "redis_host": "127.0.0.1",
+                            "redis_password": "foobar"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {"127.0.0.1:1980": 1},
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            ngx.sleep(0.1)
+
+            local code, message, res = t('/apisix/admin/routes/1', ngx.HTTP_GET)
+            res = json.decode(res)
+            ngx.say(res.value.plugins["limit-req"].redis_password)
+
+            local etcd = require("apisix.core.etcd")
+            local res = assert(etcd.get('/routes/1'))
+            local stored = res.body.node.value.plugins["limit-req"].redis_password
+            ngx.say(stored == "foobar" and "plaintext" or "encrypted")
+        }
+    }
+--- response_body
+foobar
+encrypted
+
+
+
+=== TEST 16: limit-conn redis_password is encrypted in etcd
+--- yaml_config
+apisix:
+    data_encryption:
+        enable_encrypt_fields: true
+        keyring:
+            - edd1c9f0985e76a2
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "limit-conn": {
+                            "conn": 1,
+                            "burst": 0,
+                            "default_conn_delay": 0.1,
+                            "key": "remote_addr",
+                            "policy": "redis",
+                            "redis_host": "127.0.0.1",
+                            "redis_password": "foobar"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {"127.0.0.1:1980": 1},
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            ngx.sleep(0.1)
+
+            local code, message, res = t('/apisix/admin/routes/1', ngx.HTTP_GET)
+            res = json.decode(res)
+            ngx.say(res.value.plugins["limit-conn"].redis_password)
+
+            local etcd = require("apisix.core.etcd")
+            local res = assert(etcd.get('/routes/1'))
+            local stored = res.body.node.value.plugins["limit-conn"].redis_password
+            ngx.say(stored == "foobar" and "plaintext" or "encrypted")
+        }
+    }
+--- response_body
+foobar
+encrypted


### PR DESCRIPTION
### Description

The Redis-based rate limiting policies of `limit-count`, `limit-req`, and `limit-conn` accept `redis_password` (and `sentinel_password` for `limit-count`), but these fields were not listed in the plugin schema's `encrypt_fields`. As a result they were stored in plaintext in etcd even when `data_encryption.enable_encrypt_fields` is on, unlike other Redis-using plugins such as `ai-cache` which already encrypts `redis_password`.

This PR adds the password fields to each plugin schema's `encrypt_fields`:

- `limit-count`: `redis_password`, `sentinel_password`
- `limit-req`: `redis_password`
- `limit-conn`: `redis_password`

With `data_encryption` enabled, these fields are now encrypted at rest in etcd and transparently decrypted at runtime / on Admin API reads.

### Tests

Added cases to `t/node/data_encrypt.t` that PUT a route with each plugin using `policy: redis` and a `redis_password`, then assert the Admin API returns the decrypted value while the raw etcd entry stores it encrypted.

Plugin docs (en/zh) updated with the standard `encrypt_fields` note.