### PR TITLE
fix(admin): encrypt only after successful validation

### DIFF
--- a/apisix/admin/plugin_metadata.lua
+++ b/apisix/admin/plugin_metadata.lua
@@ -94,7 +94,10 @@ local function encrypt_conf(plugin_name, conf)
     inject_metadata_schema(plugin_object)
 
     local schema = plugin_object.metadata_schema
-    if schema['$comment'] ~= injected_mark and plugin_object.check_schema then
+    -- encrypt whenever the plugin has a real metadata schema; do not gate on
+    -- check_schema, or a plugin that validates via core.schema.check would leak
+    -- its metadata encrypt_fields in plaintext
+    if schema['$comment'] ~= injected_mark then
         plugin_encrypt_conf(plugin_name, conf, core.schema.TYPE_METADATA)
     end
 end

--- a/apisix/admin/resource.lua
+++ b/apisix/admin/resource.lua
@@ -127,19 +127,21 @@ function _M:check_conf(id, conf, need_id, typ, allow_time, sub_path)
     local ok, err = self.checker(id, conf_for_check, need_id, self.schema,
                                  {secret_type = typ, sub_path = sub_path})
 
+    if not ok then
+        return ok, err
+    end
+
+    -- encrypt the real conf only after a successful check; encrypting
+    -- unvalidated input can crash on malformed structures (e.g. plugins
+    -- as a string), and invalid configs are never persisted anyway
     if self.encrypt_conf then
         self.encrypt_conf(id, conf)
     end
 
-    if not ok then
-        return ok, err
-    else
-        if no_id_res[self.name] then
-            return ok
-        else
-            return need_id and id or true
-        end
+    if no_id_res[self.name] then
+        return ok
     end
+    return need_id and id or true
 end
 
 

--- a/t/admin/encrypt-after-validation.t
+++ b/t/admin/encrypt-after-validation.t
@@ -1,0 +1,105 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+log_level("info");
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!$block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+    if (!$block->no_error_log && !$block->error_log) {
+        $block->set_value("no_error_log", "[error]\n[alert]");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: invalid non-object plugins is rejected with 400, not a 500
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": "not-an-object",
+                    "upstream": {
+                        "nodes": {"127.0.0.1:1980": 1},
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            ngx.status = code
+            ngx.say(code)
+        }
+    }
+--- error_code: 400
+--- response_body
+400
+
+
+
+=== TEST 2: valid config still encrypts secret fields on write
+--- yaml_config
+apisix:
+    data_encryption:
+        enable: true
+        keyring:
+            - edd1c9f0985e76a2
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local etcd = require("apisix.core.etcd")
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "encfoo",
+                    "plugins": {
+                        "key-auth": {
+                            "key": "plain-secret-key"
+                        }
+                    }
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            -- the stored key must be ciphertext, not the plaintext we sent
+            local res = assert(etcd.get('/consumers/encfoo'))
+            local stored = res.body.node.value.plugins["key-auth"].key
+            assert(stored ~= "plain-secret-key", "key must be encrypted at rest")
+            ngx.say("encrypted")
+        }
+    }
+--- response_body
+encrypted


### PR DESCRIPTION
### Description

`resource.check_conf` calls the per-resource `encrypt_conf` hook **before** checking whether `self.checker(...)` succeeded. For invalid input, the encryption hooks therefore run against unvalidated structures: for example, a non-object `plugins` value reaches `pairs(plugins_conf)` in `admin/plugins.lua` and raises a Lua error, turning a clean **400** schema-validation error into a **500**.

This moves the `encrypt_conf` call below the `if not ok then return` so encryption runs only on validated config (invalid configs are never persisted anyway).

Also drops the `plugin_object.check_schema` gate in `plugin_metadata.encrypt_conf`: `plugin.encrypt_conf` derives fields from `metadata_schema.encrypt_fields` and does not need a custom validator, so a plugin that validates via `core.schema.check` would otherwise skip encryption and persist its metadata secret in plaintext.

Both were introduced in #12603.

### Tests

New `t/admin/encrypt-after-validation.t`:
- a non-object `plugins` value now returns **400** (previously a 500 from `bad argument #1 to 'pairs' (table expected, got string)`);
- a valid consumer with a `key-auth` secret is still stored as ciphertext at rest when `data_encryption` is enabled, confirming encryption still runs on the success path.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (N/A - no user-facing behavior/doc change)
- [x] I have verified that the code passes the existing lint (`luacheck`)