### PR TITLE
fix(grpc-transcode): encode empty repeated fields as JSON arrays

### DIFF
--- a/apisix/plugins/grpc-transcode/proto.lua
+++ b/apisix/plugins/grpc-transcode/proto.lua
@@ -109,6 +109,11 @@ local function compile_proto(content)
         end
     end
 
+    -- an empty repeated field is decoded into an empty Lua table, which cjson would
+    -- encode as `{}`. Tag it as an array so that it is encoded as `[]` instead.
+    -- The default is bound to the current pb state, so it has to be set per proto.
+    pb.defaults("*array", core.json.array_mt)
+
     -- fetch pb state
     compiled.pb_state = pb.state(old_pb_state)
     return compiled
@@ -237,6 +242,8 @@ local function init_status_pb_state()
             pb.state(old_pb_state)
             return "failed to load grpc status protocol: " .. err
         end
+
+        pb.defaults("*array", core.json.array_mt)
 
         status_pb_state = pb.state(old_pb_state)
     end

--- a/t/plugin/grpc-transcode.t
+++ b/t/plugin/grpc-transcode.t
@@ -761,3 +761,79 @@ POST /grpctest
 Content-Type: application/json
 --- response_body eval
 qr/"gender":2/
+
+
+
+=== TEST 30: set proto(id: 1) and route with a repeated field in the reply
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/protos/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "content" : "syntax = \"proto3\";
+                      package helloworld;
+                      service Greeter {
+                          rpc SayHello (HelloRequest) returns (HelloReply) {}
+                      }
+                      message HelloRequest {
+                          string name = 1;
+                          repeated string items = 2;
+                      }
+                      message HelloReply {
+                          string message = 1;
+                          repeated string items = 2;
+                         }"
+                   }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "methods": ["POST"],
+                    "uri": "/grpctest",
+                    "plugins": {
+                        "grpc-transcode": {
+                            "proto_id": "1",
+                            "service": "helloworld.Greeter",
+                            "method": "SayHello"
+                        }
+                    },
+                    "upstream": {
+                        "scheme": "grpc",
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:10051": 1
+                        }
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 31: hit route, an empty repeated field is encoded as an empty array
+--- request
+POST /grpctest
+{"name":"world"}
+--- more_headers
+Content-Type: application/json
+--- response_body eval
+qr/"items":\[\]/

--- a/t/plugin/grpc-transcode4.t
+++ b/t/plugin/grpc-transcode4.t
@@ -1,0 +1,147 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_shuffle();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!$block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: empty repeated fields are decoded as arrays, maps stay objects
+--- config
+    location /t {
+        content_by_lua_block {
+            local grpc_proto = require("apisix.plugins.grpc-transcode.proto")
+            local core = require("apisix.core")
+            local pb = require("pb")
+
+            local compiled = assert(grpc_proto.compile_proto([[
+                syntax = "proto3";
+                package t;
+                message Inner {
+                    repeated string tags = 1;
+                }
+                message Reply {
+                    string msg = 1;
+                    repeated string items = 2;
+                    map<string, Inner> members = 3;
+                    Inner inner = 4;
+                    repeated Inner list = 5;
+                }
+            ]]))
+
+            local old_state = pb.state(compiled.pb_state)
+            local bin = pb.encode("t.Reply", {
+                msg = "hi",
+                members = {alice = {}},
+                inner = {},
+                list = {{}},
+            })
+            local decoded = pb.decode("t.Reply", bin)
+            pb.state(old_state)
+
+            ngx.say("items: ", core.json.encode(decoded.items))
+            ngx.say("members: ", core.json.encode(decoded.members))
+            ngx.say("nested in map: ", core.json.encode(decoded.members.alice.tags))
+            ngx.say("nested in message: ", core.json.encode(decoded.inner.tags))
+            ngx.say("nested in repeated: ", core.json.encode(decoded.list[1].tags))
+        }
+    }
+--- response_body
+items: []
+members: {"alice":{"tags":[]}}
+nested in map: []
+nested in message: []
+nested in repeated: []
+
+
+
+=== TEST 2: non-empty repeated fields are unaffected
+--- config
+    location /t {
+        content_by_lua_block {
+            local grpc_proto = require("apisix.plugins.grpc-transcode.proto")
+            local core = require("apisix.core")
+            local pb = require("pb")
+
+            local compiled = assert(grpc_proto.compile_proto([[
+                syntax = "proto3";
+                package t;
+                message Reply {
+                    repeated string items = 1;
+                }
+            ]]))
+
+            local old_state = pb.state(compiled.pb_state)
+            local bin = pb.encode("t.Reply", {items = {"a", "b"}})
+            local decoded = pb.decode("t.Reply", bin)
+            pb.state(old_state)
+
+            ngx.say(core.json.encode(decoded.items))
+        }
+    }
+--- response_body
+["a","b"]
+
+
+
+=== TEST 3: also works for protos loaded from a binary descriptor set
+--- config
+    location /t {
+        content_by_lua_block {
+            local grpc_proto = require("apisix.plugins.grpc-transcode.proto")
+            local core = require("apisix.core")
+            local protoc = require("protoc")
+            local pb = require("pb")
+
+            -- build a FileDescriptorSet, the same format the Admin API accepts
+            protoc.reload()
+            local parsed = protoc.new():parse([[
+                syntax = "proto3";
+                package t;
+                message Reply {
+                    string msg = 1;
+                    repeated string items = 2;
+                }
+            ]])
+            local descriptor_set = pb.encode("google.protobuf.FileDescriptorSet",
+                                             {file = {parsed}})
+
+            local compiled = assert(grpc_proto.compile_proto(
+                                        ngx.encode_base64(descriptor_set)))
+
+            local old_state = pb.state(compiled.pb_state)
+            local decoded = pb.decode("t.Reply", pb.encode("t.Reply", {msg = "hi"}))
+            pb.state(old_state)
+
+            ngx.say(core.json.encode(decoded.items))
+        }
+    }
+--- response_body
+[]


### PR DESCRIPTION
### Description

Fixes #11440

An empty `repeated` field is decoded by lua-protobuf into an empty Lua table. Lua cannot tell an empty array from an empty object, so `cjson.encode` emits `{}` where the client expects `[]`.

lua-protobuf 0.5.3 (the version pinned in the rockspec) supports a `*array` [default metatable](https://github.com/starwing/lua-protobuf#default-values). Setting it to `core.json.array_mt` inside `compile_proto()` makes `pb.decode` tag every repeated field as an array by itself:

```lua
pb.defaults("*array", core.json.array_mt)
```

Behavior with the plugin's default `pb_option`:

- empty repeated fields encode as `[]`
- map fields keep object semantics (`{}`) — lua-protobuf distinguishes maps from arrays natively
- nested repeated fields inside messages, repeated messages and map values are all covered
- it works for both the text proto path and the binary descriptor set path

`pb.defaults` is bound to the active pb state, so it is set per compiled proto rather than at module load time. The same is done for the gRPC status pb state, so that an empty `ErrorStatus.details` is also rendered as `[]`.

This is a pure decode-side change with no per-request cost.

An alternative implementation exists in #12649, which builds a message descriptor index from the proto and walks the decoded table on every response. Besides the per-request traversal, the numeric `label`/`type` comparisons it relies on do not match on the binary descriptor path (`pb.decode` of a `FileDescriptorSet` yields `"LABEL_REPEATED"` / `"TYPE_MESSAGE"` under the default `enum_as_name`), so that path is left unfixed there.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)