### PR TITLE
test: make stream traffic-split distribution assertions order-independent

### DIFF
--- a/t/stream-plugin/traffic-split.t
+++ b/t/stream-plugin/traffic-split.t
@@ -59,8 +59,23 @@ add_block_preprocessor(sub {
                 reqs[i] = { "/hit" }
             end
             local resps = { ngx.location.capture_multi(reqs) }
-            for i, resp in ipairs(resps) do
-                ngx.say(resp.body)
+            -- Count responses per upstream rather than asserting their order:
+            -- the round-robin picker starts at a random node, so which upstream
+            -- serves each request varies run to run; only the 9:1 ratio is
+            -- deterministic.
+            local count = {}
+            for _, resp in ipairs(resps) do
+                local port = resp.body and resp.body:match("port (%d+)")
+                local key = port and ("port " .. port) or "no response"
+                count[key] = (count[key] or 0) + 1
+            end
+            local keys = {}
+            for k in pairs(count) do
+                keys[#keys + 1] = k
+            end
+            table.sort(keys)
+            for _, k in ipairs(keys) do
+                ngx.say(k, ": ", count[k])
             end
         }
     }
@@ -134,25 +149,9 @@ passed
 === TEST 2: traffic split distribution between two upstreams
 --- request
 GET /test_multiple_requests
---- response_body_like
-hello world from port 1995
-
-hello world from port 1995
-
-hello world from port 1995
-
-hello world from port 1995
-
-hello world from port 1995
-
-hello world from port 1995
-
-hello world from port 1995
-
-hello world from port 1995
-
-
-hello world from port 1995
+--- response_body
+no response: 1
+port 1995: 9
 --- stream_enable
 --- error_log
 Connection refused
@@ -222,25 +221,9 @@ passed
 === TEST 4: traffic split between plugin upstream and default route upstream
 --- request
 GET /test_multiple_requests
---- response_body_like
-hello world from port 1995
-
-hello world from port 1995
-
-hello world from port 1995
-
-hello world from port 1995
-
-hello world from port 1995
-
-hello world from port 1995
-
-hello world from port 1995
-
-hello world from port 1995
-
-
-hello world from port 1995
+--- response_body
+no response: 1
+port 1995: 9
 --- stream_enable
 --- error_log
 Connection refused


### PR DESCRIPTION
### Description

`t/stream-plugin/traffic-split.t` TEST 2 and TEST 4 send 10 requests through a 9:1 weighted split and assert the **exact arrival-order sequence** of upstream responses (8 responses, then the single empty/refused one, then 1 more).

The problem is that the round-robin picker starts at a random node — `resty.roundrobin` picks its first node via `math.random` in `get_random_node_id()`. So over a full cycle of 10 requests only the **9:1 ratio** is deterministic, not the order. The position of the single low-weight response (which hits a port with no listener, hence an empty body + `Connection refused`) drifts, and the hardcoded sequence fails whenever it lands one slot off. It reproduces as:

```
#   doesn't match '(?^s:hello world from port 1995 ... )'
t/stream-plugin/traffic-split.t (Wstat: 256 Tests: 30 Failed: 1)
  Failed test:  6
```

This PR makes the helper count responses per upstream and asserts the ratio instead of the order, which is invariant to the picker's starting offset. The `Connection refused` error_log check is kept (there is always exactly one low-weight request).

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
