### PR TITLE
fix(forward-auth): re-frame buffered POST body for the auth request

### DIFF
--- a/apisix/plugins/forward-auth.lua
+++ b/apisix/plugins/forward-auth.lua
@@ -121,9 +121,9 @@ function _M.access(conf, ctx)
     }
 
     if conf.request_method == "POST" then
-        auth_headers["Content-Length"] = core.request.header(ctx, "content-length")
-        auth_headers["Expect"] = core.request.header(ctx, "expect")
-        auth_headers["Transfer-Encoding"] = core.request.header(ctx, "transfer-encoding")
+        -- body is buffered and re-framed below, so only keep content-encoding.
+        -- forwarding client transfer-encoding/content-length/expect would not
+        -- match the buffered body.
         auth_headers["Content-Encoding"] = core.request.header(ctx, "content-encoding")
     end
 

--- a/t/plugin/forward-auth.t
+++ b/t/plugin/forward-auth.t
@@ -595,3 +595,89 @@ POST /withinlimit
 --- response_body_like eval
 qr/i-am-an-user/
 --- error_code: 200
+
+
+
+=== TEST 20: setup route that reflects the framing seen by the auth service
+--- config
+    location /t {
+        content_by_lua_block {
+            local data = {
+                {
+                    url = "/apisix/admin/routes/auth-frame",
+                    data = [[{
+                        "plugins": {
+                            "serverless-pre-function": {
+                                "phase": "rewrite",
+                                "functions": [
+                                    "return function (conf, ctx)
+                                        local core = require(\"apisix.core\");
+                                        local te = core.request.header(ctx, \"transfer-encoding\") or \"none\";
+                                        core.response.set_header(\"X-Auth-Saw-Te\", te);
+                                        core.response.exit(200);
+                                    end"
+                                ]
+                            }
+                        },
+                        "uri": "/auth-frame"
+                    }]],
+                },
+                {
+                    url = "/apisix/admin/routes/pingframe",
+                    data = [[{
+                        "plugins": {
+                            "forward-auth": {
+                                "uri": "http://127.0.0.1:1984/auth-frame",
+                                "request_method": "POST",
+                                "upstream_headers": ["X-Auth-Saw-Te"]
+                            },
+                            "proxy-rewrite": {
+                                "uri": "/echo"
+                            }
+                        },
+                        "upstream_id": "u1",
+                        "uri": "/pingframe"
+                    }]],
+                },
+            }
+
+            local t = require("lib.test_admin").test
+            for _, data in ipairs(data) do
+                local code, body = t(data.url, ngx.HTTP_PUT, data.data)
+                ngx.say(body)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body eval
+"passed\n" x 2
+
+
+
+=== TEST 21: chunked POST is re-framed, auth service does not see chunked
+--- config
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            sock:settimeout(2000)
+            local ok, err = sock:connect("127.0.0.1", 1984)
+            if not ok then
+                ngx.say("connect failed: ", err)
+                return
+            end
+            local req = "POST /pingframe HTTP/1.1\r\n"
+                .. "Host: 127.0.0.1\r\n"
+                .. "Transfer-Encoding: chunked\r\n"
+                .. "Connection: close\r\n\r\n"
+                .. "5\r\nhello\r\n0\r\n\r\n"
+            sock:send(req)
+            local resp = sock:receive("*a")
+            sock:close()
+            ngx.print(resp)
+        }
+    }
+--- request
+GET /t
+--- response_body_like eval
+qr/"x-auth-saw-te":"none"/


### PR DESCRIPTION
### Description

When `forward-auth` is configured with `request_method: POST`, the plugin buffers the client request body and re-sends it as a whole to the auth service. However it also copied the client's `Transfer-Encoding`, `Content-Length` and `Expect` headers verbatim into the auth request.

Once the body has been read it is de-chunked and buffered, so those framing headers no longer describe the bytes actually sent. In particular, a client using `Transfer-Encoding: chunked` caused the auth service to receive a `Transfer-Encoding: chunked` request whose body was not chunk-framed, leaving the auth request internally inconsistent.

These framing headers were originally added when the body was streamed to the auth service via a body reader (#10589). That streaming path was later reverted to a buffered body (#12404), but the header copy was left behind and no longer matches the buffered send.

This change keeps only `Content-Encoding` (which still applies to the buffered bytes, since nginx does not decode request content-encoding) and lets the HTTP client set a fresh, correct `Content-Length` for the buffered body. `Transfer-Encoding`, `Content-Length` and `Expect` are no longer forwarded from the client on the POST path.

#### Which issue(s) this PR fixes:
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
