### PR TITLE
test(file-logger): cover per-node upstream_unresolved_host mapping

### DIFF
--- a/t/plugin/file-logger.t
+++ b/t/plugin/file-logger.t
@@ -989,3 +989,92 @@ passed
     }
 --- response_body
 enrich log format success
+
+
+
+=== TEST 25: multi-node upstream mixing a domain node and a raw-IP node
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/plugin_metadata/file-logger',
+                ngx.HTTP_PUT,
+                [[{
+                    "log_format_extra": {
+                        "upstream_host": "$upstream_unresolved_host"
+                    }
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            -- distinct hosts prove addr_to_domain maps each picked node to its own host
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "file-logger": {
+                                "path": "file-logger-mixed.log"
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "localhost:1980": 1,
+                                "127.0.0.1:1982": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 26: each node logs its own pre-DNS host, domain resolved and raw IP untouched
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local t = require("lib.test_admin").test
+            -- round-robin over two equal nodes visits both within the cycle
+            for _ = 1, 4 do
+                t("/hello", ngx.HTTP_GET)
+            end
+            local fd, err = io.open("file-logger-mixed.log", 'r')
+            if not fd then
+                core.log.error("failed to open file: file-logger-mixed.log, error info: ", err)
+                return
+            end
+
+            -- collect the pre-DNS host logged for each resolved upstream
+            local host_by_upstream = {}
+            for line in fd:lines() do
+                local m = core.json.decode(line)
+                host_by_upstream[m.upstream] = m.upstream_host
+            end
+            fd:close()
+
+            -- domain node logs its hostname, raw-IP node falls back to the ip
+            if host_by_upstream['127.0.0.1:1980'] == 'localhost' and
+               host_by_upstream['127.0.0.1:1982'] == '127.0.0.1'
+            then
+                ngx.say("enrich log format success")
+            else
+                ngx.say("enrich log format failed: "
+                        .. core.json.encode(host_by_upstream))
+            end
+        }
+    }
+--- response_body
+enrich log format success


### PR DESCRIPTION
### Description

Follow-up test coverage for `upstream_unresolved_host` (added in #13568).

The multi-node test added in #13568 (`file-logger.t` TEST 23/24) uses **two identical `localhost` nodes**. That proves the multi-node `server_picker` branch in `apisix/balancer.lua` runs, but not that `addr_to_domain[server]` maps the *picked* server to its *own* host, so a wrong-mapping regression could slip through.

### Changes

- `t/plugin/file-logger.t`: add TEST 25/26 using a **mixed** upstream, one domain node (`localhost:1980`) and one raw-IP node (`127.0.0.1:1982`). Round-robin visits both across the request cycle; the test collects the pre-DNS host logged for each resolved upstream and asserts:
  - the domain node logs its hostname (`localhost`),
  - the raw-IP node falls back to the ip (`127.0.0.1`).

  This validates the per-server `addr_to_domain` mapping and the `res.domain or res.host` fallback. Existing TEST 23/24 are preserved.

Test-only change, no source or schema change.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (N/A, test-only)
- [x] I have verified that this change is backward compatible (test-only)