### PR TITLE
feat(ldap-auth-advanced): add group-based authorization

### DIFF
--- a/apisix/consumer.lua
+++ b/apisix/consumer.lua
@@ -303,7 +303,6 @@ local plugin_unique_key_attrs = {
     ["jwt-auth"]   = "key",
     ["hmac-auth"]  = "key_id",
     ["ldap-auth"]  = "user_dn",
-    ["ldap-auth-advanced"] = "user_dn",
 }
 
 

--- a/apisix/plugins/ldap-auth-advanced.lua
+++ b/apisix/plugins/ldap-auth-advanced.lua
@@ -17,17 +17,24 @@
 local core = require("apisix.core")
 local schema_def = require("apisix.schema_def")
 local auth_utils = require("apisix.utils.auth")
-local consumer_mod = require("apisix.consumer")
 local ldap_client = require("resty.ldap.client")
 local ldap_protocol = require("resty.ldap.protocol")
 local ldap_filter = require("resty.ldap.filter")
 local ngx = ngx
 local ipairs = ipairs
+local pairs = pairs
 local type = type
+local tonumber = tonumber
 local ngx_decode_base64 = ngx.decode_base64
 local ngx_re_match = ngx.re.match
+local ngx_re_gsub = ngx.re.gsub
 local str_find = string.find
 local str_sub = string.sub
+local str_byte = string.byte
+local str_char = string.char
+local str_gsub = string.gsub
+local str_lower = string.lower
+local table_concat = table.concat
 local parse_addr = core.utils.parse_addr
 
 -- RFC 4512 attribute-description: a descriptor ("cn", "sAMAccountName") or a
