### PR TITLE
fix(cli): quote nginx_config.envs entries so values with spaces work

### DIFF
--- a/apisix/cli/ngx_tpl.lua
+++ b/apisix/cli/ngx_tpl.lua
@@ -57,7 +57,7 @@ env GCP_SERVICE_ACCOUNT;
 
 {% if envs then %}
 {% for _, name in ipairs(envs) do %}
-env {*name*};
+env "{*name*}";
 {% end %}
 {% end %}
 

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -911,6 +911,15 @@ Please modify "admin_key" in conf/config.yaml .
         sys_conf["discovery_shared_dicts"]["consul"] = consul_conf.shared_size or "64m"
     end
 
+    -- env entries are rendered as double-quoted nginx directive parameters
+    -- (`env "{*name*}";` in ngx_tpl.lua), so embedded `\` and `"` must be
+    -- escaped; nginx unescapes them when reading the quoted token
+    if sys_conf["envs"] then
+        for i, cfg_env in ipairs(sys_conf["envs"]) do
+            sys_conf["envs"][i] = cfg_env:gsub('[\\"]', '\\%0')
+        end
+    end
+
     -- fix up lua path
     sys_conf["extra_lua_path"] = get_lua_path(yaml_conf.apisix.extra_lua_path)
     sys_conf["extra_lua_cpath"] = get_lua_path(yaml_conf.apisix.extra_lua_cpath)

--- a/apisix/cli/ops.lua
+++ b/apisix/cli/ops.lua
@@ -914,8 +914,16 @@ Please modify "admin_key" in conf/config.yaml .
     -- env entries are rendered as double-quoted nginx directive parameters
     -- (`env "{*name*}";` in ngx_tpl.lua), so embedded `\` and `"` must be
     -- escaped; nginx unescapes them when reading the quoted token
+    -- entries synthesized after schema validation (kubernetes discovery copies
+    -- whatever sits between `${` and `}`) never went through the schema
+    -- pattern, so re-check them here rather than emitting a conf that nginx
+    -- rejects with an error pointing at a line the user never wrote
     if sys_conf["envs"] then
         for i, cfg_env in ipairs(sys_conf["envs"]) do
+            if cfg_env:find("%c") then
+                util.die("invalid environment variable entry: ",
+                         "control characters are not allowed\n")
+            end
             sys_conf["envs"][i] = cfg_env:gsub('[\\"]', '\\%0')
         end
     end

--- a/apisix/cli/schema.lua
+++ b/apisix/cli/schema.lua
@@ -291,6 +291,10 @@ local config_schema = {
                     minItems = 1,
                     items = {
                         type = "string",
+                        -- NUL can never be carried through the C environ and
+                        -- other control chars (newline etc.) have no sane
+                        -- config source; reject early with a clear error
+                        pattern = [[\A[^\x00-\x1f]*\z]],
                     }
                 }
             },

--- a/t/cli/test_kubernetes.sh
+++ b/t/cli/test_kubernetes.sh
@@ -30,17 +30,17 @@ discovery:
 
 make init
 
-if ! grep "env HOST_ENV" conf/nginx.conf; then
+if ! grep 'env "HOST_ENV"' conf/nginx.conf; then
   echo "kubernetes discovery env inject failed"
   exit 1
 fi
 
-if ! grep "env KUBERNETES_SERVICE_PORT" conf/nginx.conf; then
+if ! grep 'env "KUBERNETES_SERVICE_PORT"' conf/nginx.conf; then
   echo "kubernetes discovery env inject failed"
   exit 1
 fi
 
-if ! grep "env TOKEN_ENV" conf/nginx.conf; then
+if ! grep 'env "TOKEN_ENV"' conf/nginx.conf; then
   echo "kubernetes discovery env inject failed"
   exit 1
 fi
@@ -70,32 +70,32 @@ discovery:
 
 make init
 
-if ! grep "env DEV_HOST" conf/nginx.conf; then
+if ! grep 'env "DEV_HOST"' conf/nginx.conf; then
   echo "kubernetes discovery env inject failed"
   exit 1
 fi
 
-if ! grep "env DEV_PORT" conf/nginx.conf; then
+if ! grep 'env "DEV_PORT"' conf/nginx.conf; then
   echo "kubernetes discovery env inject failed"
   exit 1
 fi
 
