### PR TITLE
perf(loggly): hoist per-request closure out of log phase

### DIFF
--- a/apisix/plugins/loggly.lua
+++ b/apisix/plugins/loggly.lua
@@ -309,9 +309,7 @@ local function send_bulk_over_http(message, metadata, conf)
 end
 
 
-local handle_http_payload
-
-local function handle_log(entries)
+local function handle_log(entries, conf)
     local metadata = plugin.plugin_metadata(plugin_name)
     core.log.info("metadata: ", core.json.delay_encode(metadata))
 
@@ -330,11 +328,12 @@ local function handle_log(entries)
                 return false, err, i
             end
         end
-    else
-        return handle_http_payload(entries, metadata)
+        return true
     end
 
-    return true
+    -- loggly bulk endpoint expects entries concatenated in newline("\n")
+    local message = tab_concat(entries, "\n")
+    return send_bulk_over_http(message, metadata, conf)
 end
 
 
@@ -344,17 +343,16 @@ function _M.log(conf, ctx)
         return
     end
 
-    handle_http_payload = function (entries, metadata)
-        -- loggly bulk endpoint expects entries concatenated in newline("\n")
-        local message = tab_concat(entries, "\n")
-        return send_bulk_over_http(message, metadata, conf)
-    end
-
     if batch_processor_manager:add_entry(conf, log_data) then
         return
     end
 
-    batch_processor_manager:add_entry_to_new_processor(conf, log_data, ctx, handle_log)
+    -- bind conf once per batch processor instead of per request
+    local function func(entries)
+        return handle_log(entries, conf)
+    end
+
+    batch_processor_manager:add_entry_to_new_processor(conf, log_data, ctx, func)
 end
 
 

--- a/t/plugin/loggly.t
+++ b/t/plugin/loggly.t
@@ -908,3 +908,75 @@ true
 true
 --- no_error_log
 [alert]
+
+
+
+=== TEST 22: http bulk sends each batch with its own conf (regression)
+--- http_config
+    server {
+        listen 10420;
+
+        location ~ ^/loggly/bulk/(?<token>[^/]+)/tag/bulk$ {
+            content_by_lua_block {
+                ngx.req.read_body()
+                local headers = ngx.req.get_headers()
+                ngx.log(ngx.ERR, "loggly-recv token: ", ngx.var.token,
+                        " tags: ", require("toolkit.json").encode(headers["X-LOGGLY-TAG"]))
+                ngx.say("ok")
+            }
+        }
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+
+            local code = t('/apisix/admin/plugin_metadata/loggly', ngx.HTTP_PUT, [[{
+                "host": "127.0.0.1:10420/loggly",
+                "protocol": "http"
+            }]])
+            if code >= 300 then ngx.say("metadata failed: ", code); return end
+
+            local code = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [[{
+                "plugins": {
+                    "loggly": {
+                        "customer_token": "token-a",
+                        "tags": ["aaa"],
+                        "inactive_timeout": 1
+                    }
+                },
+                "upstream": {"nodes": {"127.0.0.1:1980": 1}, "type": "roundrobin"},
+                "host": "127.0.0.1",
+                "uri": "/route_a"
+            }]])
+            if code >= 300 then ngx.say("route_a failed: ", code); return end
+
+            local code = t('/apisix/admin/routes/2', ngx.HTTP_PUT, [[{
+                "plugins": {
+                    "loggly": {
+                        "customer_token": "token-b",
+                        "tags": ["bbb"],
+                        "inactive_timeout": 1
+                    }
+                },
+                "upstream": {"nodes": {"127.0.0.1:1980": 1}, "type": "roundrobin"},
+                "host": "127.0.0.1",
+                "uri": "/route_b"
+            }]])
+            if code >= 300 then ngx.say("route_b failed: ", code); return end
+
+            -- buffer one entry per config before either batch flushes, so the
+            -- old shared closure would send both with the last conf's token
+            t("/route_a", ngx.HTTP_GET)
+            t("/route_b", ngx.HTTP_GET)
+            ngx.say("done")
+        }
+    }
+--- wait: 3
+--- response_body
+done
+--- error_log
+loggly-recv token: token-a tags: "aaa"
+loggly-recv token: token-b tags: "bbb"
+--- no_error_log
+[alert]


### PR DESCRIPTION
### Description

The `loggly` logger reassigned the `handle_http_payload` closure on **every request** inside `_M.log()`, solely to capture `conf`. Each request therefore allocated a fresh function object, adding avoidable GC pressure in the log phase. Benchmarking loggers showed `loggly` carrying a disproportionately high per-request overhead compared to peers in the same class, and this per-request allocation was the cause (P50 is unaffected since the actual send happens in the async batch-processor timer).

This PR hoists the handler to module scope: `conf` is threaded into `handle_log(entries, conf)` directly, and the small binding closure is created **once per batch processor** (i.e. once per config version) rather than once per request. The separate `handle_http_payload` indirection is removed.

As a side effect this also removes a latent correctness bug: the shared module-level `handle_http_payload` was overwritten by whichever request ran `_M.log()` last, so with two routes using different loggly configs the async handler could send a batch with the wrong `conf`. Binding `conf` per processor fixes that.

Behavior is otherwise unchanged; existing `t/plugin/loggly.t` cases (including TEST 15, the http bulk path that asserts `conf.tags`) continue to cover both the syslog and http paths.

#### Which issue(s) this PR fixes:
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

