### PR TITLE
fix(resource): support all plugin-bearing resource types in fetch_latest_conf

### DIFF
--- a/apisix/resource.lua
+++ b/apisix/resource.lua
@@ -22,6 +22,23 @@ local config_util = require("apisix.core.config_util")
 local require = require
 
 local _M = {}
+
+
+-- resource types whose config may attach plugins via `_meta.parent`
+-- (set by plugin.set_plugins_meta_parent) and thus reach fetch_latest_conf.
+-- Every type maps to its own "/<type>" top-level config key.
+local SUPPORTED_RESOURCE_TYPES = {
+    upstreams = true,
+    routes = true,
+    services = true,
+    stream_routes = true,
+    plugin_configs = true,
+    global_rules = true,
+    consumers = true,
+    consumer_groups = true,
+}
+
+
 local function remove_etcd_prefix(key)
     local prefix = ""
     local local_conf =  require("apisix.core.config_local").local_conf()
@@ -50,19 +67,13 @@ local function fetch_latest_conf(resource_path)
         return nil
     end
 
-    local key
-    if resource_type == "upstreams" then
-        key = "/upstreams"
-    elseif resource_type == "routes" then
-        key = "/routes"
-    elseif resource_type == "services" then
-        key = "/services"
-    elseif resource_type == "stream_routes" then
-        key = "/stream_routes"
-    else
+    -- all resource types that can carry plugins (and thus reach here via
+    -- _meta.parent) map their type to their own top-level config key
+    if not SUPPORTED_RESOURCE_TYPES[resource_type] then
         log.error("unsupported resource type: ", resource_type)
         return nil
     end
+    local key = "/" .. resource_type
 
     local data = core.config.fetch_created_obj(key)
     if not data then

--- a/t/plugin/ai-proxy-multi.balancer.t
+++ b/t/plugin/ai-proxy-multi.balancer.t
@@ -1181,3 +1181,93 @@ Host: openai_internal_error
 --- error_code: 500
 --- no_error_log
 [error]
+
+
+
+=== TEST 22: set plugin_config with ai-proxy-multi (2 instances) and route referencing it
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/plugin_configs/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "plugins": {
+                        "ai-proxy-multi": {
+                            "instances": [
+                                {
+                                    "name": "openai",
+                                    "provider": "openai",
+                                    "weight": 4,
+                                    "auth": {
+                                        "header": {
+                                            "Authorization": "Bearer token"
+                                        }
+                                    },
+                                    "options": {
+                                        "model": "gpt-4"
+                                    },
+                                    "override": {
+                                        "endpoint": "http://127.0.0.1:6724"
+                                    }
+                                },
+                                {
+                                    "name": "deepseek",
+                                    "provider": "deepseek",
+                                    "weight": 1,
+                                    "auth": {
+                                        "header": {
+                                            "Authorization": "Bearer token"
+                                        }
+                                    },
+                                    "options": {
+                                        "model": "deepseek-chat"
+                                    },
+                                    "override": {
+                                        "endpoint": "http://127.0.0.1:6724/chat/completions"
+                                    }
+                                }
+                            ],
+                            "ssl_verify": false
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "uri": "/anything",
+                    "plugin_config_id": 1,
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:6724": 1
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 23: request via plugin_config_id succeeds (regression for multi-instance parent lookup)
+--- request
+POST /anything
+{ "messages": [ { "role": "system", "content": "You are a mathematician" }, { "role": "user", "content": "What is 1+1?"} ] }
+--- response_body_like eval
+qr/openai|deepseek/
+--- no_error_log
+failed to fetch the parent config


### PR DESCRIPTION
### Description

Follow-up to #13458 (and issue #13456).

`resource.fetch_latest_conf` only whitelisted `upstreams`/`routes`/`services`/`stream_routes`. Any resource that attaches plugins via `_meta.parent` (set by `plugin.set_plugins_meta_parent`) but isn't in that list — `plugin_configs`, `global_rules`, `consumers`, `consumer_groups` — hit `unsupported resource type` and returned `nil`.

Concretely, `ai-proxy-multi` with multiple instances referenced through a `plugin_config_id` calls `fetch_latest_conf(conf._meta.parent.resource_key)` in `pick_target`, gets `nil`, and the request fails with `failed to fetch the parent config` (5xx). The same 5xx happens for ai-proxy-multi carried by a global_rule / consumer / consumer_group.

#13458 fixed only `plugin_configs` by adding one more branch. As @nic-6443 pointed out there, every supported prefix just maps to itself, so this replaces the if/else chain with a whitelist lookup table covering all plugin-bearing resource types; each maps to its `/<type>` top-level config key.

### Fixes

closes #13456.

### Test

Added a regression test in `t/plugin/ai-proxy-multi.balancer.t`: an `ai-proxy-multi` plugin_config with two instances, referenced by a route via `plugin_config_id`. Without the fix the request returns 5xx (`failed to fetch the parent config`); with it, it proxies successfully. Verified locally — the whole file passes, and reverting `resource.lua` makes only the new test fail.