### PR TITLE
test: assert admin metadata GET decrypts on first request

### DIFF
--- a/t/admin/plugin-metadata3.t
+++ b/t/admin/plugin-metadata3.t
@@ -255,7 +255,10 @@ nil
             -- etcd keeps the field encrypted
             local etcd = require("apisix.core.etcd")
             local res = assert(etcd.get('/plugin_metadata/azure-functions'))
-            ngx.say("etcd encrypted: ", tostring(res.body.node.value.master_apikey ~= "foo"))
+            local encrypted = res.body.node.value.master_apikey
+            ngx.say("etcd encrypted: ",
+                    tostring(type(encrypted) == "string" and #encrypted > 0
+                             and encrypted ~= "foo"))
 
             -- simulate a fresh worker: the flag has not been initialized yet
             plugin.enable_data_encryption = nil

--- a/t/admin/plugin-metadata3.t
+++ b/t/admin/plugin-metadata3.t
@@ -60,7 +60,7 @@ __DATA__
                 ngx.HTTP_GET
             )
 
-            local_conf, err = core.config.local_conf(true)
+            local local_conf, err = core.config.local_conf(true)
             local enable_data_encryption =
             core.table.try_read_attr(local_conf, "apisix", "data_encryption",
                     "enable_encrypt_fields") and (core.config.type == "etcd")
@@ -228,3 +228,50 @@ GET /t
 --- response_body_like
 nil
 \{"message":"Key not found"\}
+
+
+
+=== TEST 8: first successful GET decrypts even when enable_data_encryption is not yet initialized
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local plugin = require("apisix.plugin")
+            local t = require("lib.test_admin").test
+
+            local code, body = t('/apisix/admin/plugin_metadata/azure-functions',
+                ngx.HTTP_PUT,
+                [[{
+                    "master_apikey": "foo"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.sleep(0.1)
+
+            -- etcd keeps the field encrypted
+            local etcd = require("apisix.core.etcd")
+            local res = assert(etcd.get('/plugin_metadata/azure-functions'))
+            ngx.say("etcd encrypted: ", tostring(res.body.node.value.master_apikey ~= "foo"))
+
+            -- simulate a fresh worker: the flag has not been initialized yet
+            plugin.enable_data_encryption = nil
+
+            -- first GET must still decrypt because enable_gde() forces init
+            local code, message, res = t('/apisix/admin/plugin_metadata/azure-functions',
+                ngx.HTTP_GET
+            )
+            res = core.json.decode(res)
+            ngx.say("admin decrypted: ", res.value.master_apikey)
+
+            t('/apisix/admin/plugin_metadata/azure-functions', ngx.HTTP_DELETE)
+        }
+    }
+--- request
+GET /t
+--- response_body
+etcd encrypted: true
+admin decrypted: foo


### PR DESCRIPTION
### Description

Follow-up test coverage for #12624.

The existing `t/admin/plugin-metadata3.t` covers the `plugin.enable_data_encryption` nil-init state and the 404-GET crash, but it uses `example-plugin`, which has no `encrypt_fields`. So it never asserts the **primary** behavior the fix restored: that the first successful GET of an encrypted metadata field returns **plaintext**, not ciphertext.

This PR adds a case using `azure-functions.master_apikey` (a real `encrypt_fields` metadata):

1. PUT the metadata (stored encrypted in etcd).
2. Assert etcd holds ciphertext.
3. Reset `plugin.enable_data_encryption = nil` to simulate a fresh worker where the flag has not been lazily initialized yet.
4. Assert the GET still returns the decrypted value - i.e. `plugin.enable_gde()` forces initialization on the GET path.

Without #12624 this case returns ciphertext; with it, plaintext.

Also scopes `local_conf`/`err` as locals in TEST 1 (they were previously assigned as globals).

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (N/A - test-only)
- [x] I have verified that this change is backward compatible (test-only, no runtime change)
