### PR TITLE
fix(request-validation): guard non-string Content-Type before lower()

### DIFF
--- a/apisix/plugins/request-validation.lua
+++ b/apisix/plugins/request-validation.lua
@@ -91,6 +91,13 @@ function _M.rewrite(conf, ctx)
 
         local body_is_json = true
         local content_type = headers["content-type"]
+        -- a duplicated Content-Type is ambiguous: APISIX and the upstream may
+        -- parse the body differently, bypassing validation. reject it.
+        if type(content_type) == "table" then
+            core.log.error("duplicated Content-Type header")
+            return conf.rejected_code, conf.rejected_msg
+        end
+
         if type(content_type) == "string"
             and core.string.has_prefix(
                 content_type:lower(),

--- a/apisix/plugins/request-validation.lua
+++ b/apisix/plugins/request-validation.lua
@@ -18,6 +18,7 @@ local core          = require("apisix.core")
 local secret        = require("apisix.secret")
 local plugin_name   = "request-validation"
 local ngx           = ngx
+local type          = type
 
 local schema = {
     type = "object",
@@ -89,9 +90,10 @@ function _M.rewrite(conf, ctx)
         end
 
         local body_is_json = true
-        if headers["content-type"]
+        local content_type = headers["content-type"]
+        if type(content_type) == "string"
             and core.string.has_prefix(
-                headers["content-type"]:lower(),
+                content_type:lower(),
                 "application/x-www-form-urlencoded"
             )
         then

--- a/t/plugin/request-validation.t
+++ b/t/plugin/request-validation.t
@@ -1786,11 +1786,25 @@ qr/101-hello/
 
 
 
-=== TEST 53: test urlencoded post data with charset header
+=== TEST 53: test urlencoded post data with charset and mixed-case media type
 --- more_headers
-Content-Type: application/x-www-form-urlencoded; charset=utf-8
+Content-Type: Application/X-WWW-Form-Urlencoded; charset=utf-8
 --- request eval
 "POST /echo
 " . "a=b&" x 101 . "required_payload=101-hello"
 --- response_body eval
 qr/101-hello/
+
+
+
+=== TEST 54: duplicated Content-Type header must not error
+--- more_headers
+Content-Type: application/x-www-form-urlencoded
+Content-Type: application/json
+--- request
+POST /echo
+{"required_payload": "hello54"}
+--- response_body eval
+qr/hello54/
+--- no_error_log
+[error]

--- a/t/plugin/request-validation.t
+++ b/t/plugin/request-validation.t
@@ -1797,14 +1797,72 @@ qr/101-hello/
 
 
 
-=== TEST 54: duplicated Content-Type header must not error
+=== TEST 54: add route for duplicated Content-Type validation
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "plugins": {
+                        "request-validation": {
+                            "body_schema": {
+                                "type": "object",
+                                "required": ["required_payload"],
+                                "properties": {
+                                    "required_payload": {"type": "string"}
+                                }
+                            },
+                            "rejected_code": 400,
+                            "rejected_msg": "duplicated content-type"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/echo"
+                }]])
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 55: duplicated Content-Type header is rejected (urlencoded, json)
 --- more_headers
 Content-Type: application/x-www-form-urlencoded
 Content-Type: application/json
 --- request
 POST /echo
-{"required_payload": "hello54"}
---- response_body eval
-qr/hello54/
---- no_error_log
-[error]
+{"required_payload": "hello"}
+--- error_code: 400
+--- response_body chomp
+duplicated content-type
+--- error_log
+duplicated Content-Type header
+
+
+
+=== TEST 56: duplicated Content-Type header is rejected (json, urlencoded)
+--- more_headers
+Content-Type: application/json
+Content-Type: application/x-www-form-urlencoded
+--- request
+POST /echo
+{"required_payload": "hello"}
+--- error_code: 400
+--- response_body chomp
+duplicated content-type
+--- error_log
+duplicated Content-Type header


### PR DESCRIPTION
### Description

The `request-validation` plugin decides whether a request body is form-urlencoded by lowercasing the `Content-Type` header and prefix-matching it:

```lua
if headers["content-type"]
    and core.string.has_prefix(headers["content-type"]:lower(), "application/x-www-form-urlencoded")
then
```

`headers` comes from `ngx.req.get_headers()`, which returns a **table** (not a string) when a header appears more than once. So a request that carries a duplicated `Content-Type` header makes `headers["content-type"]` a table, and `table:lower()` raises `attempt to call method 'lower' (a nil value)` in the `rewrite` phase. The request then fails with a 500 and an error log, instead of being validated (or cleanly rejected).

This PR guards the value with a string type check before calling `:lower()`. A non-string `Content-Type` now falls through to the JSON default path, matching the plugin's intent for anything that is not form-urlencoded.

While here, the existing charset test used an all-lowercase media type, so it never actually exercised the `:lower()` call; it now uses a mixed-case media type. A new test covers the duplicated-header path.

#### Which issue(s) this PR fixes:
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!-- Docs unchanged: this is an internal robustness fix; the documented schema-validation behavior is unchanged. -->
