### PR TITLE
perf(etcd): reuse unchanged items on a full reload

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -26,6 +26,7 @@ local json         = require("apisix.core.json")
 local etcd_apisix  = require("apisix.core.etcd")
 local core_str     = require("apisix.core.string")
 local new_tab      = require("table.new")
+local nkeys        = require("table.nkeys")
 local inspect      = require("inspect")
 local process      = require("ngx.process")
 local check_schema = require("apisix.core.schema").check
@@ -560,6 +561,8 @@ end
 local function load_full_data(self, dir_res, headers, prev_values, prev_values_hash)
     local err
     local changed = false
+    -- how many of the previous keys are still present, used to detect deletions
+    local matched_prev = 0
 
     if self.single_item then
         self.values = new_tab(1, 0)
@@ -621,6 +624,25 @@ local function load_full_data(self, dir_res, headers, prev_values, prev_values_h
 
         for _, item in ipairs(values) do
             local key = short_key(self, item.key)
+            local prev_item = get_prev_item(prev_values, prev_values_hash, key)
+            if prev_item then
+                matched_prev = matched_prev + 1
+            end
+
+            -- Nothing changed for this key, so reuse the item we already have
+            -- instead of rebuilding it. This keeps the object identity stable,
+            -- which matters because downstream caches are keyed on it, and it
+            -- leaves `changed` alone so that a reload which changed nothing
+            -- does not bump conf_version and rebuild every router.
+            -- Same semantics as the incremental watch path in sync_data, which
+            -- only re-runs the checker and filter for the keys that changed.
+            if prev_item and prev_item.modifiedIndex == item.modifiedIndex then
+                insert_tab(self.values, prev_item)
+                self.values_hash[key] = #self.values
+                self:upgrade_version(item.modifiedIndex)
+                goto continue
+            end
+
             local data_valid = true
             err = nil
             if type(item.value) ~= "table" then
@@ -660,20 +682,28 @@ local function load_full_data(self, dir_res, headers, prev_values, prev_values_h
                     self.filter(item)
                 end
 
-            else
-                local prev_item = get_prev_item(prev_values, prev_values_hash, key)
-                if prev_item then
-                    -- keep serving with the last valid configuration instead of
-                    -- silently dropping the whole item on a full reload, see the
-                    -- incremental path in sync_data for the same semantics
-                    log.warn("failed to check item data of [", self.key, "/", key,
-                             "], keep the previous configuration, err: ", err)
-                    insert_tab(self.values, prev_item)
-                    self.values_hash[key] = #self.values
-                end
+            elseif prev_item then
+                -- keep serving with the last valid configuration instead of
+                -- silently dropping the whole item on a full reload, see the
+                -- incremental path in sync_data for the same semantics
+                log.warn("failed to check item data of [", self.key, "/", key,
+                         "], keep the previous configuration, err: ", err)
+                insert_tab(self.values, prev_item)
+                self.values_hash[key] = #self.values
             end
 
             self:upgrade_version(item.modifiedIndex)
+
+            ::continue::
+        end
+
+        -- Keys present in the previous snapshot but absent now were deleted
+        -- while we were not watching. Every surviving key can be untouched and
+        -- still leave us with a changed configuration, so this has to be
+        -- checked separately or a reload that only deletes would keep serving
+        -- the removed items.
+        if prev_values_hash and matched_prev < nkeys(prev_values_hash) then
+            changed = true
         end
     end
 

--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -862,3 +862,184 @@ GET /t
 invalid new item loaded: false
 --- no_error_log
 keep the previous configuration
+
+
+
+=== TEST 19: a full reload that changes nothing reuses the items and does not bump conf_version
+--- timeout: 25
+--- yaml_config
+deployment:
+  role: traditional
+  role_traditional:
+    config_provider: etcd
+  etcd:
+    host:
+      - "http://127.0.0.1:2379"
+    prefix: /apisix
+--- extra_yaml_config
+nginx_config:
+    worker_processes: 1
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local etcd = require("resty.etcd")
+            local etcd_cli, err = etcd.new({
+                http_host = "http://127.0.0.1:2379",
+            })
+            if not etcd_cli then
+                ngx.say("failed to create etcd client: ", err)
+                return
+            end
+
+            etcd_cli:set("/apisix/global_rules/1", {
+                id = "1",
+                create_time = 1700000000,
+                update_time = 1700000000,
+                plugins = {["response-rewrite"] = {headers = {set = {["X-T"] = "a"}}}}
+            })
+            ngx.sleep(2)
+
+            local obj = core.config.fetch_created_obj("/global_rules")
+            local before_version = obj.conf_version
+
+            -- Two independent probes. A reload always builds a fresh `values`
+            -- array, so losing this one proves the reload actually ran; the
+            -- incremental path only mutates elements and would keep it.
+            obj.values.array_probe = "old"
+            -- The items inside must survive: reusing them is the whole point.
+            for _, item in ipairs(obj.values) do
+                if item and item.value and item.value.id == "1" then
+                    item.reload_probe = "kept"
+                end
+            end
+
+            -- Arm the recovery path taken after a `compacted` error, then write
+            -- a second rule. sync_data is parked in waitdir, so the write is
+            -- what wakes it: the incremental path adds /2 and bumps
+            -- conf_version once, and the next sync_data round reaches the
+            -- need_reload branch. By then /1 and /2 are both in memory at the
+            -- revisions etcd reports, so the reload has nothing to change and
+            -- must not bump conf_version a second time.
+            obj.need_reload = true
+            etcd_cli:set("/apisix/global_rules/2", {
+                id = "2",
+                create_time = 1700000000,
+                update_time = 1700000000,
+                plugins = {["response-rewrite"] = {headers = {set = {["X-T2"] = "b"}}}}
+            })
+            ngx.sleep(3)
+
+            local probe_kept = false
+            for _, item in ipairs(obj.values) do
+                if item and item.value and item.value.id == "1" then
+                    probe_kept = (item.reload_probe == "kept")
+                end
+            end
+
+            ngx.say("reload ran: ", obj.values.array_probe == nil)
+            ngx.say("item reused: ", probe_kept)
+            ngx.say("conf_version bumped once, not twice: ",
+                    obj.conf_version == before_version + 1)
+
+            etcd_cli:delete("/apisix/global_rules/1")
+            etcd_cli:delete("/apisix/global_rules/2")
+            ngx.sleep(1)
+        }
+    }
+--- request
+GET /t
+--- response_body
+reload ran: true
+item reused: true
+conf_version bumped once, not twice: true
+
+
+
+=== TEST 20: a full reload that only deletes must still bump conf_version
+--- timeout: 25
+--- yaml_config
+deployment:
+  role: traditional
+  role_traditional:
+    config_provider: etcd
+  etcd:
+    host:
+      - "http://127.0.0.1:2379"
+    prefix: /apisix
+--- extra_yaml_config
+nginx_config:
+    worker_processes: 1
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local etcd = require("resty.etcd")
+            local etcd_cli, err = etcd.new({
+                http_host = "http://127.0.0.1:2379",
+            })
+            if not etcd_cli then
+                ngx.say("failed to create etcd client: ", err)
+                return
+            end
+
+            etcd_cli:set("/apisix/global_rules/1", {
+                id = "1",
+                create_time = 1700000000,
+                update_time = 1700000000,
+                plugins = {["response-rewrite"] = {headers = {set = {["X-T"] = "a"}}}}
+            })
+            ngx.sleep(2)
+
+            local obj = core.config.fetch_created_obj("/global_rules")
+            obj.values.array_probe = "old"
+
+            -- An item that is live in memory but gone from etcd, so the reload
+            -- has to drop it. Every surviving key is untouched and therefore
+            -- reused, so without an explicit deletion check `changed` would
+            -- stay false, conf_version would not move, and the routers would
+            -- go on serving the dropped item.
+            local ghost = {
+                key = "/apisix/global_rules/ghost",
+                modifiedIndex = 1,
+                value = {id = "ghost", plugins = {}},
+            }
+            core.table.insert(obj.values, ghost)
+            obj.values_hash["ghost"] = #obj.values
+
+            local before_version = obj.conf_version
+
+            -- same wake-up mechanism as TEST 19: /2 arrives incrementally
+            -- (+1), then the reload drops the ghost (+1)
+            obj.need_reload = true
+            etcd_cli:set("/apisix/global_rules/2", {
+                id = "2",
+                create_time = 1700000000,
+                update_time = 1700000000,
+                plugins = {["response-rewrite"] = {headers = {set = {["X-T2"] = "b"}}}}
+            })
+            ngx.sleep(3)
+
+            local found_ghost = false
+            for _, item in ipairs(obj.values) do
+                if item and item.value and item.value.id == "ghost" then
+                    found_ghost = true
+                end
+            end
+
+            ngx.say("reload ran: ", obj.values.array_probe == nil)
+            ngx.say("ghost dropped: ", not found_ghost)
+            ngx.say("conf_version bumped for the deletion: ",
+                    obj.conf_version == before_version + 2)
+
+            etcd_cli:delete("/apisix/global_rules/1")
+            etcd_cli:delete("/apisix/global_rules/2")
+            ngx.sleep(1)
+        }
+    }
+--- request
+GET /t
+--- response_body
+reload ran: true
+ghost dropped: true
+conf_version bumped for the deletion: true