-if ! grep "env DEV_TOKEN" conf/nginx.conf; then
+if ! grep 'env "DEV_TOKEN"' conf/nginx.conf; then
   echo "kubernetes discovery env inject failed"
   exit 1
 fi
 
-if ! grep "env PRO_HOST" conf/nginx.conf; then
+if ! grep 'env "PRO_HOST"' conf/nginx.conf; then
   echo "kubernetes discovery env inject failed"
   exit 1
 fi
 
-if ! grep "env PRO_PORT" conf/nginx.conf; then
+if ! grep 'env "PRO_PORT"' conf/nginx.conf; then
   echo "kubernetes discovery env inject failed"
   exit 1
 fi
 
-if ! grep "env PRO_TOKEN" conf/nginx.conf; then
+if ! grep 'env "PRO_TOKEN"' conf/nginx.conf; then
   echo "kubernetes discovery env inject failed"
   exit 1
 fi

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -226,13 +226,67 @@ nginx_config:
 
 make init
 
-grep "env TEST;" conf/nginx.conf > /dev/null
+grep 'env "TEST";' conf/nginx.conf > /dev/null
 if [ ! $? -eq 0 ]; then
     echo "failed: failed to update env"
     exit 1
 fi
 
 echo "passed: change default env"
+
+# env value with spaces must be rendered as a quoted directive (#11467)
+echo '
+nginx_config:
+    envs:
+        - TEST=a b
+' > conf/config.yaml
+
+make init
+
+if ! grep 'env "TEST=a b";' conf/nginx.conf > /dev/null; then
+    echo "failed: env value with spaces should be quoted"
+    exit 1
+fi
+
+mkdir -p logs
+if ! openresty -p "$PWD" -c "$PWD/conf/nginx.conf" -t; then
+    echo "failed: nginx rejects generated conf with quoted env"
+    exit 1
+fi
+
+# embedded quote / backslash are escaped
+cat > conf/config.yaml <<'EOF'
+nginx_config:
+    envs:
+        - "TEST=a\"b\\c"
+EOF
+
+make init
+
+if ! grep -F 'env "TEST=a\"b\\c";' conf/nginx.conf > /dev/null; then
+    echo "failed: quote/backslash in env value should be escaped"
+    exit 1
+fi
+
+if ! openresty -p "$PWD" -c "$PWD/conf/nginx.conf" -t; then
+    echo "failed: nginx rejects generated conf with escaped env"
+    exit 1
+fi
+
+# control characters are rejected at schema level
+cat > conf/config.yaml <<'EOF'
+nginx_config:
+    envs:
+        - "TEST=a\nb"
+EOF
+
+out=$(make init 2>&1 || true)
+if ! echo "$out" | grep "failed to validate config"; then
+    echo "failed: env value with control chars should be rejected"
+    exit 1
+fi
+
+echo "passed: env value quoting (#11467)"
 
 # support environment variables
 echo '
@@ -243,7 +297,7 @@ nginx_config:
 
 var_test=TEST FOO=bar make init
 
-if ! grep "env TEST_bar;" conf/nginx.conf > /dev/null; then
+if ! grep 'env "TEST_bar";' conf/nginx.conf > /dev/null; then
     echo "failed: failed to resolve variables"
     exit 1
 fi
@@ -328,7 +382,7 @@ nginx_config:
 
 var_test=TEST FOO=bar make init
 
-if ! grep "env TEST_bar;" conf/nginx.conf > /dev/null; then
+if ! grep 'env "TEST_bar";' conf/nginx.conf > /dev/null; then
     echo "failed: failed to resolve variables wrapped with whitespace"
     exit 1
 fi
@@ -348,7 +402,7 @@ deployment:
 
 ETCD_HOST=127.0.0.1 ETCD_PORT=2379 make init
 
-if ! grep "env ETCD_HOST;" conf/nginx.conf > /dev/null; then
+if ! grep 'env "ETCD_HOST";' conf/nginx.conf > /dev/null; then
     echo "failed: support environment variables in local_conf"
     exit 1
 fi
