### PR TITLE
fix(xds): do not log 'no keys' as an error when an xds key has no data

### DIFF
--- a/apisix/core/config_xds.lua
+++ b/apisix/core/config_xds.lua
@@ -329,7 +329,9 @@ function _M.new(key, opts)
             err = ok2
         end
 
-        if err then
+        -- "no keys" means the xds key has no data yet, not a failure; the
+        -- periodic fetch loop above already treats it as non-error
+        if err and err ~= "no keys" then
             log.error("failed to fetch data from xds ",
                       err, ", ", key)
         end


### PR DESCRIPTION
### Description

`_automatic_fetch` logs every non-nil error returned by `sync_data`, including the `"no keys"` sentinel that `config.new` returns when an xds key simply has no data yet:

```lua
if err then
    log.error("failed to fetch data from xds ", err, ", ", key)
end
```

The periodic fetch loop a few lines up already treats `"no keys"` as non-error (`err ~= "no keys"`). This makes `_automatic_fetch` consistent with it, so a config provider watching an empty xds key no longer spams `error.log` at startup.

### Which issue(s) this PR fixes

Removes spurious `failed to fetch data from xds no keys` error-log lines for xds keys that are legitimately empty.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change — this only changes whether an existing non-error condition is logged as an error; it mirrors the `err ~= "no keys"` filter the periodic loop already applies, and the xds test harness needs a preloaded `.so`, so there is no lightweight unit for the empty-key path
- [x] I have updated the documentation accordingly
