### PR TITLE
test(core): cover the variadic form of response.exit and response.say

### DIFF
--- a/t/core/response.t
+++ b/t/core/response.t
@@ -200,3 +200,57 @@ aaa:
 GET /t
 --- response_body
 hello world
+
+
+
+=== TEST 9: exit without a status code
+--- config
+    location = /t {
+        access_by_lua_block {
+            local core = require("apisix.core")
+            core.response.exit("done\n")
+        }
+    }
+--- request
+GET /t
+--- error_code: 200
+--- response_body
+done
+--- no_error_log
+[error]
+
+
+
+=== TEST 10: exit with several body parts
+--- config
+    location = /t {
+        access_by_lua_block {
+            local core = require("apisix.core")
+            core.response.exit(201, "a", {b = "b"}, "c\n")
+        }
+    }
+--- request
+GET /t
+--- error_code: 201
+--- response_body eval
+qq{a{"b":"b"}\nc\n}
+--- no_error_log
+[error]
+
+
+
+=== TEST 11: say with several body parts
+--- config
+    location = /t {
+        access_by_lua_block {
+            local core = require("apisix.core")
+            core.response.say("a", "b", "c\n")
+            ngx.exit(200)
+        }
+    }
+--- request
+GET /t
+--- response_body
+abc
+--- no_error_log
+[error]


### PR DESCRIPTION
### Description

`resp_exit` is variadic — it accepts a non-numeric first argument (no status code), and any number of body parts which are printed in order, with tables encoded as JSON:

```lua
local function resp_exit(code, ...)
    ...
    if code and type(code) ~= "number" then
        idx = idx + 1
        t[idx] = code
        code = nil
    end
```

`t/core/response.t` only ever calls `exit(code, body)`, so none of that is covered, and `_M.say` is not exercised at all. `apisix/plugins/mcp/server_wrapper.lua` already depends on the variadic form:

```lua
return core.response.exit(message_handler(conf, ctx, opts))
```

### Changes

Three tests, no production code touched:

- TEST 9 — `exit("done\n")`: no status code, body still written, response stays 200
- TEST 10 — `exit(201, "a", {b = "b"}, "c\n")`: parts printed in order, the table encoded as JSON
- TEST 11 — `say("a", "b", "c\n")`

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation accordingly
- [x] I have verified that the change is backward compatible