### PR TITLE
fix(ci): wait for the kafka broker before creating topics

### DIFF
--- a/ci/init-last-test-service.sh
+++ b/ci/init-last-test-service.sh
@@ -16,16 +16,39 @@
 # limitations under the License.
 #
 
+# A broker that is not registered in ZooKeeper yet rejects topic creation with
+# "Replication factor: 1 larger than available brokers: 0". The failure used to be
+# silent, and the topic was then auto-created with the default single partition on
+# first produce, which quietly broke tests that expect a specific partition layout.
+create_kafka_topic() {
+    local container="$1"
+    local zookeeper="$2"
+    local partitions="$3"
+    local topic="$4"
+
+    for _ in $(seq 30); do
+        if docker exec -i "$container" /opt/bitnami/kafka/bin/kafka-topics.sh --create \
+            --zookeeper "$zookeeper" --replication-factor 1 \
+            --partitions "$partitions" --topic "$topic"; then
+            return 0
+        fi
+        sleep 2
+    done
+
+    echo "failed to create kafka topic $topic on $container"
+    exit 1
+}
+
 before() {
     # generating SSL certificates for Kafka
     sudo keytool -genkeypair -keyalg RSA -dname "CN=127.0.0.1" -alias 127.0.0.1 -keystore ./ci/pod/kafka/kafka-server/selfsigned.jks -validity 365 -keysize 2048 -storepass changeit
 }
 
 after() {
-    docker exec -i apache-apisix-kafka-server1-1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server1:2181 --replication-factor 1 --partitions 1 --topic test2
-    docker exec -i apache-apisix-kafka-server1-1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server1:2181 --replication-factor 1 --partitions 3 --topic test3
-    docker exec -i apache-apisix-kafka-server2-1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server2:2181 --replication-factor 1 --partitions 1 --topic test4
-    docker exec -i apache-apisix-kafka-server1-1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server1:2181 --replication-factor 1 --partitions 1 --topic test-consumer
+    create_kafka_topic apache-apisix-kafka-server1-1 zookeeper-server1:2181 1 test2
+    create_kafka_topic apache-apisix-kafka-server1-1 zookeeper-server1:2181 3 test3
+    create_kafka_topic apache-apisix-kafka-server2-1 zookeeper-server2:2181 1 test4
+    create_kafka_topic apache-apisix-kafka-server1-1 zookeeper-server1:2181 1 test-consumer
     # create messages for test-consumer
     for i in `seq 30`
     do

--- a/ci/init-plugin-test-service.sh
+++ b/ci/init-plugin-test-service.sh
@@ -16,12 +16,35 @@
 # limitations under the License.
 #
 
+# A broker that is not registered in ZooKeeper yet rejects topic creation with
+# "Replication factor: 1 larger than available brokers: 0". The failure used to be
+# silent, and the topic was then auto-created with the default single partition on
+# first produce, which quietly broke tests that expect a specific partition layout.
+create_kafka_topic() {
+    local container="$1"
+    local zookeeper="$2"
+    local partitions="$3"
+    local topic="$4"
+
+    for _ in $(seq 30); do
+        if docker exec -i "$container" /opt/bitnami/kafka/bin/kafka-topics.sh --create \
+            --zookeeper "$zookeeper" --replication-factor 1 \
+            --partitions "$partitions" --topic "$topic"; then
+            return 0
+        fi
+        sleep 2
+    done
+
+    echo "failed to create kafka topic $topic on $container"
+    exit 1
+}
+
 after() {
-    docker exec -i apache-apisix-kafka-server1-1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server1:2181 --replication-factor 1 --partitions 1 --topic test2
-    docker exec -i apache-apisix-kafka-server1-1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server1:2181 --replication-factor 1 --partitions 3 --topic test3
-    docker exec -i apache-apisix-kafka-server2-1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server2:2181 --replication-factor 1 --partitions 1 --topic test4
-    docker exec -i apache-apisix-kafka-server3-scram-1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server3:2181 --replication-factor 1 --partitions 1 --topic test-scram-256
-    docker exec -i apache-apisix-kafka-server3-scram-1 /opt/bitnami/kafka/bin/kafka-topics.sh --create --zookeeper zookeeper-server3:2181 --replication-factor 1 --partitions 1 --topic test-scram-512
+    create_kafka_topic apache-apisix-kafka-server1-1 zookeeper-server1:2181 1 test2
+    create_kafka_topic apache-apisix-kafka-server1-1 zookeeper-server1:2181 3 test3
+    create_kafka_topic apache-apisix-kafka-server2-1 zookeeper-server2:2181 1 test4
+    create_kafka_topic apache-apisix-kafka-server3-scram-1 zookeeper-server3:2181 1 test-scram-256
+    create_kafka_topic apache-apisix-kafka-server3-scram-1 zookeeper-server3:2181 1 test-scram-512
     # Create user with SCRAM-SHA-512
     docker exec apache-apisix-kafka-server3-scram-1 /opt/bitnami/kafka/bin/kafka-configs.sh \
         --zookeeper zookeeper-server3:2181 \


### PR DESCRIPTION
### Description

`t/plugin/kafka-logger.t` TEST 18 fails intermittently in CI, e.g. https://github.com/apache/apisix/actions/runs/29567552409/job/88251295446:

```
#   Failed test 't/plugin/kafka-logger.t TEST 18: report log to kafka by different partitions - pattern "(?^:partition_id: 1)" should match a line in error.log (req 0)'
#   Failed test 't/plugin/kafka-logger.t TEST 18: report log to kafka by different partitions - pattern "(?^:partition_id: 2)" should match a line in error.log (req 0)'
```

The cause is in the CI setup, not in the test. Earlier in the same job log:

```
Error while executing topic command : Replication factor: 1 larger than available brokers: 0.
Error while executing topic command : Replication factor: 1 larger than available brokers: 0.
Created topic test4.
```

`ci/init-plugin-test-service.sh` creates the topics right after `make ci-env-up` returns. When the broker has not registered itself in ZooKeeper yet, creating `test2` and `test3` fails. The failure is ignored, and since `KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true`, `test3` is then auto-created with the broker default of **one** partition on first produce.

TEST 18 expects `test3` to have 3 partitions and asserts that partition ids 0, 1 and 2 all show up in the error log. With a single-partition topic every message goes to partition 0, so `partition_id: 1` and `partition_id: 2` never appear — exactly the observed failure. Whether the run is affected depends purely on broker startup timing, which is why it looks flaky.

Fix: retry topic creation until the broker accepts it, and fail the setup loudly instead of starting a test run against a wrong partition layout. `ci/init-last-test-service.sh` had the same pattern and gets the same treatment.

Verified locally by reproducing the race (broker deliberately started 20s late):

```
Error while executing topic command : Replication factor: 1 larger than available brokers: 0.
Created topic test3.
real	0m25.180s
```

and the resulting topic has the expected layout:

```
Topic: test3	PartitionCount: 3	ReplicationFactor: 1
```

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