### PR DESCRIPTION
Fixes #12167

**Makes the `compacted` recovery reload cheap instead of trying to avoid it.** A reload that changes nothing now reuses the existing items, leaves `conf_version` alone and rebuilds no routers.

Companion to #13721, which removes the unsafe way of avoiding the reload. Together they close #12167 and #13067; each stands on its own and they can be reviewed independently.

## The problem

#12167 reports periodic CPU spikes correlated with this log line:

```
waitdir [/proxygw/services] err: compacted, will read the configuration again via readdir
```

The reporter's ask is specific — *"APISIX CPU usage fluctuates when 'compacted' errors occur. I want to avoid this problem."* Not the log line: the CPU.

Recovery from `compacted` is a full reload, and today it rebuilds everything unconditionally:

- every item is re-validated through `check_schema`, the `checker` and the `filter`
- `load_full_data` sets `changed` as soon as **any** item is valid, so `conf_version` always moves and every router rebuilds its radixtree
- the item tables are new objects, so downstream caches keyed on them all miss

And it happens for **every resource type** — routes, services, upstreams, consumers, ssls, global_rules, plugin_configs … — in **every worker**, because `need_reload` is per config instance and `produce_res(nil, "compacted")` broadcasts to all of them.

None of that work is necessary when nothing actually changed — which is precisely the case for the deployment that suffers from this. A prefix idle enough to fall behind compaction is a prefix whose configuration did not change.

