### PR TITLE
fix(opentelemetry): give inject_core_spans its own tracer cache key

### DIFF
--- a/apisix/plugins/opentelemetry.lua
+++ b/apisix/plugins/opentelemetry.lua
@@ -450,8 +450,9 @@ local function inject_core_spans(root_span_ctx, api_ctx, conf)
         additional_attributes = conf.additional_attributes,
         additional_header_prefix_attributes = conf.additional_header_prefix_attributes
     }
-    -- key the cache on modifiedIndex so the tracer is rebuilt when metadata changes
-    local tracer, err = core.lrucache.plugin_ctx(lrucache, api_ctx, metadata.modifiedIndex,
+    -- separate key from the rewrite tracer; modifiedIndex rebuilds it on metadata change
+    local cache_key = "inject_core_spans#" .. tostring(metadata.modifiedIndex)
+    local tracer, err = core.lrucache.plugin_ctx(lrucache, api_ctx, cache_key,
                                                 create_tracer_obj, inject_conf, plugin_info)
     if not tracer then
         core.log.error("failed to fetch tracer object: ", err)

--- a/t/plugin/opentelemetry.t
+++ b/t/plugin/opentelemetry.t
@@ -653,18 +653,35 @@ qr/.*x-injected-by-plugin.*test-value.*/
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local plugin = require("apisix.plugin")
-            t('/apisix/admin/plugin_metadata/opentelemetry', ngx.HTTP_PUT,
+            local code, body = t('/apisix/admin/plugin_metadata/opentelemetry', ngx.HTTP_PUT,
                 [[{"batch_span_processor":{"max_export_batch_size":1,"inactive_timeout":0.5},"collector":{"address":"127.0.0.1:4318"},"resource":{"service.name":"otel-meta-change-first"}}]])
-            t('/apisix/admin/routes/1', ngx.HTTP_PUT,
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT,
                 [[{"plugins":{"opentelemetry":{"sampler":{"name":"always_on"}}},"upstream":{"nodes":{"127.0.0.1:1980":1},"type":"roundrobin"},"uri":"/opentracing"}]])
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
             -- wait until this worker sees the metadata so the warm-up span uses it
+            local seen
             for _ = 1, 50 do
                 local m = plugin.plugin_metadata("opentelemetry")
                 if m and m.value and m.value.resource
                     and m.value.resource["service.name"] == "otel-meta-change-first" then
+                    seen = true
                     break
                 end
                 ngx.sleep(0.1)
+            end
+            if not seen then
+                ngx.status = 500
+                ngx.say("metadata did not propagate")
+                return
             end
             ngx.say("ok")
         }
@@ -673,16 +690,28 @@ qr/.*x-injected-by-plugin.*test-value.*/
         content_by_lua_block {
             local t = require("lib.test_admin").test
             local plugin = require("apisix.plugin")
-            t('/apisix/admin/plugin_metadata/opentelemetry', ngx.HTTP_PUT,
+            local code, body = t('/apisix/admin/plugin_metadata/opentelemetry', ngx.HTTP_PUT,
                 [[{"batch_span_processor":{"max_export_batch_size":1,"inactive_timeout":0.5},"collector":{"address":"127.0.0.1:4318"},"resource":{"service.name":"otel-meta-change-second"}}]])
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
             -- wait until this worker sees the updated metadata before the next span
+            local seen
             for _ = 1, 50 do
                 local m = plugin.plugin_metadata("opentelemetry")
                 if m and m.value and m.value.resource
                     and m.value.resource["service.name"] == "otel-meta-change-second" then
+                    seen = true
                     break
                 end
                 ngx.sleep(0.1)
+            end
+            if not seen then
+                ngx.status = 500
+                ngx.say("metadata did not propagate")
+                return
             end
             ngx.say("ok")
         }

--- a/t/plugin/opentelemetry.t
+++ b/t/plugin/opentelemetry.t
@@ -648,6 +648,11 @@ qr/.*x-injected-by-plugin.*test-value.*/
 
 
 === TEST 29: updating plugin_metadata rebuilds the cached tracer on a warm worker
+--- extra_yaml_config
+apisix:
+    tracing: true
+plugins:
+    - opentelemetry
 --- config
     location /setup_first {
         content_by_lua_block {
@@ -724,8 +729,8 @@ qr/.*x-injected-by-plugin.*test-value.*/
 
 
 
-=== TEST 30: last exported span must carry the updated service.name, not the stale one
+=== TEST 30: core span from inject_core_spans must carry the updated service.name
 --- exec
-tail -n 1 ci/pod/otelcol-contrib/data-otlp.json
+grep apisix.phase.access ci/pod/otelcol-contrib/data-otlp.json | tail -n 1
 --- response_body eval
 qr/otel-meta-change-second/


### PR DESCRIPTION
### Description

Follow-up to #13618.

`_M.rewrite()` and `inject_core_spans()` build **different** tracers: `rewrite` uses the route's configured sampler, while `inject_core_spans` deliberately forces an `always_on` sampler so that, once a trace's root span is recording, the full internal core-span tree is kept unconditionally regardless of the route sampler.

After #13618 both paths called `core.lrucache.plugin_ctx()` with the same extra key (`metadata.modifiedIndex`) on the same `api_ctx`, so they shared a single lrucache slot. On a warm worker, `rewrite` (rewrite phase) populates the slot first, and `inject_core_spans` (log phase) then reuses that route-sampler tracer instead of the `always_on` one it built, silently dropping the always_on guarantee for any sampler that is not trace_id-deterministic.

This change namespaces the inject cache key (`inject_core_spans#<modifiedIndex>`) so the two tracers no longer collide, while preserving the rebuild-on-metadata-change behavior from #13618.

It also hardens the regression test setup added in #13618 to fail fast when the admin update is rejected or the metadata never propagates to the worker, so the test cannot return `ok` on a broken setup and mask the real assertion.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (no doc change needed; internal behavior)
- [x] I have verified that the changes are backward compatible