### PR TITLE
fix(logger): prevent meta_filter from caching access-phase verdict for log phase

### DIFF
--- a/apisix/core/ctx.lua
+++ b/apisix/core/ctx.lua
@@ -208,6 +208,9 @@ do
         -- var.args should not be cached as it can be changed via set_uri_args
         args = true,
         is_args = true,
+        -- status is only valid after the response starts; caching the
+        -- access-phase value (0) would corrupt log output
+        status = true,
     }
 
     local ngx_var_names = {

--- a/apisix/plugin.lua
+++ b/apisix/plugin.lua
@@ -533,7 +533,8 @@ local function meta_filter(ctx, plugin_name, plugin_conf)
 
     local match_cache_key =
         ctx.conf_type .. "#" .. ctx.conf_id .. "#"
-            .. ctx.conf_version .. "#" .. plugin_name .. "#meta_filter_matched"
+            .. ctx.conf_version .. "#" .. plugin_name .. "#"
+            .. ngx.get_phase() .. "#meta_filter_matched"
     if ctx[match_cache_key] ~= nil then
         return ctx[match_cache_key]
     end


### PR DESCRIPTION
## Description

Fixes #13724

Since 3.16.0, every logger plugin carries an `access`-phase handler (`_M.access = log_util.check_and_read_req_body`, introduced in #13034). Because the plugin now runs in `access`, `run_plugin("access", ...)` invokes `meta_filter()`, which evaluates the plugin's `_meta.filter` **and caches the verdict for the rest of the request**. This causes two problems:

**A. Filter conditions on response-phase variables are decided before those variables have values.**

A filter referencing `$status` or `$upstream_status` is evaluated against `0` / empty at access phase, and that wrong verdict is reused at log phase.

**B. `$status` is cached as `0`, corrupting the output of every plugin on the request.**

`status` is not in `no_cacheable_var_names`, so the access-phase read of `$status` (which is `0` at access time) is cached into `ctx.var` for the remainder of the request. Every plugin that later reads `$status` gets `0`.

## Changes

### apisix/plugin.lua

Include `ngx.get_phase()` in the `meta_filter` cache key so that access-phase and log-phase verdicts are cached separately. The log-phase call recomputes the verdict with correct response-phase variables.

### apisix/core/ctx.lua

Add `status` to `no_cacheable_var_names` so that `$status` is never cached. Each read fetches from `ngx.var.status` directly, avoiding the access-phase `0` contamination.

## Related

- This re-introduces the class of problem previously addressed in #8162 / #8256.
