### PR TITLE
fix(radixtree_host_uri): add route id to service-fetch failure log

### DIFF
--- a/apisix/http/router/radixtree_host_uri.lua
+++ b/apisix/http/router/radixtree_host_uri.lua
@@ -61,7 +61,8 @@ local function push_host_router(route, host_routes, only_uri_routes)
             local service = service_fetch(route.value.service_id)
             if not service then
                 core.log.error("failed to fetch service configuration by ",
-                                "id: ", route.value.service_id)
+                                "id: ", route.value.service_id,
+                                " route id: ", route.value.id)
                 -- we keep the behavior that missing service won't affect the route matching
             else
                 hosts = service.value.hosts


### PR DESCRIPTION
### Description

When a route with no `hosts`/`host` references a service that cannot be fetched, `push_host_router` logs:

```
failed to fetch service configuration by id: <service_id>
```

without the referencing route id, so an operator has no way to locate which route holds the dangling reference. The sibling `filter_func` error in the same file already logs `route id: <id>`; this aligns the service-fetch error to the same format.

This is not a routing-match bug. The route tree is rebuilt on demand (any request after a route/service version change triggers a full rebuild), and the rebuild iterates every route — so the error is emitted with the log context of whatever request triggered the rebuild, not the offending route. That is by design: the route with the missing service keeps matching as an only-uri route (`missing service won't affect the route matching`), traffic is unaffected. A dangling route→service reference only arises from user-side data: deleting a service with `?force=true` (which bypasses the delete_checker) or writing to etcd directly, or a transient route/service watch ordering skew that self-heals. This PR only closes the diagnosability gap so the offending route can be found; it does not change matching behavior.

Fixes #13552

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change (log-text-only change; no behavior change — relying on existing coverage and CI)
- [x] I have updated the documentation to reflect this change (N/A)
- [x] I have verified that this change is backward compatible (log content only)
