### PR TITLE
fix(cli): skip commented-out lines when resolving env vars in apisix.yaml

### DIFF
--- a/apisix/cli/file.lua
+++ b/apisix/cli/file.lua
@@ -31,6 +31,7 @@ local getenv = os.getenv
 local str_gmatch = string.gmatch
 local str_find = string.find
 local str_sub = string.sub
+local table_concat = table.concat
 local print = print
 
 local _M = {}
@@ -92,12 +93,32 @@ end
 
 -- Substitute env vars in raw text before parsing. YAML parser then infers
 -- types naturally: `"${{VAR}}"` stays string, `${{VAR}}` infers from value.
+-- Substitution runs line by line so that full-line comments stay untouched:
+-- a commented-out `# ${{VAR}}` must not fail startup when VAR is unset.
+-- Known limits of this text-level heuristic: an inline trailing comment is
+-- still substituted (`#` may legally appear inside YAML strings), and a
+-- block-scalar content line starting with `#` is skipped like a comment.
 local function resolve_conf_var_in_text(text)
-    local new_text, _, err = var_sub(text)
-    if err then
-        return nil, err
+    local parts = {}
+    -- a UTF-8 BOM would hide the `#` of a first-line comment, so detach it
+    if str_sub(text, 1, 3) == "\239\187\191" then
+        parts[1] = str_sub(text, 1, 3)
+        text = str_sub(text, 4)
     end
-    return new_text
+    for line, eol in str_gmatch(text, "([^\n]*)(\n?)") do
+        if is_empty_yaml_line(line) or not str_find(line, "${{", 1, true) then
+            -- comment / blank / no reference: keep the line as-is
+            parts[#parts + 1] = line
+        else
+            local new_line, _, err = var_sub(line)
+            if err then
+                return nil, err
+            end
+            parts[#parts + 1] = new_line
+        end
+        parts[#parts + 1] = eol
+    end
+    return table_concat(parts)
 end
 
 

--- a/t/cli/test_standalone.sh
+++ b/t/cli/test_standalone.sh
@@ -660,5 +660,55 @@ fi
 
 echo "passed: missing env var produces clear startup error"
 
+# test: unset env vars referenced only in commented-out lines must be ignored
+echo '
+apisix:
+  enable_admin: false
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+' > conf/config.yaml
+
+echo '
+# ${{COMMENTED_UNSET_VAR}}
+routes:
+  -
+    uri: /test-commented-var
+    # indented comment: ${{ANOTHER_COMMENTED_UNSET_VAR}}
+    plugins:
+      response-rewrite:
+        body: "commented-ok"
+        status_code: 200
+    upstream:
+      nodes:
+        "127.0.0.1:9091": 1
+      type: roundrobin
+#END
+' > conf/apisix.yaml
+
+unset COMMENTED_UNSET_VAR
+unset ANOTHER_COMMENTED_UNSET_VAR
+make init
+
+if ! make run > output.log 2>&1; then
+    cat output.log
+    echo "failed: make run should ignore env vars in commented-out lines"
+    exit 1
+fi
+sleep 0.1
+
+code=$(curl -o /tmp/response_body -s -m 5 -w %{http_code} http://127.0.0.1:9080/test-commented-var)
+body=$(cat /tmp/response_body)
+if [ "$code" -ne 200 ] || [ "$body" != "commented-ok" ]; then
+    echo "failed: expected 200/commented-ok for /test-commented-var, got code: $code body: $body"
+    exit 1
+fi
+
+make stop
+sleep 0.5
+
+echo "passed: commented-out env var references are not resolved"
+
 git checkout conf/config.yaml
 git checkout conf/apisix.yaml


### PR DESCRIPTION
### Description

Standalone mode fails to boot when `apisix.yaml` contains a commented-out env var reference:

```yaml
# ${{MY_ENV_VAR}}
```

Since #13078 (shipped in 3.17.0), `${{VAR}}` is substituted on the raw text *before* YAML parsing so the parser can infer scalar types — which means comment lines are substituted too, and an unset var inside a comment aborts startup with `can't find environment variable MY_ENV_VAR`. (`config.yaml` is unaffected: it substitutes on the parsed table where comments are already gone; same for JSON standalone configs, which also resolve post-parse.)

This patch makes the raw-text substitution run line by line, keeping full-line comments (and blank / no-reference lines) verbatim, reusing the existing `is_empty_yaml_line` predicate. A leading UTF-8 BOM is detached first so a first-line comment is still recognized. Unset vars on data lines still fail with the same error message; output is byte-identical to the previous implementation for comment-free input (line endings, missing trailing newline, and the `#END` marker are all preserved). Both callers — CLI init (`cli/file.lua`) and the runtime hot-reload (`core/config_yaml.lua`) — share the fixed function.

Behavior notes (accepted trade-offs of the text-level heuristic, documented in the code comment):

- inline trailing comments (`key: val # ${{VAR}}`) are still substituted — `#` may legally appear inside YAML strings, and telling those apart requires a full parse, which can only happen after substitution;
- a block-scalar content line that itself starts with `#` is now skipped like a comment (no in-tree config or doc example hits this; the failure mode is a visible literal `${{VAR}}`, not a crash);
- a `${{...}}` reference spanning a physical line no longer matches (all in-tree references are single-line);
- a var referenced *only* in a comment no longer emits an `env VAR;` nginx directive (comments having side effects was part of the bug).

The new test in `t/cli/test_standalone.sh` covers both paths: `make init` (CLI) and `make run` + request (runtime hot-reload) against a config whose commented-out lines reference unset vars.

#### Which issue(s) this PR fixes:

Fixes #13685

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