@@ -39,7 +46,6 @@ local ATTR_PATTERN = "^(?:[A-Za-z][A-Za-z0-9-]*"
 
 local schema = {
     type = "object",
-    title = "work with route or service object",
     properties = {
         -- connection
         ldap_uri     = { type = "string",                          -- "host[:port]"
@@ -69,28 +75,53 @@ local schema = {
         size_limit = { type = "integer", minimum = 2, default = 2 },
         time_limit = { type = "integer", minimum = 0, default = 5 }, -- seconds; 0 = server default
 
+        -- groups
+        group_base_dn = { type = "string",                  -- absent => memberOf attribute path
+                          minLength = 1, maxLength = 4096 },
+        group_name_attribute = { type = "string", maxLength = 256,
+                                 default = "cn", pattern = ATTR_PATTERN },
+        group_member_attribute = { type = "string", maxLength = 256,
+                                   default = "member", pattern = ATTR_PATTERN },
+        user_membership_attribute = { type = "string", maxLength = 256,
+                                      default = "memberOf",
+                                      pattern = ATTR_PATTERN },
 
-
-        -- consumer
-        consumer_required  = { type = "boolean", default = true },
+        -- authorization: outer array ORs, inner array ANDs
+        groups_required = {
+            type = "array", minItems = 1,
+            items = { type = "array", minItems = 1,
+                      items = { type = "string",
+                                minLength = 1, maxLength = 4096 } },
+        },
 
         -- request handling
         header_type      = { type = "string", enum = {"ldap", "basic"}, default = "ldap" },
         realm            = schema_def.get_realm_schema("ldap"),
+
+        -- identity export
+        set_username_header = {
+            description = "Whether the authenticated username should be added in the "
+                .. "X-Authenticated-Username header to the request for downstream.",
+            type = "boolean", default = true },
+        set_user_dn_header = {
+            description = "Whether the resolved user DN should be added in the "
+                .. "X-Authenticated-User-Dn header to the request for downstream.",
+            type = "boolean", default = false },
+        set_groups_header = {
+            description = "Whether the collected group names should be added in the "
+                .. "X-Authenticated-Groups header to the request for downstream.",
+            type = "boolean", default = true },
+
+        -- observability
+        ldap_debug = { type = "boolean", default = false },
 
     },
     encrypt_fields = {"ldap_password"},
     required = {"ldap_uri", "base_dn"},
 }
 
-local consumer_schema = {
-    type = "object",
-    title = "work with consumer object",
-    properties = {
-        user_dn  = { type = "string", minLength = 1, maxLength = 4096 },
-    },
-    required = {"user_dn"},
-}
+local GROUP_NAME_DEFAULT = schema.properties.group_name_attribute.default
+local GROUP_MEMBER_DEFAULT = schema.properties.group_member_attribute.default
 
 local plugin_name = "ldap-auth-advanced"
 
@@ -101,12 +132,13 @@ local _M = {
     type = 'auth',
     name = plugin_name,
     schema = schema,
-    consumer_schema = consumer_schema,
 }
 
 function _M.check_schema(conf, schema_type)
     if schema_type == core.schema.TYPE_CONSUMER then
-        return core.schema.check(consumer_schema, conf)
+        return false, "ldap-auth-advanced does not support consumer-scoped "
+                      .. "configuration; use the ldap-auth plugin for "
+                      .. "Consumer-backed LDAP authentication"
     end
 
     local ok, err = core.schema.check(schema, conf)
@@ -120,6 +152,17 @@ function _M.check_schema(conf, schema_type)
 
     if conf.bind_dn and not conf.ldap_password then
         return false, "ldap_password is required when bind_dn is set"
+    end
+
+    -- Compared against the schema default, not presence: jsonschema injects
+    -- defaults into conf, and stored config is re-validated on every reload.
+    if not conf.group_base_dn then
+        if conf.group_name_attribute ~= GROUP_NAME_DEFAULT then
+            return false, "group_name_attribute is only used with group_base_dn"
+        end
+        if conf.group_member_attribute ~= GROUP_MEMBER_DEFAULT then
+            return false, "group_member_attribute is only used with group_base_dn"
+        end
     end
 
     -- ldap_uri may omit ":port"; the effective port (636 with use_ldaps,
@@ -153,6 +196,27 @@ local function auth_failed(conf, ctx, reason)
 end
 
 
+-- groups_required is an outer OR of inner ANDs, matched against the collected
+-- group names verbatim (no case folding, no trimming).
+local function groups_satisfied(groups_required, groups)
+    local have = {}
+    for i = 1, #groups do
+        have[groups[i].name] = true
+    end
+    for _, inner in ipairs(groups_required) do
+        local all = true
+        for _, name in ipairs(inner) do
+            if not have[name] then
+                all = false
+                break
+            end
+        end
+        if all then
+            return true
+        end
+    end
+    return false
+end
 
 
 -- Parse one credential header value: the scheme word is conf.header_type
@@ -233,12 +297,115 @@ local function is_result_code(err, op, result_msg)
 end
 
 
+-- Attribute lookup with a case-insensitive fallback: the server may echo the
+-- requested descriptor in a different case.
+local function attr_values(attributes, name)
+    if not attributes then
+        return nil
+    end
+    local vals = attributes[name]
+    if vals then
+        return vals
+    end
+    local lname = str_lower(name)
+    for k, v in pairs(attributes) do
+        if str_lower(k) == lname then
+            return v
+        end
+    end
+    return nil
+end
 
 
--- The LDAP round trip: resolve the user DN and authenticate the user's bind
--- on ONE pinned connection. Returns (nil, nil, user_dn) on success, or
--- (code, body) on failure. The socket is closed on every failure path and
--- released to the pool only on success, so a poisoned socket is never pooled.
+-- Reverse RFC 4514 RDN-value escaping ("\2C" or "\," -> the literal char) so
+-- group names taken from a DN match the unescaped attribute values byte for
+-- byte. Single pass, hex escape first, so "\\2C" stays a backslash plus the
+-- literal "2C"; a lone trailing backslash is kept as-is.
+local function unescape_rdn_value(v)
+    if not str_find(v, "\\", 1, true) then
+        return v
+    end
+    return (ngx_re_gsub(v, [[\\([0-9A-Fa-f]{2}|.)]], function(m)
+        local esc = m[1]
+        return #esc == 2 and str_char(tonumber(esc, 16)) or esc
+    end, "jos"))
+end
+
+
+-- The value of a DN's first RDN, unescaped, e.g.
+-- "cn=Domain Admins,ou=groups,..." -> "Domain Admins".
+local function first_rdn_value(dn)
+    local eq = str_find(dn, "=", 1, true)
+    if not eq then
+        return dn
+    end
+    local i = eq + 1
+    local n = #dn
+    while i <= n do
+        local b = str_byte(dn, i)
+        if b == 92 then           -- '\' escapes the next byte
+            i = i + 2
+        elseif b == 44 then       -- ',' ends the first RDN
+            return unescape_rdn_value(str_sub(dn, eq + 1, i - 1))
+        else
+            i = i + 1
+        end
+    end
+    return unescape_rdn_value(str_sub(dn, eq + 1))
+end
+
+
+-- Map group search entries to {dn, name} pairs; when an entry did not carry
+-- the name attribute, fall back to its DN's first RDN value.
+local function collect_search_groups(entries, name_attr)
+    local groups = {}
+    for _, entry in ipairs(entries) do
+        if entry.entry_dn then
+            local vals = attr_values(entry.attributes, name_attr)
+            groups[#groups + 1] = {
+                dn = entry.entry_dn,
+                name = (vals and vals[1]) or first_rdn_value(entry.entry_dn),
+            }
+        end
+    end
+    return groups
+end
+
+
+-- Each membership-attribute value on the user entry is a group DN; its name
+-- is the DN's first RDN value. No extra LDAP round trip.
+local function collect_membership_groups(user_entry, member_attr)
+    local groups = {}
+    local vals = attr_values(user_entry.attributes, member_attr)
+    if vals then
+        for _, dn in ipairs(vals) do
+            groups[#groups + 1] = { dn = dn, name = first_rdn_value(dn) }
+        end
+    end
+    return groups
+end
+
+
+-- Strip CR/LF and other control bytes from a directory-sourced value before
+-- it is written into an upstream header (header-injection defense). Group
+-- matching always uses the raw name, never this sanitized copy.
+local function sanitize_header_value(v)
+    return (str_gsub(v, "[%z\1-\31\127]", ""))
+end
+
+
+-- Returns the client's own (ok, err): false is a directory rejection, nil is
+-- a transport failure.
+local function bind_as_service(client, conf)
+    if conf.bind_dn then
+        return client:simple_bind(conf.bind_dn, conf.ldap_password)
+    end
+    return client:simple_bind("", "")
+end
+
+
+-- Resolve, authenticate, and collect groups on ONE pinned connection. The
+-- socket is closed on every failure path and pooled only on success.
 local function ldap_resolve(conf, ctx, username, password)
     -- The only client-controlled part of the search filter is the escaped
     -- username. filter.escape leaves bytes the filter grammar rejects (e.g.
@@ -273,12 +440,7 @@ local function ldap_resolve(conf, ctx, username, password)
     -- The client connects lazily on the first operation, so a socket/TLS
     -- failure surfaces here as (nil, err) -- an outage, never auth -- while
     -- a directory rejection is (false, err).
-    local bind_ok, berr
-    if conf.bind_dn then
-        bind_ok, berr = client:simple_bind(conf.bind_dn, conf.ldap_password)
-    else
-        bind_ok, berr = client:simple_bind("", "")
-    end
+    local bind_ok, berr = bind_as_service(client, conf)
     if not bind_ok then
         client:close()
         if bind_ok == nil then
@@ -291,15 +453,20 @@ local function ldap_resolve(conf, ctx, username, password)
         return 500
     end
 
-    -- Search for the user. size_limit floors at 2 (schema minimum) so a 2nd
-    -- match is observable.
+    -- Search for the user. On the memberOf path, request
+    -- user_membership_attribute so groups can be read off this same entry
+    -- with no extra round trip; on the group-search path the entry's
+    -- attributes are unused, so request none ("1.1", RFC 4511) -- an AD
+    -- user's memberOf can be tens of KB that would be decoded and dropped.
+    -- size_limit floors at 2 (schema minimum) so a 2nd match is observable.
     local entries, serr = client:search(
         conf.base_dn,
         ldap_protocol.SEARCH_SCOPE_WHOLE_SUBTREE,
         ldap_protocol.SEARCH_DEREF_ALIASES_ALWAYS,
         conf.size_limit, conf.time_limit,
         false,
-        search_filter)
+        search_filter,
+        { conf.group_base_dn and "1.1" or conf.user_membership_attribute })
     if entries == false then
         client:close()
         if is_result_code(serr, "search", RESULT_SIZE_LIMIT_EXCEEDED) then
@@ -314,12 +481,12 @@ local function ldap_resolve(conf, ctx, username, password)
     end
 
     -- count SearchResultEntry rows (the library drops SearchResultDone)
-    local user_dn
+    local user_entry
     local match_count = 0
     for _, entry in ipairs(entries) do
         if entry.entry_dn then
             match_count = match_count + 1
-            user_dn = entry.entry_dn
+            user_entry = entry
         end
     end
     if match_count == 0 then
@@ -333,6 +500,7 @@ local function ldap_resolve(conf, ctx, username, password)
         return auth_failed(conf, ctx,
                            "ambiguous user match (>1 entry); check attribute uniqueness")
     end
+    local user_dn = user_entry.entry_dn
 
     -- Authenticate: bind as the resolved user. invalidCredentials is a wrong
     -- password (401); any other result code (busy, unavailable, ...) or a
@@ -347,6 +515,45 @@ local function ldap_resolve(conf, ctx, username, password)
         return 500
     end
 
+    local groups
+    if conf.group_base_dn then
+        -- Currently bound as the END USER. Re-bind as the configured identity
+        -- so the group search never runs under the caller. The extra round
+        -- trip is deliberate: searching groups before the auth bind would
+        -- avoid it, but then every wrong-password request would still incur
+        -- a group search.
+        local rb_ok, rberr = bind_as_service(client, conf)
+        if not rb_ok then
+            client:close()
+            core.log.error(plugin_name, ": LDAP group-search re-bind failed: ",
+                           rberr)
+            return 500
+        end
+
+        local group_filter = "(" .. conf.group_member_attribute .. "="
+                             .. ldap_filter.escape(user_dn) .. ")"
+        -- sizeLimit is deliberately 0 (not conf.size_limit) so a user's
+        -- groups are never silently truncated.
+        local gentries, gerr = client:search(
+            conf.group_base_dn,
+            ldap_protocol.SEARCH_SCOPE_WHOLE_SUBTREE,
+            ldap_protocol.SEARCH_DEREF_ALIASES_ALWAYS,
+            0, conf.time_limit,
+            false,
+            group_filter,
+            { conf.group_name_attribute })
+        if gentries == false then
+            -- already authenticated: unlike the user search, any failure here
+            -- (sizeLimitExceeded included) is operational, never a 401
+            client:close()
+            core.log.error(plugin_name, ": LDAP group search failed: ", gerr)
+            return 500
+        end
+        groups = collect_search_groups(gentries, conf.group_name_attribute)
+    else
+        groups = collect_membership_groups(user_entry,
+                                           conf.user_membership_attribute)
+    end
 
     if conf.keepalive == false then
         client:close()
@@ -354,14 +561,17 @@ local function ldap_resolve(conf, ctx, username, password)
         client:set_keepalive()
     end
 
-    return nil, nil, user_dn
+    return nil, nil, user_dn, groups
 end
 
 
 function _M.rewrite(conf, ctx)
-    -- Strip the client-supplied identity headers before any auth work: only
-    -- attach_consumer() may set them, and with consumer_required=false it
-    -- never runs, so an inbound value would otherwise pass through untouched.
+    -- Strip client-supplied identity headers before any auth work, so a
+    -- spoofed value can never survive to the upstream. The X-Consumer-*
+    -- family is stripped too: this plugin never attaches a Consumer, so
+    -- nothing downstream would overwrite a forged value on this route.
+    core.request.set_header(ctx, "X-Authenticated-Username", nil)
+    core.request.set_header(ctx, "X-Authenticated-User-Dn", nil)
     core.request.set_header(ctx, "X-Authenticated-Groups", nil)
     core.request.set_header(ctx, "X-Consumer-Username", nil)
     core.request.set_header(ctx, "X-Credential-Identifier", nil)
@@ -374,26 +584,44 @@ function _M.rewrite(conf, ctx)
         return auth_failed(conf, ctx, err)
     end
 
-    local code, body, user_dn = ldap_resolve(conf, ctx, username, password)
+    local code, body, user_dn, groups = ldap_resolve(conf, ctx, username, password)
     if code then
         return code, body
     end
 
-    -- Associate a Consumer with the authenticated identity, unless
-    -- consumer_required is false. find_consumer() resolves secret references
-    -- in the Consumer's user_dn and skips unresolved ones fail-closed.
-    if conf.consumer_required ~= false then
-        local consumer, consumer_conf, err =
-            consumer_mod.find_consumer(plugin_name, "user_dn", user_dn)
-        if err then
-            return auth_failed(conf, ctx, "consumer_required but no Consumer is configured")
+    local groups_header
+    if conf.set_groups_header or conf.ldap_debug then
+        local names = {}
+        for i = 1, #groups do
+            names[i] = sanitize_header_value(groups[i].name)
         end
-        if not consumer then
-            return auth_failed(conf, ctx,
-                               "no Consumer maps to the authenticated user_dn")
+        groups_header = table_concat(names, ",")
+        if conf.ldap_debug then
+            core.log.warn(plugin_name, ": groups: ", groups_header)
         end
+    end
 
-        consumer_mod.attach_consumer(ctx, consumer, consumer_conf)
+    -- an already-authenticated user failing authorization gets a real 403,
+    -- never a 401; the warn names the denied user because no identity
+    -- is exported on this path
+    if conf.groups_required and not groups_satisfied(conf.groups_required, groups) then
+        core.log.warn(plugin_name, ": groups_required not satisfied for ", user_dn)
+        return 403, { message = "Forbidden" }
+    end
+
+    -- Reached only after authentication AND authorization pass, so these
+    -- headers are absent on every 401/403/500 path. Each export follows its
+    -- set_*_header toggle; the inbound strip above stays unconditional.
+    if conf.set_username_header then
+        core.request.set_header(ctx, "X-Authenticated-Username",
+                                sanitize_header_value(username))
+    end
+    if conf.set_user_dn_header then
+        core.request.set_header(ctx, "X-Authenticated-User-Dn",
+                                sanitize_header_value(user_dn))
+    end
+    if conf.set_groups_header then
+        core.request.set_header(ctx, "X-Authenticated-Groups", groups_header)
     end
 end
 

--- a/ci/pod/docker-compose.plugin.yml
+++ b/ci/pod/docker-compose.plugin.yml
@@ -257,6 +257,9 @@ services:
       - ./t/certs:/certs
       - ./ci/pod/openldap/ad.ldif:/ldifs/ad.ldif
       - ./ci/pod/openldap/enable-anon-bind.sh:/docker-entrypoint-initdb.d/enable-anon-bind.sh
+      - ./ci/pod/openldap/memberof.ldif:/overlays/memberof.ldif
+      - ./ci/pod/openldap/groups.ldif:/overlays/groups.ldif
+      - ./ci/pod/openldap/setup-groups.sh:/docker-entrypoint-initdb.d/setup-groups.sh
 
 
   ## Grafana Loki

--- a/ci/pod/openldap/ad.ldif
+++ b/ci/pod/openldap/ad.ldif
@@ -100,3 +100,23 @@ cn: Secret User
 sn: Secret
 uid: secretuser
 userPassword: secretpass
+
+# Member of three groups (groups.ldif): exercises the unbounded group search.
+dn: cn=Multi User,ou=users,dc=example,dc=org
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+cn: Multi User
+sn: User
+uid: multiuser
+userPassword: multipass
+
+# Sole member of the comma-in-cn group "Sales, EMEA" (DN unescape case).
+dn: cn=Sales User,ou=users,dc=example,dc=org
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+cn: Sales User
+sn: User
+uid: salesuser
+userPassword: salespass

--- a/ci/pod/openldap/enable-anon-bind.sh
+++ b/ci/pod/openldap/enable-anon-bind.sh
@@ -25,8 +25,11 @@
 #   * cn=Secret User: invisible to an anonymous search, readable by any
 #     authenticated identity (userPassword keeps `auth` so the entry can
 #     still be bound once found) -- the bind-state-leak tripwire.
+#   * ou=groups `member`: readable by anonymous (the group-search identity)
+#     but NOT by end users -- a group search that skipped the re-bind would
+#     match nothing. The rootdn (cn=admin) bypasses ACLs entirely.
 #   * The catch-all keeps everything else readable, so the ldap-auth
-#     regression is unaffected.
+#     regression and the memberOf attribute are unaffected.
 
 set -o errexit
 set -o nounset
@@ -66,7 +69,8 @@ changetype: modify
 replace: olcAccess
 olcAccess: {0}to dn.exact="cn=Secret User,ou=users,dc=example,dc=org" attrs=userPassword by anonymous auth by users read by * none
 olcAccess: {1}to dn.exact="cn=Secret User,ou=users,dc=example,dc=org" by users read by * none
-olcAccess: {2}to * by * read
+olcAccess: {2}to dn.subtree="ou=groups,dc=example,dc=org" attrs=member by anonymous read by users none
+olcAccess: {3}to * by * read
 EOF
 
 ldap_stop

--- a/ci/pod/openldap/groups.ldif
+++ b/ci/pod/openldap/groups.ldif
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authorization groups for the ldap-auth-advanced tests. Loaded by
+# setup-groups.sh AFTER the memberof overlay is active, so the overlay
+# back-populates memberOf on the member user entries.
+
+dn: ou=groups,dc=example,dc=org
+objectClass: organizationalUnit
+ou: groups
+
+dn: cn=Domain Admins,ou=groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: Domain Admins
+member: cn=Jane Doe,ou=users,dc=example,dc=org
+member: cn=user01,ou=users,dc=example,dc=org
+member: cn=Multi User,ou=users,dc=example,dc=org
+
+dn: cn=developers,ou=groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: developers
+member: cn=user01,ou=users,dc=example,dc=org
+member: cn=Multi User,ou=users,dc=example,dc=org
+
+dn: cn=ops,ou=groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: ops
+member: cn=Jane Doe,ou=users,dc=example,dc=org
+member: cn=Multi User,ou=users,dc=example,dc=org
+
+dn: cn=superadmin,ou=groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: superadmin
+member: cn=user02,ou=users,dc=example,dc=org
+
+# The cn contains a comma, escaped in the DN as cn=Sales\, EMEA.
+dn: cn=Sales\, EMEA,ou=groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: Sales, EMEA
+member: cn=Sales User,ou=users,dc=example,dc=org

--- a/ci/pod/openldap/memberof.ldif
+++ b/ci/pod/openldap/memberof.ldif
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Activates the memberof + refint overlays on the data database
+# (olcDatabase={2}mdb). Must be applied BEFORE the groups are added: the
+# overlay only back-populates memberOf for member links added after it is
+# active.
+
+dn: cn=module,cn=config
+cn: module
+objectClass: olcModuleList
+olcModulePath: /opt/bitnami/openldap/lib/openldap
+olcModuleLoad: memberof.so
+olcModuleLoad: refint.so
+
+dn: olcOverlay=memberof,olcDatabase={2}mdb,cn=config
+objectClass: olcMemberOf
+objectClass: olcOverlayConfig
+olcOverlay: memberof
+
+dn: olcOverlay=refint,olcDatabase={2}mdb,cn=config
+objectClass: olcConfig
+objectClass: olcOverlayConfig
+objectClass: olcRefintConfig
+objectClass: top
+olcOverlay: refint
+olcRefintAttribute: memberof member manager owner

--- a/ci/pod/openldap/setup-groups.sh
+++ b/ci/pod/openldap/setup-groups.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Boot hook (docker-entrypoint-initdb.d): activates the memberof overlay,
+# THEN loads the groups. The overlay only back-populates memberOf for member
+# links added after it is active, so the groups cannot live in /ldifs.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+. /opt/bitnami/scripts/liblog.sh
+. /opt/bitnami/scripts/libopenldap.sh
+
+eval "$(ldap_env)"
+
+ldap_start_bg
+
+info "Activating the memberof + refint overlays"
+
+ldapadd -Y EXTERNAL -H "ldapi:///" -f /overlays/memberof.ldif
+
+info "Loading authorization groups (overlay back-populates memberOf)"
+
+ldapadd -H "ldapi:///" -D "$LDAP_ADMIN_DN" -w "$LDAP_ADMIN_PASSWORD" -f /overlays/groups.ldif
+
+ldap_stop

--- a/t/admin/consumers.t
+++ b/t/admin/consumers.t
@@ -702,83 +702,12 @@ GET /t
 
 
 
-=== TEST 21: add consumer adv_case_a with ldap-auth-advanced user_dn
+=== TEST 21: clean up consumers
 --- config
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/consumers',
-                ngx.HTTP_PUT,
-                [[{
-                     "username": "adv_case_a",
-                     "plugins": {
-                         "ldap-auth-advanced": {
-                             "user_dn": "cn=adv-duplicate-check,ou=users,dc=example,dc=org"
-                         }
-                     }
-                }]]
-                )
-
-            if code >= 300 then
-                ngx.status = code
-            end
-            ngx.say(body)
-        }
-    }
---- request
-GET /t
---- response_body
-passed
-
-
-
-=== TEST 22: add consumer adv_case_b with the same ldap-auth-advanced user_dn, should fail
---- config
-    location /t {
-        content_by_lua_block {
-            local t = require("lib.test_admin").test
-            -- the duplicate check runs against the locally synced consumer
-            -- data, wait until the watcher catches up with the previous write
-            local find_consumer = require("apisix.consumer").find_consumer
-            for _ = 1, 100 do
-                if find_consumer("ldap-auth-advanced", "user_dn",
-                                 "cn=adv-duplicate-check,ou=users,dc=example,dc=org") then
-                    break
-                end
-                ngx.sleep(0.05)
-            end
-
-            local code, body = t('/apisix/admin/consumers',
-                ngx.HTTP_PUT,
-                [[{
-                     "username": "adv_case_b",
-                     "plugins": {
-                         "ldap-auth-advanced": {
-                             "user_dn": "cn=adv-duplicate-check,ou=users,dc=example,dc=org"
-                         }
-                     }
-                }]]
-                )
-
-            ngx.status = code
-            ngx.print(body)
-        }
-    }
---- request
-GET /t
---- error_code: 400
---- response_body
-{"error_msg":"duplicate user_dn of plugin ldap-auth-advanced found with consumer: adv_case_a"}
-
-
-
-=== TEST 23: clean up consumers
---- config
-    location /t {
-        content_by_lua_block {
-            local t = require("lib.test_admin").test
-            for _, name in ipairs({"case_a", "case_b", "case_c", "enc_case_a", "ldap_case_a",
-                                   "adv_case_a"}) do
+            for _, name in ipairs({"case_a", "case_b", "case_c", "enc_case_a", "ldap_case_a"}) do
                 local code, body = t('/apisix/admin/consumers/' .. name, ngx.HTTP_DELETE)
                 if code >= 300 then
                     ngx.say("failed to delete consumer ", name, ": ", body)

--- a/t/plugin/ldap-auth-advanced.t
+++ b/t/plugin/ldap-auth-advanced.t
@@ -228,39 +228,7 @@ rejected
 
 
 
-=== TEST 12: consumer schema with user_dn passes
---- config
-    location /t {
-        content_by_lua_block {
-            local core = require("apisix.core")
-            local plugin = require("apisix.plugins.ldap-auth-advanced")
-            local ok, err = plugin.check_schema(
-                { user_dn = "cn=user01,ou=users,dc=example,dc=org" },
-                core.schema.TYPE_CONSUMER)
-            ngx.say(ok and "passed" or err)
-        }
-    }
---- response_body
-passed
-
-
-
-=== TEST 13: empty consumer schema is rejected
---- config
-    location /t {
-        content_by_lua_block {
-            local core = require("apisix.core")
-            local plugin = require("apisix.plugins.ldap-auth-advanced")
-            local ok, err = plugin.check_schema({}, core.schema.TYPE_CONSUMER)
-            ngx.say(ok and "passed" or "rejected")
-        }
-    }
---- response_body
-rejected
-
-
-
-=== TEST 14: set up a route protected by ldap-auth-advanced (live LDAP)
+=== TEST 12: set up a route protected by ldap-auth-advanced (live LDAP)
 --- config
     location /t {
         content_by_lua_block {
@@ -295,7 +263,7 @@ passed
 
 
 
-=== TEST 15: no credential header -> 401 with WWW-Authenticate ldap realm
+=== TEST 13: no credential header -> 401 with WWW-Authenticate ldap realm
 --- request
 GET /hello
 --- error_code: 401
@@ -304,7 +272,7 @@ WWW-Authenticate: ldap realm="ldap"
 
 
 
-=== TEST 16: malformed base64 payload ("aca_a" does not decode) -> 401
+=== TEST 14: malformed base64 payload ("aca_a" does not decode) -> 401
 --- request
 GET /hello
 --- more_headers
@@ -313,7 +281,7 @@ Authorization: ldap aca_a
 
 
 
-=== TEST 17: base64 payload without a ':' separator (decodes to "useronly") -> 401
+=== TEST 15: base64 payload without a ':' separator (decodes to "useronly") -> 401
 --- request
 GET /hello
 --- more_headers
@@ -322,7 +290,7 @@ Authorization: ldap dXNlcm9ubHk=
 
 
 
-=== TEST 18: empty password (payload decodes to "user01:") rejected before any bind (RFC 4513 5.1.2 unauthenticated bind)
+=== TEST 16: empty password (payload decodes to "user01:") rejected before any bind (RFC 4513 5.1.2 unauthenticated bind)
 --- request
 GET /hello
 --- more_headers
@@ -335,7 +303,7 @@ empty password
 
 
 
-=== TEST 19: scheme word parsed case-insensitively (uppercase), empty password still rejected (creds: user01:)
+=== TEST 17: scheme word parsed case-insensitively (uppercase), empty password still rejected (creds: user01:)
 --- request
 GET /hello
 --- more_headers
@@ -348,7 +316,7 @@ empty password
 
 
 
-=== TEST 20: scheme word parsed case-insensitively (mixed case), empty password still rejected (creds: user01:)
+=== TEST 18: scheme word parsed case-insensitively (mixed case), empty password still rejected (creds: user01:)
 --- request
 GET /hello
 --- more_headers
@@ -361,7 +329,7 @@ empty password
 
 
 
-=== TEST 21: set up a route with header_type basic
+=== TEST 19: set up a route with header_type basic
 --- config
     location /t {
         content_by_lua_block {
@@ -397,7 +365,7 @@ passed
 
 
 
-=== TEST 22: header_type basic emits a Basic-scheme WWW-Authenticate
+=== TEST 20: header_type basic emits a Basic-scheme WWW-Authenticate
 --- request
 GET /hello
 --- error_code: 401
@@ -406,7 +374,7 @@ WWW-Authenticate: Basic realm="ldap"
 
 
 
-=== TEST 23: inbound identity headers are cleared before any auth work, on every path
+=== TEST 21: inbound identity headers are cleared before any auth work, on every path
 --- config
     location /t {
         content_by_lua_block {
@@ -415,6 +383,7 @@ WWW-Authenticate: Basic realm="ldap"
             local headers = {
                 "X-Authenticated-Groups", "X-Consumer-Username",
                 "X-Credential-Identifier", "X-Consumer-Custom-ID",
+                "X-Authenticated-User-Dn", "X-Authenticated-Username",
             }
             local ctx = { var = {} }
             local before = {}
@@ -436,13 +405,15 @@ X-Authenticated-Groups: injected
 X-Consumer-Username: spoofed-user
 X-Credential-Identifier: spoofed-cred
 X-Consumer-Custom-ID: spoofed-id
+X-Authenticated-User-Dn: spoofed-dn
+X-Authenticated-Username: spoofed-login
 --- response_body
-before: injected spoofed-user spoofed-cred spoofed-id
-after: nil nil nil nil
+before: injected spoofed-user spoofed-cred spoofed-id spoofed-dn spoofed-login
+after: nil nil nil nil nil nil
 
 
 
-=== TEST 24: set up a route with multi-auth wrapping ldap-auth-advanced and basic-auth
+=== TEST 22: set up a route with multi-auth wrapping ldap-auth-advanced and basic-auth
 --- config
     location /t {
         content_by_lua_block {
@@ -486,7 +457,7 @@ passed
 
 
 
-=== TEST 25: under multi-auth ldap-auth-advanced declines quietly (creds: user01:)
+=== TEST 23: under multi-auth ldap-auth-advanced declines quietly (creds: user01:)
 --- request
 GET /hello
 --- more_headers
@@ -501,7 +472,7 @@ empty password
 
 
 
-=== TEST 26: set up the plain search-then-bind route (uid attribute)
+=== TEST 24: set up the plain search-then-bind route (uid attribute)
 --- config
     location /t {
         content_by_lua_block {
@@ -537,81 +508,7 @@ passed
 
 
 
-=== TEST 27: consumer_required (default true) with NO matching Consumer -> 401 (fails closed) (creds: user01:password1)
---- request
-GET /hello
---- more_headers
-Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
---- error_code: 401
---- grep_error_log eval
-qr/no Consumer is configured/
---- grep_error_log_out
-no Consumer is configured
-
-
-
-=== TEST 28: create the ldap-auth-advanced Consumers (user_dn associations)
---- config
-    location /t {
-        content_by_lua_block {
-            local core = require("apisix.core")
-            local t = require("lib.test_admin").test
-            local users = {
-                { name = "ldapadvuser01", dn = "cn=user01,ou=users,dc=example,dc=org" },
-                { name = "ldapadvuser02", dn = "cn=user02,ou=users,dc=example,dc=org" },
-                { name = "ldapadvjdoe",   dn = "cn=Jane Doe,ou=users,dc=example,dc=org" },
-                { name = "ldapadvsecret", dn = "cn=Secret User,ou=users,dc=example,dc=org" },
-            }
-            for _, u in ipairs(users) do
-                local code, body = t('/apisix/admin/consumers',
-                    ngx.HTTP_PUT,
-                    core.json.encode({
-                        username = u.name,
-                        plugins = {
-                            ["ldap-auth-advanced"] = { user_dn = u.dn },
-                        },
-                    }))
-                if code >= 300 then
-                    ngx.status = code
-                    ngx.say(body)
-                    return
-                end
-            end
-            ngx.say("passed")
-        }
-    }
---- response_body
-passed
-
-
-
-=== TEST 29: happy path -- uid=user01 (cn=user01) matches Consumer ldapadvuser01 (200 + attached) (creds: user01:password1)
---- request
-GET /hello
---- more_headers
-Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
---- error_code: 200
---- response_body
-hello world
---- error_log
-find consumer ldapadvuser01
-
-
-
-=== TEST 30: AD-shape happy path -- uid=jdoe (cn=Jane Doe) matches Consumer ldapadvjdoe (200) (creds: jdoe:janesecret)
---- request
-GET /hello
---- more_headers
-Authorization: ldap amRvZTpqYW5lc2VjcmV0
---- error_code: 200
---- response_body
-hello world
---- error_log
-find consumer ldapadvjdoe
-
-
-
-=== TEST 31: wrong password -> 401 (a result-code failure, not a transport error) (creds: user01:wrong)
+=== TEST 25: wrong password -> 401 (a result-code failure, not a transport error) (creds: user01:wrong)
 --- request
 GET /hello
 --- more_headers
@@ -620,7 +517,7 @@ Authorization: ldap dXNlcjAxOndyb25n
 
 
 
-=== TEST 32: unknown user -> 401 (the user search returns 0 entries) (creds: nouser:x)
+=== TEST 26: unknown user -> 401 (the user search returns 0 entries) (creds: nouser:x)
 --- request
 GET /hello
 --- more_headers
@@ -629,7 +526,7 @@ Authorization: ldap bm91c2VyOng=
 
 
 
-=== TEST 33: ambiguous match (two uid=dupuser entries) -> 401 + "ambiguous" warn (creds: dupuser:duppass1)
+=== TEST 27: ambiguous match (two uid=dupuser entries) -> 401 + "ambiguous" warn (creds: dupuser:duppass1)
 --- request
 GET /hello
 --- more_headers
@@ -642,56 +539,7 @@ ambiguous user match
 
 
 
-=== TEST 34: set up the search-then-bind route with consumer_required=false
---- config
-    location /t {
-        content_by_lua_block {
-            local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/routes/1',
-                ngx.HTTP_PUT,
-                [[{
-                    "plugins": {
-                        "ldap-auth-advanced": {
-                            "ldap_uri": "127.0.0.1:1389",
-                            "base_dn": "ou=users,dc=example,dc=org",
-                            "attribute": "uid",
-                            "consumer_required": false
-                        }
-                    },
-                    "upstream": {
-                        "nodes": {
-                            "127.0.0.1:1980": 1
-                        },
-                        "type": "roundrobin"
-                    },
-                    "uri": "/hello"
-                }]]
-                )
-            if code >= 300 then
-                ngx.status = code
-            end
-            ngx.say(body)
-        }
-    }
---- response_body
-passed
-
-
-
-=== TEST 35: consumer_required=false -> user01 authenticated, no Consumer attached (200) (creds: user01:password1)
---- request
-GET /hello
---- more_headers
-Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
---- error_code: 200
---- response_body
-hello world
---- no_error_log
-find consumer
-
-
-
-=== TEST 36: point the route at a dead LDAP port (transport-error case)
+=== TEST 28: point the route at a dead LDAP port (transport-error case)
 --- config
     location /t {
         content_by_lua_block {
@@ -727,7 +575,7 @@ passed
 
 
 
-=== TEST 37: LDAP unreachable -> 500 (a transport error is never an auth failure) (creds: user01:password1)
+=== TEST 29: LDAP unreachable -> 500 (a transport error is never an auth failure) (creds: user01:password1)
 --- request
 GET /hello
 --- more_headers
@@ -738,7 +586,7 @@ LDAP connect failed
 
 
 
-=== TEST 38: set up an LDAPS route on 1636 (use_ldaps, ssl_verify off)
+=== TEST 30: set up an LDAPS route on 1636 (use_ldaps, ssl_verify off)
 --- config
     location /t {
         content_by_lua_block {
@@ -775,7 +623,7 @@ passed
 
 
 
-=== TEST 39: happy path over LDAPS (200) (creds: user01:password1)
+=== TEST 31: happy path over LDAPS (200) (creds: user01:password1)
 --- request
 GET /hello
 --- more_headers
@@ -786,7 +634,7 @@ hello world
 
 
 
-=== TEST 40: set up a StartTLS route on 1389 (use_starttls, ssl_verify off)
+=== TEST 32: set up a StartTLS route on 1389 (use_starttls, ssl_verify off)
 --- config
     location /t {
         content_by_lua_block {
@@ -823,7 +671,7 @@ passed
 
 
 
-=== TEST 41: happy path over StartTLS (200) (creds: user01:password1)
+=== TEST 33: happy path over StartTLS (200) (creds: user01:password1)
 --- request
 GET /hello
 --- more_headers
@@ -834,7 +682,7 @@ hello world
 
 
 
-=== TEST 42: restore the plain search-then-bind route for the injection suite
+=== TEST 34: restore the plain search-then-bind route for the injection suite
 --- config
     location /t {
         content_by_lua_block {
@@ -869,7 +717,7 @@ passed
 
 
 
-=== TEST 43: filter-injection usernames each 401 (none widens the search)
+=== TEST 35: filter-injection usernames each 401 (none widens the search)
 --- config
     location /t {
         content_by_lua_block {
@@ -909,7 +757,7 @@ ambiguous user match
 
 
 
-=== TEST 44: username with an invalid UTF-8 byte -> clean 401, never a 500
+=== TEST 36: username with an invalid UTF-8 byte -> clean 401, never a 500
 --- config
     location /t {
         content_by_lua_block {
@@ -938,7 +786,7 @@ LDAP user search failed
 
 
 
-=== TEST 45: well-formed multibyte UTF-8 username reaches the search and 401s as not-found
+=== TEST 37: well-formed multibyte UTF-8 username reaches the search and 401s as not-found
 --- config
     location /t {
         content_by_lua_block {
@@ -967,7 +815,7 @@ invalid username
 
 
 
-=== TEST 46: username with a trailing '~' reaches the search and 401s as not-found
+=== TEST 38: username with a trailing '~' reaches the search and 401s as not-found
 --- config
     location /t {
         content_by_lua_block {
@@ -998,7 +846,7 @@ invalid username
 
 
 
-=== TEST 47: set up the three concurrent-probe routes (churn + anon-secret + svc-secret)
+=== TEST 39: set up the three concurrent-probe routes (churn + anon-secret + svc-secret)
 --- config
     location /t {
         content_by_lua_block {
@@ -1047,7 +895,7 @@ passed
 
 
 
-=== TEST 48: CONCURRENT bind-state-leak probe: anon re-bind must not leak
+=== TEST 40: CONCURRENT bind-state-leak probe: anon re-bind must not leak
 --- config
     location /probe {
         content_by_lua_block {
@@ -1126,70 +974,7 @@ routeB_svc_all_200: true
 
 
 
-=== TEST 49: swap in a Consumer whose user_dn is an $ENV:// secret reference
---- main_config
-env ADV_LDAP_USER_DN=cn=user02,ou=users,dc=example,dc=org;
---- config
-    location /t {
-        content_by_lua_block {
-            local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/consumers/ldapadvuser02', ngx.HTTP_DELETE)
-            if code >= 300 then
-                ngx.status = code
-                return ngx.say(body)
-            end
-
-            code, body = t('/apisix/admin/consumers',
-                ngx.HTTP_PUT,
-                [[{
-                     "username": "ldapadvenvref",
-                     "plugins": {
-                         "ldap-auth-advanced": {
-                             "user_dn": "$ENV://ADV_LDAP_USER_DN"
-                         }
-                     }
-                }]]
-                )
-            if code >= 300 then
-                ngx.status = code
-                return ngx.say(body)
-            end
-
-            -- wait until the watcher has synced BOTH writes: the resolved
-            -- env-ref consumer must be the one the runtime map returns
-            local find_consumer = require("apisix.consumer").find_consumer
-            for _ = 1, 100 do
-                local consumer = find_consumer("ldap-auth-advanced", "user_dn",
-                                               "cn=user02,ou=users,dc=example,dc=org")
-                if consumer and consumer.consumer_name == "ldapadvenvref" then
-                    break
-                end
-                ngx.sleep(0.05)
-            end
-            ngx.say("passed")
-        }
-    }
---- response_body
-passed
-
-
-
-=== TEST 50: env-ref user_dn resolves and matches the Consumer (200) (creds: user02:password2)
---- main_config
-env ADV_LDAP_USER_DN=cn=user02,ou=users,dc=example,dc=org;
---- request
-GET /hello
---- more_headers
-Authorization: ldap dXNlcjAyOnBhc3N3b3JkMg==
---- error_code: 200
---- response_body
-hello world
---- error_log
-find consumer ldapadvenvref
-
-
-
-=== TEST 51: set the /uri header-printing route to consumer_required=false
+=== TEST 41: set up the /uri header-printing route
 --- config
     location /t {
         content_by_lua_block {
@@ -1202,7 +987,7 @@ find consumer ldapadvenvref
                             "ldap_uri": "127.0.0.1:1389",
                             "base_dn": "ou=users,dc=example,dc=org",
                             "attribute": "uid",
-                            "consumer_required": false
+                            "set_user_dn_header": true
                         }
                     },
                     "upstream": {
@@ -1225,7 +1010,7 @@ passed
 
 
 
-=== TEST 52: spoofed identity headers never reach the upstream without a Consumer (creds: user01:password1)
+=== TEST 42: spoofed identity headers never reach the upstream (creds: user01:password1)
 --- request
 GET /uri
 --- more_headers
@@ -1234,16 +1019,17 @@ X-Consumer-Username: spoofed-user
 X-Credential-Identifier: spoofed-cred
 X-Consumer-Custom-ID: spoofed-id
 X-Authenticated-Groups: spoofed-groups
+X-Authenticated-User-Dn: spoofed-dn
+X-Authenticated-Username: spoofed-login
 --- error_code: 200
---- response_body
-uri: /uri
-authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
-host: localhost
-x-real-ip: 127.0.0.1
+--- response_body_like eval
+qr/uri: \/uri\nauthorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==\nhost: localhost\nx-authenticated-groups: (Domain Admins,developers|developers,Domain Admins)\nx-authenticated-user-dn: cn=user01,ou=users,dc=example,dc=org\nx-authenticated-username: user01\nx-real-ip: 127\.0\.0\.1\n/
+--- response_body_unlike eval
+qr/spoofed/
 
 
 
-=== TEST 53: RFC 4512 attribute forms are accepted (descriptor, OID, options)
+=== TEST 43: RFC 4512 attribute forms are accepted (descriptor, OID, options)
 --- config
     location /t {
         content_by_lua_block {
@@ -1272,7 +1058,7 @@ cn;lang-en: passed
 
 
 
-=== TEST 54: malformed attribute forms are rejected
+=== TEST 44: malformed attribute forms are rejected
 --- config
     location /t {
         content_by_lua_block {
@@ -1303,7 +1089,7 @@ cn;: rejected
 
 
 
-=== TEST 55: set up the search-then-bind route with the uid attribute's numeric OID
+=== TEST 45: set up the search-then-bind route with the uid attribute's numeric OID
 --- config
     location /t {
         content_by_lua_block {
@@ -1338,7 +1124,7 @@ passed
 
 
 
-=== TEST 56: OID attribute resolves the user end-to-end (200) (creds: user01:password1)
+=== TEST 46: OID attribute resolves the user end-to-end (200) (creds: user01:password1)
 --- request
 GET /hello
 --- more_headers
@@ -1346,12 +1132,10 @@ Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
 --- error_code: 200
 --- response_body
 hello world
---- error_log
-find consumer ldapadvuser01
 
 
 
-=== TEST 57: a proxy's own Basic Proxy-Authorization must not mask a valid Authorization
+=== TEST 47: a proxy's own Basic Proxy-Authorization must not mask a valid Authorization
 --- request
 GET /hello
 --- more_headers
@@ -1360,12 +1144,10 @@ Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
 --- error_code: 200
 --- response_body
 hello world
---- error_log
-find consumer ldapadvuser01
 
 
 
-=== TEST 58: Proxy-Authorization alone carries the credential (200) (creds: user01:password1)
+=== TEST 48: Proxy-Authorization alone carries the credential (200) (creds: user01:password1)
 --- request
 GET /hello
 --- more_headers
@@ -1373,12 +1155,10 @@ Proxy-Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
 --- error_code: 200
 --- response_body
 hello world
---- error_log
-find consumer ldapadvuser01
 
 
 
-=== TEST 59: when both headers parse, Proxy-Authorization wins (proxy: user01, auth: jdoe)
+=== TEST 49: when both headers parse, Proxy-Authorization wins (proxy: user01, auth: jdoe)
 --- request
 GET /hello
 --- more_headers
@@ -1387,12 +1167,10 @@ Authorization: ldap amRvZTpqYW5lc2VjcmV0
 --- error_code: 200
 --- response_body
 hello world
---- error_log
-find consumer ldapadvuser01
 
 
 
-=== TEST 60: undecodable Proxy-Authorization payload falls back to Authorization
+=== TEST 50: undecodable Proxy-Authorization payload falls back to Authorization
 --- request
 GET /hello
 --- more_headers
@@ -1401,12 +1179,10 @@ Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
 --- error_code: 200
 --- response_body
 hello world
---- error_log
-find consumer ldapadvuser01
 
 
 
-=== TEST 61: unusable Proxy-Authorization with no Authorization still 401s
+=== TEST 51: unusable Proxy-Authorization with no Authorization still 401s
 --- request
 GET /hello
 --- more_headers
@@ -1415,7 +1191,7 @@ Proxy-Authorization: Basic cHJveHk6aHVudGVyMg==
 
 
 
-=== TEST 62: Proxy-Authorization with an empty username falls back to Authorization (proxy: ":pass")
+=== TEST 52: Proxy-Authorization with an empty username falls back to Authorization (proxy: ":pass")
 --- request
 GET /hello
 --- more_headers
@@ -1424,12 +1200,10 @@ Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
 --- error_code: 200
 --- response_body
 hello world
---- error_log
-find consumer ldapadvuser01
 
 
 
-=== TEST 63: Proxy-Authorization with an empty password falls back to Authorization (proxy: "user:")
+=== TEST 53: Proxy-Authorization with an empty password falls back to Authorization (proxy: "user:")
 --- request
 GET /hello
 --- more_headers
@@ -1438,12 +1212,10 @@ Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
 --- error_code: 200
 --- response_body
 hello world
---- error_log
-find consumer ldapadvuser01
 
 
 
-=== TEST 64: an empty-field Proxy-Authorization with no Authorization still 401s (proxy: ":")
+=== TEST 54: an empty-field Proxy-Authorization with no Authorization still 401s (proxy: ":")
 --- request
 GET /hello
 --- more_headers
@@ -1456,7 +1228,7 @@ empty password
 
 
 
-=== TEST 65: set up a route whose service-account password is wrong
+=== TEST 55: set up a route whose service-account password is wrong
 --- config
     location /t {
         content_by_lua_block {
@@ -1493,7 +1265,7 @@ passed
 
 
 
-=== TEST 66: rejected service bind -> 500, never a client auth failure (creds: user01:password1)
+=== TEST 56: rejected service bind -> 500, never a client auth failure (creds: user01:password1)
 --- request
 GET /hello
 --- more_headers
@@ -1504,7 +1276,7 @@ LDAP search bind failed
 
 
 
-=== TEST 67: set up a route with a nonexistent base_dn
+=== TEST 57: set up a route with a nonexistent base_dn
 --- config
     location /t {
         content_by_lua_block {
@@ -1539,7 +1311,7 @@ passed
 
 
 
-=== TEST 68: search against a nonexistent base_dn -> 500 (noSuchObject is a misconfiguration) (creds: user01:password1)
+=== TEST 58: search against a nonexistent base_dn -> 500 (noSuchObject is a misconfiguration) (creds: user01:password1)
 --- request
 GET /hello
 --- more_headers
@@ -1550,7 +1322,7 @@ LDAP user search failed
 
 
 
-=== TEST 69: set up a route whose login attribute matches many entries (objectClass)
+=== TEST 59: set up a route whose login attribute matches many entries (objectClass)
 --- config
     location /t {
         content_by_lua_block {
@@ -1585,7 +1357,7 @@ passed
 
 
 
-=== TEST 70: sizeLimitExceeded stays a fail-closed 401, not a 500 (creds: inetOrgPerson:x)
+=== TEST 60: sizeLimitExceeded stays a fail-closed 401, not a 500 (creds: inetOrgPerson:x)
 --- request
 GET /hello
 --- more_headers
@@ -1598,7 +1370,7 @@ ambiguous user match (size limit exceeded)
 
 
 
-=== TEST 71: empty ldap_uri is rejected (minLength)
+=== TEST 61: empty ldap_uri is rejected (minLength)
 --- config
     location /t {
         content_by_lua_block {
@@ -1615,7 +1387,7 @@ qr/property "ldap_uri" validation failed/
 
 
 
-=== TEST 72: overlong base_dn is rejected (maxLength)
+=== TEST 62: overlong base_dn is rejected (maxLength)
 --- config
     location /t {
         content_by_lua_block {
@@ -1632,16 +1404,256 @@ qr/property "base_dn" validation failed/
 
 
 
-=== TEST 73: empty consumer user_dn is rejected (minLength)
+=== TEST 63: set up the /hello route with a log-phase identity-header reader
 --- config
     location /t {
         content_by_lua_block {
-            local core = require("apisix.core")
-            local plugin = require("apisix.plugins.ldap-auth-advanced")
-            local ok, err = plugin.check_schema({ user_dn = "" },
-                                                core.schema.TYPE_CONSUMER)
-            ngx.say(ok and "passed" or err)
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "ldap-auth-advanced": {
+                            "ldap_uri": "127.0.0.1:1389",
+                            "base_dn": "ou=users,dc=example,dc=org",
+                            "attribute": "uid",
+                            "set_user_dn_header": true
+                        },
+                        "serverless-post-function": {
+                            "phase": "log",
+                            "functions": ["return function(conf, ctx) ngx.log(ngx.WARN, \"ldapheaders: [\", ctx.var.http_x_authenticated_username, \"][\", ctx.var.http_x_authenticated_user_dn, \"][\", ctx.var.http_x_authenticated_groups, \"]\") end"]
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 64: identity headers reach a log-phase reader as $http_ vars (creds: user01:password1)
+--- request
+GET /hello
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 200
+--- error_log eval
+qr/ldapheaders: \[user01\]\[cn=user01,ou=users,dc=example,dc=org\]\[(Domain Admins,developers|developers,Domain Admins)\]/
+
+
+
+=== TEST 65: X-Authenticated-User-Dn and X-Authenticated-Username reach the upstream (creds: user01:password1)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-user-dn: cn=user01,ou=users,dc=example,dc=org\nx-authenticated-username: user01\n/
+
+
+
+=== TEST 66: a lower-priority plugin's _meta.filter can match the identity header via $http_
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/2',
+                ngx.HTTP_PUT,
+                [=[{
+                    "plugins": {
+                        "ldap-auth-advanced": {
+                            "ldap_uri": "127.0.0.1:1389",
+                            "base_dn": "ou=users,dc=example,dc=org",
+                            "attribute": "uid",
+                            "set_user_dn_header": true
+                        },
+                        "response-rewrite": {
+                            "_meta": {
+                                "filter": [["http_x_authenticated_user_dn", "==", "cn=user01,ou=users,dc=example,dc=org"]]
+                            },
+                            "body": "var-filter-hit\n"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/uri"
+                }]=]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 67: the filter fires for user01 and stays quiet for jdoe
+--- pipelined_requests eval
+["GET /uri", "GET /uri"]
+--- more_headers eval
+["Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==", "Authorization: ldap amRvZTpqYW5lc2VjcmV0"]
+--- response_body_like eval
+[qr/var-filter-hit/, qr/uri: \/uri/]
+
+
+
+=== TEST 68: set up a multi-auth route where a denied LDAP principal is followed by a key-auth win
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "ldapadvmixed",
+                    "plugins": {
+                        "key-auth": {
+                            "key": "ldapadv-mixed-key"
+                        }
+                    }
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            local code2, body2 = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [=[{
+                    "plugins": {
+                        "multi-auth": {
+                            "auth_plugins": [
+                                {
+                                    "ldap-auth-advanced": {
+                                        "ldap_uri": "127.0.0.1:1389",
+                                        "base_dn": "ou=users,dc=example,dc=org",
+                                        "attribute": "uid",
+                                        "groups_required": [["no-such-group"]]
+                                    }
+                                },
+                                {
+                                    "key-auth": {}
+                                }
+                            ]
+                        },
+                        "serverless-post-function": {
+                            "phase": "log",
+                            "functions": ["return function(conf, ctx) ngx.log(ngx.WARN, \"ldapheaders: [\", ctx.var.http_x_authenticated_username, \"][\", ctx.var.http_x_authenticated_user_dn, \"][\", ctx.var.http_x_authenticated_groups, \"]\") end"]
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]=]
+                )
+            if code2 >= 300 then
+                ngx.status = code2
+            end
+            ngx.say(body2)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 69: a denied LDAP principal leaves no identity headers behind for a sibling key-auth win (creds: user01:password1 + apikey)
+--- request
+GET /hello
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+apikey: ldapadv-mixed-key
+--- error_code: 200
+--- error_log eval
+qr/ldapheaders: \[nil\]\[nil\]\[nil\]/
+
+
+
+=== TEST 70: attaching ldap-auth-advanced to a Consumer is rejected with a pointer to ldap-auth
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            -- the slice-1 consumer shape: exactly what a stale pre-release
+            -- Consumer would still carry
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "ldapadvnoconsumer",
+                    "plugins": {
+                        "ldap-auth-advanced": {
+                            "user_dn": "cn=user01,ou=users,dc=example,dc=org"
+                        }
+                    }
+                }]]
+                )
+            ngx.status = code
+            ngx.print(body)
+        }
+    }
+--- error_code: 400
+--- response_body_like eval
+qr/does not support consumer-scoped configuration; use the ldap-auth plugin/
+
+
+
+=== TEST 71: a Credential carrying ldap-auth-advanced is rejected the same way
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            -- a plugin-less Consumer is fine; only the credential must fail
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{ "username": "ldapadvcredcase" }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+                ngx.print(body)
+                return
+            end
+            local code2, body2 = t(
+                '/apisix/admin/consumers/ldapadvcredcase/credentials/cred1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "ldap-auth-advanced": {
+                            "user_dn": "cn=user01,ou=users,dc=example,dc=org"
+                        }
+                    }
+                }]]
+                )
+            ngx.say(code2)
+            ngx.print(body2)
+            t('/apisix/admin/consumers/ldapadvcredcase', ngx.HTTP_DELETE)
         }
     }
 --- response_body_like eval
-qr/property "user_dn" validation failed/
+qr/^400\n.*does not support consumer-scoped configuration/

--- a/t/plugin/ldap-auth-advanced2.t
+++ b/t/plugin/ldap-auth-advanced2.t
@@ -1,0 +1,1104 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!$block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests();
+
+
+__DATA__
+
+=== TEST 1: group schema fields default correctly (cn / member / memberOf)
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local conf = {
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                group_base_dn = "ou=groups,dc=example,dc=org",
+            }
+            local ok, err = plugin.check_schema(conf)
+            if not ok then
+                ngx.say(err)
+                return
+            end
+            ngx.say(conf.group_name_attribute, " ",
+                    conf.group_member_attribute, " ",
+                    conf.user_membership_attribute)
+        }
+    }
+--- response_body
+cn member memberOf
+
+
+
+=== TEST 2: group_name_attribute with a bad pattern is rejected
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                group_base_dn = "ou=groups,dc=example,dc=org",
+                group_name_attribute = "a b",
+            })
+            ngx.say(ok and "passed" or "rejected")
+        }
+    }
+--- response_body
+rejected
+
+
+
+=== TEST 3: group_member_attribute with a bad pattern is rejected
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                group_base_dn = "ou=groups,dc=example,dc=org",
+                group_member_attribute = "1bad",
+            })
+            ngx.say(ok and "passed" or "rejected")
+        }
+    }
+--- response_body
+rejected
+
+
+
+=== TEST 4: user_membership_attribute with a bad pattern is rejected
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                user_membership_attribute = "has space",
+            })
+            ngx.say(ok and "passed" or "rejected")
+        }
+    }
+--- response_body
+rejected
+
+
+
+=== TEST 5: set up the three group-collection routes
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "group_base_dn": "ou=groups,dc=example,dc=org",
+                    "bind_dn": "cn=admin,dc=example,dc=org",
+                    "ldap_password": "adminpassword",
+                    "ldap_debug": true
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/hello"
+            }]])
+            local code2 = t('/apisix/admin/routes/2', ngx.HTTP_PUT, [[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "ldap_debug": true
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/uri"
+            }]])
+            local code3 = t('/apisix/admin/routes/3', ngx.HTTP_PUT, [[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "group_base_dn": "ou=groups,dc=example,dc=org",
+                    "ldap_debug": true
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/hello1"
+            }]])
+            local ok = code < 300 and code2 < 300 and code3 < 300
+            ngx.say(ok and "passed" or "failed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 6: user01 via the SEARCH path collects Domain Admins + developers (creds: user01:password1)
+--- request
+GET /hello
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 200
+--- response_body
+hello world
+--- error_log
+groups:
+Domain Admins
+developers
+
+
+
+=== TEST 7: user01 via the memberOf path collects Domain Admins + developers (creds: user01:password1)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 200
+--- error_log
+groups:
+Domain Admins
+developers
+
+
+
+=== TEST 8: jdoe (space in the login->cn) via the SEARCH path collects Domain Admins + ops (creds: jdoe:janesecret)
+--- request
+GET /hello
+--- more_headers
+Authorization: ldap amRvZTpqYW5lc2VjcmV0
+--- error_code: 200
+--- response_body
+hello world
+--- error_log
+groups:
+Domain Admins
+ops
+
+
+
+=== TEST 9: jdoe via the memberOf path collects Domain Admins + ops (space in the group RDN value) (creds: jdoe:janesecret)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap amRvZTpqYW5lc2VjcmV0
+--- error_code: 200
+--- error_log
+groups:
+Domain Admins
+ops
+
+
+
+=== TEST 10: user02 via the SEARCH path collects superadmin only (creds: user02:password2)
+--- request
+GET /hello
+--- more_headers
+Authorization: ldap dXNlcjAyOnBhc3N3b3JkMg==
+--- error_code: 200
+--- response_body
+hello world
+--- error_log
+groups: superadmin
+
+
+
+=== TEST 11: user02 via the memberOf path collects superadmin only (creds: user02:password2)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAyOnBhc3N3b3JkMg==
+--- error_code: 200
+--- error_log
+groups: superadmin
+
+
+
+=== TEST 12: fixture ACL check -- the group member attribute is identity-dependent
+--- config
+    location /t {
+        content_by_lua_block {
+            -- Fixture ACL: `member` is readable by the configured identity
+            -- (anonymous) but not by a regular end user, so this search only
+            -- resolves groups when bound as the configured identity -- proving
+            -- the re-bind test is non-vacuous (a skipped re-bind would collect 0).
+            local client = require("resty.ldap.client")
+            local protocol = require("resty.ldap.protocol")
+            local filter = require("resty.ldap.filter")
+
+            local function member_hits(bind_dn, bind_pw)
+                local c = client:new("127.0.0.1", 1389, { socket_timeout = 3000 })
+                assert(c:simple_bind(bind_dn, bind_pw))
+                local entries = assert(c:search(
+                    "ou=groups,dc=example,dc=org",
+                    protocol.SEARCH_SCOPE_WHOLE_SUBTREE,
+                    protocol.SEARCH_DEREF_ALIASES_ALWAYS,
+                    10, 5, false,
+                    "(member=" .. filter.escape(
+                        "cn=user01,ou=users,dc=example,dc=org") .. ")",
+                    { "cn" }))
+                c:close()
+                local n = 0
+                for _, e in ipairs(entries) do
+                    if e.entry_dn then n = n + 1 end
+                end
+                return n
+            end
+
+            ngx.say("end_user_hits: ",
+                    member_hits("cn=user01,ou=users,dc=example,dc=org", "password1"))
+            ngx.say("anonymous_hits: ", member_hits("", ""))
+        }
+    }
+--- response_body
+end_user_hits: 0
+anonymous_hits: 2
+
+
+
+=== TEST 13: user01 on the anonymous-rebind SEARCH route still collects its groups (creds: user01:password1)
+--- request
+GET /hello1
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 200
+--- error_log
+groups:
+Domain Admins
+developers
+
+
+
+=== TEST 14: multiuser via the SEARCH path collects ALL three groups (unbounded group search) (creds: multiuser:multipass)
+--- request
+GET /hello
+--- more_headers
+Authorization: ldap bXVsdGl1c2VyOm11bHRpcGFzcw==
+--- error_code: 200
+--- response_body
+hello world
+--- error_log
+groups:
+Domain Admins
+developers
+ops
+
+
+
+=== TEST 15: multiuser via the memberOf path also collects all three groups (creds: multiuser:multipass)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap bXVsdGl1c2VyOm11bHRpcGFzcw==
+--- error_code: 200
+--- error_log
+groups:
+Domain Admins
+developers
+ops
+
+
+
+=== TEST 16: groups_required (outer OR of inner ANDs) is a valid schema
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                groups_required = {{"Domain Admins", "ops"}, {"superadmin"}},
+            })
+            ngx.say(ok and "passed" or err)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 17: groups_required that is not an array is rejected
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                groups_required = "superadmin",
+            })
+            ngx.say(ok and "passed" or "rejected")
+        }
+    }
+--- response_body
+rejected
+
+
+
+=== TEST 18: groups_required with an empty inner array is rejected (inner minItems 1)
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                groups_required = {{}},
+            })
+            ngx.say(ok and "passed" or "rejected")
+        }
+    }
+--- response_body
+rejected
+
+
+
+=== TEST 19: groups_required with a non-string group name is rejected
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                groups_required = {{123}},
+            })
+            ngx.say(ok and "passed" or "rejected")
+        }
+    }
+--- response_body
+rejected
+
+
+
+=== TEST 20: set up the groups_required route (memberOf path, /uri echoes the outbound header)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [=[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "groups_required": [["Domain Admins", "ops"], ["superadmin"]]
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/uri"
+            }]=])
+            if code >= 300 then ngx.status = code end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 21: jdoe satisfies inner AND [Domain Admins, ops] -> 200 + outbound header carries both names (creds: jdoe:janesecret)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap amRvZTpqYW5lc2VjcmV0
+X-Authenticated-Groups: injected
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-groups: (Domain Admins,ops|ops,Domain Admins)\n/
+--- response_body_unlike eval
+qr/injected/
+
+
+
+=== TEST 22: user01 (Domain Admins + developers) satisfies no inner AND -> 403, distinct from the 401 body (creds: user01:password1)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+X-Authenticated-Groups: injected
+--- error_code: 403
+--- response_body
+{"message":"Forbidden"}
+--- response_headers
+X-Authenticated-Groups:
+--- grep_error_log eval
+qr/groups_required not satisfied/
+--- grep_error_log_out
+groups_required not satisfied
+
+
+
+=== TEST 23: user02 satisfies the OR alternate [superadmin] -> 200 + exact single-group header (inbound stripped) (creds: user02:password2)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAyOnBhc3N3b3JkMg==
+X-Authenticated-Groups: injected
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-groups: superadmin\n/
+--- response_body_unlike eval
+qr/injected/
+
+
+
+=== TEST 24: on the groups_required route a wrong password -> 401 body, distinct from the 403 body, no outbound header (creds: user01:wrong)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAxOndyb25n
+X-Authenticated-Groups: injected
+--- error_code: 401
+--- response_body
+{"message":"Authorization required"}
+--- response_headers
+X-Authenticated-Groups:
+
+
+
+=== TEST 25: set up a groups_required route with a space-containing name in the OR position
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [=[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "groups_required": [["developers"], ["Domain Admins"]]
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/uri"
+            }]=])
+            if code >= 300 then ngx.status = code end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 26: jdoe passes via the space-containing OR alternate "Domain Admins" (verbatim match, space preserved) (creds: jdoe:janesecret)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap amRvZTpqYW5lc2VjcmV0
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-groups: (Domain Admins,ops|ops,Domain Admins)\n/
+
+
+
+=== TEST 27: set up a groups_required route with a space-containing name inside an inner AND
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [=[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "groups_required": [["Domain Admins", "developers"]]
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/uri"
+            }]=])
+            if code >= 300 then ngx.status = code end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 28: user01 satisfies the inner AND [Domain Admins, developers] (space-containing AND term) -> 200 (creds: user01:password1)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-groups: (Domain Admins,developers|developers,Domain Admins)\n/
+
+
+
+=== TEST 29: user02 (superadmin only) fails the inner AND [Domain Admins, developers] -> 403 (creds: user02:password2)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAyOnBhc3N3b3JkMg==
+--- error_code: 403
+--- response_body
+{"message":"Forbidden"}
+
+
+
+=== TEST 30: set up a groups_required route whose required name differs only by case
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [=[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "groups_required": [["domain admins"]]
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/uri"
+            }]=])
+            if code >= 300 then ngx.status = code end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 31: "domain admins" does NOT match the collected "Domain Admins" -> 403 (no case folding) (creds: user01:password1)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 403
+--- response_body
+{"message":"Forbidden"}
+--- grep_error_log eval
+qr/groups_required not satisfied/
+--- grep_error_log_out
+groups_required not satisfied
+
+
+
+=== TEST 32: point a groups_required route at a dead LDAP port (transport-error case)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [=[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1390",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "timeout": 1000,
+                    "groups_required": [["superadmin"]]
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/uri"
+            }]=])
+            if code >= 300 then ngx.status = code end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 33: LDAP unreachable -> 500 and the outbound header is absent (creds: user02:password2)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAyOnBhc3N3b3JkMg==
+X-Authenticated-Groups: injected
+--- error_code: 500
+--- response_headers
+X-Authenticated-Groups:
+--- error_log
+LDAP connect failed
+
+
+
+=== TEST 34: set up the unescape-observation routes (comma-in-cn group "Sales, EMEA")
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "group_base_dn": "ou=groups,dc=example,dc=org",
+                    "bind_dn": "cn=admin,dc=example,dc=org",
+                    "ldap_password": "adminpassword",
+                    "ldap_debug": true
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/hello"
+            }]])
+            -- OpenLDAP renders the comma in "Sales, EMEA" hex-escaped in the
+            -- memberOf DN (cn=Sales\2C EMEA); TEST 36 checks it unescapes back.
+            local code2 = t('/apisix/admin/routes/2', ngx.HTTP_PUT, [[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "ldap_debug": true
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/uri"
+            }]])
+            local ok = code < 300 and code2 < 300
+            ngx.say(ok and "passed" or "failed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 35: salesuser via the SEARCH path -- group NAME is the cn value "Sales, EMEA" (creds: salesuser:salespass)
+--- request
+GET /hello
+--- more_headers
+Authorization: ldap c2FsZXN1c2VyOnNhbGVzcGFzcw==
+--- error_code: 200
+--- response_body
+hello world
+--- error_log
+groups: Sales, EMEA
+
+
+
+=== TEST 36: salesuser via the memberOf path -- UNESCAPED first RDN equals the SEARCH-path name "Sales, EMEA" (creds: salesuser:salespass)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap c2FsZXN1c2VyOnNhbGVzcGFzcw==
+X-Authenticated-Groups: injected
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-groups: Sales, EMEA\n/
+--- response_body_unlike eval
+qr/Sales\\2C EMEA|injected/
+--- error_log
+groups: Sales, EMEA
+
+
+
+=== TEST 37: set up the /uri route with a service bind, no group_base_dn, for the no-groups header-omission check
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            -- secretuser is invisible to an anonymous search (fixture ACL), so
+            -- this route needs a service bind_dn to resolve it at all.
+            local code, body = t('/apisix/admin/routes/2', ngx.HTTP_PUT, [[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "bind_dn": "cn=admin,dc=example,dc=org",
+                    "ldap_password": "adminpassword"
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/uri"
+            }]])
+            if code >= 300 then ngx.status = code end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 38: a zero-group user reaches the upstream with no X-Authenticated-Groups (empty value is dropped), inbound value still stripped (creds: secretuser:secretpass)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap c2VjcmV0dXNlcjpzZWNyZXRwYXNz
+X-Authenticated-Groups: injected
+--- error_code: 200
+--- response_body_unlike eval
+qr/x-authenticated-groups|injected/
+
+
+
+=== TEST 39: point the /uri route's group search at a nonexistent base DN (group-search-failure case)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/2', ngx.HTTP_PUT, [[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "group_base_dn": "ou=nogroups,dc=example,dc=org",
+                    "bind_dn": "cn=admin,dc=example,dc=org",
+                    "ldap_password": "adminpassword"
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/uri"
+            }]])
+            if code >= 300 then ngx.status = code end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 40: user01 authenticates but the group search against a nonexistent base DN fails -> 500 (creds: user01:password1)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 500
+--- error_log
+LDAP group search failed
+
+
+
+=== TEST 41: group_name_attribute set without group_base_dn is rejected (memberOf path ignores it)
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                group_name_attribute = "displayName",
+            })
+            ngx.say(ok and "passed" or err)
+        }
+    }
+--- response_body
+group_name_attribute is only used with group_base_dn
+
+
+
+=== TEST 42: group_member_attribute set without group_base_dn is rejected (memberOf path ignores it)
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                group_member_attribute = "uniqueMember",
+            })
+            ngx.say(ok and "passed" or err)
+        }
+    }
+--- response_body
+group_member_attribute is only used with group_base_dn
+
+
+
+=== TEST 43: both group attributes set alongside group_base_dn pass (SEARCH path uses them)
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                group_base_dn = "ou=groups,dc=example,dc=org",
+                group_name_attribute = "displayName",
+                group_member_attribute = "uniqueMember",
+            })
+            ngx.say(ok and "passed" or err)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 44: REGRESSION GUARD -- re-validating stored config (defaults already injected) still passes, not a naive presence check
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local conf = {
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+            }
+            local ok1 = plugin.check_schema(conf)
+            -- conf now carries injected defaults; re-validating the SAME table
+            -- simulates APISIX re-checking already-stored config on reload.
+            local ok2 = plugin.check_schema(conf)
+            ngx.say(ok1 and "passed" or "rejected", " ", ok2 and "passed" or "rejected")
+        }
+    }
+--- response_body
+passed passed
+
+
+
+=== TEST 45: set up a groups_required route on the SEARCH path (group_base_dn + service bind)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [=[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "group_base_dn": "ou=groups,dc=example,dc=org",
+                    "bind_dn": "cn=admin,dc=example,dc=org",
+                    "ldap_password": "adminpassword",
+                    "groups_required": [["Domain Admins", "developers"]]
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/hello"
+            }]=])
+            if code >= 300 then ngx.status = code end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 46: user01 satisfies the inner AND [Domain Admins, developers] via the SEARCH path (cn-derived names) -> 200 (creds: user01:password1)
+--- request
+GET /hello
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 200
+--- response_body
+hello world
+
+
+
+=== TEST 47: user02 (superadmin only) fails the inner AND [Domain Admins, developers] via the SEARCH path -> 403 (creds: user02:password2)
+--- request
+GET /hello
+--- more_headers
+Authorization: ldap dXNlcjAyOnBhc3N3b3JkMg==
+--- error_code: 403
+--- response_body
+{"message":"Forbidden"}
+
+
+
+=== TEST 48: set up a groups_required route with a log-phase identity-header reader
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [=[{
+                    "plugins": {
+                        "ldap-auth-advanced": {
+                            "ldap_uri": "127.0.0.1:1389",
+                            "base_dn": "ou=users,dc=example,dc=org",
+                            "attribute": "uid",
+                            "group_base_dn": "ou=groups,dc=example,dc=org",
+                            "bind_dn": "cn=admin,dc=example,dc=org",
+                            "ldap_password": "adminpassword",
+                            "groups_required": [["Domain Admins"]],
+                            "set_user_dn_header": true
+                        },
+                        "serverless-post-function": {
+                            "phase": "log",
+                            "functions": ["return function(conf, ctx) ngx.log(ngx.WARN, \"ldapheaders2: [\", ctx.var.http_x_authenticated_username, \"][\", ctx.var.http_x_authenticated_user_dn, \"][\", ctx.var.http_x_authenticated_groups, \"]\") end"]
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]=]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 49: authorized user exports identity headers on the 200 path (creds: user01:password1)
+--- request
+GET /hello
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 200
+--- error_log eval
+qr/ldapheaders2: \[user01\]\[cn=user01,ou=users,dc=example,dc=org\]\[(Domain Admins,developers|developers,Domain Admins)\]/
+
+
+
+=== TEST 50: no identity is exported when authorization denies with 403; the warn names the denied user (creds: user02:password2)
+--- request
+GET /hello
+--- more_headers
+Authorization: ldap dXNlcjAyOnBhc3N3b3JkMg==
+--- error_code: 403
+--- error_log eval
+[qr/ldapheaders2: \[nil\]\[nil\]\[nil\]/, qr/groups_required not satisfied for cn=user02,ou=users,dc=example,dc=org/]
+
+
+
+=== TEST 51: identity-export toggles default to username on, user DN off, groups on
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local conf = {
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+            }
+            local ok, err = plugin.check_schema(conf)
+            if not ok then
+                ngx.say(err)
+                return
+            end
+            ngx.say(tostring(conf.set_username_header), " ",
+                    tostring(conf.set_user_dn_header), " ",
+                    tostring(conf.set_groups_header))
+        }
+    }
+--- response_body
+true false true
+
+
+
+=== TEST 52: set up a default-toggles route with a log-phase identity-header reader
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [=[{
+                    "plugins": {
+                        "ldap-auth-advanced": {
+                            "ldap_uri": "127.0.0.1:1389",
+                            "base_dn": "ou=users,dc=example,dc=org",
+                            "attribute": "uid"
+                        },
+                        "serverless-post-function": {
+                            "phase": "log",
+                            "functions": ["return function(conf, ctx) ngx.log(ngx.WARN, \"ldapheaders3: [\", ctx.var.http_x_authenticated_username, \"][\", ctx.var.http_x_authenticated_user_dn, \"][\", ctx.var.http_x_authenticated_groups, \"]\") end"]
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]=]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 53: by default the username and groups export, the user DN does not (creds: user01:password1)
+--- request
+GET /hello
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 200
+--- error_log eval
+qr/ldapheaders3: \[user01\]\[nil\]\[(Domain Admins,developers|developers,Domain Admins)\]/
+
+
+
+=== TEST 54: set up a route exporting ONLY the user DN (username and groups toggled off)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [=[{
+                    "plugins": {
+                        "ldap-auth-advanced": {
+                            "ldap_uri": "127.0.0.1:1389",
+                            "base_dn": "ou=users,dc=example,dc=org",
+                            "attribute": "uid",
+                            "set_username_header": false,
+                            "set_user_dn_header": true,
+                            "set_groups_header": false
+                        },
+                        "serverless-post-function": {
+                            "phase": "log",
+                            "functions": ["return function(conf, ctx) ngx.log(ngx.WARN, \"ldapheaders4: [\", ctx.var.http_x_authenticated_username, \"][\", ctx.var.http_x_authenticated_user_dn, \"][\", ctx.var.http_x_authenticated_groups, \"]\") end"]
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]=]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 55: only X-Authenticated-User-Dn reaches the reader; username and groups stay nil (creds: user01:password1)
+--- request
+GET /hello
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 200
+--- error_log eval
+qr/ldapheaders4: \[nil\]\[cn=user01,ou=users,dc=example,dc=org\]\[nil\]/


### PR DESCRIPTION
### Description

Group-based authorization for the `ldap-auth-advanced` plugin:

- collect the authenticated user's groups, either by group search under `group_base_dn` or from the user entry's `memberOf` attribute (no extra round trip)
- `groups_required` (outer array ORs, inner array ANDs) is enforced after authentication; a denied user gets a 403, distinct from the 401 paths
- identity is exported to the upstream via `X-Authenticated-Username`, `X-Authenticated-User-Dn`, and `X-Authenticated-Groups`, each behind a `set_*_header` toggle (same idiom as `openid-connect`)

This PR also removes the plugin's Consumer support:

- with groups in play, mapping an authenticated user to a Consumer is unstable: a user who belongs to several groups cannot deterministically resolve to one Consumer
- external-directory authentication does not need Consumers, matching the existing external auth plugins (`openid-connect`, `forward-auth`, `authz-keycloak`) which attach none -- the directory is the identity store; users who want Consumer-backed LDAP keep `ldap-auth`
- attaching `ldap-auth-advanced` to a Consumer or Credential now fails with a clear error pointing at `ldap-auth`

The plugin is not part of any released version, so this is not a breaking change.

#### Which issue(s) this PR fixes:

Part of #8958

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
