### PR TITLE
feat: support custom apisix.yaml path

### DIFF
--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -937,6 +937,7 @@ local function cleanup(env)
     end
 
     os_remove(profile:customized_yaml_index())
+    os_remove(profile:customized_apisix_yaml_index())
 end
 
 
@@ -1015,11 +1016,13 @@ local function start(env, ...)
     local parser = argparse()
     parser:argument("_", "Placeholder")
     parser:option("-c --config", "location of customized config.yaml")
+    parser:option("--apisix-yaml", "location of customized apisix.yaml")
     -- TODO: more logs for APISIX cli could be added using this feature
     parser:flag("-v --verbose", "show init_etcd debug information")
     local args = parser:parse()
 
     local customized_yaml = args["config"]
+    local customized_apisix_yaml = args["apisix_yaml"] or getenv("APISIX_YAML_PATH")
     if customized_yaml then
         local customized_yaml_path
         local idx = str_find(customized_yaml, "/")
@@ -1043,6 +1046,32 @@ local function start(env, ...)
         end
 
         print("Use customized yaml: ", customized_yaml)
+    end
+
+    if customized_apisix_yaml then
+        local customized_apisix_yaml_path
+        local idx = str_find(customized_apisix_yaml, "/")
+        if idx and idx == 1 then
+            customized_apisix_yaml_path = customized_apisix_yaml
+        else
+            local cur_dir, err = lfs.currentdir()
+            if err then
+                util.die("failed to get current directory")
+            end
+            customized_apisix_yaml_path = cur_dir .. "/" .. customized_apisix_yaml
+        end
+
+        if not util.file_exists(customized_apisix_yaml_path) then
+           util.die("customized apisix.yaml file not exists, path: " .. customized_apisix_yaml_path)
+        end
+
+        local ok, err = util.write_file(profile:customized_apisix_yaml_index(),
+                                        customized_apisix_yaml_path)
+        if not ok then
+            util.die("write customized apisix.yaml index failed, err: " .. err)
+        end
+
+        print("Use customized apisix.yaml: ", customized_apisix_yaml)
     end
 
     init(env)

--- a/apisix/core/profile.lua
+++ b/apisix/core/profile.lua
@@ -41,7 +41,14 @@ local _M = {
 -- profile.apisix_home = env.apisix_home .. "/"
 -- local local_conf_path = profile:yaml_path("config")
 function _M.yaml_path(self, file_name)
-    local file_path = self.apisix_home  .. "conf/" .. file_name
+    if file_name == "apisix" then
+        local customized_apisix_yaml_path = self:customized_apisix_yaml_path()
+        if customized_apisix_yaml_path then
+            return customized_apisix_yaml_path
+        end
+    end
+
+    local file_path = self.apisix_home .. "conf/" .. file_name
     if self.profile ~= "" and file_name ~= "config-default" then
         file_path = file_path .. "-" .. self.profile
     end
@@ -59,6 +66,20 @@ function _M.customized_yaml_path(self)
     local customized_config_index = self:customized_yaml_index()
     if util.file_exists(customized_config_index) then
         return util.read_file(customized_config_index)
+    end
+    return nil
+end
+
+
+function _M.customized_apisix_yaml_index(self)
+    return self.apisix_home .. "/conf/.customized_apisix_yaml_path"
+end
+
+
+function _M.customized_apisix_yaml_path(self)
+    local customized_apisix_yaml_index = self:customized_apisix_yaml_index()
+    if util.file_exists(customized_apisix_yaml_index) then
+        return util.read_file(customized_apisix_yaml_index)
     end
     return nil
 end

--- a/t/core/profile.t
+++ b/t/core/profile.t
@@ -50,3 +50,27 @@ GET /t
 GET /t
 --- response_body
 ./test/conf/config.yaml
+
+=== TEST 3: customized apisix yaml path
+--- config
+    location /t {
+        content_by_lua_block {
+            local profile = require("apisix.core.profile")
+            local util = require("apisix.cli.util")
+
+            profile.apisix_home = ngx.config.prefix()
+            profile.profile = ""
+
+            local customized_path = "/tmp/custom-apisix.yaml"
+            util.write_file(profile:customized_apisix_yaml_index(), customized_path)
+
+            local apisix_conf_path = profile:yaml_path("apisix")
+            ngx.say(apisix_conf_path)
+
+            os.remove(profile:customized_apisix_yaml_index())
+        }
+    }
+--- request
+GET /t
+--- response_body
+/tmp/custom-apisix.yaml


### PR DESCRIPTION
### Description

This PR adds support for specifying a custom `apisix.yaml` path when running APISIX in standalone mode.

Previously, APISIX only allowed overriding the path to `config.yaml` using the `--config` option, while the location of `apisix.yaml` was fixed under the default `conf/` directory. This made it difficult to use a custom standalone configuration file.

This PR introduces:

- A new CLI option: `--apisix-yaml`
- Support for the `APISIX_YAML_PATH` environment variable
- Support for resolving a customized `apisix.yaml` path before falling back to the default location
- A regression test covering the customized `apisix.yaml` path

#### Which issue(s) this PR fixes:

Fixes #13338

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the APISIX mailing list first)