### PR TITLE
fix: normalize the case of hosts carried on a service

### DIFF
--- a/apisix/http/service.lua
+++ b/apisix/http/service.lua
@@ -20,6 +20,8 @@ local plugin_checker = require("apisix.plugin").plugin_checker
 local plugin = require("apisix.plugin")
 local services
 local error = error
+local ipairs = ipairs
+local str_lower = string.lower
 
 
 local _M = {
@@ -47,6 +49,13 @@ local function filter(service)
         return
     end
 
+    -- normalize the hosts like `apisix/router.lua` does for routes: hostnames are
+    -- case-insensitive, and they are matched against $host, which is always lowercase
+    if service.value.hosts then
+        for i, v in ipairs(service.value.hosts) do
+            service.value.hosts[i] = str_lower(v)
+        end
+    end
 
     plugin.set_plugins_meta_parent(service.value.plugins, service)
 

--- a/t/router/radixtree-host-uri3.t
+++ b/t/router/radixtree-host-uri3.t
@@ -353,3 +353,67 @@ Host: foo.com
 qr/func\(\): matched host: [^,]+/
 --- grep_error_log_out
 func(): matched host: *.com
+
+
+
+=== TEST 10: hosts in services are matched case-insensitively
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port
+                        .. "/hello"
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/services/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "hosts": ["MixedCase.com"]
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "service_id": "1",
+                        "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.sleep(0.1)
+
+            for _, h in ipairs({"MixedCase.com", "mixedcase.com", "other.com"}) do
+                local httpc = http.new()
+                local res, err = httpc:request_uri(uri, {headers = {Host = h}})
+                if not res then
+                    ngx.say(err)
+                    return
+                end
+                if res.status == 404 then
+                    ngx.say(res.status)
+                else
+                    ngx.print(res.body)
+                end
+            end
+        }
+    }
+--- response_body
+hello world
+hello world
+404


### PR DESCRIPTION
### Description

Hostnames are case-insensitive, and route matching runs against `$host`, which nginx always lowercases (`ngx_http_validate_host()`). `apisix/router.lua` normalizes this on the route object:

```lua
if route.value.host then
    route.value.host = str_lower(route.value.host)
elseif route.value.hosts then
    for i, v in ipairs(route.value.hosts) do
        route.value.hosts[i] = str_lower(v)
    end
end
```

`apisix/http/service.lua` has no equivalent, so `service.hosts` is stored verbatim. `radixtree_host_uri` — the default router — builds its host buckets itself, keyed on the raw reversed host string:

```lua
-- apisix/http/router/radixtree_host_uri.lua
for i, host in ipairs(hosts) do
    local host_rev = host:reverse()
```

A service host containing an uppercase character therefore ends up in a bucket keyed on e.g. `moc.elpmaxe.esaCdexiM`, which the lowercase `$host` can never reach. The route falls through to `only_uri_router`, and if nothing host-agnostic matches, the request 404s — for every path and every casing of the request `Host`, so the host is silently unroutable.

`radixtree_uri` is not affected, because it passes `hosts` to lua-resty-radixtree, which lowercases on both the config side and the request side.

Reproduced on 3.16.0 in standalone mode, with `service.hosts: ["MixedCase.example.com"]` and a route with no `hosts` of its own:

| request `Host` | `radixtree_host_uri` (default) | `radixtree_uri` | after this patch |
| --- | --- | --- | --- |
| `MixedCase.example.com` | 404 | 200 | 200 |
| `mixedcase.example.com` | 404 | 200 | 200 |
| `MIXEDCASE.EXAMPLE.COM` | 404 | 200 | 200 |

This patch lowercases the hosts in the service `filter()`, mirroring what `router.lua` already does for routes.

The new `t/router/radixtree-host-uri3.t` TEST 10 covers it — its functional assertions pass with the patch and fail without it:

```
# with the fix
ok 29 - TEST 10: hosts in services are matched case-insensitively - status code ok
ok 30 - TEST 10: hosts in services are matched case-insensitively - response_body - response is expected

# with apisix/http/service.lua reverted
not ok 30 - TEST 10: hosts in services are matched case-insensitively - response_body - response is expected
```

Found via apache/apisix-ingress-controller#2822: the controller carries the host constraint on the service object, so an ingress route with an uppercase hostname is unroutable.

#### Which issue(s) this PR fixes:

N/A

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
