### PR TITLE
fix(etcd): do not advance the watch revision on a timeout, and make the recovery reload cheap

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -26,6 +26,7 @@ local json         = require("apisix.core.json")
 local etcd_apisix  = require("apisix.core.etcd")
 local core_str     = require("apisix.core.string")
 local new_tab      = require("table.new")
+local nkeys        = require("table.nkeys")
 local inspect      = require("inspect")
 local process      = require("ngx.process")
 local check_schema = require("apisix.core.schema").check
@@ -549,6 +550,8 @@ end
 local function load_full_data(self, dir_res, headers, prev_values, prev_values_hash)
     local err
     local changed = false
+    -- how many of the previous keys are still present, used to detect deletions
+    local matched_prev = 0
 
     if self.single_item then
         self.values = new_tab(1, 0)
@@ -610,6 +613,25 @@ local function load_full_data(self, dir_res, headers, prev_values, prev_values_h
 
         for _, item in ipairs(values) do
             local key = short_key(self, item.key)
+            local prev_item = get_prev_item(prev_values, prev_values_hash, key)
+            if prev_item then
+                matched_prev = matched_prev + 1
+            end
+
+            -- Nothing changed for this key, so reuse the item we already have
+            -- instead of rebuilding it. This keeps the object identity stable,
+            -- which matters because downstream caches are keyed on it, and it
+            -- leaves `changed` alone so that a reload which changed nothing
+            -- does not bump conf_version and rebuild every router.
+            -- Same semantics as the incremental watch path in sync_data, which
+            -- only re-runs the checker and filter for the keys that changed.
+            if prev_item and prev_item.modifiedIndex == item.modifiedIndex then
+                insert_tab(self.values, prev_item)
+                self.values_hash[key] = #self.values
+                self:upgrade_version(item.modifiedIndex)
+                goto continue
+            end
+
             local data_valid = true
             err = nil
             if type(item.value) ~= "table" then
@@ -649,20 +671,28 @@ local function load_full_data(self, dir_res, headers, prev_values, prev_values_h
                     self.filter(item)
                 end
 
-            else
-                local prev_item = get_prev_item(prev_values, prev_values_hash, key)
-                if prev_item then
-                    -- keep serving with the last valid configuration instead of
-                    -- silently dropping the whole item on a full reload, see the
-                    -- incremental path in sync_data for the same semantics
-                    log.warn("failed to check item data of [", self.key, "/", key,
-                             "], keep the previous configuration, err: ", err)
-                    insert_tab(self.values, prev_item)
-                    self.values_hash[key] = #self.values
-                end
+            elseif prev_item then
+                -- keep serving with the last valid configuration instead of
+                -- silently dropping the whole item on a full reload, see the
+                -- incremental path in sync_data for the same semantics
+                log.warn("failed to check item data of [", self.key, "/", key,
+                         "], keep the previous configuration, err: ", err)
+                insert_tab(self.values, prev_item)
+                self.values_hash[key] = #self.values
             end
 
             self:upgrade_version(item.modifiedIndex)
+
+            ::continue::
+        end
+
+        -- Keys present in the previous snapshot but absent now were deleted
+        -- while we were not watching. Every surviving key can be untouched and
+        -- still leave us with a changed configuration, so this has to be
+        -- checked separately or a reload that only deletes would keep serving
+        -- the removed items.
+        if prev_values_hash and matched_prev < nkeys(prev_values_hash) then
+            changed = true
         end
     end
 

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -196,18 +196,13 @@ local function do_run_watch(premature)
     opts.need_cancel = true
     opts.start_revision = watch_ctx.rev
 
-    -- get latest revision
-    local res, err = watch_ctx.cli:readdir(watch_ctx.prefix .. "/phantomkey")
-    if err then
-        log.error("failed to get latest revision, err: ", err)
-    end
-    local latest_rev
-    if res and res.body and res.body.header and res.body.header.revision then
-        latest_rev = tonumber(res.body.header.revision)
-    else
-        log.error("failed to get latest revision, res: ", json.delay_encode(res))
-    end
-
+    -- Do not advance start_revision on a watch timeout. A timeout only means
+    -- that no bytes arrived for watch_timeout seconds; it cannot tell an idle
+    -- prefix apart from a stream that established and then died silently. In
+    -- the latter case etcd has already written the pending events into the
+    -- dead stream, so moving the revision forward skips them for good, and the
+    -- loss never heals: the next start revision is fresh, so compaction is not
+    -- triggered and need_reload is never set. See #13067.
     log.info("restart watchdir: start_revision=", opts.start_revision)
 
     local res_func, err, http_cli = watch_ctx.cli:watchdir(watch_ctx.prefix, opts)
@@ -226,12 +221,6 @@ local function do_run_watch(premature)
                 err ~= "broken pipe"
             then
                 log.error("wait watch event: ", err)
-            end
-            if err == "timeout" then
-                if latest_rev and watch_ctx.rev < latest_rev + 1 then
-                    watch_ctx.rev = latest_rev + 1
-                    log.info("etcd watch timeout, upgrade revision to ", watch_ctx.rev)
-                end
             end
             cancel_watch(http_cli)
             break

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -197,13 +197,9 @@ local function do_run_watch(premature)
     opts.need_cancel = true
     opts.start_revision = watch_ctx.rev
 
-    -- Do not advance start_revision on a watch timeout. A timeout only means
-    -- that no bytes arrived for watch_timeout seconds; it cannot tell an idle
-    -- prefix apart from a stream that established and then died silently. In
-    -- the latter case etcd has already written the pending events into the
-    -- dead stream, so moving the revision forward skips them for good, and the
-    -- loss never heals: the next start revision is fresh, so compaction is not
-    -- triggered and need_reload is never set. See #13067.
+    -- A watch timeout must not advance start_revision: it cannot tell an idle
+    -- prefix from a stream that died silently, and skipping ahead loses the
+    -- events etcd already wrote into that stream. See #13067.
     log.info("restart watchdir: start_revision=", opts.start_revision)
 
     local res_func, err, http_cli = watch_ctx.cli:watchdir(watch_ctx.prefix, opts)
@@ -550,8 +546,7 @@ end
 local function load_full_data(self, dir_res, headers, prev_values, prev_values_hash)
     local err
     local changed = false
-    -- how many of the previous keys are still present, used to detect deletions
-    local matched_prev = 0
+    local prev_keys_still_present = 0
 
     if self.single_item then
         self.values = new_tab(1, 0)
@@ -615,16 +610,13 @@ local function load_full_data(self, dir_res, headers, prev_values, prev_values_h
             local key = short_key(self, item.key)
             local prev_item = get_prev_item(prev_values, prev_values_hash, key)
             if prev_item then
-                matched_prev = matched_prev + 1
+                prev_keys_still_present = prev_keys_still_present + 1
             end
 
-            -- Nothing changed for this key, so reuse the item we already have
-            -- instead of rebuilding it. This keeps the object identity stable,
-            -- which matters because downstream caches are keyed on it, and it
-            -- leaves `changed` alone so that a reload which changed nothing
-            -- does not bump conf_version and rebuild every router.
-            -- Same semantics as the incremental watch path in sync_data, which
-            -- only re-runs the checker and filter for the keys that changed.
+            -- Deliberately leaves `changed` alone, so a reload that changed
+            -- nothing does not bump conf_version and rebuild every router.
+            -- Same semantics as sync_data, which re-runs the checker and filter
+            -- only for the keys that changed.
             if prev_item and prev_item.modifiedIndex == item.modifiedIndex then
                 insert_tab(self.values, prev_item)
                 self.values_hash[key] = #self.values
@@ -686,12 +678,10 @@ local function load_full_data(self, dir_res, headers, prev_values, prev_values_h
             ::continue::
         end
 
-        -- Keys present in the previous snapshot but absent now were deleted
-        -- while we were not watching. Every surviving key can be untouched and
-        -- still leave us with a changed configuration, so this has to be
-        -- checked separately or a reload that only deletes would keep serving
-        -- the removed items.
-        if prev_values_hash and matched_prev < nkeys(prev_values_hash) then
+        -- A deletion leaves every surviving key untouched, so it has to be
+        -- detected separately or a reload that only deletes would keep
+        -- serving the removed items.
+        if prev_values_hash and prev_keys_still_present < nkeys(prev_values_hash) then
             changed = true
         end
     end

--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -521,7 +521,7 @@ main etcd watcher initialised, revision=
 
 
 
-=== TEST 14: watch revision should be upgraded when timeout occurs
+=== TEST 14: watch revision must not be upgraded when the watch times out
 --- yaml_config
 deployment:
   role: traditional
@@ -547,7 +547,8 @@ nginx_config:
                 return
             end
             ngx.sleep(2)
-            -- we will assert 4 lines of revision upgrade log because we have one worker and one privileged agent
+            -- write outside the watched prefix so that the global revision
+            -- moves on while the watch itself stays idle and keeps timing out
             for i = 1, 2 do
                local _, err = etcd_cli:set("/apache", "apisix")
                if err then
@@ -563,10 +564,8 @@ nginx_config:
 GET /t
 --- response_body
 passed
---- grep_error_log eval
-qr/etcd watch timeout, upgrade revision to/
---- grep_error_log_out eval
-qr/(etcd watch timeout, upgrade revision to\n){2,}/
+--- no_error_log
+etcd watch timeout, upgrade revision to
 
 
 

--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -538,6 +538,7 @@ nginx_config:
 --- config
     location /t {
         content_by_lua_block {
+            local core = require("apisix.core")
             local etcd = require("resty.etcd")
             local etcd_cli, err = etcd.new({
                 http_host = "http://127.0.0.1:2379",
@@ -557,13 +558,44 @@ nginx_config:
                end
                ngx.sleep(1)
             end
-            ngx.say("passed")
+
+            -- The watch has timed out and restarted several times by now. Assert
+            -- it still delivers events for the watched prefix: the other
+            -- assertion here is the absence of a log line, which would also hold
+            -- if the watch were broken outright.
+            local _, err = etcd_cli:set("/apisix/routes/after-timeout", {
+                id = "after-timeout",
+                uri = "/after-timeout",
+                create_time = 1700000000,
+                update_time = 1700000000,
+                upstream = {type = "roundrobin", nodes = {["127.0.0.1:1980"] = 1}}
+            })
+            if err then
+                ngx.say("failed to set route: ", err)
+                return
+            end
+            ngx.sleep(1)
+
+            local delivered = false
+            local obj = core.config.fetch_created_obj("/routes")
+            for _, item in ipairs(obj and obj.values or {}) do
+                if item and item.value and item.value.id == "after-timeout" then
+                    delivered = true
+                end
+            end
+            ngx.say("update after timeout delivered: ", delivered)
+
+            local _, err = etcd_cli:delete("/apisix/routes/after-timeout")
+            if err then
+                ngx.log(ngx.WARN, "failed to clean up route: ", err)
+            end
+            ngx.sleep(1)
         }
     }
 --- request
 GET /t
 --- response_body
-passed
+update after timeout delivered: true
 --- no_error_log
 etcd watch timeout, upgrade revision to
 
@@ -891,12 +923,16 @@ nginx_config:
                 return
             end
 
-            etcd_cli:set("/apisix/global_rules/1", {
+            local _, err = etcd_cli:set("/apisix/global_rules/1", {
                 id = "1",
                 create_time = 1700000000,
                 update_time = 1700000000,
                 plugins = {["response-rewrite"] = {headers = {set = {["X-T"] = "a"}}}}
             })
+            if err then
+                ngx.say("failed to set global_rules/1: ", err)
+                return
+            end
             ngx.sleep(2)
 
             local obj = core.config.fetch_created_obj("/global_rules")
@@ -921,12 +957,16 @@ nginx_config:
             -- revisions etcd reports, so the reload has nothing to change and
             -- must not bump conf_version a second time.
             obj.need_reload = true
-            etcd_cli:set("/apisix/global_rules/2", {
+            local _, err = etcd_cli:set("/apisix/global_rules/2", {
                 id = "2",
                 create_time = 1700000000,
                 update_time = 1700000000,
                 plugins = {["response-rewrite"] = {headers = {set = {["X-T2"] = "b"}}}}
             })
+            if err then
+                ngx.say("failed to set global_rules/2: ", err)
+                return
+            end
             ngx.sleep(3)
 
             local probe_kept = false
@@ -941,8 +981,12 @@ nginx_config:
             ngx.say("conf_version bumped once, not twice: ",
                     obj.conf_version == before_version + 1)
 
-            etcd_cli:delete("/apisix/global_rules/1")
-            etcd_cli:delete("/apisix/global_rules/2")
+            for _, key in ipairs({"/apisix/global_rules/1", "/apisix/global_rules/2"}) do
+                local _, del_err = etcd_cli:delete(key)
+                if del_err then
+                    ngx.log(ngx.WARN, "failed to clean up ", key, ": ", del_err)
+                end
+            end
             ngx.sleep(1)
         }
     }
@@ -982,12 +1026,16 @@ nginx_config:
                 return
             end
 
-            etcd_cli:set("/apisix/global_rules/1", {
+            local _, err = etcd_cli:set("/apisix/global_rules/1", {
                 id = "1",
                 create_time = 1700000000,
                 update_time = 1700000000,
                 plugins = {["response-rewrite"] = {headers = {set = {["X-T"] = "a"}}}}
             })
+            if err then
+                ngx.say("failed to set global_rules/1: ", err)
+                return
+            end
             ngx.sleep(2)
 
             local obj = core.config.fetch_created_obj("/global_rules")
@@ -1011,12 +1059,16 @@ nginx_config:
             -- same wake-up mechanism as TEST 19: /2 arrives incrementally
             -- (+1), then the reload drops the ghost (+1)
             obj.need_reload = true
-            etcd_cli:set("/apisix/global_rules/2", {
+            local _, err = etcd_cli:set("/apisix/global_rules/2", {
                 id = "2",
                 create_time = 1700000000,
                 update_time = 1700000000,
                 plugins = {["response-rewrite"] = {headers = {set = {["X-T2"] = "b"}}}}
             })
+            if err then
+                ngx.say("failed to set global_rules/2: ", err)
+                return
+            end
             ngx.sleep(3)
 
             local found_ghost = false
@@ -1031,8 +1083,12 @@ nginx_config:
             ngx.say("conf_version bumped for the deletion: ",
                     obj.conf_version == before_version + 2)
 
-            etcd_cli:delete("/apisix/global_rules/1")
-            etcd_cli:delete("/apisix/global_rules/2")
+            for _, key in ipairs({"/apisix/global_rules/1", "/apisix/global_rules/2"}) do
+                local _, del_err = etcd_cli:delete(key)
+                if del_err then
+                    ngx.log(ngx.WARN, "failed to clean up ", key, ": ", del_err)
+                end
+            end
             ngx.sleep(1)
         }
     }

--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -574,13 +574,21 @@ nginx_config:
                 ngx.say("failed to set route: ", err)
                 return
             end
-            ngx.sleep(1)
-
+            -- poll rather than sleep a fixed amount: delivery is normally
+            -- immediate, and a fixed wait would only be a guess about how slow
+            -- the etcd round trip can get on a loaded CI machine
             local delivered = false
-            local obj = core.config.fetch_created_obj("/routes")
-            for _, item in ipairs(obj and obj.values or {}) do
-                if item and item.value and item.value.id == "after-timeout" then
-                    delivered = true
+            for _ = 1, 25 do
+                ngx.sleep(0.2)
+                local obj = core.config.fetch_created_obj("/routes")
+                for _, item in ipairs(obj and obj.values or {}) do
+                    if item and item.value and item.value.id == "after-timeout" then
+                        delivered = true
+                        break
+                    end
+                end
+                if delivered then
+                    break
                 end
             end
             ngx.say("update after timeout delivered: ", delivered)
@@ -589,9 +597,9 @@ nginx_config:
             if err then
                 ngx.log(ngx.WARN, "failed to clean up route: ", err)
             end
-            ngx.sleep(1)
         }
     }
+--- timeout: 20
 --- request
 GET /t
 --- response_body

--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -559,10 +559,8 @@ nginx_config:
                ngx.sleep(1)
             end
 
-            -- The watch has timed out and restarted several times by now. Assert
-            -- it still delivers events for the watched prefix: the other
-            -- assertion here is the absence of a log line, which would also hold
-            -- if the watch were broken outright.
+            -- The only other assertion here is that a log line is absent, which
+            -- would also hold if the watch were broken outright. So check delivery.
             local _, err = etcd_cli:set("/apisix/routes/after-timeout", {
                 id = "after-timeout",
                 uri = "/after-timeout",
@@ -574,9 +572,7 @@ nginx_config:
                 ngx.say("failed to set route: ", err)
                 return
             end
-            -- poll rather than sleep a fixed amount: delivery is normally
-            -- immediate, and a fixed wait would only be a guess about how slow
-            -- the etcd round trip can get on a loaded CI machine
+            -- polled, not slept: a fixed wait would just guess at CI latency
             local delivered = false
             for _ = 1, 25 do
                 ngx.sleep(0.2)
@@ -946,9 +942,8 @@ nginx_config:
             local obj = core.config.fetch_created_obj("/global_rules")
             local before_version = obj.conf_version
 
-            -- Two independent probes. A reload always builds a fresh `values`
-            -- array, so losing this one proves the reload actually ran; the
-            -- incremental path only mutates elements and would keep it.
+            -- A reload always builds a fresh `values` array, so losing this probe
+            -- proves it ran; the incremental path only mutates elements.
             obj.values.array_probe = "old"
             -- The items inside must survive: reusing them is the whole point.
             for _, item in ipairs(obj.values) do
@@ -957,13 +952,10 @@ nginx_config:
                 end
             end
 
-            -- Arm the recovery path taken after a `compacted` error, then write
-            -- a second rule. sync_data is parked in waitdir, so the write is
-            -- what wakes it: the incremental path adds /2 and bumps
-            -- conf_version once, and the next sync_data round reaches the
-            -- need_reload branch. By then /1 and /2 are both in memory at the
-            -- revisions etcd reports, so the reload has nothing to change and
-            -- must not bump conf_version a second time.
+            -- Arm the recovery path taken after `compacted`. sync_data is parked
+            -- in waitdir, so the write below is what wakes it: /2 arrives
+            -- incrementally (+1), then the reload runs with /1 and /2 already in
+            -- memory at the revisions etcd reports, so it must not bump again.
             obj.need_reload = true
             local _, err = etcd_cli:set("/apisix/global_rules/2", {
                 id = "2",
@@ -1049,11 +1041,9 @@ nginx_config:
             local obj = core.config.fetch_created_obj("/global_rules")
             obj.values.array_probe = "old"
 
-            -- An item that is live in memory but gone from etcd, so the reload
-            -- has to drop it. Every surviving key is untouched and therefore
-            -- reused, so without an explicit deletion check `changed` would
-            -- stay false, conf_version would not move, and the routers would
-            -- go on serving the dropped item.
+            -- Live in memory, gone from etcd. Every surviving key is untouched
+            -- and therefore reused, so without an explicit deletion check
+            -- conf_version would not move and the routers would keep serving it.
             local ghost = {
                 key = "/apisix/global_rules/ghost",
                 modifiedIndex = 1,

--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -861,3 +861,184 @@ GET /t
 invalid new item loaded: false
 --- no_error_log
 keep the previous configuration
+
+
+
+=== TEST 19: a full reload that changes nothing reuses the items and does not bump conf_version
+--- timeout: 25
+--- yaml_config
+deployment:
+  role: traditional
+  role_traditional:
+    config_provider: etcd
+  etcd:
+    host:
+      - "http://127.0.0.1:2379"
+    prefix: /apisix
+--- extra_yaml_config
+nginx_config:
+    worker_processes: 1
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local etcd = require("resty.etcd")
+            local etcd_cli, err = etcd.new({
+                http_host = "http://127.0.0.1:2379",
+            })
+            if not etcd_cli then
+                ngx.say("failed to create etcd client: ", err)
+                return
+            end
+
+            etcd_cli:set("/apisix/global_rules/1", {
+                id = "1",
+                create_time = 1700000000,
+                update_time = 1700000000,
+                plugins = {["response-rewrite"] = {headers = {set = {["X-T"] = "a"}}}}
+            })
+            ngx.sleep(2)
+
+            local obj = core.config.fetch_created_obj("/global_rules")
+            local before_version = obj.conf_version
+
+            -- Two independent probes. A reload always builds a fresh `values`
+            -- array, so losing this one proves the reload actually ran; the
+            -- incremental path only mutates elements and would keep it.
+            obj.values.array_probe = "old"
+            -- The items inside must survive: reusing them is the whole point.
+            for _, item in ipairs(obj.values) do
+                if item and item.value and item.value.id == "1" then
+                    item.reload_probe = "kept"
+                end
+            end
+
+            -- Arm the recovery path taken after a `compacted` error, then write
+            -- a second rule. sync_data is parked in waitdir, so the write is
+            -- what wakes it: the incremental path adds /2 and bumps
+            -- conf_version once, and the next sync_data round reaches the
+            -- need_reload branch. By then /1 and /2 are both in memory at the
+            -- revisions etcd reports, so the reload has nothing to change and
+            -- must not bump conf_version a second time.
+            obj.need_reload = true
+            etcd_cli:set("/apisix/global_rules/2", {
+                id = "2",
+                create_time = 1700000000,
+                update_time = 1700000000,
+                plugins = {["response-rewrite"] = {headers = {set = {["X-T2"] = "b"}}}}
+            })
+            ngx.sleep(3)
+
+            local probe_kept = false
+            for _, item in ipairs(obj.values) do
+                if item and item.value and item.value.id == "1" then
+                    probe_kept = (item.reload_probe == "kept")
+                end
+            end
+
+            ngx.say("reload ran: ", obj.values.array_probe == nil)
+            ngx.say("item reused: ", probe_kept)
+            ngx.say("conf_version bumped once, not twice: ",
+                    obj.conf_version == before_version + 1)
+
+            etcd_cli:delete("/apisix/global_rules/1")
+            etcd_cli:delete("/apisix/global_rules/2")
+            ngx.sleep(1)
+        }
+    }
+--- request
+GET /t
+--- response_body
+reload ran: true
+item reused: true
+conf_version bumped once, not twice: true
+
+
+
+=== TEST 20: a full reload that only deletes must still bump conf_version
+--- timeout: 25
+--- yaml_config
+deployment:
+  role: traditional
+  role_traditional:
+    config_provider: etcd
+  etcd:
+    host:
+      - "http://127.0.0.1:2379"
+    prefix: /apisix
+--- extra_yaml_config
+nginx_config:
+    worker_processes: 1
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local etcd = require("resty.etcd")
+            local etcd_cli, err = etcd.new({
+                http_host = "http://127.0.0.1:2379",
+            })
+            if not etcd_cli then
+                ngx.say("failed to create etcd client: ", err)
+                return
+            end
+
+            etcd_cli:set("/apisix/global_rules/1", {
+                id = "1",
+                create_time = 1700000000,
+                update_time = 1700000000,
+                plugins = {["response-rewrite"] = {headers = {set = {["X-T"] = "a"}}}}
+            })
+            ngx.sleep(2)
+
+            local obj = core.config.fetch_created_obj("/global_rules")
+            obj.values.array_probe = "old"
+
+            -- An item that is live in memory but gone from etcd, so the reload
+            -- has to drop it. Every surviving key is untouched and therefore
+            -- reused, so without an explicit deletion check `changed` would
+            -- stay false, conf_version would not move, and the routers would
+            -- go on serving the dropped item.
+            local ghost = {
+                key = "/apisix/global_rules/ghost",
+                modifiedIndex = 1,
+                value = {id = "ghost", plugins = {}},
+            }
+            core.table.insert(obj.values, ghost)
+            obj.values_hash["ghost"] = #obj.values
+
+            local before_version = obj.conf_version
+
+            -- same wake-up mechanism as TEST 19: /2 arrives incrementally
+            -- (+1), then the reload drops the ghost (+1)
+            obj.need_reload = true
+            etcd_cli:set("/apisix/global_rules/2", {
+                id = "2",
+                create_time = 1700000000,
+                update_time = 1700000000,
+                plugins = {["response-rewrite"] = {headers = {set = {["X-T2"] = "b"}}}}
+            })
+            ngx.sleep(3)
+
+            local found_ghost = false
+            for _, item in ipairs(obj.values) do
+                if item and item.value and item.value.id == "ghost" then
+                    found_ghost = true
+                end
+            end
+
+            ngx.say("reload ran: ", obj.values.array_probe == nil)
+            ngx.say("ghost dropped: ", not found_ghost)
+            ngx.say("conf_version bumped for the deletion: ",
+                    obj.conf_version == before_version + 2)
+
+            etcd_cli:delete("/apisix/global_rules/1")
+            etcd_cli:delete("/apisix/global_rules/2")
+            ngx.sleep(1)
+        }
+    }
+--- request
+GET /t
+--- response_body
+reload ran: true
+ghost dropped: true
+conf_version bumped for the deletion: true


### PR DESCRIPTION
Fixes #13067
Fixes #12167

Two commits, one for each issue. They belong together: the first removes an unsafe way of avoiding the recovery reload, the second makes that reload cheap enough not to need avoiding.

| commit | issue | change |
|---|---|---|
| `fix(etcd): do not advance the watch revision on a timeout` | #13067 | −18/+7, all additions comments |
| `perf(etcd): reuse unchanged items on a full reload` | #12167 | −11/+41 |

---

# Part 1 — #13067: silent, permanent config loss

## The problem

`config_etcd.lua` samples the global etcd revision on a **separate connection** before each watch, then jumps to it if the watch times out:

```lua
-- before every watch: sample the latest revision on another connection
local res, err = watch_ctx.cli:readdir(watch_ctx.prefix .. "/phantomkey")
local latest_rev = tonumber(res.body.header.revision)

-- ... and when the watch times out:
if err == "timeout" then
    if latest_rev and watch_ctx.rev < latest_rev + 1 then
        watch_ctx.rev = latest_rev + 1        -- skip straight to the sample
    end
end
```

A timeout only means **"no bytes arrived for `watch_timeout` seconds"**. That is equally true of an idle prefix and of a stream that established and then died silently — and the code cannot tell them apart:

```
t0   watch established, start_revision = R
t1   readdir samples latest = A            (on a different, healthy connection)
t2   watch stream dies silently            (no FIN, no RST — nothing observable)
t3   etcd writes the events for (R, A] into that dead stream
t4   50s elapse, zero bytes read           -> "timeout"
t5   watch_ctx.rev = A + 1                 -> everything in (R, A] is skipped
```

The root of it: the health of one connection is used to infer the delivery progress of another. Those two facts are unrelated.

### It never heals

`sync_data` only sets `need_reload` on `compacted` / `restarted`. After the jump the start revision is fresh, so compaction never fires either — nothing will ever go back for the skipped range.

The worker keeps serving a stale configuration until that key is written again or the worker restarts:

- deleted routes keep routing traffic
- new routes and certificates never take effect
- the only trace is a single **info**-level log line

Each worker has its own watcher, so some workers can be stale while others are current.

## The fix

Delete the sampling and the jump.

## Reproducing it

Needs an **asymmetric** fault: the watch stream goes dark while short requests keep working. If the whole link fails, the sampling `readdir` fails too, `latest_rev` is `nil`, and the existing guard already prevents the jump.

<details>
<summary><b>Option 1 — iptables, no code needed</b></summary>

```bash
# 1. start etcd + APISIX, wait for the watch to establish
grep "restart watchdir: start_revision=" logs/error.log

# 2. find the watch connection (the long-lived one; short requests use new sockets)
ss -tn 'dst :2379'

# 3. blackhole only that connection — no RST, and range requests are untouched
iptables -I INPUT -p tcp --sport 2379 --dport <WATCH_SPORT> -j DROP

# 4. write a route during the blackhole
curl -X PUT http://127.0.0.1:9180/apisix/admin/routes/blackhole \
  -H "X-API-KEY: $admin_key" \
  -d '{"uri":"/blackhole","upstream":{"nodes":{"127.0.0.1:1980":1}}}'

# 5. wait out watch_timeout (50s), then restore
grep "etcd watch timeout, upgrade revision to" logs/error.log
iptables -D INPUT -p tcp --sport 2379 --dport <WATCH_SPORT> -j DROP
```

**Result:** `etcdctl get /apisix/routes/blackhole` returns the route, but `/blackhole` stays 404 — across every healthy watch cycle that follows, indefinitely.

</details>

<details>
<summary><b>Option 2 — selectively silent TCP proxy (what I used)</b></summary>

Put a proxy between APISIX and etcd, point `deployment.etcd.host` at it, and have it read the first request line:

- `POST /v3/watch` → forward the request, forward the response **headers**, then silently discard the body and hold the connection open (no FIN, no RST)
- anything else (`/v3/kv/range`, …) → forward normally

Then follow steps 4–5 above.

</details>

Real-world equivalents: NAT/conntrack reaping long-lived connections while short ones pass, conntrack tables being flushed (kube-proxy restart, `iptables -F`, CNI rebuild), asymmetric packet loss, an etcd-side watch stall with `range` still healthy.

## Alternatives considered

<details>
<summary><b>Verify the <code>(rev, latest]</code> range is event-free before jumping</b> — killed by deletes</summary>

Worth spelling out, because it looks like it should work.

`RangeRequest` does have `min_mod_revision` / `max_mod_revision`, so the check is expressible. Non-atomicity is not the problem either: an event landing after the check carries a revision above `latest`, so the next watch starting at `latest + 1` still receives it.

What kills it is **deletion**. A key deleted inside `(rev, latest]` is not in the range result at all — the check comes back empty, the jump is taken, and the delete event is lost for good. Deletes are the worst case to lose: a removed route keeps serving traffic. No range-based verification can see them.

</details>

<details>
<summary><b>Use <code>progress_notify</code> and advance only on in-stream notifications</b> — correct, but inert by default</summary>

etcd only sends progress notifications to fully synced watchers, so the revision one carries is a server-side guarantee that everything up to it was already delivered on that same stream. Correct in principle.

The catch: the progress ticker is created **per stream** and defaults to 10 minutes, while an idle APISIX watch stream only lives for `watch_timeout` (50s). Under a default etcd it never fires. It would be inert unless the operator also sets `--watch-progress-notify-interval` (`--experimental-watch-progress-notify-interval` before etcd 3.6; the flag only exists since 3.4.11).

An ordering-sensitive new branch, a `lua-resty-etcd` version floor and an FAQ entry, for something that does nothing out of the box — not worth it next to Part 2. Can be revisited on its own merits.

</details>

---

# Part 2 — #12167: the CPU spike this used to paper over

Removing the jump means an idle prefix on a **shared** etcd can fall behind compaction again and recover with a full `readdir`. That is exactly what #12167 reported, so it gets fixed properly rather than avoided by guesswork.

The reporter's ask is specific — *"APISIX CPU usage fluctuates when 'compacted' errors occur. I want to avoid this problem."* Not the log line: the CPU.

## Why the reload is expensive

Recovery from `compacted` rebuilds everything unconditionally:

- every item is re-validated through `check_schema`, the `checker` and the `filter`
- `load_full_data` sets `changed` as soon as **any** item is valid, so `conf_version` always moves and every router rebuilds its radixtree
- the item tables are new objects, so downstream caches keyed on them all miss

And it happens for **every resource type** — routes, services, upstreams, consumers, ssls, global_rules, plugin_configs … — in **every worker**, because `need_reload` is per config instance and `produce_res(nil, "compacted")` broadcasts to all of them.

None of that work is necessary when nothing actually changed — which is precisely the case here. A prefix idle enough to fall behind compaction is a prefix whose configuration did not change.

## The fix

Compare each key against the previous snapshot and reuse the item when `modifiedIndex` matches:

```lua
local prev_item = get_prev_item(prev_values, prev_values_hash, key)
if prev_item and prev_item.modifiedIndex == item.modifiedIndex then
    insert_tab(self.values, prev_item)
    self.values_hash[key] = #self.values
    self:upgrade_version(item.modifiedIndex)
    goto continue                       -- note: `changed` is left alone
end
```

etcd increments `mod_revision` on every write, so an equal `modifiedIndex` means equal content. The `prev_values` / `get_prev_item` plumbing already exists — it was added so an item whose new data fails validation can keep serving its last valid value.

### Why skipping the filter is safe

The incremental watch path already works this way: `sync_data` re-runs the checker and filter only for the keys that changed, and never touches the other items. This aligns the reload path with the watch path rather than inventing new semantics.

Checked every filter individually:

| config | what its filter does | reused? |
|---|---|---|
| `/routes` | `has_domain`, `set_plugins_meta_parent`, host lowercasing, `filter_upstream` | ✅ reused |
| `/services` | same | ✅ reused |
| `/upstreams` | `has_domain`, `filter_upstream` | ✅ reused |
| `/consumers`, `/consumer_groups`, `/global_rules`, `/plugin_configs` | `set_plugins_meta_parent` | ✅ reused |
| `/ssls` | sni lowercasing, trailing-dot strip | ✅ reused |
| `/plugins` | `plugin.load(item)` — rebuilds the global plugin registry, touches nothing on the item | ❌ **not reused** — excluded from the optimisation |

The first eight are idempotent and only mutate fields of the item they are handed, so an item filtered once is already in its filtered state.

`/plugins` is the one exception and is handled by construction rather than by a special case: it is the only config in the tree declared `single_item` (`plugin.lua:893`), and the reuse branch lives entirely in the multi-item `else` branch of `load_full_data`. The `single_item` path is untouched, so `plugin.load()` still runs on every reload. Reusing there would skip the registry rebuild — newly enabled plugins would not take effect and disabled ones would keep running — and it would save nothing anyway, since there is exactly one item.

### Deletions need an explicit check

This is the trap. Keys that vanished while we were not watching leave *every surviving key untouched*, so `changed` would stay `false`, `conf_version` would not move, and the routers would go on serving the deleted items:

```lua
if prev_values_hash and matched_prev < nkeys(prev_values_hash) then
    changed = true
end
```

## What this does not do

The `readdir` itself still happens on every `compacted`: without reading the full snapshot there is no way to know what was missed. The transfer and JSON parse remain. What goes away is the rebuild on top of it — the part that scales with configuration size and shows up as the spike.

---

# Tests

Every assertion below was verified to be **discriminating** — a test that passes either way proves nothing.

**TEST 14** (Part 1) asserted exactly the removed behaviour (`etcd watch timeout, upgrade revision to` appearing at least twice). Same topology, inverted assertion: the log must not appear at all. Old and new are mirrors, pinning the change in both directions.

**TEST 19** (Part 2) — a reload with nothing changed. Two independent probes: a tag on the `values` **array** (a reload always allocates a fresh one, so losing it proves the reload really ran) and a tag on the **item** inside it (which must survive). Asserts `conf_version` moved once for the incremental write that wakes the watcher, not twice. Against unpatched `master`:

```
 reload ran: true
-item reused: true
+item reused: false
-conf_version bumped once, not twice: true
+conf_version bumped once, not twice: false
```

**TEST 20** (Part 2) — a reload whose only change is a deletion. This one passes on unpatched `master` (which bumps unconditionally), so it was verified against the variant that actually matters: the reuse optimisation *with the deletion check disabled*:

```
 reload ran: true
 ghost dropped: true
-conf_version bumped for the deletion: true
+conf_version bumped for the deletion: false
```

Local full-file run: the failure set is identical with and without this branch (TEST 3/4/5/6/9/12, which need a TLS etcd on :12379 that this machine does not have), except that TEST 14 and TEST 19 flip from failing to passing. TEST 16/17/18 — the existing full-reload tests — still pass.

The blackhole scenario cannot be expressed in test-nginx (it needs a selectively silent TCP proxy), so it stays the manual procedure above.

# Backport

Part 1 affects 3.14.0 and later and should be backported to the 3.14 / 3.15 release branches. Part 2 is a performance change and can follow or not, as maintainers prefer — the two commits are separable if you would rather backport only the first.
