### PR TITLE
fix(ai-proxy): log upstream error responses for better diagnostics

### DIFF
--- a/apisix/plugins/ai-proxy/base.lua
+++ b/apisix/plugins/ai-proxy/base.lua
@@ -338,6 +338,8 @@ function _M.before_proxy(conf, ctx, on_error)
                 if res._httpc then
                     res._httpc:close()
                 end
+                core.log.warn("upstream AI service returned status: ", res.status,
+                             ", body: ", error_body or "")
                 return res.status, error_body
             end
 

--- a/t/plugin/ai-proxy.t
+++ b/t/plugin/ai-proxy.t
@@ -1325,5 +1325,7 @@ POST /anything
 { "messages": [ { "role": "user", "content": "What is 1+1?"} ] }
 --- error_code: 500
 --- response_body_like: upstream boom
+--- error_log
+upstream AI service returned status: 500
 --- response_headers
 Content-Type: application/json


### PR DESCRIPTION
### Description

This PR adds error logging for upstream AI service responses in the ai-proxy plugin.

**Problem:**
When upstream AI services return error responses (non-2xx status codes), the current implementation returns the error to the client but doesn't log the upstream response details. This makes troubleshooting production issues difficult, as operators have no visibility into what the upstream service actually returned.

**Solution:**
Add a warning-level log entry that captures:
- The HTTP status code from the upstream AI service
- The error response body

This improves observability and helps diagnose issues like:
- Upstream service outages or rate limiting
- Authentication/authorization failures with AI providers
- Invalid request format errors
- API quota exhaustions


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
