### PR TITLE
fix(error-log-logger): do not log the kafka sasl password

### DIFF
--- a/apisix/plugins/error-log-logger.lua
+++ b/apisix/plugins/error-log-logger.lua
@@ -378,6 +378,17 @@ local function create_producer(broker_list, broker_config, cluster_name)
 end
 
 
+-- redact_brokers returns a copy of the kafka broker list carrying only host and
+-- port, so the sasl_config credentials are never written to logs.
+local function redact_brokers(brokers)
+    local safe = {}
+    for i, b in ipairs(brokers or {}) do
+        safe[i] = {host = b.host, port = b.port}
+    end
+    return safe
+end
+
+
 local function send_to_kafka(log_message)
     -- avoid race of the global config
     local metadata = plugin.plugin_metadata(plugin_name)
@@ -390,7 +401,7 @@ local function send_to_kafka(log_message)
     end
 
     core.log.info("sending a batch logs to kafka brokers: ",
-                  core.json.delay_encode(config.kafka.brokers))
+                  core.json.delay_encode(redact_brokers(config.kafka.brokers)))
 
     local broker_config = {}
     broker_config["request_timeout"] = config.timeout * 1000
@@ -418,7 +429,7 @@ local function send_to_kafka(log_message)
                             config.kafka.key, core.json.encode(log_message[i]))
         if not ok then
             return false, "failed to send data to Kafka topic: " .. err ..
-                          ", brokers: " .. core.json.encode(config.kafka.brokers)
+                          ", brokers: " .. core.json.encode(redact_brokers(config.kafka.brokers))
         end
         core.log.info("send data to kafka: ", core.json.delay_encode(log_message[i]))
     end

--- a/t/plugin/error-log-logger-kafka.t
+++ b/t/plugin/error-log-logger-kafka.t
@@ -372,3 +372,42 @@ qr/send data to kafka: .*this is a error message for tls test/]
 --- no_error_log
 failed to do SSL handshake
 --- wait: 3
+
+
+
+=== TEST 11: kafka send failure must not leak the sasl password
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local t = require("lib.test_admin").test
+            local code = t('/apisix/admin/plugin_metadata/error-log-logger',
+                ngx.HTTP_PUT,
+                [[{
+                    "kafka": {
+                        "brokers": [{
+                            "host": "127.0.0.1",
+                            "port": 29999,
+                            "sasl_config": {
+                                "mechanism": "PLAIN",
+                                "user": "admin",
+                                "password": "super-secret-pw"
+                            }
+                        }],
+                        "producer_type": "sync",
+                        "kafka_topic": "no_such_topic"
+                    },
+                    "level": "ERROR",
+                    "inactive_timeout": 1
+                }]]
+                )
+            ngx.sleep(2)
+            core.log.error("trigger a send to the dead broker")
+            ngx.sleep(1)
+        }
+    }
+--- error_log eval
+qr/failed to send data to Kafka topic/
+--- no_error_log
+super-secret-pw
+--- wait: 3


### PR DESCRIPTION
### Description

When a kafka send fails, `error-log-logger` built its error string with `core.json.encode(config.kafka.brokers)`, which includes the decrypted `sasl_config.password`. That string is written at ERROR level by the batch processor, which is emitted at the default `warn` log level, so the kafka SASL password leaks into the error log — and this plugin's own purpose is to ship the error log onward. The same broker structure was also logged at INFO on each flush.

This redacts the broker list to `host`/`port` only before logging (both the failure error string and the INFO flush line).

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (no user-facing config/behavior change)
- [x] I have verified that this change is backward compatible
