### PR TITLE
fix: reject consumer auth when secret reference fails to resolve

### DIFF
--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -252,9 +252,14 @@ function create_consume_cache(consumers_conf, key_attr)
         local key_value = new_consumer.auth_conf[key_attr]
         -- fail closed: skip if the credential is unset or an unresolved secret ref,
         -- else a client could auth with the literal $ENV://... reference string
-        if key_value == nil or secret.has_secret_ref(new_consumer.auth_conf) then
+        if key_value == nil then
+            core.log.error("missing consumer auth credential '", key_attr,
+                           "', skipping consumer: ", new_consumer.consumer_name)
+
+        elseif secret.has_secret_ref(new_consumer.auth_conf) then
             core.log.error("failed to resolve secret reference in consumer auth ",
                            "credential, skipping consumer: ", new_consumer.consumer_name)
+
         else
             consumer_names[key_value] = new_consumer
         end

--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -249,7 +249,15 @@ function create_consume_cache(consumers_conf, key_attr)
     for _, consumer in ipairs(consumers_conf.nodes) do
         local new_consumer = consumer_lrucache(consumer, nil,
                                 fill_consumer_secret, consumer)
-        consumer_names[new_consumer.auth_conf[key_attr]] = new_consumer
+        local key_value = new_consumer.auth_conf[key_attr]
+        -- fail closed: skip if the credential is unset or an unresolved secret ref,
+        -- else a client could auth with the literal $ENV://... reference string
+        if key_value == nil or secret.has_secret_ref(new_consumer.auth_conf) then
+            core.log.error("failed to resolve secret reference in consumer auth ",
+                           "credential, skipping consumer: ", new_consumer.consumer_name)
+        else
+            consumer_names[key_value] = new_consumer
+        end
     end
 
     return consumer_names

--- a/t/plugin/key-auth.t
+++ b/t/plugin/key-auth.t
@@ -737,3 +737,46 @@ passed
 GET /hello?auth=authtwo
 --- response_args
 auth: authtwo
+
+
+
+=== TEST 33: consumer key uses an env ref that fails to resolve
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "jack",
+                    "plugins": {
+                        "key-auth": {
+                            "key": "$env://KEYAUTH_UNRESOLVED_SECRET"
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 34: fail closed, literal ref is not accepted as a credential
+--- request
+GET /hello
+--- more_headers
+apikey: $env://KEYAUTH_UNRESOLVED_SECRET
+--- error_code: 401
+--- response_body
+{"message":"Invalid API key in request"}
+--- error_log
+invalid api key


### PR DESCRIPTION
### Description

When a consumer authentication credential is configured with a secret reference (`$ENV://...` or `$secret://...`) and that reference fails to resolve (env var unset, or the secret object is missing), `secret.lua`'s `retrieve_refs` preserves the literal reference string (`refs[k] = fetch(v) or v`). `consumer.lua`'s `create_consume_cache` then indexes the consumer under that literal string, so a client that sends the literal reference string as its credential authenticates successfully (fail-open).

Reproduced with `key-auth`: a consumer with `key-auth.key = "$env://MISSING"` (env unset) authenticates a request sending `apikey: $env://MISSING`. The same fail-open shape affects `basic-auth`, `hmac-auth`, and `jwt-auth` HS* secrets, since all route through `create_consume_cache`.

### Fix

Fail closed in `create_consume_cache`: skip indexing a consumer whose auth credential is unset or still an unresolved secret reference (`secret.has_secret_ref(auth_conf)`). Using `has_secret_ref` over the whole `auth_conf` (not just the lookup key) also covers plugins whose secret is not the lookup field (e.g. `basic-auth` password, `jwt-auth` HS secret). Also removes a latent nil-index case.

### Test

Added a `key-auth` regression case: a consumer whose key is an unresolved env ref, then a request sending the literal ref is rejected `401`. Verified it fails on the old code (returns `200`) and passes with the fix.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (no user-facing config/API change; behavior-only hardening)
- [x] I have verified that this change is backward compatible
