### PR TITLE
perf(plugin): reuse the filtered global-rule plugin set across phases

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -1244,6 +1244,10 @@ function _M.http_log_phase()
         core.tablepool.release("plugins", api_ctx.plugins)
     end
 
+    if api_ctx.global_plugins then
+        core.tablepool.release("global_plugins", api_ctx.global_plugins)
+    end
+
     if api_ctx.curr_req_matched then
         core.tablepool.release("matched_route_record", api_ctx.curr_req_matched)
     end

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -1525,17 +1525,37 @@ function _M.run_global_rules(api_ctx, global_rules, conf_version, phase_name)
                                                              global_rules,
                                                              conf_version)
 
-        local plugins = core.tablepool.fetch("plugins", 32, 0)
         local route = api_ctx.matched_route
         api_ctx.conf_type = "global_rule"
         api_ctx.conf_version = dummy_global_rule.modifiedIndex
         api_ctx.conf_id = dummy_global_rule.value.id
 
-        core.table.clear(plugins)
-        plugins = _M.filter(api_ctx, dummy_global_rule, plugins, route)
+        -- The filtered set depends only on the merged global rule (itself cached
+        -- per conf_version) and on the matched route, so it does not need
+        -- recomputing in every phase. This matters most for body_filter, which
+        -- runs once per response buffer. Route plugins are already reused this
+        -- way through api_ctx.plugins; global rules were not.
+        -- The route is part of the key because plugins with
+        -- run_policy == "prefer_route" are skipped when the route configures the
+        -- same plugin, and api_ctx.matched_route is replaced when a consumer's
+        -- configuration is merged in -- which happens after the rewrite phase
+        -- has run but before access.
+        -- The table is returned to the pool in http_log_phase.
+        local plugins = api_ctx.global_plugins
+        if not (plugins
+                and api_ctx.global_plugins_route == route
+                and api_ctx.global_plugins_version == dummy_global_rule.modifiedIndex)
+        then
+            plugins = plugins or core.tablepool.fetch("global_plugins", 32, 0)
+            core.table.clear(plugins)
+            plugins = _M.filter(api_ctx, dummy_global_rule, plugins, route)
+
+            api_ctx.global_plugins = plugins
+            api_ctx.global_plugins_route = route
+            api_ctx.global_plugins_version = dummy_global_rule.modifiedIndex
+        end
 
         _M.run_plugin(phase_name, plugins, api_ctx)
-        core.tablepool.release("plugins", plugins)
 
         api_ctx.conf_type = orig_conf_type
         api_ctx.conf_version = orig_conf_version

