### PR TITLE
perf(zipkin): skip span tag construction for unsampled requests

### DIFF
--- a/apisix/plugins/zipkin.lua
+++ b/apisix/plugins/zipkin.lua
@@ -182,19 +182,34 @@ function _M.rewrite(plugin_conf, ctx)
 
     local wire_context = tracer:extract("http_headers", ctx)
 
-    local start_timestamp = ngx.req.start_time()
-    local request_span = tracer:start_span("apisix.request", {
-        child_of = wire_context,
-        start_timestamp = start_timestamp,
+    -- Decide sampling before building the span. The reporter drops unsampled
+    -- spans, so skip tag construction and remote-addr lookups for them.
+    if sampled == "1" or sampled == "true" then
+        per_req_sample_ratio = 1
+    elseif sampled == "0" or sampled == "false" then
+        per_req_sample_ratio = 0
+    end
+    local sample = tracer.sampler:sample(per_req_sample_ratio or conf.sample_ratio)
+    ctx.opentracing_sample = sample
+
+    local tags
+    if sample then
         tags = {
             component = "apisix",
             ["span.kind"] = "server",
             ["http.method"] = ctx.var.request_method,
             ["http.url"] = ctx.var.request_uri,
-             -- TODO: support ipv6
+            -- TODO: support ipv6
             ["peer.ipv4"] = core.request.get_remote_client_ip(ctx),
             ["peer.port"] = core.request.get_remote_client_port(ctx),
         }
+    end
+
+    local start_timestamp = ngx.req.start_time()
+    local request_span = tracer:start_span("apisix.request", {
+        child_of = wire_context,
+        start_timestamp = start_timestamp,
+        tags = tags,
     })
 
     ctx.opentracing = {
@@ -203,18 +218,10 @@ function _M.rewrite(plugin_conf, ctx)
         request_span = request_span,
     }
 
-    -- Process sampled
-    if sampled == "1" or sampled == "true" then
-        per_req_sample_ratio = 1
-    elseif sampled == "0" or sampled == "false" then
-        per_req_sample_ratio = 0
-    end
-
-    ctx.opentracing_sample = tracer.sampler:sample(per_req_sample_ratio or conf.sample_ratio)
-    if not ctx.opentracing_sample then
-        request_span:set_baggage_item("x-b3-sampled","0")
+    if not sample then
+        request_span:set_baggage_item("x-b3-sampled", "0")
     else
-       request_span:set_baggage_item("x-b3-sampled","1")
+        request_span:set_baggage_item("x-b3-sampled", "1")
     end
 
     if plugin_info.set_ngx_var then
@@ -227,11 +234,10 @@ function _M.rewrite(plugin_conf, ctx)
         ngx_var.zipkin_span_id = to_hex(span_context.span_id)
     end
 
-    if not ctx.opentracing_sample then
+    if not sample then
         return
     end
 
-    local request_span = ctx.opentracing.request_span
     if conf.span_version == ZIPKIN_SPAN_VER_1 then
         ctx.opentracing.rewrite_span = request_span:start_child_span("apisix.rewrite",
                                                                      start_timestamp)
@@ -245,9 +251,9 @@ end
 
 function _M.access(conf, ctx)
     local opentracing = ctx.opentracing
-    local tracer = opentracing.tracer
 
-    if conf.span_version == ZIPKIN_SPAN_VER_1 then
+    if ctx.opentracing_sample and conf.span_version == ZIPKIN_SPAN_VER_1 then
+        local tracer = opentracing.tracer
         opentracing.access_span = opentracing.request_span:start_child_span(
             "apisix.access", ctx.REWRITE_END_TIME)
 

--- a/docs/en/latest/plugins/skywalking.md
+++ b/docs/en/latest/plugins/skywalking.md
@@ -63,6 +63,12 @@ Reload APISIX for changes to take effect.
 |--------------|--------|----------|---------|--------------|----------------------------------------------------------------------------|
 | sample_ratio | number | False     | 1       | [0.00001, 1] | Frequency of request sampling. Setting the sample ratio to `1` means to sample all requests. |
 
+:::tip Performance
+
+The plugin hooks several request phases and builds a trace per sampled request, so tracing adds per-request overhead. Sampling is the primary lever to control it: unsampled requests skip trace creation entirely. Lower `sample_ratio` on high-throughput routes to reduce overhead while keeping representative traces.
+
+:::
+
 ## Example
 
 To follow along the example, start a storage, OAP and Booster UI with Docker Compose, following [Skywalking's documentation](https://skywalking.apache.org/docs/main/next/en/setup/backend/backend-docker/). Once set up, the OAP server should be listening on `12800` and you should be able to access the UI at [http://localhost:8080](http://localhost:8080).

--- a/docs/en/latest/plugins/zipkin.md
+++ b/docs/en/latest/plugins/zipkin.md
@@ -63,6 +63,12 @@ See the configuration file for configuration options available to all Plugins.
 |server_addr | string  | False    |the value of `$server_addr` | IPv4 address | IPv4 address for the Zipkin reporter. For example, you can set this to your external IP address. |
 |span_version | integer | False    | 2             | [1, 2]       | Version of the span type. |
 
+:::tip Performance
+
+The plugin hooks several request phases and builds a span per sampled request, so tracing adds per-request overhead. Sampling is the primary lever to control it: `sample_ratio` is the fraction of requests traced, and unsampled requests skip span tag construction entirely. Lower `sample_ratio` on high-throughput routes to reduce overhead while keeping representative traces.
+
+:::
+
 ## Examples
 
 The examples below show different use cases of the `zipkin` Plugin.

--- a/t/plugin/zipkin3.t
+++ b/t/plugin/zipkin3.t
@@ -159,3 +159,13 @@ plugin_attr:
 GET /echo
 --- error_log
 ngx_var.zipkin_context_traceparent is empty
+
+
+
+=== TEST 6: unsampled request still builds span context for set_ngx_var
+--- request
+GET /echo
+--- more_headers
+x-b3-sampled: 0
+--- error_log eval
+qr/ngx_var.zipkin_context_traceparent:00-\w{32}-\w{16}-00/


### PR DESCRIPTION
### Description

The zipkin plugin builds the request span with its full tags table (`http.method`, `http.url`, and the `get_remote_client_ip`/`get_remote_client_port` lookups) **before** deciding whether the request is sampled. But `apisix/plugins/zipkin/reporter.lua` drops any span whose `x-b3-sampled` baggage is `0`, so that per-request work is pure waste on unsampled requests. On high-throughput routes with a low `sample_ratio` this overhead is paid on every request.

This PR:

- Moves the sampling decision ahead of span construction. On unsampled requests the tags table and the two remote-addr lookups are skipped (`tags = nil`, which `opentracing` `start_span` handles cleanly). The bare span is still created because header propagation (`inject_header`) needs its trace context, and `set_ngx_var` output is unchanged.
- Guards the span-version-1 child spans in the `access` phase behind `ctx.opentracing_sample` so unsampled requests skip those allocations too (also removes a latent nil-timestamp path).
- Documents sampling as the primary performance lever for the zipkin and skywalking plugins.

No behavior change for sampled requests: identical tags, span order, and `x-b3-sampled` propagation.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change (`t/plugin/zipkin3.t` TEST 6 asserts an unsampled request still builds span context for `set_ngx_var`; sampled propagation covered by existing cases)
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible