### PR TITLE
fix(patch): load the bundled cjson, not a copy shadowed under deps/

### DIFF
--- a/apisix/patch.lua
+++ b/apisix/patch.lua
@@ -395,6 +395,24 @@ end
 
 
 function _M.patch()
+    -- deps/ precedes OpenResty's lualib in package.cpath, so a lua-cjson pulled
+    -- into deps/ by an unpinned transitive dependency (e.g. an openapi-validator
+    -- rockspec) shadows the cjson bundled with OpenResty. That copy re-encodes
+    -- empty arrays as invalid JSON on arm64 (apache/apisix#13593). Move the
+    -- lualib entries ahead of deps/ so the require() just below loads the
+    -- bundled copy. Done here because this is the first require of cjson.
+    local head, rest = {}, {}
+    for seg in package.cpath:gmatch("[^;]+") do
+        if seg:find("/lualib/", 1, true) then
+            head[#head + 1] = seg
+        else
+            rest[#rest + 1] = seg
+        end
+    end
+    if #head > 0 then
+        package.cpath = concat_tab(head, ";") .. ";" .. concat_tab(rest, ";")
+    end
+
     patch_cjson(require("cjson"))
     patch_cjson(require("cjson.safe"))
 

--- a/apisix/patch.lua
+++ b/apisix/patch.lua
@@ -21,6 +21,7 @@ local socket = require("socket")
 local unix_socket = require("socket.unix")
 local ssl = require("ssl")
 local ngx = ngx
+local package = package
 local get_phase = ngx.get_phase
 local ngx_socket = ngx.socket
 local original_tcp = ngx.socket.tcp

--- a/t/core/cjson-bundled.t
+++ b/t/core/cjson-bundled.t
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+no_root_location();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: cjson resolves to the OpenResty bundled copy, never the one under deps/
+--- config
+    location /t {
+        content_by_lua_block {
+            local path = package.searchpath("cjson", package.cpath)
+            if path and path:find("/deps/", 1, true) then
+                ngx.say("BAD: cjson resolved from deps: ", path)
+            else
+                ngx.say("OK: cjson resolved from bundled")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+OK: cjson resolved from bundled

--- a/t/core/cjson-bundled.t
+++ b/t/core/cjson-bundled.t
@@ -16,6 +16,8 @@
 #
 use t::APISIX 'no_plan';
 
+repeat_each(1);
+no_long_string();
 no_root_location();
 
 run_tests();
@@ -27,7 +29,9 @@ __DATA__
     location /t {
         content_by_lua_block {
             local path = package.searchpath("cjson", package.cpath)
-            if path and path:find("/deps/", 1, true) then
+            if not path then
+                ngx.say("BAD: cjson could not be resolved")
+            elseif path:find("/deps/", 1, true) then
                 ngx.say("BAD: cjson resolved from deps: ", path)
             else
                 ngx.say("OK: cjson resolved from bundled")


### PR DESCRIPTION
### Description

Fixes #13593

An unpinned `lua-cjson` declared by a transitive dependency (currently `lua-resty-openapi-validator`, but any dependency could do it) gets installed into `deps/`. Because `deps/` precedes OpenResty's `lualib` in `package.cpath`, `require("cjson")` loads that copy instead of the one bundled with OpenResty. On arm64 the deps copy (2.1.0.10) re-encodes empty arrays as invalid JSON — the symptom reported in #13593.

Removing the declaration from one rockspec (the openapi-validator route) only treats the current source. The root cause is the cpath order: **any** dependency that drops a cjson into `deps/` reproduces this. This fixes it at the resolution layer instead.

`apisix/patch.lua` `_M.patch()` is the first place cjson is required. Right before that require, reorder the `lualib` entries of `package.cpath` ahead of `deps/`, so the bundled cjson always wins regardless of what lands in `deps/`. `lualib` is already on the cpath (via `;;`), just after `deps/` — this only moves it forward. Verified the only overlap between `lualib` and `deps/` is `cjson.so` itself (`lualib` ships only `cjson.so` and `librestysignal.so`), so nothing else changes resolution.

Timing is safe: cjson is not loaded before `require("apisix")` (checked), and `resty.core` does not require it, so the reorder at the top of `_M.patch()` runs before the first require — no `package.loaded` caching to fight.

### Tests

New `t/core/cjson-bundled.t` asserts the runtime resolves cjson outside `deps/`. It fails on master today (`cjson resolved from deps: .../deps/lib/lua/5.1/cjson.so`) and passes with this change (`from bundled`) — committed as a separate test-first commit. Verified discriminating: reverting the patch turns it red again.