### PR TITLE
docs: update Debian APT repo instructions

### DIFF
--- a/docs/en/latest/installation-guide.md
+++ b/docs/en/latest/installation-guide.md
@@ -166,23 +166,23 @@ Run `apisix help` to get a list of all available operations.
 
 ### Installation via DEB repository
 
-Currently the only DEB repository supported by APISIX is Debian 11 (Bullseye) and supports both amd64 and arm64 architectures.
+Currently the only DEB repository supported by APISIX is Debian 12 and supports both amd64 and arm64 architectures.
 
 ```shell
 # amd64
 wget -O - http://repos.apiseven.com/pubkey.gpg | sudo apt-key add -
-echo "deb http://repos.apiseven.com/packages/debian bullseye main" | sudo tee /etc/apt/sources.list.d/apisix.list
+echo "deb http://repos.apiseven.com/packages/debian debian12 main" | sudo tee /etc/apt/sources.list.d/apisix.list
 
 # arm64
 wget -O - http://repos.apiseven.com/pubkey.gpg | sudo apt-key add -
-echo "deb http://repos.apiseven.com/packages/arm64/debian bullseye main" | sudo tee /etc/apt/sources.list.d/apisix.list
+echo "deb http://repos.apiseven.com/packages/arm64/debian debian12 main" | sudo tee /etc/apt/sources.list.d/apisix.list
 ```
 
 Then, to install APISIX, run:
 
 ```shell
 sudo apt update
-sudo apt install -y apisix=3.8.0-0
+sudo apt install -y apisix
 ```
 
 ### Managing APISIX server

--- a/docs/zh/latest/installation-guide.md
+++ b/docs/zh/latest/installation-guide.md
@@ -169,23 +169,23 @@ apisix start
 
 ### 通过 DEB 仓库安装
 
-目前 APISIX 支持的 DEB 仓库仅支持 Debian 11（Bullseye），并且支持 amd64 和 arm64 架构。
+目前 APISIX 支持的 DEB 仓库仅支持 Debian 12，并且支持 amd64 和 arm64 架构。
 
 ```shell
 # amd64
 wget -O - http://repos.apiseven.com/pubkey.gpg | sudo apt-key add -
-echo "deb http://repos.apiseven.com/packages/debian bullseye main" | sudo tee /etc/apt/sources.list.d/apisix.list
+echo "deb http://repos.apiseven.com/packages/debian debian12 main" | sudo tee /etc/apt/sources.list.d/apisix.list
 
 # arm64
 wget -O - http://repos.apiseven.com/pubkey.gpg | sudo apt-key add -
-echo "deb http://repos.apiseven.com/packages/arm64/debian bullseye main" | sudo tee /etc/apt/sources.list.d/apisix.list
+echo "deb http://repos.apiseven.com/packages/arm64/debian debian12 main" | sudo tee /etc/apt/sources.list.d/apisix.list
 ```
 
 完成上述操作后使用以下命令安装 APISIX：
 
 ```shell
 sudo apt update
-sudo apt install -y apisix=3.8.0-0
+sudo apt install -y apisix
 ```
 
 ### 管理 APISIX 服务


### PR DESCRIPTION
### Description

Update the DEB installation instructions to use the current Debian 12 APISIX APT repository instead of the old Debian 11/Bullseye repository.

This also removes the stale fixed package version `apisix=3.8.0-0` from the install command. The docs now install `apisix` from the configured repo, so the example does not go stale on every APISIX release.

### Investigation

- `api7/apisix-build-tools#454` intentionally removed the Debian Bullseye publish target and replaced it with Debian 12 because Debian 11 reaches EOL in June 2026.
- The current package repo metadata uses `Codename: debian12`, not `bullseye`.
- The Debian 12 amd64 and arm64 package indexes both contain `apisix 3.17.0-0`.
- The old Bullseye repo remains capped at `3.16.0-0`, which is why apache/apisix#13604 happens with the existing docs.

### Validation

- Verified `http://repos.apiseven.com/packages/debian/dists/debian12/Release` reports `Suite: debian12`, `Codename: debian12`, and `Architectures: amd64`.
- Verified `http://repos.apiseven.com/packages/arm64/debian/dists/debian12/Release` reports `Suite: debian12`, `Codename: debian12`, and `Architectures: arm64`.
- Verified `http://repos.apiseven.com/packages/debian/dists/debian12/main/binary-amd64/Packages` contains `apisix 3.17.0-0`.
- Verified `http://repos.apiseven.com/packages/arm64/debian/dists/debian12/main/binary-arm64/Packages` contains `apisix 3.17.0-0`.
- Checked that the edited install guides no longer contain `bullseye`, `Debian 11`, or `apisix=3.8.0-0`.

Closes apache/apisix#13604

