### PR TITLE
chore(ci): Restrict trigger push branch for GitHub Workflow

### DIFF
--- a/.github/workflows/doc-lint.yml
+++ b/.github/workflows/doc-lint.yml
@@ -2,6 +2,7 @@ name: Doc Lint
 
 on:
   push:
+    branches: [master, "release/**"]
     paths:
       - "docs/**"
       - "**/*.md"

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -7,7 +7,7 @@ name: 'Link Checker'
 on:
   workflow_dispatch:
   push:
-    # branches: [master, 'release/**']
+    branches: [master, 'release/**']
     paths:
       - '**/*.md'
       - '**/link-check.yml'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: ❄️ Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master, "release/**"]
+  pull_request:
+    branches: [master, "release/**"]
 
 permissions:
   contents: read

--- a/.github/workflows/push-dev-image-on-commit.yml
+++ b/.github/workflows/push-dev-image-on-commit.yml
@@ -6,6 +6,7 @@ on:
       - "docs/**"
       - "**/*.md"
   push:
+    branches: [master, "release/**"]
     paths-ignore:
       - "docs/**"
       - "**/*.md"


### PR DESCRIPTION
Feature branches rarely need their own CI runs: the code is already tested when a pull request is opened against a release branch. If the push trigger has no branch restriction and pull_request is also configured, every push to a branch with an open PR runs the workflow twice: once for the push and once for the PR synchronisation.

Always give the push trigger an explicit list of branches: this stops branches created from a release branch from inheriting its workflow runs.

see https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=430408443#GitHubActionsRecommendedPractices-Restrictthepushtriggertospecificbranches

### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
