### PR TITLE
fix: encode control characters in $upstream_uri to prevent CRLF injection

### DIFF
--- a/apisix/core/utils.lua
+++ b/apisix/core/utils.lua
@@ -224,6 +224,17 @@ function _M.uri_safe_encode(uri)
 end
 
 
+-- escape_uri_control_chars percent-encodes control characters (0x00-0x1F and 0x7F,
+-- which include CR and LF) while leaving every other byte untouched. It is used on
+-- parts of $upstream_uri that must keep their query delimiters (?, =, &) but must not
+-- be able to inject CR/LF into the upstream request line.
+function _M.escape_uri_control_chars(uri)
+    return (str_gsub(uri, "[%z\1-\31\127]", function(c)
+        return str_format("%%%02X", str_byte(c))
+    end))
+end
+
+
 function _M.validate_header_field(field)
     for i = 1, #field do
         local b = str_byte(field, i, i)

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -813,8 +813,9 @@ function _M.http_access_phase()
 
             api_ctx.var.uri = new_uri
             -- forward the original uri so the servlet upstream
-            -- can consume the param after ';'
-            api_ctx.var.upstream_uri = uri
+            -- can consume the param after ';'. Encode control characters so a
+            -- CR/LF in the decoded uri cannot inject into the upstream request line.
+            api_ctx.var.upstream_uri = core.utils.escape_uri_control_chars(uri)
         end
     end
 

--- a/apisix/plugins/proxy-rewrite.lua
+++ b/apisix/plugins/proxy-rewrite.lua
@@ -382,8 +382,12 @@ function _M.rewrite(conf, ctx)
         end
 
         if index then
+            -- The query part (after '?') keeps its ?, =, & delimiters, but control
+            -- characters in it (e.g. a CR/LF reflected from $uri or a regex capture)
+            -- must still be encoded so they cannot be written verbatim into the
+            -- upstream request line.
             upstream_uri = core.utils.uri_safe_encode(sub_str(upstream_uri, 1, index - 1)) ..
-                sub_str(upstream_uri, index)
+                core.utils.escape_uri_control_chars(sub_str(upstream_uri, index))
         else
             -- The '?' may come from client request '%3f' when we use ngx.var.uri directly or
             -- via regex_uri

--- a/t/plugin/proxy-rewrite.t
+++ b/t/plugin/proxy-rewrite.t
@@ -1724,3 +1724,38 @@ GET /test/echo
 x-src: from-src
 --- response_body_like eval
 qr/x-multi: cap-echo\nx-multi: from-src/
+
+
+
+=== TEST 66: CRLF in a reflected uri is encoded, not injected into the upstream request line
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, {
+                uri = "/reflect*",
+                plugins = {
+                    ["proxy-rewrite"] = {
+                        regex_uri = {"^(/reflect.*)", "/print_request_received?orig=$1"}
+                    }
+                },
+                upstream = {
+                    type = "roundrobin",
+                    nodes = {["127.0.0.1:1980"] = 1}
+                }
+            })
+            if code >= 300 then ngx.status = code; ngx.say(body); return end
+
+            local http = require("resty.http")
+            local httpc = http.new()
+            local res = httpc:request_uri("http://127.0.0.1:" .. ngx.var.server_port
+                .. "/reflect%0d%0aX-Injected:pwn")
+            ngx.print(res.body)
+        }
+    }
+--- request
+GET /t
+--- response_body eval
+qr{request_uri: /print_request_received\?orig=/reflect%0[Dd]%0[Aa]X-Injected}
+--- no_error_log
+[error]


### PR DESCRIPTION
### Description

`ngx.var.uri` is percent-decoded, so `%0d%0a` in a client URI becomes raw CR/LF in it. The nginx template proxies with `proxy_pass $upstream_scheme://apisix_backend$upstream_uri;`, and nginx writes a Lua-set `$upstream_uri` into the upstream request line verbatim (no re-escaping). Two paths reach `$upstream_uri` with unescaped bytes:

- `proxy-rewrite` `uri_safe_encode()`s only the path portion of the rewritten URI and concatenates the query portion (after `?`) raw. A CR/LF reflected from `$uri` / `$request_uri` / a regex capture therefore lands in the upstream request line — a header-injection / request-smuggling primitive against the upstream.
- The `normalize_uri_like_servlet` path assigns the raw decoded URI to `upstream_uri` with no encoding at all.

This adds `core.utils.escape_uri_control_chars`, which percent-encodes control characters (`0x00-0x1F`, `0x7F`, including CR and LF) while leaving `?`, `=`, `&` intact, and applies it to the query portion in `proxy-rewrite` and to the servlet `upstream_uri`.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change (internal encoding change; no config/behavior change for well-formed URIs)
- [x] I have verified that this change is backward compatible (only control characters, which are invalid in a request line, are now encoded)