@@ -369,12 +423,12 @@ nginx_config:
 
 ETCD_HOST=127.0.0.1 ETCD_PORT=2379 make init
 
-if grep "env ETCD_HOST=.*;" conf/nginx.conf > /dev/null; then
+if grep 'env "ETCD_HOST=.*";' conf/nginx.conf > /dev/null; then
     echo "failed: support environment variables in local_conf"
     exit 1
 fi
 
-if ! grep "env ETCD_HOST;" conf/nginx.conf > /dev/null; then
+if ! grep 'env "ETCD_HOST";' conf/nginx.conf > /dev/null; then
     echo "failed: support environment variables in local_conf"
     exit 1
 fi
@@ -394,12 +448,12 @@ nginx_config:
 
 ETCD_HOST=127.0.0.1 ETCD_PORT=2379 make init
 
-if grep "env ETCD_HOST;" conf/nginx.conf > /dev/null; then
+if grep 'env "ETCD_HOST";' conf/nginx.conf > /dev/null; then
     echo "failed: support environment variables in local_conf"
     exit 1
 fi
 
-if ! grep "env ETCD_HOST=1.1.1.1;" conf/nginx.conf > /dev/null; then
+if ! grep 'env "ETCD_HOST=1.1.1.1";' conf/nginx.conf > /dev/null; then
     echo "failed: support environment variables in local_conf"
     exit 1
 fi
@@ -414,7 +468,7 @@ tests:
 
 make init
 
-if ! grep "env TEST_ENV;" conf/nginx.conf > /dev/null; then
+if ! grep 'env "TEST_ENV";' conf/nginx.conf > /dev/null; then
     echo "failed: should use default value when environment not set"
     exit 1
 fi
@@ -426,7 +480,7 @@ tests:
 
 make init
 
-if ! grep "env TEST_ENV;" conf/nginx.conf > /dev/null; then
+if ! grep 'env "TEST_ENV";' conf/nginx.conf > /dev/null; then
     echo "failed: should use default value when environment not set"
     exit 1
 fi
@@ -438,7 +492,7 @@ tests:
 
 TEST_ENV=127.0.0.1 make init
 
-if ! grep "env TEST_ENV;" conf/nginx.conf > /dev/null; then
+if ! grep 'env "TEST_ENV";' conf/nginx.conf > /dev/null; then
     echo "failed: should use environment variable when environment is set"
     exit 1
 fi

--- a/t/cli/test_main.sh
+++ b/t/cli/test_main.sh
@@ -286,6 +286,21 @@ if ! echo "$out" | grep "failed to validate config"; then
     exit 1
 fi
 
+# entries synthesized by kubernetes discovery bypass the config schema, so the
+# control-character check must also run on the final list
+cat > conf/config.yaml <<'EOF'
+discovery:
+    kubernetes:
+        client:
+            token_file: "${A\nB}"
+EOF
+
+out=$(make init 2>&1 || true)
+if ! echo "$out" | grep "control characters are not allowed"; then
+    echo "failed: synthesized env entry with control chars should be rejected"
+    exit 1
+fi
+
 echo "passed: env value quoting (#11467)"
 
 # support environment variables

--- a/t/cli/test_standalone.sh
+++ b/t/cli/test_standalone.sh
@@ -54,7 +54,7 @@ routes:
 # check for resolve variables
 var_test_path=/test make init
 
-if ! grep "env var_test_path;" conf/nginx.conf > /dev/null; then
+if ! grep 'env "var_test_path";' conf/nginx.conf > /dev/null; then
     echo "failed: failed to resolve variables"
     exit 1
 fi


### PR DESCRIPTION
### What this PR does

Makes `nginx_config.envs` entries whose value contains a space (or `;`, `{`, `#`, tab) work instead of producing an nginx.conf that fails to parse.

Fixes #11467

### Root cause

`apisix/cli/ngx_tpl.lua` renders each entry verbatim into the `env` directive, without quoting:

```
{% for _, name in ipairs(envs) do %}
env {*name*};
{% end %}
```

So `nginx_config.envs: [TEST=a b]` generates `env TEST=a b;`. nginx's tokenizer splits that into two parameters, and `env` accepts exactly one:

```
[emerg] invalid number of arguments in "env" directive in conf/nginx.conf:32
```

