### PR TITLE
refactor(cas-auth): drop unnecessary raw Cookie header fallback

### DIFF
--- a/apisix/plugins/cas-auth.lua
+++ b/apisix/plugins/cas-auth.lua
@@ -173,28 +173,6 @@ local function set_our_cookie(conf, name, val)
     core.response.add_header("Set-Cookie", name .. "=" .. val .. cookie_attrs(conf))
 end
 
--- nginx's $cookie_<name> variable doesn't reliably expose cookies whose names
--- exceed certain lengths in older OpenResty builds (the per-config cookie name
--- is "CAS_SESSION_<sha256-hex>"). Parse the raw Cookie header as a fallback.
-local function get_cookie(ctx, name)
-    local val = ctx.var["cookie_" .. name]
-    if val ~= nil then
-        return val
-    end
-    local cookie_header = ctx.var.http_cookie
-    if not cookie_header then
-        return nil
-    end
-    local prefix = name .. "="
-    for piece in (cookie_header .. ";"):gmatch("([^;]+);") do
-        piece = piece:gsub("^%s+", "")
-        if piece:sub(1, #prefix) == prefix then
-            return piece:sub(#prefix + 1)
-        end
-    end
-    return nil
-end
-
 local function compute_hmac(secret, val)
     local m, err = openssl_mac.new(secret, "HMAC", nil, "sha256")
     if not m then return nil, err end
@@ -357,7 +335,7 @@ end
 
 local function logout(conf, ctx)
     local opts = session_opts(conf)
-    local session_id = get_cookie(ctx, opts.cookie_name)
+    local session_id = ctx.var["cookie_" .. opts.cookie_name]
     if session_id == nil then
         return ngx.HTTP_UNAUTHORIZED
     end
@@ -399,7 +377,7 @@ function _M.access(conf, ctx)
         return ngx.HTTP_OK
     else
         local opts = session_opts(conf)
-        local session_id = get_cookie(ctx, opts.cookie_name)
+        local session_id = ctx.var["cookie_" .. opts.cookie_name]
         if session_id ~= nil then
             return with_session_id(conf, ctx, opts, session_id)
         end


### PR DESCRIPTION
### Description

The `get_cookie` helper in cas-auth was added to fall back to parsing the raw `Cookie` header when `$cookie_<name>` returned nil, on the theory that nginx's `$cookie_<name>` variable doesn't reliably expose cookies with long names (the per-config session cookie is `CAS_SESSION_<sha256-hex>`, 76 chars).

That fallback isn't needed: nginx exposes cookies via `$cookie_<name>` regardless of name length on supported OpenResty builds. This drops the helper and reads the session cookie directly via `ctx.var["cookie_" .. opts.cookie_name]`, consistent with how the `CAS_REQUEST_URI` cookie is already read in the same plugin.

No behavior change on supported runtimes; pure cleanup of dead code.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change (existing cas-auth tests cover cookie reads; no new behavior)
- [x] I have updated the documentation to reflect this change (internal helper, no doc impact)
- [x] I have verified that this change passes lint