## The fix

Compare each key against the previous snapshot and reuse the item when `modifiedIndex` matches:

```lua
local prev_item = get_prev_item(prev_values, prev_values_hash, key)
if prev_item and prev_item.modifiedIndex == item.modifiedIndex then
    insert_tab(self.values, prev_item)
    self.values_hash[key] = #self.values
    self:upgrade_version(item.modifiedIndex)
    goto continue                       -- note: `changed` is left alone
end
```

etcd increments `mod_revision` on every write, so an equal `modifiedIndex` means equal content.

The `prev_values` / `get_prev_item` plumbing already exists — it was added so an item whose new data fails validation can keep serving its last valid value. This reuses it.

### Why skipping the filter is safe

The incremental watch path already works this way: `sync_data` re-runs the checker and filter only for the keys that changed, and never touches the other items. So this is not new semantics, it aligns the reload path with the watch path.

Checked every filter individually:

| config | what its filter does | only touches its own item |
|---|---|---|
| `/routes` | `has_domain`, `set_plugins_meta_parent`, host lowercasing, `filter_upstream` | ✅ |
| `/services` | same | ✅ |
| `/upstreams` | `has_domain`, `filter_upstream` | ✅ |
| `/consumers`, `/consumer_groups`, `/global_rules`, `/plugin_configs` | `set_plugins_meta_parent` | ✅ |
| `/ssls` | sni lowercasing, trailing-dot strip | ✅ |
| `/plugins` | **`plugin.load(item)` — global effects** | ❌ |

The first eight are idempotent and only mutate fields of the item they are handed, so an item that was filtered once is already in its filtered state. `/plugins` is the exception, and it is `single_item` — one item, negligible gain — so the `single_item` branch is left out of the optimisation entirely.

### Deletions need an explicit check

This is the trap. Keys that vanished while we were not watching leave *every surviving key untouched*, so `changed` would stay `false`, `conf_version` would not move, and the routers would go on serving the deleted items:

```lua
if prev_values_hash and matched_prev < nkeys(prev_values_hash) then
    changed = true
end
```

## Tests

Both are verified to be discriminating — a test that passes either way proves nothing.

**TEST 19** — a reload with nothing changed. Two independent probes: a tag on the `values` array (a reload always allocates a fresh one, so losing it proves the reload really ran) and a tag on the item inside it (which must survive). Asserts `conf_version` moved once for the incremental write that wakes the watcher, not twice.

Against unpatched `master`:

```
 reload ran: true
-item reused: true
+item reused: false
-conf_version bumped once, not twice: true
+conf_version bumped once, not twice: false
```

**TEST 20** — a reload whose only change is a deletion. Passes on unpatched `master` (which bumps unconditionally), so it was verified against the variant that matters: the reuse optimisation *with the deletion check disabled*:

```
 reload ran: true
 ghost dropped: true
-conf_version bumped for the deletion: true
+conf_version bumped for the deletion: false
```

Full file run locally: the failure set is identical before and after this change (TEST 3/4/5/9, which need a TLS etcd on :12379 that this machine does not have), and TEST 16/17/18 — the existing full-reload tests — still pass.

## What this does not do

The `readdir` itself still happens on every `compacted`: without reading the full snapshot there is no way to know what was missed. The transfer and JSON parse remain. What goes away is the rebuild on top of it, which is the part that scales with configuration size and shows up as the spike.