This writing has been unchanged since 952450bd7 (2020-10). Only `nginx_config.envs` entries written as `NAME=value` are affected; entries exported via `${{VAR}}` render as a bare `env NAME;` and were never broken.

### This is not an nginx limitation

The issue thread concludes "This is also a limitation of nginx." That is wrong — nginx handles env values with spaces fine, the value just has to arrive as a single token.

Verified against nginx 1.29.2 `src/core/ngx_conf_file.c: ngx_conf_read_token()`: inside a double-quoted token, space / `;` / `{` / `#` / tab / newline are all taken literally and only `"` ends the token; the copy stage turns `\"` into `"` and `\\` into `\`. Confirmed empirically too — hand-editing the generated conf to `env "TEST=a b";` makes `nginx -t` pass, and a worker-side `os.getenv("TEST")` returns `a b`.

So this is purely a template rendering bug on the APISIX side.

### Changes

1. `ngx_tpl.lua` — render as `env "{*name*}";`.
2. `ops.lua` — escape `\` and `"` in each entry, placed right before `-- fix up lua path`, which is where all three envs sources (explicit `nginx_config.envs`, `${{VAR}}` exported names, kubernetes discovery injected names) have converged. Escaping is a no-op for bare `NAME` entries, so no branching is needed.
3. `schema.lua` — `pattern = [[\A[^\x00-\x1f]*\z]]` on the array items.

Quoting is unconditional rather than "only when the value looks special". Getting that character set wrong by one character reproduces the original bug, and the tokenizer guarantees quoting is lossless for any non-control value, so the simple version is also the correct one.

### Why `$` is not escaped

`env` is a core directive and does not compile its argument as a script, and nginx's conf parser does no interpolation at tokenize time — `ngx_conf_read_token()` only uses a `variable` flag so that `${...}` doesn't break the token, then stores the bytes literally. A value like `TEST=$FOO` reaches the environment as the literal `$FOO`, both before and after this change.

### Why the control-character rejection

NUL cannot be carried through the C environ at all (it would silently truncate), and other control characters have no sane config source. nginx would technically accept a literal newline inside a quoted token, but a multi-line `env` directive makes the generated conf unreadable and ungreppable, so `\x00-\x1f` is rejected wholesale.

Note `\A...\z` rather than `^...$`: cli/schema.lua patterns are PCRE, where `$` also matches before a trailing newline, so `^[^\x00-\x1f]*$` would let a value ending in `\n` through.

### Test changes

`t/cli` has ~20 assertions grepping the generated conf for `env NAME;`. Those patterns no longer match once the directive is quoted, so they are updated to `env "NAME";` in `test_main.sh`, `test_standalone.sh` and `test_kubernetes.sh`. Without this they would all fail on the fixed code — the assertions are checking the rendered form, and the rendered form is exactly what this PR changes.

One assertion is deliberately left alone: `test_main.sh` `env APISIX_DEPLOYMENT_ETCD_HOST;` is a hardcoded line in the template, not part of the `envs` loop.

New cases added to `test_main.sh` after "change default env": value with spaces renders quoted and survives `nginx -t`; embedded `"` / `\` are escaped and survive `nginx -t`; a value with a control character is rejected at `apisix init` with `failed to validate config`.

### Compatibility

Configs that work today are unaffected — for a value with no `\`, `"` or control character, the token nginx parses out of the quoted form is byte-identical to the unquoted one. Configs that were guaranteed to fail at startup now work. The one new hard failure is control characters, which move from "generates an invalid nginx.conf and dies with an obscure nginx syntax error" to a clear schema error at init time.

External tooling that greps the generated `conf/nginx.conf` for `env NAME;` will stop matching. That file declares itself read-only and generated, and its format is not a stability promise.

### Not covered

The template renders several other values unquoted (`user`, `error_log`, `access_log`, `lua_ssl_trusted_certificate`, `ssl_certificate`, ...), which have the same theoretical problem for paths containing spaces. No issue reports on those and the fix surface is independent, so this PR deliberately stays scoped to `envs`.

### Test status

Lua syntax checks and luacheck pass. The `t/cli` suite has not been run locally; relying on CI for that.
