### PR TITLE
docs: add SEO metadata for HTTP/3 guide

### DIFF
--- a/docs/en/latest/http3.md
+++ b/docs/en/latest/http3.md
@@ -1,5 +1,12 @@
 ---
 title: HTTP/3 Protocol
+keywords:
+  - Apache APISIX
+  - API Gateway
+  - HTTP/3
+  - HTTP 3
+  - QUIC
+description: Learn how to enable experimental HTTP/3 support in Apache APISIX for downstream client connections over QUIC.
 ---
 
 <!--


### PR DESCRIPTION
## Summary

- add search metadata for HTTP/3, HTTP 3, QUIC, Apache APISIX, and API gateway queries
- add a concise description covering experimental downstream HTTP/3 support over QUIC
- keep the existing guide content, examples, URL, and runtime behavior unchanged

## Context

This page was reviewed as part of a deduplicated SEMrush on-page SEO audit across Autoimport and Organic Research on desktop and phone. The other APISIX documentation suggestions in the audit were either already covered by the current pages, mapped to irrelevant queries, targeted a frozen historical version, or used an intentional external canonical, so they were not changed.

## Validation

- `markdownlint docs/en/latest/http3.md`
- `python3 utils/check-category.py`
- `git diff --check`
- independent final-diff review: no blockers or actionable findings
