### PR TITLE
fix(key-auth): propagate real auth error to multi-auth orchestrator

### DIFF
--- a/apisix/plugins/key-auth.lua
+++ b/apisix/plugins/key-auth.lua
@@ -18,6 +18,7 @@ local core     = require("apisix.core")
 local consumer_mod = require("apisix.consumer")
 local plugin_name = "key-auth"
 local schema_def = require("apisix.schema_def")
+local auth_utils = require("apisix.utils.auth")
 
 local schema = {
     type = "object",
@@ -83,7 +84,12 @@ local function find_consumer(ctx, conf)
 
     local consumer, consumer_conf, err = consumer_mod.find_consumer(plugin_name, "key", key)
     if not consumer then
-        core.log.warn("failed to find consumer: ", err or "invalid api key")
+        err = "failed to find consumer: " .. (err or "invalid api key")
+        -- surface the real reason to the multi-auth orchestrator
+        if auth_utils.is_running_under_multi_auth(ctx) then
+            return nil, nil, err
+        end
+        core.log.warn(err)
         return nil, nil, "Invalid API key in request"
     end
 
@@ -125,9 +131,13 @@ function _M.rewrite(conf, ctx)
         end
         consumer, consumer_conf, err = consumer_mod.get_anonymous_consumer(conf.anonymous_consumer)
         if not consumer then
+            core.response.set_header("WWW-Authenticate", "apikey realm=\"" .. conf.realm .. "\"")
+            -- surface the real reason to the multi-auth orchestrator
+            if auth_utils.is_running_under_multi_auth(ctx) then
+                return 401, err
+            end
             err = "key-auth failed to authenticate the request, code: 401. error: " .. err
             core.log.error(err)
-            core.response.set_header("WWW-Authenticate", "apikey realm=\"" .. conf.realm .. "\"")
             return 401, { message = "Invalid user authorization"}
         end
     end

--- a/docs/en/latest/plugins/multi-auth.md
+++ b/docs/en/latest/plugins/multi-auth.md
@@ -39,6 +39,8 @@ import TabItem from '@theme/TabItem';
 
 The `multi-auth` Plugin allows Consumers using different authentication methods to share the same Route or Service. It supports the configuration of multiple authentication Plugins, so that a request would be allowed through if it authenticates successfully against any configured authentication method.
 
+When every configured method fails, the request is rejected with a `401` and each method's underlying failure reason is written to the error log (for example, `key-auth failed to authenticate the request, code: 401. error: failed to find consumer: invalid api key`), which helps diagnose why a particular authentication method rejected the request.
+
 ## Attributes
 
 | Name | Type | Required | Default | Valid values | Description |

--- a/t/plugin/multi-auth2.t
+++ b/t/plugin/multi-auth2.t
@@ -116,9 +116,11 @@ apikey: 123
 {"message":"Authorization Failed"}
 --- error_log
 basic-auth failed to authenticate the request, code: 401. error: Missing authorization in request
-key-auth failed to authenticate the request, code: 401. error: Invalid API key in request
+key-auth failed to authenticate the request, code: 401. error: failed to find consumer: invalid api key
 jwt-auth failed to authenticate the request, code: 401. error: Missing JWT token in request
 hmac-auth failed to authenticate the request, code: 401. error: client request can't be validated: missing Authorization header
+--- no_error_log
+error: Invalid API key in request
 
 
 


### PR DESCRIPTION
### Description

Under the `multi-auth` plugin, `key-auth` returned the generic `Invalid API key in request` instead of the real failure reason, so the orchestrator could not surface *why* key-auth rejected the request. Its sibling auth plugins (`basic-auth`, `hmac-auth`, `jwt-auth`) already propagate the real reason via `auth_utils.is_running_under_multi_auth(ctx)`; key-auth was the one plugin skipped when this behavior was introduced (#11775 touched `utils/auth.lua` + basic/hmac/jwt but not key-auth).

This applies APISIX's own established pattern to key-auth:

- `find_consumer`: on the consumer-not-found path, return the real `failed to find consumer: <reason>` to the orchestrator when running under multi-auth (mirrors `basic-auth.lua`).
- `rewrite`: on the anonymous-fallback failure, return the real error to the orchestrator when running under multi-auth (mirrors `hmac-auth.lua`).

Standalone key-auth behavior is unchanged: clients still receive the generic message and the detailed reason is still logged.

### Tests

- Updated `t/plugin/multi-auth2.t` TEST 3 to assert the detailed key-auth reason now reaches the multi-auth error log, plus a `no_error_log` guard that the old generic message is gone.
- `t/plugin/multi-auth.t`, `t/plugin/multi-auth2.t`, `t/plugin/key-auth.t` all pass locally.
- Added a note to `docs/en/latest/plugins/multi-auth.md`.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible