### PR TITLE
fix(loki-logger): encrypt the headers field

### DIFF
--- a/apisix/plugins/loki-logger.lua
+++ b/apisix/plugins/loki-logger.lua
@@ -111,6 +111,7 @@ local schema = {
         max_req_body_bytes = {type = "integer", minimum = 1, default = 524288},
         max_resp_body_bytes = {type = "integer", minimum = 1, default = 524288},
     },
+    encrypt_fields = {"headers"},
     required = {"endpoint_addrs"}
 }
 

--- a/t/plugin/loki-logger.t
+++ b/t/plugin/loki-logger.t
@@ -616,3 +616,68 @@ hello world
         }
     }
 --- error_code: 200
+
+
+
+=== TEST 22: data encryption for headers
+--- yaml_config
+apisix:
+    data_encryption:
+        enable_encrypt_fields: true
+        keyring:
+            - edd1c9f0985e76a2
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, {
+                uri = "/hello",
+                upstream = {
+                    type = "roundrobin",
+                    nodes = {
+                        ["127.0.0.1:1980"] = 1
+                    }
+                },
+                plugins = {
+                    ["loki-logger"] = {
+                        endpoint_addrs = {"http://127.0.0.1:8199"},
+                        headers = {
+                            Authorization = "Basic ZWxhc3RpYzoxMjM0NTY="
+                        },
+                        batch_max_size = 1,
+                        inactive_timeout = 1
+                    }
+                }
+            })
+
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.sleep(0.1)
+
+            -- get plugin conf from admin api, header is decrypted
+            local code, message, res = t('/apisix/admin/routes/1',
+                ngx.HTTP_GET
+            )
+            res = json.decode(res)
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(message)
+                return
+            end
+
+            ngx.say(res.value.plugins["loki-logger"].headers.Authorization)
+
+            -- get plugin conf from etcd, header is encrypted
+            local etcd = require("apisix.core.etcd")
+            local res = assert(etcd.get('/routes/1'))
+            local stored = res.body.node.value.plugins["loki-logger"].headers.Authorization
+            ngx.say(stored ~= "Basic ZWxhc3RpYzoxMjM0NTY=" and "encrypted" or "plaintext")
+        }
+    }
+--- response_body
+Basic ZWxhc3RpYzoxMjM0NTY=
+encrypted


### PR DESCRIPTION
### Description

The `loki-logger` `headers` field is the documented place for the Loki / Grafana Cloud `Authorization` token, and it is copied verbatim into the outbound request. But `headers` is not listed in the plugin's `encrypt_fields`, so the token is stored in plaintext in etcd and returned unmasked from the Admin API — unlike the identically-shaped `elasticsearch-logger` `headers`, which is encrypted.

This adds `headers` to `loki-logger`'s `encrypt_fields`, matching `elasticsearch-logger`.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (no doc change needed — behavior is at-rest encryption of an existing field)
- [x] I have verified that this change is backward compatible
