### PR TITLE
fix: invalidate secret LRU cache on /secrets changes

### DIFF
--- a/apisix/secret.lua
+++ b/apisix/secret.lua
@@ -233,7 +233,9 @@ local function fetch(uri, use_cache)
         return val
     end
 
-    return secrets_cache(uri, "", fetch_by_uri, uri)
+    -- pass the secrets conf_version so the cache re-resolves when /secrets changes
+    local version = secrets and secrets.conf_version or ""
+    return secrets_cache(uri, version, fetch_by_uri, uri)
 end
 
 local function retrieve_refs(refs, use_cache)

--- a/t/secret/secret_lru.t
+++ b/t/secret/secret_lru.t
@@ -96,3 +96,75 @@ GET /t
     }
 --- response_body
 nil
+
+
+
+=== TEST 2: store secret into vault
+--- exec
+VAULT_TOKEN='root' VAULT_ADDR='http://0.0.0.0:8200' vault kv put kv/apisix/lru-key/jack key=value
+--- response_body
+Success! Data written to: kv/apisix/lru-key/jack
+
+
+
+=== TEST 3: deleted secret is evicted from the LRU cache
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local secret = require("apisix.secret")
+
+            -- configure the vault secret manager
+            local code, body = t('/apisix/admin/secrets/vault/lru',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "http://127.0.0.1:8200",
+                    "prefix": "kv/apisix",
+                    "token": "root"
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+                return ngx.say(body)
+            end
+
+            local ref = { key = "$secret://vault/lru/lru-key/jack/key" }
+
+            -- resolve through the cache once the manager config is synced
+            local resolved
+            for _ = 1, 50 do
+                resolved = secret.fetch_secrets(ref, true)
+                if resolved.key == "value" then
+                    break
+                end
+                ngx.sleep(0.1)
+            end
+            ngx.say(resolved.key)
+
+            local _, ver = secret.secrets()
+
+            code, body = t('/apisix/admin/secrets/vault/lru', ngx.HTTP_DELETE)
+            if code >= 300 then
+                ngx.status = code
+                return ngx.say(body)
+            end
+
+            -- wait for the /secrets config version to bump
+            for _ = 1, 50 do
+                local _, new_ver = secret.secrets()
+                if new_ver ~= ver then
+                    break
+                end
+                ngx.sleep(0.1)
+            end
+
+            -- cache must re-resolve: the manager is gone, so it falls back to the literal ref
+            resolved = secret.fetch_secrets(ref, true)
+            ngx.say(resolved.key)
+        }
+    }
+--- request
+GET /t
+--- response_body
+value
+$secret://vault/lru/lru-key/jack/key

--- a/t/secret/secret_lru.t
+++ b/t/secret/secret_lru.t
@@ -165,6 +165,7 @@ Success! Data written to: kv/apisix/lru-key/jack
     }
 --- request
 GET /t
+--- timeout: 20
 --- response_body
 value
 $secret://vault/lru/lru-key/jack/key


### PR DESCRIPTION
### Description

After a `secret` object is deleted via the Admin API, `$secret://` references keep resolving to the previously cached value indefinitely. Updates to a secret are only picked up after the cache TTL window.

**Root cause:** `apisix/secret.lua` resolved secret URIs through the secret LRU cache with a constant version string:

```lua
return secrets_cache(uri, "", fetch_by_uri, uri)
```

`core.lrucache` uses the `version` argument to detect staleness (an entry is re-resolved only when `obj.ver ~= version`). Every other cached resource passes its real `conf_version`; the secret cache passed `""`, so no `/secrets` change ever invalidated an entry. With `refresh_stale = true` an expired entry keeps being served while a background timer retries, so once the secret is deleted the refresh fails forever and the stale value is served forever.

**Fix:** Pass the real secrets `conf_version` (already exposed via `_M.secrets()`). A change to `/secrets` bumps the version, so the cache re-resolves on the next access, matching how route/service caches behave.

Notes:
- `/secrets` has one shared `conf_version`, so any secret change invalidates all cached secret values (consistent with route/service cache behavior).
- `$env://` shares this cache; bumping on `/secrets` changes also drops env entries, which is harmless since env values are static.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (no user-facing config/behavior change; restores expected behavior)
- [x] I have verified that this change is backward compatible

### Test

`t/secret/secret_lru.t` adds a case that resolves a secret through the cache, deletes it, and asserts the reference stops resolving (falls back to the literal string) instead of serving the stale value. Verified the test fails before the fix and passes after.