### PR TITLE
fix(wolf-rbac): clear upstream identity headers when auth response omits userInfo

### DIFF
--- a/apisix/plugins/wolf-rbac.lua
+++ b/apisix/plugins/wolf-rbac.lua
@@ -287,13 +287,17 @@ function _M.rewrite(conf, ctx)
 
     local username = nil
     local nickname = nil
+    local prefix = cur_consumer.auth_conf.header_prefix or ''
+    -- drop client-supplied identity headers before trusting the auth response
+    core.request.set_header(ctx, prefix .. "UserId", nil)
+    core.request.set_header(ctx, prefix .. "Username", nil)
+    core.request.set_header(ctx, prefix .. "Nickname", nil)
     if type(res.userInfo) == 'table' then
         local userInfo = res.userInfo
         ctx.userInfo = userInfo
         local userId = userInfo.id
         username = userInfo.username
         nickname = userInfo.nickname or userInfo.username
-        local prefix = cur_consumer.auth_conf.header_prefix or ''
         core.response.set_header(prefix .. "UserId", userId)
         core.response.set_header(prefix .. "Username", username)
         core.response.set_header(prefix .. "Nickname", ngx.escape_uri(nickname))

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -323,6 +323,9 @@ function _M.wolf_rbac_access_check()
         ngx.say(json_encode({ok=true,
                             data={ userInfo={nickname="administrator",
                                 username="admin", id="100"} }}))
+    elseif resName == '/hello/no_userinfo' then
+        -- authorized (200) but the backend returns no userInfo
+        ngx.say(json_encode({ok=true, data={}}))
     elseif resName == '/hello/500' then
         ngx.status = 500
         ngx.say(json_encode({ok=false, reason="ERR_SERVER_ERROR"}))

--- a/t/plugin/wolf-rbac.t
+++ b/t/plugin/wolf-rbac.t
@@ -890,3 +890,74 @@ X-Real-IP: 192.0.2.10
 wolf_rbac_access_check clientIP: 127.0.0.1
 --- no_error_log
 wolf_rbac_access_check clientIP: 192.0.2.10
+
+
+
+=== TEST 43: consumer and route that echo upstream-bound request headers
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "wolf_rbac_no_echo",
+                    "plugins": {
+                        "wolf-rbac": {
+                            "appid": "wolf-rbac-app-noecho",
+                            "server": "http://127.0.0.1:1982"
+                        }
+                    }
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            code, body = t('/apisix/admin/routes/2',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "wolf-rbac": {},
+                        "serverless-post-function": {
+                            "phase": "access",
+                            "functions": [
+                                "return function(conf, ctx) local core = require(\"apisix.core\"); core.response.exit(200, core.request.headers(ctx)); end"
+                            ]
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1982": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello/no_userinfo"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 44: client-supplied identity headers dropped when auth response omits userInfo
+--- request
+GET /hello/no_userinfo
+--- more_headers
+Authorization: V1#wolf-rbac-app-noecho#wolf-rbac-token
+X-UserId: spoofid007
+X-Username: spoofadmin
+--- error_code: 200
+--- response_body_like eval
+qr/(?s)^(?!.*spoofid007)(?!.*spoofadmin).*authorization/
+--- no_error_log
+[error]


### PR DESCRIPTION
### Description

The `wolf-rbac` plugin injects `X-UserId` / `X-Username` / `X-Nickname` upstream headers from the auth server's `userInfo`, but only inside the `if type(res.userInfo) == 'table'` guard. When the access-check backend authorizes a request (HTTP 200) without returning `userInfo`, that block is skipped and any client-supplied `X-UserId` / `X-Username` / `X-Nickname` headers reach the upstream unchanged.

This aligns `wolf-rbac` with the other auth plugins (`forward-auth`, `opa`, `openid-connect`, `dingtalk-auth`, `feishu-auth`), which already clear these client-supplied identity headers unconditionally before applying the auth response. The plugin now drops the three headers before the `userInfo` gate, so the happy path still overwrites them from `userInfo` and the no-`userInfo` path no longer forwards client values.

#### Which issue(s) this PR fixes:
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change (no user-facing config or documented behavior changes)
- [x] I have verified that this change is backward compatible
