### PR TITLE
feat(plugin): Add `span_name_strategy` to OpenTelemetry plug-in config

### DIFF
--- a/apisix/plugins/opentelemetry.lua
+++ b/apisix/plugins/opentelemetry.lua
@@ -197,6 +197,12 @@ local schema = {
             },
             default = {name = "always_off", options = {fraction = 0, root = {name = "always_off"}}}
         },
+        span_name_strategy = {
+            type = "string",
+            enum = {"path", "target"},
+            description = "For trace name, either use APISIX Route path or HTTP target / URL.",
+            default = "path",
+        },
         additional_attributes = {
             type = "array",
             items = {
@@ -375,6 +381,18 @@ local function inject_attributes(attributes, wanted_attributes, source, with_pre
 end
 
 
+-- Choose span name depending on the provided config (or use default "route")...
+local function resolve_span_name(conf, api_ctx)
+    local span_name_strategy = conf.span_name_strategy or "route"
+
+    if strategy == "target" then
+        return api_ctx.var.uri
+    end
+
+    return api_ctx.curr_req_matched._path
+end
+
+
 function _M.rewrite(conf, api_ctx)
     local metadata = plugin.plugin_metadata(plugin_name)
     if metadata == nil then
@@ -414,7 +432,8 @@ function _M.rewrite(conf, api_ctx)
         table.insert(attributes, attr.string("apisix.route_id", api_ctx.route_id))
         table.insert(attributes, attr.string("apisix.route_name", api_ctx.route_name))
         table.insert(attributes, attr.string("http.route", api_ctx.curr_req_matched._path))
-        span_name = span_name .. " " .. api_ctx.curr_req_matched._path
+        local span_name_suffix = resolve_span_name_suffix(plugin_info, api_ctx)
+        span_name = span_name .. " " .. api_ctx.curr_req_matched.span_name_suffix
     end
 
     if api_ctx.service_id then


### PR DESCRIPTION
### Description

For OpenTelemetry plug-in, add `span_name_strategy` (either "path" (default) or "target") to `schema`.
Resolver will now use suffix for `span_name`, depending on the strategy provided (or default). It will either utilize `api_ctx.var.uri` ("target") or `api_ctx.curr_req_matched._path` ("path"). It should only reflect the root span (Trace's Name).

#### Which issue(s) this PR fixes:
Fixes #13748

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