--- a/t/plugin/global-rule-phase-cache.t
+++ b/t/plugin/global-rule-phase-cache.t
@@ -1,0 +1,206 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# run_global_rules() caches the filtered plugin list on api_ctx instead of
+# re-filtering in every phase, and _M.filter() takes a fast path that iterates
+# the enabled set rather than every loaded plugin. Neither may change *which*
+# plugins run, in what order, or when the cached set has to be rebuilt.
+use t::APISIX 'no_plan';
+
+no_long_string();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: global rule running a plugin in more than one phase
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/global_rules/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "serverless-pre-function": {
+                            "phase": "rewrite",
+                            "functions": [
+                                "return function() ngx.log(ngx.WARN, 'gr-phase: rewrite') end"
+                            ]
+                        },
+                        "serverless-post-function": {
+                            "phase": "body_filter",
+                            "functions": [
+                                "return function() ngx.log(ngx.WARN, 'gr-phase: body_filter') end"
+                            ]
+                        }
+                    }
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 2: set route
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 3: every phase still runs off the cached plugin list
+--- request
+GET /hello
+--- response_body
+hello world
+--- error_log
+gr-phase: rewrite
+gr-phase: body_filter
+
+
+
+=== TEST 4: body_filter still runs for every chunk of a chunked response
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code = t('/apisix/admin/routes/2',
+                ngx.HTTP_PUT,
+                [[{
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello_chunked"
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+                return
+            end
+
+            local http = require "resty.http"
+            local httpc = http.new()
+            local res = httpc:request_uri("http://127.0.0.1:" ..
+                                          ngx.var.server_port .. "/hello_chunked")
+            ngx.say(res.status)
+        }
+    }
+--- response_body
+200
+--- grep_error_log eval
+qr/gr-phase: body_filter/
+--- grep_error_log_out eval
+qr/(gr-phase: body_filter\n){2,}/
+
+
+
+=== TEST 5: the cache is rebuilt when the global rule changes mid-flight
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local http = require "resty.http"
+            local httpc = http.new()
+            local base = "http://127.0.0.1:" .. ngx.var.server_port
+
+            httpc:request_uri(base .. "/hello")
+
+            -- new modifiedIndex => the cached set must not be reused
+            local code = t('/apisix/admin/global_rules/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "serverless-pre-function": {
+                            "phase": "rewrite",
+                            "functions": [
+                                "return function() ngx.log(ngx.WARN, 'gr-phase: reloaded') end"
+                            ]
+                        }
+                    }
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+                return
+            end
+
+            ngx.sleep(0.5)
+            local res = httpc:request_uri(base .. "/hello")
+            ngx.say(res.status)
+        }
+    }
+--- response_body
+200
+--- error_log
+gr-phase: reloaded
+
+
+
+=== TEST 6: clean up the global rule
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code = t('/apisix/admin/global_rules/1', ngx.HTTP_DELETE)
+            if code >= 300 then
+                ngx.status = code
+                return
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed


### PR DESCRIPTION
ref: https://github.com/api7/ticket-analysis/issues/541

### Description

`run_global_rules()` rebuilds the same plugin set on every phase. Route plugins are computed once and reused through `api_ctx.plugins`; global rules had no equivalent, so a single request re-ran `_M.filter()` for the same merged rule again and again — 9 times for a plain request, and more for a streamed response, since `body_filter` and `delayed_body_filter` run once per response buffer.

This caches the filtered set on `api_ctx`, keyed by the merged rule's `modifiedIndex` and by the matched route.

The route belongs in the key: plugins declaring `run_policy = "prefer_route"` are skipped when the route configures the same plugin, and `api_ctx.matched_route` is replaced when a consumer's configuration is merged in — which happens after the `rewrite` phase has run but before `access`.

Since the table now outlives a single phase, it is taken from the `global_plugins` pool and released in `http_log_phase` rather than at the end of every phase.

### Measurements

Measured on an APISIX 3.2-based fork carrying the same change. Single worker, CPU-pinned (worker and load generator on separate cores), wrk2, 5 runs each, median, with a `global_rule` enabling prometheus:

| build | rps |
|---|---|
| baseline | 21,453 |
| cross-phase reuse | 24,062 (**+12.2%**) |

Not measured on master itself.

### Tests

`t/plugin/global-rule-phase-cache.t`:

- every phase still runs off the cached set (a global rule with plugins in `rewrite` and `body_filter`)
- `body_filter` still runs per response buffer on a chunked response — the case the cache affects most
- the set is rebuilt when the global rule changes mid-flight

**Known gap:** the fork also carries a case proving the set is rebuilt when a consumer merge replaces `matched_route` — verified there by deleting the route key and watching it fail. It observes `prefer_route` through prometheus metrics, and I could not port it: `Test::Nginx` restarts nginx between blocks whose `--- config` differs, and the metrics live in a per-process shared dict, so cross-block observation resets. As `prometheus` and `skywalking` are the only `prefer_route` plugins, I did not find another observation point. The route cache key is therefore untested here — suggestions welcome.

### Checklist

- [x] I have explained why we need this PR and what problem it solves
- [x] I have explained the changes in this PR
- [x] I have added tests
- [ ] I have updated the documentation — no user-facing behaviour change
