### PR TITLE
fix(openid-connect): handle temporarily_unavailable from IDP by restarting auth flow (#13776)

### DIFF
--- a/apisix/plugins/openid-connect.lua
+++ b/apisix/plugins/openid-connect.lua
@@ -913,6 +913,27 @@ function _M.rewrite(plugin_conf, ctx)
                 return 302
             end
 
+            -- Transient authorization error from the identity provider: the ID
+            -- provider redirected to the redirect_uri with
+            -- error=temporarily_unavailable instead of a code, e.g. Keycloak's
+            -- login session expiring before the user completed authentication.
+            -- This is recoverable, so restart the authentication flow by
+            -- sending the browser back to the original URL instead of
+            -- dead-ending with a 500. Other error codes (access_denied,
+            -- login_required, ...) are not retried here, since they reflect a
+            -- deliberate outcome rather than a transient failure.
+            local uri_args = ngx.req.get_uri_args()
+            if uri_args.error == "temporarily_unavailable" and target_url
+               and ngx.req.get_method() == "GET" then
+                core.log.warn("OIDC authorization callback reported a temporarily ",
+                              "unavailable identity provider",
+                              uri_args.error_description and
+                                  (" (" .. uri_args.error_description .. ")") or "",
+                              ", restarting the authentication flow")
+                core.response.set_header("Location", target_url)
+                return 302
+            end
+
             core.log.error("OIDC authentication failed: ", err)
             return 500
         end


### PR DESCRIPTION
### What does this PR do?

Fixes #13776. When an OAuth2 identity provider redirects back to APISIX's redirect_uri with a standard error response (per RFC 6749 §4.1.2.1), the openid-connect plugin currently falls through to a generic 500 error. This is particularly problematic for the `temporarily_unavailable` code, which can occur during entirely nominal operation — e.g. Keycloak's login session expiring before the user completes authentication.

This PR detects `error=temporarily_unavailable` on a GET callback and restarts the authentication flow (302 redirect back to the original URL) instead of dead-ending with a 500. Other error codes like `access_denied` / `login_required` reflect a deliberate outcome and are intentionally NOT retried.

### Why is this needed?

`temporarily_unavailable` is a transient failure — the login attempt can be automatically retried without any user interaction. Returning a 500 on a recoverable condition is a bug.

### Verification

- `error=temporarily_unavailable` on a GET callback → 302 redirect, flow restarts (recoverable)
- `error=access_denied` → still 500 (deliberate outcome, not retried)
- non-GET callback → still 500
- callback without session cookie → still 500

### PR Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features this PR contains
- [ ] I have added tests to cover this change (test suite in `t/`)