### PR TITLE
feat(ldap-auth-advanced): add group collection, group authorization and group-based Consumers

### DIFF
--- a/apisix/plugins/ldap-auth-advanced.lua
+++ b/apisix/plugins/ldap-auth-advanced.lua
@@ -18,16 +18,26 @@ local core = require("apisix.core")
 local schema_def = require("apisix.schema_def")
 local auth_utils = require("apisix.utils.auth")
 local consumer_mod = require("apisix.consumer")
+local secret = require("apisix.secret")
 local ldap_client = require("resty.ldap.client")
 local ldap_protocol = require("resty.ldap.protocol")
 local ldap_filter = require("resty.ldap.filter")
 local ngx = ngx
 local ipairs = ipairs
+local pairs = pairs
 local type = type
+local tonumber = tonumber
 local ngx_decode_base64 = ngx.decode_base64
 local ngx_re_match = ngx.re.match
+local ngx_re_gsub = ngx.re.gsub
+local str_byte = string.byte
+local str_char = string.char
 local str_find = string.find
+local str_gsub = string.gsub
+local str_lower = string.lower
 local str_sub = string.sub
+local table_concat = table.concat
+local table_sort = table.sort
 local parse_addr = core.utils.parse_addr
 
 -- RFC 4512 attribute-description: a descriptor ("cn", "sAMAccountName") or a
@@ -69,7 +79,24 @@ local schema = {
         size_limit = { type = "integer", minimum = 2, default = 2 },
         time_limit = { type = "integer", minimum = 0, default = 5 }, -- seconds; 0 = server default
 
+        -- groups
+        group_base_dn = { type = "string",                  -- absent => memberOf attribute path
+                          minLength = 1, maxLength = 4096 },
+        group_name_attribute = { type = "string", maxLength = 256,
+                                 default = "cn", pattern = ATTR_PATTERN },
+        group_member_attribute = { type = "string", maxLength = 256,
+                                   default = "member", pattern = ATTR_PATTERN },
+        user_membership_attribute = { type = "string", maxLength = 256,
+                                      default = "memberOf",
+                                      pattern = ATTR_PATTERN },
 
+        -- authorization: outer array ORs, inner array ANDs
+        groups_required = {
+            type = "array", minItems = 1,
+            items = { type = "array", minItems = 1,
+                      items = { type = "string",
+                                minLength = 1, maxLength = 4096 } },
+        },
 
         -- consumer
         consumer_required  = { type = "boolean", default = true },
@@ -77,19 +104,39 @@ local schema = {
         -- request handling
         header_type      = { type = "string", enum = {"ldap", "basic"}, default = "ldap" },
         realm            = schema_def.get_realm_schema("ldap"),
+        set_groups_header = {
+            description = "Whether the collected group names should be added in the "
+                .. "X-Authenticated-Groups header to the request for downstream.",
+            type = "boolean", default = true },
 
     },
     encrypt_fields = {"ldap_password"},
     required = {"ldap_uri", "base_dn"},
 }
 
+local GROUP_NAME_DEFAULT = schema.properties.group_name_attribute.default
+local GROUP_MEMBER_DEFAULT = schema.properties.group_member_attribute.default
+
 local consumer_schema = {
     type = "object",
     title = "work with consumer object",
     properties = {
         user_dn  = { type = "string", minLength = 1, maxLength = 4096 },
+        -- one group DN, or several that must ALL contain the user
+        group_dn = {
+            oneOf = {
+                { type = "string", minLength = 1, maxLength = 4096 },
+                { type = "array", minItems = 1, uniqueItems = true,
+                  items = { type = "string", minLength = 1, maxLength = 4096 } },
+            },
+        },
     },
-    required = {"user_dn"},
+    -- exactly one association key: both set matches both branches, neither
+    -- matches none -- either way oneOf rejects
+    oneOf = {
+        { required = {"user_dn"} },
+        { required = {"group_dn"} },
+    },
 }
 
 local plugin_name = "ldap-auth-advanced"
@@ -120,6 +167,17 @@ function _M.check_schema(conf, schema_type)
 
     if conf.bind_dn and not conf.ldap_password then
         return false, "ldap_password is required when bind_dn is set"
+    end
+
+    -- Compared against the schema default, not presence: jsonschema injects
+    -- defaults into conf, and stored config is re-validated on every reload.
+    if not conf.group_base_dn then
+        if conf.group_name_attribute ~= GROUP_NAME_DEFAULT then
+            return false, "group_name_attribute is only used with group_base_dn"
+        end
+        if conf.group_member_attribute ~= GROUP_MEMBER_DEFAULT then
+            return false, "group_member_attribute is only used with group_base_dn"
+        end
     end
 
     -- ldap_uri may omit ":port"; the effective port (636 with use_ldaps,
@@ -153,6 +211,27 @@ local function auth_failed(conf, ctx, reason)
 end
 
 
+-- groups_required is an outer OR of inner ANDs, matched against the collected
+-- group names verbatim (no case folding, no trimming).
+local function groups_satisfied(groups_required, groups)
+    local have = {}
+    for i = 1, #groups do
+        have[groups[i].name] = true
+    end
+    for _, inner in ipairs(groups_required) do
+        local all = true
+        for _, name in ipairs(inner) do
+            if not have[name] then
+                all = false
+                break
+            end
+        end
+        if all then
+            return true
+        end
+    end
+    return false
+end
 
 
 -- Parse one credential header value: the scheme word is conf.header_type
@@ -233,12 +312,223 @@ local function is_result_code(err, op, result_msg)
 end
 
 
+-- Attribute lookup with a case-insensitive fallback: the server may echo the
+-- requested descriptor in a different case.
+local function attr_values(attributes, name)
+    if not attributes then
+        return nil
+    end
+    local vals = attributes[name]
+    if vals then
+        return vals
+    end
+    local lname = str_lower(name)
+    for k, v in pairs(attributes) do
+        if str_lower(k) == lname then
+            return v
+        end
+    end
+    return nil
+end
 
 
--- The LDAP round trip: resolve the user DN and authenticate the user's bind
--- on ONE pinned connection. Returns (nil, nil, user_dn) on success, or
--- (code, body) on failure. The socket is closed on every failure path and
--- released to the pool only on success, so a poisoned socket is never pooled.
+-- Reverse RFC 4514 RDN-value escaping ("\2C" or "\," -> the literal char) so
+-- group names taken from a DN match the unescaped attribute values byte for
+-- byte. Single pass, hex escape first, so "\\2C" stays a backslash plus the
+-- literal "2C"; a lone trailing backslash is kept as-is.
+local function unescape_rdn_value(v)
+    if not str_find(v, "\\", 1, true) then
+        return v
+    end
+    return (ngx_re_gsub(v, [[\\([0-9A-Fa-f]{2}|.)]], function(m)
+        local esc = m[1]
+        return #esc == 2 and str_char(tonumber(esc, 16)) or esc
+    end, "jos"))
+end
+
+
+-- The value of a DN's first RDN, unescaped, e.g.
+-- "cn=Domain Admins,ou=groups,..." -> "Domain Admins".
+local function first_rdn_value(dn)
+    local eq = str_find(dn, "=", 1, true)
+    if not eq then
+        return dn
+    end
+    local i = eq + 1
+    local n = #dn
+    while i <= n do
+        local b = str_byte(dn, i)
+        if b == 92 then           -- '\' escapes the next byte
+            i = i + 2
+        elseif b == 44 then       -- ',' ends the first RDN
+            return unescape_rdn_value(str_sub(dn, eq + 1, i - 1))
+        else
+            i = i + 1
+        end
+    end
+    return unescape_rdn_value(str_sub(dn, eq + 1))
+end
+
+
+-- Map group search entries to {dn, name} pairs; when an entry did not carry
+-- the name attribute, fall back to its DN's first RDN value.
+local function collect_search_groups(entries, name_attr)
+    local groups = {}
+    for _, entry in ipairs(entries) do
+        if entry.entry_dn then
+            local vals = attr_values(entry.attributes, name_attr)
+            groups[#groups + 1] = {
+                dn = entry.entry_dn,
+                name = (vals and vals[1]) or first_rdn_value(entry.entry_dn),
+            }
+        end
+    end
+    return groups
+end
+
+
+-- Each membership-attribute value on the user entry is a group DN; its name
+-- is the DN's first RDN value. No extra LDAP round trip.
+local function collect_membership_groups(user_entry, member_attr)
+    local groups = {}
+    local vals = attr_values(user_entry.attributes, member_attr)
+    if vals then
+        for _, dn in ipairs(vals) do
+            groups[#groups + 1] = { dn = dn, name = first_rdn_value(dn) }
+        end
+    end
+    return groups
+end
+
+
+-- Strip CR/LF and other control bytes from a directory-sourced value before
+-- it is written into an upstream header (header-injection defense). Group
+-- matching always uses the raw name, never this sanitized copy.
+local function sanitize_header_value(v)
+    return (str_gsub(v, "[%z\1-\31\127]", ""))
+end
+
+
+-- Returns the client's own (ok, err): false is a directory rejection, nil is
+-- a transport failure.
+local function bind_as_service(client, conf)
+    if conf.bind_dn then
+        return client:simple_bind(conf.bind_dn, conf.ldap_password)
+    end
+    return client:simple_bind("", "")
+end
+
+
+-- One index per consumer-config version: user_dn consumers hash by DN;
+-- group_dn consumers are pre-sorted so the request-time scan realizes the
+-- documented order -- walk the user's groups alphabetically, a consumer
+-- ranks at its alphabetically-smallest group_dn, a larger group_dn set
+-- (more specific) wins the same slot, the consumer name breaks exact ties.
+-- Secrets resolve here, fail-closed, mirroring create_consume_cache.
+local function build_consumer_index(consumer_conf)
+    local index = { by_user_dn = {}, group_list = {} }
+    for _, consumer in ipairs(consumer_conf.nodes) do
+        local c = core.table.clone(consumer)
+        c.auth_conf = secret.fetch_secrets(c.auth_conf, false)
+        if not c.auth_conf or secret.has_secret_ref(c.auth_conf) then
+            core.log.error(plugin_name, ": failed to resolve secret reference ",
+                           "in consumer auth credential, skipping consumer: ",
+                           c.consumer_name)
+        elseif c.auth_conf.user_dn ~= nil then
+            index.by_user_dn[c.auth_conf.user_dn] = c
+        elseif c.auth_conf.group_dn ~= nil then
+            local group_dns = c.auth_conf.group_dn
+            if type(group_dns) == "string" then
+                group_dns = { group_dns }
+            else
+                group_dns = core.table.clone(group_dns)
+            end
+            table_sort(group_dns)
+            index.group_list[#index.group_list + 1] = {
+                consumer = c,
+                group_dns = group_dns,
+            }
+        else
+            core.log.error(plugin_name, ": consumer has neither user_dn nor ",
+                           "group_dn, skipping consumer: ", c.consumer_name)
+        end
+    end
+
+    table_sort(index.group_list, function(a, b)
+        if a.group_dns[1] ~= b.group_dns[1] then
+            return a.group_dns[1] < b.group_dns[1]
+        end
+        if #a.group_dns ~= #b.group_dns then
+            return #a.group_dns > #b.group_dns
+        end
+        return a.consumer.consumer_name < b.consumer.consumer_name
+    end)
+
+    return index
+end
+
+
+local index_cache = core.lrucache.new({ ttl = 300, count = 16 })
+
+-- Two-phase Consumer resolution: the exact user_dn binding is the most
+-- specific and always wins; group_dn consumers are consulted only when it
+-- misses. Returns (consumer, consumer_conf) or (nil, nil, err) when no
+-- Consumer carries this plugin at all.
+local function find_ldap_consumer(user_dn, groups)
+    local consumer_conf = consumer_mod.plugin(plugin_name)
+    if not consumer_conf then
+        return nil, nil, "Missing related consumer"
+    end
+
+    local index = index_cache(plugin_name .. "#consumer_index",
+                              consumer_conf.conf_version,
+                              build_consumer_index, consumer_conf)
+
+    local consumer = index.by_user_dn[user_dn]
+    if consumer then
+        return consumer, consumer_conf
+    end
+
+    if #index.group_list == 0 or #groups == 0 then
+        return nil, consumer_conf
+    end
+
+    local have = {}
+    for i = 1, #groups do
+        have[groups[i].dn] = true
+    end
+
+    local chosen, matched
+    for _, entry in ipairs(index.group_list) do
+        local eligible = true
+        for _, dn in ipairs(entry.group_dns) do
+            if not have[dn] then
+                eligible = false
+                break
+            end
+        end
+        if eligible then
+            chosen = chosen or entry.consumer
+            matched = matched or {}
+            matched[#matched + 1] = entry.consumer.consumer_name
+        end
+    end
+
+    if matched and #matched > 1 then
+        core.log.warn(plugin_name, ": multiple consumers matched by group_dn (",
+                      table_concat(matched, ", "), "); picked ", matched[1],
+                      "; unintended consumers may have been matched")
+    end
+
+    return chosen, consumer_conf
+end
+
+
+-- The LDAP round trip: resolve the user DN and authenticate the user's bind,
+-- then collect groups, on ONE pinned connection. Returns
+-- (nil, nil, user_dn, groups) on success, or (code, body) on failure. The
+-- socket is closed on every failure path and released to the pool only on
+-- success, so a poisoned socket is never pooled.
 local function ldap_resolve(conf, ctx, username, password)
     -- The only client-controlled part of the search filter is the escaped
     -- username. filter.escape leaves bytes the filter grammar rejects (e.g.
@@ -273,12 +563,7 @@ local function ldap_resolve(conf, ctx, username, password)
     -- The client connects lazily on the first operation, so a socket/TLS
     -- failure surfaces here as (nil, err) -- an outage, never auth -- while
     -- a directory rejection is (false, err).
-    local bind_ok, berr
-    if conf.bind_dn then
-        bind_ok, berr = client:simple_bind(conf.bind_dn, conf.ldap_password)
-    else
-        bind_ok, berr = client:simple_bind("", "")
-    end
+    local bind_ok, berr = bind_as_service(client, conf)
     if not bind_ok then
         client:close()
         if bind_ok == nil then
@@ -291,15 +576,20 @@ local function ldap_resolve(conf, ctx, username, password)
         return 500
     end
 
-    -- Search for the user. size_limit floors at 2 (schema minimum) so a 2nd
-    -- match is observable.
+    -- Search for the user. On the memberOf path, request
+    -- user_membership_attribute so groups can be read off this same entry
+    -- with no extra round trip; on the group-search path the entry's
+    -- attributes are unused, so request none ("1.1", RFC 4511) -- an AD
+    -- user's memberOf can be tens of KB that would be decoded and dropped.
+    -- size_limit floors at 2 (schema minimum) so a 2nd match is observable.
     local entries, serr = client:search(
         conf.base_dn,
         ldap_protocol.SEARCH_SCOPE_WHOLE_SUBTREE,
         ldap_protocol.SEARCH_DEREF_ALIASES_ALWAYS,
         conf.size_limit, conf.time_limit,
         false,
-        search_filter)
+        search_filter,
+        { conf.group_base_dn and "1.1" or conf.user_membership_attribute })
     if entries == false then
         client:close()
         if is_result_code(serr, "search", RESULT_SIZE_LIMIT_EXCEEDED) then
@@ -314,12 +604,12 @@ local function ldap_resolve(conf, ctx, username, password)
     end
 
     -- count SearchResultEntry rows (the library drops SearchResultDone)
-    local user_dn
+    local user_entry
     local match_count = 0
     for _, entry in ipairs(entries) do
         if entry.entry_dn then
             match_count = match_count + 1
-            user_dn = entry.entry_dn
+            user_entry = entry
         end
     end
     if match_count == 0 then
@@ -333,6 +623,7 @@ local function ldap_resolve(conf, ctx, username, password)
         return auth_failed(conf, ctx,
                            "ambiguous user match (>1 entry); check attribute uniqueness")
     end
+    local user_dn = user_entry.entry_dn
 
     -- Authenticate: bind as the resolved user. invalidCredentials is a wrong
     -- password (401); any other result code (busy, unavailable, ...) or a
@@ -347,6 +638,45 @@ local function ldap_resolve(conf, ctx, username, password)
         return 500
     end
 
+    local groups
+    if conf.group_base_dn then
+        -- Currently bound as the END USER. Re-bind as the configured identity
+        -- so the group search never runs under the caller. The extra round
+        -- trip is deliberate: searching groups before the auth bind would
+        -- avoid it, but then every wrong-password request would still incur
+        -- a group search.
+        local rb_ok, rberr = bind_as_service(client, conf)
+        if not rb_ok then
+            client:close()
+            core.log.error(plugin_name, ": LDAP group-search re-bind failed: ",
+                           rberr)
+            return 500
+        end
+
+        local group_filter = "(" .. conf.group_member_attribute .. "="
+                             .. ldap_filter.escape(user_dn) .. ")"
+        -- sizeLimit is deliberately 0 (not conf.size_limit) so a user's
+        -- groups are never silently truncated.
+        local gentries, gerr = client:search(
+            conf.group_base_dn,
+            ldap_protocol.SEARCH_SCOPE_WHOLE_SUBTREE,
+            ldap_protocol.SEARCH_DEREF_ALIASES_ALWAYS,
+            0, conf.time_limit,
+            false,
+            group_filter,
+            { conf.group_name_attribute })
+        if gentries == false then
+            -- already authenticated: unlike the user search, any failure here
+            -- (sizeLimitExceeded included) is operational, never a 401
+            client:close()
+            core.log.error(plugin_name, ": LDAP group search failed: ", gerr)
+            return 500
+        end
+        groups = collect_search_groups(gentries, conf.group_name_attribute)
+    else
+        groups = collect_membership_groups(user_entry,
+                                           conf.user_membership_attribute)
+    end
 
     if conf.keepalive == false then
         client:close()
@@ -354,14 +684,16 @@ local function ldap_resolve(conf, ctx, username, password)
         client:set_keepalive()
     end
 
-    return nil, nil, user_dn
+    return nil, nil, user_dn, groups
 end
 
 
 function _M.rewrite(conf, ctx)
     -- Strip the client-supplied identity headers before any auth work: only
-    -- attach_consumer() may set them, and with consumer_required=false it
-    -- never runs, so an inbound value would otherwise pass through untouched.
+    -- attach_consumer() sets X-Consumer-*, and only the success-path export
+    -- below sets X-Authenticated-Groups; either can be skipped (consumer_
+    -- required=false, set_groups_header=false), so an inbound value would
+    -- otherwise pass through untouched.
     core.request.set_header(ctx, "X-Authenticated-Groups", nil)
     core.request.set_header(ctx, "X-Consumer-Username", nil)
     core.request.set_header(ctx, "X-Credential-Identifier", nil)
@@ -374,17 +706,27 @@ function _M.rewrite(conf, ctx)
         return auth_failed(conf, ctx, err)
     end
 
-    local code, body, user_dn = ldap_resolve(conf, ctx, username, password)
+    local code, body, user_dn, groups = ldap_resolve(conf, ctx, username, password)
     if code then
         return code, body
     end
 
+    -- an already-authenticated user failing authorization gets a real 403,
+    -- never a 401; the warn names the denied user because no identity
+    -- has been exported yet on this path
+    if conf.groups_required and not groups_satisfied(conf.groups_required, groups) then
+        core.log.warn(plugin_name, ": groups_required not satisfied for ", user_dn)
+        return 403, { message = "Forbidden" }
+    end
+
     -- Associate a Consumer with the authenticated identity, unless
-    -- consumer_required is false. find_consumer() resolves secret references
-    -- in the Consumer's user_dn and skips unresolved ones fail-closed.
+    -- consumer_required is false. find_ldap_consumer() is the two-phase
+    -- lookup: an exact user_dn binding always wins, group_dn consumers are
+    -- consulted only when it misses. Either way, secret references in the
+    -- Consumer's auth credential are resolved fail-closed (unresolved ones
+    -- are skipped, never matched verbatim).
     if conf.consumer_required ~= false then
-        local consumer, consumer_conf, err =
-            consumer_mod.find_consumer(plugin_name, "user_dn", user_dn)
+        local consumer, consumer_conf, err = find_ldap_consumer(user_dn, groups)
         if err then
             return auth_failed(conf, ctx, "consumer_required but no Consumer is configured")
         end
@@ -394,6 +736,17 @@ function _M.rewrite(conf, ctx)
         end
 
         consumer_mod.attach_consumer(ctx, consumer, consumer_conf)
+    end
+
+    -- Reached only after every auth decision passed, so the header is absent
+    -- on all 401/500 paths. The inbound strip above stays unconditional.
+    if conf.set_groups_header and #groups > 0 then
+        local names = {}
+        for i = 1, #groups do
+            names[i] = sanitize_header_value(groups[i].name)
+        end
+        core.request.set_header(ctx, "X-Authenticated-Groups",
+                                table_concat(names, ","))
     end
 end
 

--- a/ci/pod/docker-compose.plugin.yml
+++ b/ci/pod/docker-compose.plugin.yml
@@ -257,6 +257,9 @@ services:
       - ./t/certs:/certs
       - ./ci/pod/openldap/ad.ldif:/ldifs/ad.ldif
       - ./ci/pod/openldap/enable-anon-bind.sh:/docker-entrypoint-initdb.d/enable-anon-bind.sh
+      - ./ci/pod/openldap/memberof.ldif:/overlays/memberof.ldif
+      - ./ci/pod/openldap/groups.ldif:/overlays/groups.ldif
+      - ./ci/pod/openldap/setup-groups.sh:/docker-entrypoint-initdb.d/setup-groups.sh
 
 
   ## Grafana Loki

--- a/ci/pod/openldap/ad.ldif
+++ b/ci/pod/openldap/ad.ldif
@@ -100,3 +100,23 @@ cn: Secret User
 sn: Secret
 uid: secretuser
 userPassword: secretpass
+
+# Member of three groups (groups.ldif): exercises the unbounded group search.
+dn: cn=Multi User,ou=users,dc=example,dc=org
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+cn: Multi User
+sn: User
+uid: multiuser
+userPassword: multipass
+
+# Sole member of the comma-in-cn group "Sales, EMEA" (DN unescape case).
+dn: cn=Sales User,ou=users,dc=example,dc=org
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+cn: Sales User
+sn: User
+uid: salesuser
+userPassword: salespass

--- a/ci/pod/openldap/groups.ldif
+++ b/ci/pod/openldap/groups.ldif
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authorization groups for the ldap-auth-advanced tests. Loaded by
+# setup-groups.sh AFTER the memberof overlay is active, so the overlay
+# back-populates memberOf on the member user entries.
+
+dn: ou=groups,dc=example,dc=org
+objectClass: organizationalUnit
+ou: groups
+
+dn: cn=Domain Admins,ou=groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: Domain Admins
+member: cn=Jane Doe,ou=users,dc=example,dc=org
+member: cn=user01,ou=users,dc=example,dc=org
+member: cn=Multi User,ou=users,dc=example,dc=org
+
+dn: cn=developers,ou=groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: developers
+member: cn=user01,ou=users,dc=example,dc=org
+member: cn=Multi User,ou=users,dc=example,dc=org
+
+dn: cn=ops,ou=groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: ops
+member: cn=Jane Doe,ou=users,dc=example,dc=org
+member: cn=Multi User,ou=users,dc=example,dc=org
+
+dn: cn=superadmin,ou=groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: superadmin
+member: cn=user02,ou=users,dc=example,dc=org
+
+# The cn contains a comma, escaped in the DN as cn=Sales\, EMEA.
+dn: cn=Sales\, EMEA,ou=groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: Sales, EMEA
+member: cn=Sales User,ou=users,dc=example,dc=org

--- a/ci/pod/openldap/memberof.ldif
+++ b/ci/pod/openldap/memberof.ldif
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Activates the memberof + refint overlays on the data database
+# (olcDatabase={2}mdb). Must be applied BEFORE the groups are added: the
+# overlay only back-populates memberOf for member links added after it is
+# active.
+
+dn: cn=module,cn=config
+cn: module
+objectClass: olcModuleList
+olcModulePath: /opt/bitnami/openldap/lib/openldap
+olcModuleLoad: memberof.so
+olcModuleLoad: refint.so
+
+dn: olcOverlay=memberof,olcDatabase={2}mdb,cn=config
+objectClass: olcMemberOf
+objectClass: olcOverlayConfig
+olcOverlay: memberof
+
+dn: olcOverlay=refint,olcDatabase={2}mdb,cn=config
+objectClass: olcConfig
+objectClass: olcOverlayConfig
+objectClass: olcRefintConfig
+objectClass: top
+olcOverlay: refint
+olcRefintAttribute: memberof member manager owner

--- a/ci/pod/openldap/setup-groups.sh
+++ b/ci/pod/openldap/setup-groups.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Boot hook (docker-entrypoint-initdb.d): activates the memberof overlay,
+# THEN loads the groups. The overlay only back-populates memberOf for member
+# links added after it is active, so the groups cannot live in /ldifs.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+. /opt/bitnami/scripts/liblog.sh
+. /opt/bitnami/scripts/libopenldap.sh
+
+eval "$(ldap_env)"
+
+ldap_start_bg
+
+info "Activating the memberof + refint overlays"
+
+ldapadd -Y EXTERNAL -H "ldapi:///" -f /overlays/memberof.ldif
+
+info "Loading authorization groups (overlay back-populates memberOf)"
+
+ldapadd -H "ldapi:///" -D "$LDAP_ADMIN_DN" -w "$LDAP_ADMIN_PASSWORD" -f /overlays/groups.ldif
+
+ldap_stop

--- a/docs/en/latest/config.json
+++ b/docs/en/latest/config.json
@@ -138,6 +138,7 @@
             "plugins/hmac-auth",
             "plugins/authz-casbin",
             "plugins/ldap-auth",
+            "plugins/ldap-auth-advanced",
             "plugins/opa",
             "plugins/forward-auth",
             "plugins/multi-auth",

--- a/docs/en/latest/plugins/ldap-auth-advanced.md
+++ b/docs/en/latest/plugins/ldap-auth-advanced.md
@@ -1,0 +1,422 @@
+---
+title: ldap-auth-advanced
+keywords:
+  - Apache APISIX
+  - API Gateway
+  - Plugin
+  - LDAP Authentication
+  - LDAP Groups
+  - ldap-auth-advanced
+description: The ldap-auth-advanced Plugin authenticates users against an LDAP directory using search-then-bind, collects their groups, and can authorize requests on group membership.
+---
+
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+<head>
+  <link rel="canonical" href="https://docs.api7.ai/hub/ldap-auth-advanced" />
+</head>
+
+## Description
+
+The `ldap-auth-advanced` Plugin adds LDAP authentication to a Route or a Service. Unlike [`ldap-auth`](./ldap-auth.md), which binds with a DN assembled from the Consumer configuration, this Plugin *searches* the directory for the user first, then binds as the entry it found. Users therefore do not need to be enumerated in APISIX, and the Plugin can additionally collect their group memberships to authorize requests and to inform the Upstream service.
+
+On each request the Plugin:
+
+1. Reads the credentials from the `Proxy-Authorization` header, falling back to `Authorization`.
+2. Searches `base_dn` for the entry whose `attribute` matches the supplied username, then binds as that entry with the supplied password.
+3. Collects the user's groups, either from the `memberOf` attribute on the user entry (the default) or by searching a group subtree (`group_base_dn`).
+4. Enforces `groups_required`, if configured.
+5. Attaches a matching [Consumer](../terminology/consumer.md), unless `consumer_required` is `false`.
+6. Adds the group names to the request in the `X-Authenticated-Groups` header.
+
+The credential header uses the scheme word given by `header_type`, which defaults to `ldap` rather than `basic`, so the default expects `Authorization: ldap <base64(username:password)>`. Set `header_type` to `basic` to accept ordinary [basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) instead.
+
+The Plugin distinguishes three failure modes, so an outage is never reported as a rejected credential:
+
+| Status | Cause |
+|--------|-------|
+| `401` | Missing, malformed, or rejected credentials; a username matching more than one entry; or `consumer_required` is `true` and no Consumer matches. Returned with a `WWW-Authenticate` header. |
+| `403` | The user authenticated, but does not satisfy `groups_required`. |
+| `500` | The directory is unreachable, the `bind_dn` credentials were rejected, or the group search failed. |
+
+This Plugin uses [lua-resty-ldap](https://github.com/api7/lua-resty-ldap) to connect to the LDAP server.
+
+## Attributes
+
+For Consumer:
+
+| Name | Type | Required | Default | Valid values | Description |
+|------|------|----------|---------|--------------|-------------|
+| user_dn | string | False | | | DN of the LDAP user bound to this Consumer, for example `cn=Jane Doe,ou=users,dc=example,dc=org`. Mutually exclusive with `group_dn`; exactly one of the two is required. This field supports storing the value in Secret Manager using the [APISIX Secret](../terminology/secret.md) resource. |
+| group_dn | string or array[string] | False | | | DN of a group, or several group DNs that the user must **all** belong to, for example `cn=ops,ou=groups,dc=example,dc=org`. Mutually exclusive with `user_dn`; exactly one of the two is required. This field supports storing the value in Secret Manager using the [APISIX Secret](../terminology/secret.md) resource. |
+
+For Route:
+
+| Name | Type | Required | Default | Valid values | Description |
+|------|------|----------|---------|--------------|-------------|
+| ldap_uri | string | True | | | Address of the LDAP server as `host` or `host:port`. When the port is omitted, `636` is used if `use_ldaps` is enabled and `389` otherwise. |
+| base_dn | string | True | | | DN of the subtree searched for the user, for example `ou=users,dc=example,dc=org`. |
+| attribute | string | False | cn | | User attribute matched against the supplied username, for example `uid` or `sAMAccountName`. |
+| bind_dn | string | False | | | DN used to bind before searching for the user. When unset, the search binds anonymously. |
+| ldap_password | string | False | | | Password for `bind_dn`. Required when `bind_dn` is set. The password is encrypted with AES before being stored in etcd. |
+| use_ldaps | boolean | False | false | | If true, connect over LDAPS. Mutually exclusive with `use_starttls`. |
+| use_starttls | boolean | False | false | | If true, upgrade the connection with StartTLS. Mutually exclusive with `use_ldaps`. |
+| ssl_verify | boolean | False | true | | If true, verify the LDAP server's certificate. Requires `ssl_trusted_certificate` to be set in `config.yaml`, and the host in `ldap_uri` to match the host in the server certificate. |
+| timeout | integer | False | 10000 | [1, 60000] | Socket timeout in milliseconds. |
+| keepalive | boolean | False | true | | If true, return the connection to the pool for reuse instead of closing it. |
+| keepalive_timeout | integer | False | 60000 | >= 1000 | Idle time in milliseconds after which a pooled connection is closed. |
+| keepalive_pool_size | integer | False | 5 | >= 1 | Maximum number of connections kept in the pool. |
+| keepalive_pool_name | string | False | | | Name of the connection pool. Set this to keep connections that use different credentials in separate pools. |
+| size_limit | integer | False | 2 | >= 2 | Maximum number of entries the user search may return. The login attribute is expected to be unique, so more than one match is treated as ambiguous and rejected. |
+| time_limit | integer | False | 5 | >= 0 | Time limit of the search in seconds. `0` uses the server default. |
+| group_base_dn | string | False | | | DN of the subtree searched for the user's groups. When set, groups are found by searching this subtree for entries whose `group_member_attribute` contains the user's DN. When unset, groups are read from `user_membership_attribute` on the user entry, without an extra round trip. |
+| group_name_attribute | string | False | cn | | Group attribute used as the group name. Only valid together with `group_base_dn`. |
+| group_member_attribute | string | False | member | | Group attribute listing member DNs. Only valid together with `group_base_dn`. |
+| user_membership_attribute | string | False | memberOf | | User attribute listing the DNs of the groups the user belongs to. Used when `group_base_dn` is unset. |
+| groups_required | array[array[string]] | False | | | Group names the user must belong to. The outer array is a logical OR and each inner array a logical AND, so `[["a","b"],["c"]]` admits users in both `a` and `b`, as well as users in `c`. Names are matched exactly, including case. |
+| consumer_required | boolean | False | true | | If true, reject the request with `401` when no Consumer matches the authenticated user. |
+| header_type | string | False | ldap | ["ldap", "basic"] | Scheme word expected in the credential header. |
+| realm | string | False | ldap | | Realm in the [`WWW-Authenticate`](https://datatracker.ietf.org/doc/html/rfc7235#section-4.1) response header returned with a `401 Unauthorized` response. |
+| set_groups_header | boolean | False | true | | If true, add the collected group names to the request in the `X-Authenticated-Groups` header, comma-separated. Any inbound value of this header is always removed, whether or not the Plugin sets its own. |
+
+## Examples
+
+The examples below assume an LDAP directory under `dc=example,dc=org` that contains a user `Jane Doe` with `uid` of `jdoe` and password `janesecret`, belonging to the groups `Domain Admins` and `ops`, and a user `user01` with password `password1`, belonging to `Domain Admins` and `developers`.
+
+:::note
+
+You can fetch the `admin_key` from `config.yaml` and save it to an environment variable with the following command:
+
+```bash
+admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
+```
+
+:::
+
+### Authenticate Against an LDAP Directory
+
+The following example shows the minimum configuration: search `base_dn` for a matching `uid`, then bind as that user.
+
+Create a Route with `ldap-auth-advanced`:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "ldap-auth-advanced-route",
+    "uri": "/anything",
+    "plugins": {
+      "ldap-auth-advanced": {
+        "ldap_uri": "127.0.0.1:1389",
+        "base_dn": "ou=users,dc=example,dc=org",
+        "attribute": "uid",
+        "consumer_required": false
+      }
+    },
+    "upstream": {
+      "type": "roundrobin",
+      "nodes": {
+        "httpbin.org:80": 1
+      }
+    }
+  }'
+```
+
+Send a request with valid credentials:
+
+```shell
+curl -i "http://127.0.0.1:9080/anything" \
+  -H "Authorization: ldap $(echo -n 'jdoe:janesecret' | base64)"
+```
+
+You should receive an `HTTP/1.1 200 OK` response.
+
+Send a request without credentials:
+
+```shell
+curl -i "http://127.0.0.1:9080/anything"
+```
+
+You should receive an `HTTP/1.1 401 Unauthorized` response with the following body:
+
+```text
+{"message":"Authorization required"}
+```
+
+The response also carries the challenge built from `realm`:
+
+```text
+WWW-Authenticate: ldap realm="ldap"
+```
+
+A request with a wrong password is rejected the same way.
+
+If your directory does not allow anonymous searches, bind with a service account by adding `bind_dn` and `ldap_password`. The user is still authenticated with their own bind:
+
+```json
+{
+  "ldap-auth-advanced": {
+    "ldap_uri": "127.0.0.1:1389",
+    "base_dn": "ou=users,dc=example,dc=org",
+    "attribute": "uid",
+    "bind_dn": "cn=admin,dc=example,dc=org",
+    "ldap_password": "adminpassword",
+    "consumer_required": false
+  }
+}
+```
+
+To accept standard basic authentication instead of the `ldap` scheme, set `header_type` to `basic`. Clients can then use `curl -u jdoe:janesecret`.
+
+### Send LDAP Groups to the Upstream
+
+By default the Plugin reads the user's groups from the `memberOf` attribute on the user entry and forwards them in the `X-Authenticated-Groups` header, so the Upstream service can apply its own authorization without querying the directory.
+
+Using the Route from the previous example, send an authenticated request:
+
+```shell
+curl "http://127.0.0.1:9080/anything" \
+  -H "Authorization: ldap $(echo -n 'jdoe:janesecret' | base64)"
+```
+
+You should see the header echoed back in the response:
+
+```json
+{
+  "headers": {
+    "Authorization": "ldap amRvZTpqYW5lc2VjcmV0",
+    "X-Authenticated-Groups": "Domain Admins,ops",
+    ...
+  },
+  ...
+}
+```
+
+Set `set_groups_header` to `false` to omit the header.
+
+Directories that do not maintain a `memberOf` attribute list their members on the group entries instead. Set `group_base_dn` to search that subtree for the groups containing the user:
+
+```json
+{
+  "ldap-auth-advanced": {
+    "ldap_uri": "127.0.0.1:1389",
+    "base_dn": "ou=users,dc=example,dc=org",
+    "attribute": "uid",
+    "group_base_dn": "ou=groups,dc=example,dc=org",
+    "group_member_attribute": "member",
+    "group_name_attribute": "cn",
+    "consumer_required": false
+  }
+}
+```
+
+Both paths produce the same group names. The order of the names is not guaranteed.
+
+### Restrict Access by LDAP Group
+
+Configure `groups_required` to admit only users holding a given combination of groups. The outer array is a logical OR and each inner array a logical AND.
+
+Update the Route to admit users who are in both `Domain Admins` and `ops`, as well as users in `superadmin`:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "ldap-auth-advanced-route",
+    "uri": "/anything",
+    "plugins": {
+      "ldap-auth-advanced": {
+        "ldap_uri": "127.0.0.1:1389",
+        "base_dn": "ou=users,dc=example,dc=org",
+        "attribute": "uid",
+        "groups_required": [["Domain Admins", "ops"], ["superadmin"]],
+        "consumer_required": false
+      }
+    },
+    "upstream": {
+      "type": "roundrobin",
+      "nodes": {
+        "httpbin.org:80": 1
+      }
+    }
+  }'
+```
+
+`jdoe` holds both groups of the first alternative:
+
+```shell
+curl -i "http://127.0.0.1:9080/anything" \
+  -H "Authorization: ldap $(echo -n 'jdoe:janesecret' | base64)"
+```
+
+You should receive an `HTTP/1.1 200 OK` response.
+
+`user01` authenticates successfully but is in `developers` rather than `ops`, satisfying neither alternative:
+
+```shell
+curl -i "http://127.0.0.1:9080/anything" \
+  -H "Authorization: ldap $(echo -n 'user01:password1' | base64)"
+```
+
+You should receive an `HTTP/1.1 403 Forbidden` response with the following body:
+
+```text
+{"message":"Forbidden"}
+```
+
+### Map LDAP Identities to Consumers
+
+Associating an LDAP identity with a Consumer lets APISIX apply per-Consumer configuration, such as rate limits, and adds the `X-Consumer-Username` header to the Upstream request. A Consumer is bound either to one user, with `user_dn`, or to a group, with `group_dn`.
+
+Create a Consumer bound to a single user:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "username": "jane",
+    "plugins": {
+      "ldap-auth-advanced": {
+        "user_dn": "cn=Jane Doe,ou=users,dc=example,dc=org"
+      }
+    }
+  }'
+```
+
+Create a Consumer bound to everyone in a group:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "username": "opsteam",
+    "plugins": {
+      "ldap-auth-advanced": {
+        "group_dn": "cn=ops,ou=groups,dc=example,dc=org"
+      }
+    }
+  }'
+```
+
+Update the Route to require a Consumer by removing `consumer_required`, which defaults to `true`:
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "ldap-auth-advanced-route",
+    "uri": "/anything",
+    "plugins": {
+      "ldap-auth-advanced": {
+        "ldap_uri": "127.0.0.1:1389",
+        "base_dn": "ou=users,dc=example,dc=org",
+        "attribute": "uid"
+      }
+    },
+    "upstream": {
+      "type": "roundrobin",
+      "nodes": {
+        "httpbin.org:80": 1
+      }
+    }
+  }'
+```
+
+Send a request as `jdoe`:
+
+```shell
+curl "http://127.0.0.1:9080/anything" \
+  -H "Authorization: ldap $(echo -n 'jdoe:janesecret' | base64)"
+```
+
+You should see the Consumer identified in the Upstream request:
+
+```json
+{
+  "headers": {
+    "X-Consumer-Username": "jane",
+    "X-Authenticated-Groups": "Domain Admins,ops",
+    ...
+  },
+  ...
+}
+```
+
+`jdoe` is also in `ops`, but a `user_dn` binding is more specific and always wins. Other members of `ops` match `opsteam`. Users matching no Consumer are rejected with `401`, unless `consumer_required` is set to `false`.
+
+To require membership in several groups at once, set `group_dn` to an array. The user must belong to every DN listed:
+
+```json
+{
+  "ldap-auth-advanced": {
+    "group_dn": [
+      "cn=Domain Admins,ou=groups,dc=example,dc=org",
+      "cn=ops,ou=groups,dc=example,dc=org"
+    ]
+  }
+}
+```
+
+When more than one `group_dn` Consumer is eligible, the Plugin makes a deterministic choice and logs a warning naming every candidate. Configure group Consumers so that they do not overlap.
+
+### Connect over LDAPS
+
+Set `use_ldaps` to connect over LDAPS, or `use_starttls` to upgrade a plaintext connection. The two are mutually exclusive and the configuration is rejected if both are enabled.
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "ldap-auth-advanced-route",
+    "uri": "/anything",
+    "plugins": {
+      "ldap-auth-advanced": {
+        "ldap_uri": "ldap.example.org",
+        "use_ldaps": true,
+        "ssl_verify": true,
+        "base_dn": "ou=users,dc=example,dc=org",
+        "attribute": "uid",
+        "consumer_required": false
+      }
+    },
+    "upstream": {
+      "type": "roundrobin",
+      "nodes": {
+        "httpbin.org:80": 1
+      }
+    }
+  }'
+```
+
+When the port is omitted from `ldap_uri`, `636` is used with `use_ldaps` and `389` otherwise.
+
+`ssl_verify` is enabled by default. Verification requires `ssl_trusted_certificate` in `config.yaml` to point at the CA that signed the LDAP server certificate, and the host in `ldap_uri` to match the certificate. A certificate that cannot be verified fails the request with `500`.
+
+## Delete Plugin
+
+To remove the `ldap-auth-advanced` Plugin, you can delete the corresponding JSON configuration from the Plugin configuration. APISIX will automatically reload and you do not have to restart for this to take effect.
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes/ldap-auth-advanced-route" -X PATCH \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "plugins": {}
+  }'
+```

--- a/docs/zh/latest/config.json
+++ b/docs/zh/latest/config.json
@@ -126,6 +126,7 @@
             "plugins/feishu-auth",
             "plugins/authz-casbin",
             "plugins/ldap-auth",
+            "plugins/ldap-auth-advanced",
             "plugins/opa",
             "plugins/forward-auth",
             "plugins/multi-auth",

--- a/docs/zh/latest/plugins/ldap-auth-advanced.md
+++ b/docs/zh/latest/plugins/ldap-auth-advanced.md
@@ -1,0 +1,422 @@
+---
+title: ldap-auth-advanced
+keywords:
+  - Apache APISIX
+  - API 网关
+  - Plugin
+  - LDAP Authentication
+  - LDAP Groups
+  - ldap-auth-advanced
+description: ldap-auth-advanced 插件通过“先搜索后绑定”的方式在 LDAP 目录中认证用户，收集用户所属的用户组，并可基于用户组成员关系对请求进行鉴权。
+---
+
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+<head>
+  <link rel="canonical" href="https://docs.api7.ai/hub/ldap-auth-advanced" />
+</head>
+
+## 描述
+
+`ldap-auth-advanced` 插件可用于给路由或服务添加 LDAP 身份认证。与使用 Consumer 配置拼接 DN 后直接绑定的 [`ldap-auth`](./ldap-auth.md) 不同，该插件会先在目录中**搜索**用户，再以搜索到的条目进行绑定。因此无需在 APISIX 中逐个维护用户，插件还可以收集用户所属的用户组，用于鉴权以及向上游服务传递身份信息。
+
+插件在每个请求中依次执行以下操作：
+
+1. 从 `Proxy-Authorization` 请求头中读取凭证，若不可用则回退到 `Authorization`。
+2. 在 `base_dn` 子树中搜索 `attribute` 与用户名匹配的条目，并使用请求中的密码以该条目进行绑定。
+3. 收集用户所属的用户组：默认从用户条目的 `memberOf` 属性读取，也可以通过 `group_base_dn` 搜索用户组子树获得。
+4. 如果配置了 `groups_required`，则校验用户组成员关系。
+5. 关联匹配的 [Consumer](../terminology/consumer.md)，除非 `consumer_required` 设置为 `false`。
+6. 将用户组名称通过 `X-Authenticated-Groups` 请求头添加到请求中。
+
+凭证请求头使用 `header_type` 指定的认证方案关键字，其默认值为 `ldap` 而非 `basic`，即默认要求 `Authorization: ldap <base64(username:password)>`。如需使用标准的 [basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication)，请将 `header_type` 设置为 `basic`。
+
+插件会区分以下三种失败场景，因此服务端故障不会被误判为凭证错误：
+
+| 状态码 | 原因 |
+|--------|------|
+| `401` | 凭证缺失、格式错误或被拒绝；用户名匹配到多个条目；或 `consumer_required` 为 `true` 但没有匹配的 Consumer。响应中会携带 `WWW-Authenticate` 请求头。 |
+| `403` | 用户认证成功，但不满足 `groups_required`。 |
+| `500` | LDAP 服务器不可达、`bind_dn` 凭证被拒绝，或用户组搜索失败。 |
+
+该插件使用 [lua-resty-ldap](https://github.com/api7/lua-resty-ldap) 连接 LDAP 服务器。
+
+## 属性
+
+Consumer 端：
+
+| 名称 | 类型 | 必选项 | 默认值 | 有效值 | 描述 |
+|------|------|--------|--------|--------|------|
+| user_dn | string | 否 | | | 与该 Consumer 绑定的 LDAP 用户 DN，例如 `cn=Jane Doe,ou=users,dc=example,dc=org`。与 `group_dn` 互斥，两者必须且只能配置其一。该字段支持使用 [APISIX Secret](../terminology/secret.md) 资源保存在密钥管理服务中。 |
+| group_dn | string 或 array[string] | 否 | | | 用户组 DN，或用户必须**同时**属于的多个用户组 DN，例如 `cn=ops,ou=groups,dc=example,dc=org`。与 `user_dn` 互斥，两者必须且只能配置其一。该字段支持使用 [APISIX Secret](../terminology/secret.md) 资源保存在密钥管理服务中。 |
+
+Route 端：
+
+| 名称 | 类型 | 必选项 | 默认值 | 有效值 | 描述 |
+|------|------|--------|--------|--------|------|
+| ldap_uri | string | 是 | | | LDAP 服务器地址，格式为 `host` 或 `host:port`。省略端口时，启用 `use_ldaps` 使用 `636`，否则使用 `389`。 |
+| base_dn | string | 是 | | | 搜索用户的子树 DN，例如 `ou=users,dc=example,dc=org`。 |
+| attribute | string | 否 | cn | | 与请求中用户名匹配的用户属性，例如 `uid` 或 `sAMAccountName`。 |
+| bind_dn | string | 否 | | | 搜索用户前用于绑定的 DN。未配置时使用匿名绑定进行搜索。 |
+| ldap_password | string | 否 | | | `bind_dn` 对应的密码。配置 `bind_dn` 时必填。该密码在存入 etcd 前使用 AES 加密。 |
+| use_ldaps | boolean | 否 | false | | 如果为 true，则使用 LDAPS 连接。与 `use_starttls` 互斥。 |
+| use_starttls | boolean | 否 | false | | 如果为 true，则通过 StartTLS 升级明文连接。与 `use_ldaps` 互斥。 |
+| ssl_verify | boolean | 否 | true | | 如果为 true，则校验 LDAP 服务器证书。此时需要在 `config.yaml` 中配置 `ssl_trusted_certificate`，并确保 `ldap_uri` 中的主机名与服务器证书中的主机名一致。 |
+| timeout | integer | 否 | 10000 | [1, 60000] | 套接字超时时间，单位为毫秒。 |
+| keepalive | boolean | 否 | true | | 如果为 true，则将连接放回连接池复用，而不是直接关闭。 |
+| keepalive_timeout | integer | 否 | 60000 | >= 1000 | 连接池中连接的空闲超时时间，单位为毫秒。 |
+| keepalive_pool_size | integer | 否 | 5 | >= 1 | 连接池中保持的最大连接数。 |
+| keepalive_pool_name | string | 否 | | | 连接池名称。当不同配置使用不同凭证时，可通过该字段将连接隔离到不同的连接池。 |
+| size_limit | integer | 否 | 2 | >= 2 | 用户搜索返回条目数的上限。登录属性应当唯一，因此匹配到多个条目会被视为歧义并拒绝。 |
+| time_limit | integer | 否 | 5 | >= 0 | 搜索的时间限制，单位为秒。`0` 表示使用服务器默认值。 |
+| group_base_dn | string | 否 | | | 搜索用户组的子树 DN。配置后，插件会在该子树中搜索 `group_member_attribute` 包含用户 DN 的条目。未配置时，则直接从用户条目的 `user_membership_attribute` 属性读取用户组，无需额外的请求往返。 |
+| group_name_attribute | string | 否 | cn | | 作为用户组名称的用户组属性。仅可与 `group_base_dn` 一起使用。 |
+| group_member_attribute | string | 否 | member | | 记录成员 DN 的用户组属性。仅可与 `group_base_dn` 一起使用。 |
+| user_membership_attribute | string | 否 | memberOf | | 记录用户所属用户组 DN 的用户属性。在未配置 `group_base_dn` 时使用。 |
+| groups_required | array[array[string]] | 否 | | | 用户必须满足的用户组条件。外层数组为逻辑“或”，每个内层数组为逻辑“与”。例如 `[["a","b"],["c"]]` 允许同时属于 `a` 与 `b` 的用户，也允许属于 `c` 的用户。名称按大小写敏感的方式精确匹配。 |
+| consumer_required | boolean | 否 | true | | 如果为 true，当没有 Consumer 与认证用户匹配时，返回 `401` 拒绝请求。 |
+| header_type | string | 否 | ldap | ["ldap", "basic"] | 凭证请求头中期望的认证方案关键字。 |
+| realm | string | 否 | ldap | | 认证失败返回 `401 Unauthorized` 时，[`WWW-Authenticate`](https://datatracker.ietf.org/doc/html/rfc7235#section-4.1) 响应头中的 realm 值。 |
+| set_groups_header | boolean | 否 | true | | 如果为 true，则将收集到的用户组名称以逗号分隔添加到请求的 `X-Authenticated-Groups` 请求头中。无论插件是否设置该请求头，客户端传入的该请求头都会被移除。 |
+
+## 示例
+
+以下示例假设 LDAP 目录位于 `dc=example,dc=org` 下，其中用户 `Jane Doe` 的 `uid` 为 `jdoe`、密码为 `janesecret`，属于 `Domain Admins` 与 `ops` 用户组；用户 `user01` 的密码为 `password1`，属于 `Domain Admins` 与 `developers` 用户组。
+
+:::note
+
+您可以通过以下命令从 `config.yaml` 中获取 `admin_key`，并将其保存到环境变量中：
+
+```bash
+admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
+```
+
+:::
+
+### 使用 LDAP 目录进行身份认证
+
+以下示例展示了最小配置：在 `base_dn` 中搜索 `uid` 匹配的用户，然后以该用户进行绑定。
+
+创建路由并启用 `ldap-auth-advanced` 插件：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "ldap-auth-advanced-route",
+    "uri": "/anything",
+    "plugins": {
+      "ldap-auth-advanced": {
+        "ldap_uri": "127.0.0.1:1389",
+        "base_dn": "ou=users,dc=example,dc=org",
+        "attribute": "uid",
+        "consumer_required": false
+      }
+    },
+    "upstream": {
+      "type": "roundrobin",
+      "nodes": {
+        "httpbin.org:80": 1
+      }
+    }
+  }'
+```
+
+使用正确的凭证发送请求：
+
+```shell
+curl -i "http://127.0.0.1:9080/anything" \
+  -H "Authorization: ldap $(echo -n 'jdoe:janesecret' | base64)"
+```
+
+您将会收到 `HTTP/1.1 200 OK` 响应。
+
+不携带凭证发送请求：
+
+```shell
+curl -i "http://127.0.0.1:9080/anything"
+```
+
+您将会收到 `HTTP/1.1 401 Unauthorized` 响应，响应体如下：
+
+```text
+{"message":"Authorization required"}
+```
+
+响应中同时会携带由 `realm` 生成的认证质询：
+
+```text
+WWW-Authenticate: ldap realm="ldap"
+```
+
+密码错误的请求也会以同样的方式被拒绝。
+
+如果目录不允许匿名搜索，可以添加 `bind_dn` 与 `ldap_password` 使用服务账号进行绑定。用户本身仍然通过自己的绑定完成认证：
+
+```json
+{
+  "ldap-auth-advanced": {
+    "ldap_uri": "127.0.0.1:1389",
+    "base_dn": "ou=users,dc=example,dc=org",
+    "attribute": "uid",
+    "bind_dn": "cn=admin,dc=example,dc=org",
+    "ldap_password": "adminpassword",
+    "consumer_required": false
+  }
+}
+```
+
+如需使用标准的 basic authentication 而非 `ldap` 方案，请将 `header_type` 设置为 `basic`，此后客户端即可使用 `curl -u jdoe:janesecret` 发送请求。
+
+### 将 LDAP 用户组传递给上游服务
+
+插件默认从用户条目的 `memberOf` 属性读取用户组，并通过 `X-Authenticated-Groups` 请求头转发给上游服务，使上游服务无需查询目录即可实现自己的鉴权逻辑。
+
+使用上一个示例中的路由发送认证请求：
+
+```shell
+curl "http://127.0.0.1:9080/anything" \
+  -H "Authorization: ldap $(echo -n 'jdoe:janesecret' | base64)"
+```
+
+您将在响应中看到该请求头：
+
+```json
+{
+  "headers": {
+    "Authorization": "ldap amRvZTpqYW5lc2VjcmV0",
+    "X-Authenticated-Groups": "Domain Admins,ops",
+    ...
+  },
+  ...
+}
+```
+
+将 `set_groups_header` 设置为 `false` 可以不添加该请求头。
+
+对于不维护 `memberOf` 属性的目录，成员关系记录在用户组条目上。此时可以配置 `group_base_dn`，在该子树中搜索包含该用户的用户组：
+
+```json
+{
+  "ldap-auth-advanced": {
+    "ldap_uri": "127.0.0.1:1389",
+    "base_dn": "ou=users,dc=example,dc=org",
+    "attribute": "uid",
+    "group_base_dn": "ou=groups,dc=example,dc=org",
+    "group_member_attribute": "member",
+    "group_name_attribute": "cn",
+    "consumer_required": false
+  }
+}
+```
+
+两种方式得到的用户组名称相同，但名称的顺序不作保证。
+
+### 基于 LDAP 用户组限制访问
+
+配置 `groups_required` 后，只有满足指定用户组组合的用户才能访问。外层数组为逻辑“或”，每个内层数组为逻辑“与”。
+
+更新路由，允许同时属于 `Domain Admins` 与 `ops` 的用户，以及属于 `superadmin` 的用户访问：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "ldap-auth-advanced-route",
+    "uri": "/anything",
+    "plugins": {
+      "ldap-auth-advanced": {
+        "ldap_uri": "127.0.0.1:1389",
+        "base_dn": "ou=users,dc=example,dc=org",
+        "attribute": "uid",
+        "groups_required": [["Domain Admins", "ops"], ["superadmin"]],
+        "consumer_required": false
+      }
+    },
+    "upstream": {
+      "type": "roundrobin",
+      "nodes": {
+        "httpbin.org:80": 1
+      }
+    }
+  }'
+```
+
+`jdoe` 同时属于第一个条件中的两个用户组：
+
+```shell
+curl -i "http://127.0.0.1:9080/anything" \
+  -H "Authorization: ldap $(echo -n 'jdoe:janesecret' | base64)"
+```
+
+您将会收到 `HTTP/1.1 200 OK` 响应。
+
+`user01` 可以通过认证，但其属于 `developers` 而非 `ops`，两个条件均不满足：
+
+```shell
+curl -i "http://127.0.0.1:9080/anything" \
+  -H "Authorization: ldap $(echo -n 'user01:password1' | base64)"
+```
+
+您将会收到 `HTTP/1.1 403 Forbidden` 响应，响应体如下：
+
+```text
+{"message":"Forbidden"}
+```
+
+### 将 LDAP 身份映射到 Consumer
+
+将 LDAP 身份与 Consumer 关联后，APISIX 可以应用针对该 Consumer 的配置（例如限流），并在转发给上游的请求中添加 `X-Consumer-Username` 请求头。Consumer 既可以通过 `user_dn` 绑定到单个用户，也可以通过 `group_dn` 绑定到某个用户组。
+
+创建绑定到单个用户的 Consumer：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "username": "jane",
+    "plugins": {
+      "ldap-auth-advanced": {
+        "user_dn": "cn=Jane Doe,ou=users,dc=example,dc=org"
+      }
+    }
+  }'
+```
+
+创建绑定到某个用户组全体成员的 Consumer：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/consumers" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "username": "opsteam",
+    "plugins": {
+      "ldap-auth-advanced": {
+        "group_dn": "cn=ops,ou=groups,dc=example,dc=org"
+      }
+    }
+  }'
+```
+
+更新路由，移除 `consumer_required` 使其恢复默认值 `true`，从而要求匹配 Consumer：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "ldap-auth-advanced-route",
+    "uri": "/anything",
+    "plugins": {
+      "ldap-auth-advanced": {
+        "ldap_uri": "127.0.0.1:1389",
+        "base_dn": "ou=users,dc=example,dc=org",
+        "attribute": "uid"
+      }
+    },
+    "upstream": {
+      "type": "roundrobin",
+      "nodes": {
+        "httpbin.org:80": 1
+      }
+    }
+  }'
+```
+
+以 `jdoe` 发送请求：
+
+```shell
+curl "http://127.0.0.1:9080/anything" \
+  -H "Authorization: ldap $(echo -n 'jdoe:janesecret' | base64)"
+```
+
+您将在转发给上游的请求中看到 Consumer 信息：
+
+```json
+{
+  "headers": {
+    "X-Consumer-Username": "jane",
+    "X-Authenticated-Groups": "Domain Admins,ops",
+    ...
+  },
+  ...
+}
+```
+
+`jdoe` 同时也属于 `ops`，但 `user_dn` 绑定更精确，始终优先生效；`ops` 的其他成员则会匹配到 `opsteam`。未匹配到任何 Consumer 的用户会被返回 `401`，除非将 `consumer_required` 设置为 `false`。
+
+如需要求用户同时属于多个用户组，可以将 `group_dn` 配置为数组，此时用户必须属于其中的每一个 DN：
+
+```json
+{
+  "ldap-auth-advanced": {
+    "group_dn": [
+      "cn=Domain Admins,ou=groups,dc=example,dc=org",
+      "cn=ops,ou=groups,dc=example,dc=org"
+    ]
+  }
+}
+```
+
+当有多个 `group_dn` Consumer 同时满足条件时，插件会做出确定性的选择，并记录警告日志列出所有候选 Consumer。建议在配置时避免用户组 Consumer 之间出现重叠。
+
+### 通过 LDAPS 连接
+
+配置 `use_ldaps` 可以使用 LDAPS 连接，配置 `use_starttls` 则可以通过 StartTLS 升级明文连接。两者互斥，同时启用时配置会被拒绝。
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes" -X PUT \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "id": "ldap-auth-advanced-route",
+    "uri": "/anything",
+    "plugins": {
+      "ldap-auth-advanced": {
+        "ldap_uri": "ldap.example.org",
+        "use_ldaps": true,
+        "ssl_verify": true,
+        "base_dn": "ou=users,dc=example,dc=org",
+        "attribute": "uid",
+        "consumer_required": false
+      }
+    },
+    "upstream": {
+      "type": "roundrobin",
+      "nodes": {
+        "httpbin.org:80": 1
+      }
+    }
+  }'
+```
+
+`ldap_uri` 省略端口时，启用 `use_ldaps` 使用 `636`，否则使用 `389`。
+
+`ssl_verify` 默认开启。此时需要在 `config.yaml` 中通过 `ssl_trusted_certificate` 配置签发 LDAP 服务器证书的 CA 证书，并确保 `ldap_uri` 中的主机名与证书一致。证书校验失败的请求会返回 `500`。
+
+## 删除插件
+
+当您需要禁用 `ldap-auth-advanced` 插件时，可以将对应的 JSON 配置从插件配置中删除，APISIX 将会自动重新加载，无需重启服务：
+
+```shell
+curl "http://127.0.0.1:9180/apisix/admin/routes/ldap-auth-advanced-route" -X PATCH \
+  -H "X-API-KEY: ${admin_key}" \
+  -d '{
+    "plugins": {}
+  }'
+```

--- a/t/plugin/ldap-auth-advanced.t
+++ b/t/plugin/ldap-auth-advanced.t
@@ -1239,6 +1239,7 @@ X-Authenticated-Groups: spoofed-groups
 uri: /uri
 authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
 host: localhost
+x-authenticated-groups: Domain Admins,developers
 x-real-ip: 127.0.0.1
 
 

--- a/t/plugin/ldap-auth-advanced2.t
+++ b/t/plugin/ldap-auth-advanced2.t
@@ -1,0 +1,1154 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!$block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests();
+
+
+__DATA__
+
+=== TEST 1: group schema fields default correctly (cn / member / memberOf)
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local conf = {
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                group_base_dn = "ou=groups,dc=example,dc=org",
+            }
+            local ok, err = plugin.check_schema(conf)
+            if not ok then
+                ngx.say(err)
+                return
+            end
+            ngx.say(conf.group_name_attribute, " ",
+                    conf.group_member_attribute, " ",
+                    conf.user_membership_attribute, " ",
+                    tostring(conf.set_groups_header))
+        }
+    }
+--- response_body
+cn member memberOf true
+
+
+
+=== TEST 2: group_name_attribute with a space is rejected
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                group_base_dn = "ou=groups,dc=example,dc=org",
+                group_name_attribute = "a b",
+            })
+            ngx.say(ok and "passed" or "rejected")
+        }
+    }
+--- response_body
+rejected
+
+
+
+=== TEST 3: group_member_attribute with a space is rejected
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                group_base_dn = "ou=groups,dc=example,dc=org",
+                group_member_attribute = "a b",
+            })
+            ngx.say(ok and "passed" or "rejected")
+        }
+    }
+--- response_body
+rejected
+
+
+
+=== TEST 4: user_membership_attribute with a space is rejected
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                user_membership_attribute = "has space",
+            })
+            ngx.say(ok and "passed" or "rejected")
+        }
+    }
+--- response_body
+rejected
+
+
+
+=== TEST 5: group_name_attribute without group_base_dn is rejected
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                group_name_attribute = "displayName",
+            })
+            ngx.say(ok and "passed" or err)
+        }
+    }
+--- response_body_like eval
+qr/only used with group_base_dn/
+
+
+
+=== TEST 6: group_member_attribute without group_base_dn is rejected
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                group_member_attribute = "uniqueMember",
+            })
+            ngx.say(ok and "passed" or err)
+        }
+    }
+--- response_body_like eval
+qr/only used with group_base_dn/
+
+
+
+=== TEST 7: groups_required with valid OR-of-AND groups passes
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                groups_required = {{"Domain Admins", "ops"}, {"superadmin"}},
+            })
+            ngx.say(ok and "passed" or "rejected")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 8: groups_required that is not an array is rejected
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                groups_required = "Domain Admins",
+            })
+            ngx.say(ok and "passed" or "rejected")
+        }
+    }
+--- response_body
+rejected
+
+
+
+=== TEST 9: groups_required with an empty inner array is rejected
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                groups_required = {{}},
+            })
+            ngx.say(ok and "passed" or "rejected")
+        }
+    }
+--- response_body
+rejected
+
+
+
+=== TEST 10: groups_required with a non-string group name is rejected
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema({
+                ldap_uri = "127.0.0.1:1389",
+                base_dn = "ou=users,dc=example,dc=org",
+                groups_required = {{"ok"}, {123}},
+            })
+            ngx.say(ok and "passed" or "rejected")
+        }
+    }
+--- response_body
+rejected
+
+
+
+=== TEST 11: consumer schema accepts a string group_dn
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema(
+                { group_dn = "cn=Domain Admins,ou=groups,dc=example,dc=org" },
+                core.schema.TYPE_CONSUMER)
+            ngx.say(ok and "passed" or err)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 12: consumer schema accepts an array of group_dn
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema(
+                { group_dn = {"cn=developers,ou=groups,dc=example,dc=org",
+                               "cn=ops,ou=groups,dc=example,dc=org"} },
+                core.schema.TYPE_CONSUMER)
+            ngx.say(ok and "passed" or err)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 13: consumer schema rejects an empty group_dn array
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema(
+                { group_dn = {} },
+                core.schema.TYPE_CONSUMER)
+            ngx.say(ok and "passed" or err)
+        }
+    }
+--- response_body_like eval
+qr/value should match only one schema, but matches none/
+
+
+
+=== TEST 14: consumer schema rejects duplicate group_dn entries
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema(
+                { group_dn = {"cn=a,dc=x", "cn=a,dc=x"} },
+                core.schema.TYPE_CONSUMER)
+            ngx.say(ok and "passed" or err)
+        }
+    }
+--- response_body_like eval
+qr/value should match only one schema, but matches none/
+
+
+
+=== TEST 15: consumer schema rejects an empty string group_dn
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema(
+                { group_dn = "" },
+                core.schema.TYPE_CONSUMER)
+            ngx.say(ok and "passed" or err)
+        }
+    }
+--- response_body_like eval
+qr/validation failed/
+
+
+
+=== TEST 16: consumer schema rejects both user_dn and group_dn together
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema(
+                { user_dn = "cn=user01,ou=users,dc=example,dc=org",
+                  group_dn = "cn=ops,ou=groups,dc=example,dc=org" },
+                core.schema.TYPE_CONSUMER)
+            ngx.say(ok and "passed" or err)
+        }
+    }
+--- response_body_like eval
+qr/value should match only one schema, but matches both schemas 1 and 2/
+
+
+
+=== TEST 17: consumer schema rejects neither user_dn nor group_dn
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local plugin = require("apisix.plugins.ldap-auth-advanced")
+            local ok, err = plugin.check_schema(
+                { },
+                core.schema.TYPE_CONSUMER)
+            ngx.say(ok and "passed" or err)
+        }
+    }
+--- response_body_like eval
+qr/value should match only one schema, but matches none/
+
+
+
+=== TEST 18: set up route 1 for the SEARCH-path collection tests
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "group_base_dn": "ou=groups,dc=example,dc=org",
+                    "bind_dn": "cn=admin,dc=example,dc=org",
+                    "ldap_password": "adminpassword",
+                    "consumer_required": false
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/uri"
+            }]])
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 19: user01 via the SEARCH path collects Domain Admins + developers (creds: user01:password1)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-groups: (?=[^\n]*Domain Admins)(?=[^\n]*developers)/
+
+
+
+=== TEST 20: jdoe via the SEARCH path collects Domain Admins + ops (creds: jdoe:janesecret)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap amRvZTpqYW5lc2VjcmV0
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-groups: (?=[^\n]*Domain Admins)(?=[^\n]*ops)/
+
+
+
+=== TEST 21: user02 via the SEARCH path collects only superadmin (creds: user02:password2)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAyOnBhc3N3b3JkMg==
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-groups: superadmin\n/
+
+
+
+=== TEST 22: multiuser via the SEARCH path collects Domain Admins + developers + ops (creds: multiuser:multipass)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap bXVsdGl1c2VyOm11bHRpcGFzcw==
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-groups: (?=[^\n]*Domain Admins)(?=[^\n]*developers)(?=[^\n]*ops)/
+
+
+
+=== TEST 23: salesuser via the SEARCH path collects the comma-named group unescaped (creds: salesuser:salespass)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap c2FsZXN1c2VyOnNhbGVzcGFzcw==
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-groups: Sales, EMEA\n/
+
+
+
+=== TEST 24: set up route 1 for the MEMBEROF-path collection tests
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "consumer_required": false
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/uri"
+            }]])
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 25: user01 via the MEMBEROF path collects Domain Admins + developers (creds: user01:password1)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-groups: (?=[^\n]*Domain Admins)(?=[^\n]*developers)/
+
+
+
+=== TEST 26: jdoe via the MEMBEROF path collects Domain Admins + ops (creds: jdoe:janesecret)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap amRvZTpqYW5lc2VjcmV0
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-groups: (?=[^\n]*Domain Admins)(?=[^\n]*ops)/
+
+
+
+=== TEST 27: user02 via the MEMBEROF path collects only superadmin (creds: user02:password2)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAyOnBhc3N3b3JkMg==
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-groups: superadmin\n/
+
+
+
+=== TEST 28: multiuser via the MEMBEROF path collects Domain Admins + developers + ops (creds: multiuser:multipass)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap bXVsdGl1c2VyOm11bHRpcGFzcw==
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-groups: (?=[^\n]*Domain Admins)(?=[^\n]*developers)(?=[^\n]*ops)/
+
+
+
+=== TEST 29: salesuser via the MEMBEROF path collects the comma-named group unescaped (creds: salesuser:salespass; unescaped first-RDN parity between paths)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap c2FsZXN1c2VyOnNhbGVzcGFzcw==
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-groups: Sales, EMEA\n/
+
+
+
+=== TEST 30: wrong password is rejected before any group collection (creds: user01:wrong)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAxOndyb25n
+--- error_code: 401
+--- response_body_unlike eval
+qr/x-authenticated-groups/
+
+
+
+=== TEST 31: set up route 1 for the SEARCH path with anonymous re-bind
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "group_base_dn": "ou=groups,dc=example,dc=org",
+                    "consumer_required": false
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/uri"
+            }]])
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 32: user01 via the SEARCH path with anonymous re-bind still collects groups (creds: user01:password1)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-groups: (?=[^\n]*Domain Admins)(?=[^\n]*developers)/
+
+
+
+=== TEST 33: set up route 1 for the service-bind MEMBEROF path
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "bind_dn": "cn=admin,dc=example,dc=org",
+                    "ldap_password": "adminpassword",
+                    "consumer_required": false
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/uri"
+            }]])
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 34: zero-group user -> no groups header; forged inbound value stripped (creds: secretuser:secretpass)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap c2VjcmV0dXNlcjpzZWNyZXRwYXNz
+X-Authenticated-Groups: forged-group
+--- error_code: 200
+--- response_body_unlike eval
+qr/x-authenticated-groups/
+
+
+
+=== TEST 35: set up the group-search-failure route (bad group_base_dn)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "group_base_dn": "ou=nowhere,dc=example,dc=org",
+                    "bind_dn": "cn=admin,dc=example,dc=org",
+                    "ldap_password": "adminpassword",
+                    "consumer_required": false
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/uri"
+            }]])
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 36: authenticated user, failing group search -> 500, never 401 (creds: user01:password1)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 500
+--- error_log
+LDAP group search failed
+
+
+
+=== TEST 37: set up the set_groups_header=false route (memberOf path)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "consumer_required": false,
+                    "set_groups_header": false
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/uri"
+            }]])
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 38: set_groups_header=false hides the header though user01 has groups (creds: user01:password1)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 200
+--- response_body_unlike eval
+qr/x-authenticated-groups/
+
+
+
+=== TEST 39: set up the groups_required route (memberOf path)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [=[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "consumer_required": false,
+                    "groups_required": [["Domain Admins", "ops"], ["superadmin"]]
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/uri"
+            }]=])
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 40: jdoe satisfies the inner AND [Domain Admins, ops] (creds: jdoe:janesecret)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap amRvZTpqYW5lc2VjcmV0
+--- error_code: 200
+--- response_body_like eval
+qr/x-authenticated-groups:/
+
+
+
+=== TEST 41: user01 (Domain Admins+developers) satisfies neither alternative (creds: user01:password1)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 403
+--- response_body_like eval
+qr/Forbidden/
+--- error_log
+groups_required not satisfied
+
+
+
+=== TEST 42: user02 satisfies the OR alternate [superadmin] (creds: user02:password2)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAyOnBhc3N3b3JkMg==
+--- error_code: 200
+
+
+
+=== TEST 43: wrong password on the authz route is 401, not 403 (creds: user01:wrong)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAxOndyb25n
+--- error_code: 401
+--- response_body_like eval
+qr/Authorization required/
+
+
+
+=== TEST 44: replace route 1's groups_required with a lowercase name (memberOf path)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [=[{
+                "plugins": { "ldap-auth-advanced": {
+                    "ldap_uri": "127.0.0.1:1389",
+                    "base_dn": "ou=users,dc=example,dc=org",
+                    "attribute": "uid",
+                    "consumer_required": false,
+                    "groups_required": [["domain admins"]]
+                } },
+                "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                "uri": "/uri"
+            }]=])
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 45: case-mismatched group name does not match (verbatim matching, creds: user01:password1)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 403
+
+
+
+=== TEST 46: create the group-associated Consumers
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local t = require("lib.test_admin").test
+            local consumers = {
+                { username = "ldapg2user01",
+                  conf = { user_dn = "cn=user01,ou=users,dc=example,dc=org" } },
+                { username = "ldapgadmins",
+                  conf = { group_dn = "cn=Domain Admins,ou=groups,dc=example,dc=org" } },
+                { username = "ldapgdevs",
+                  conf = { group_dn = { "cn=developers,ou=groups,dc=example,dc=org" } } },
+                { username = "ldapgdevops",
+                  conf = { group_dn = { "cn=developers,ou=groups,dc=example,dc=org",
+                                        "cn=ops,ou=groups,dc=example,dc=org" } } },
+                { username = "ldapgsuper",
+                  conf = { group_dn = "cn=superadmin,ou=groups,dc=example,dc=org" } },
+            }
+            for _, c in ipairs(consumers) do
+                local code, body = t('/apisix/admin/consumers',
+                    ngx.HTTP_PUT,
+                    core.json.encode({
+                        username = c.username,
+                        plugins = { ["ldap-auth-advanced"] = c.conf },
+                    }))
+                if code >= 300 then
+                    ngx.status = code
+                    ngx.say(body)
+                    return
+                end
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 47: create the group-matching route
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "ldap-auth-advanced": {
+                            "ldap_uri": "127.0.0.1:1389",
+                            "base_dn": "ou=users,dc=example,dc=org",
+                            "attribute": "uid"
+                        }
+                    },
+                    "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                    "uri": "/uri"
+                }]])
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 48: user_dn precedence over group_dn consumers (creds: user01:password1)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAxOnBhc3N3b3JkMQ==
+--- error_code: 200
+--- response_body_like eval
+qr/x-consumer-username: ldapg2user01\n/
+
+
+
+=== TEST 49: single eligible group consumer, array must match ALL (creds: jdoe:janesecret)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap amRvZTpqYW5lc2VjcmV0
+--- error_code: 200
+--- response_body_like eval
+qr/x-consumer-username: ldapgadmins\n/
+--- no_error_log
+multiple consumers matched
+
+
+
+=== TEST 50: string-form group_dn works (creds: user02:password2)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap dXNlcjAyOnBhc3N3b3JkMg==
+--- error_code: 200
+--- response_body_like eval
+qr/x-consumer-username: ldapgsuper\n/
+
+
+
+=== TEST 51: deterministic pick under multiple matches (creds: multiuser:multipass)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap bXVsdGl1c2VyOm11bHRpcGFzcw==
+--- error_code: 200
+--- response_body_like eval
+qr/x-consumer-username: ldapgadmins\n/
+--- error_log
+multiple consumers matched
+
+
+
+=== TEST 52: delete consumer ldapgadmins
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers/ldapgadmins', ngx.HTTP_DELETE)
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 53: specificity tie-break, the 2-group consumer wins (creds: multiuser:multipass)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap bXVsdGl1c2VyOm11bHRpcGFzcw==
+--- error_code: 200
+--- response_body_like eval
+qr/x-consumer-username: ldapgdevops\n/
+--- error_log
+multiple consumers matched
+
+
+
+=== TEST 54: delete ldapgdevops, ldapgdevs, ldapgsuper
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local names = { "ldapgdevops", "ldapgdevs", "ldapgsuper" }
+            for _, name in ipairs(names) do
+                local code, body = t('/apisix/admin/consumers/' .. name, ngx.HTTP_DELETE)
+                if code >= 300 then
+                    ngx.status = code
+                    ngx.say(body)
+                    return
+                end
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 55: no eligible consumer, consumer_required=true -> 401 (creds: multiuser:multipass)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap bXVsdGl1c2VyOm11bHRpcGFzcw==
+--- error_code: 401
+--- error_log
+no Consumer maps to the authenticated user_dn
+
+
+
+=== TEST 56: set up route 1 with consumer_required=false
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "ldap-auth-advanced": {
+                            "ldap_uri": "127.0.0.1:1389",
+                            "base_dn": "ou=users,dc=example,dc=org",
+                            "attribute": "uid",
+                            "consumer_required": false
+                        }
+                    },
+                    "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                    "uri": "/uri"
+                }]])
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 57: consumer_required=false skips matching entirely (creds: multiuser:multipass)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap bXVsdGl1c2VyOm11bHRpcGFzcw==
+--- error_code: 200
+--- response_body_unlike eval
+qr/x-consumer-username/
+
+
+
+=== TEST 58: create consumer ldapgsecret with an unresolved group_dn secret ref
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                core.json.encode({
+                    username = "ldapgsecret",
+                    plugins = { ["ldap-auth-advanced"] = {
+                        group_dn = "$ENV://ADV_LDAP_GROUP_DN_UNSET",
+                    } },
+                }))
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 59: restore route 1 to consumer_required default (memberOf path)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "ldap-auth-advanced": {
+                            "ldap_uri": "127.0.0.1:1389",
+                            "base_dn": "ou=users,dc=example,dc=org",
+                            "attribute": "uid"
+                        }
+                    },
+                    "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                    "uri": "/uri"
+                }]])
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 60: secret-ref fail-closed skips the consumer (creds: multiuser:multipass)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap bXVsdGl1c2VyOm11bHRpcGFzcw==
+--- error_code: 401
+--- error_log
+skipping consumer: ldapgsecret
+
+
+
+=== TEST 61: restore ldapgadmins and create the 403-precedence route
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                core.json.encode({
+                    username = "ldapgadmins",
+                    plugins = { ["ldap-auth-advanced"] = {
+                        group_dn = "cn=Domain Admins,ou=groups,dc=example,dc=org",
+                    } },
+                }))
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [=[{
+                    "plugins": {
+                        "ldap-auth-advanced": {
+                            "ldap_uri": "127.0.0.1:1389",
+                            "base_dn": "ou=users,dc=example,dc=org",
+                            "attribute": "uid",
+                            "groups_required": [["no-such-group"]]
+                        }
+                    },
+                    "upstream": { "nodes": { "127.0.0.1:1980": 1 }, "type": "roundrobin" },
+                    "uri": "/uri"
+                }]=])
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 62: 403 from groups_required beats consumer matching (creds: multiuser:multipass)
+--- request
+GET /uri
+--- more_headers
+Authorization: ldap bXVsdGl1c2VyOm11bHRpcGFzcw==
+--- error_code: 403
+--- response_body_like eval
+qr/Forbidden/
+--- response_body_unlike eval
+qr/x-consumer-username/


### PR DESCRIPTION
### Description

Part 2 of 3 for the `ldap-auth-advanced` plugin (part 1: #13762). Adds group support:

- Collect the authenticated user's groups, either from the `memberOf` attribute on the user entry (default, no extra round trip) or by searching `group_base_dn` as the service identity (never as the end user; `sizeLimit 0` so groups are never truncated).
- `groups_required` authorization: outer OR of inner ANDs over group names, matched verbatim; an authenticated user failing it gets `403`, kept distinct from every `401` path.
- Export collected group names to the upstream in `X-Authenticated-Groups` (toggle `set_groups_header`, default `true`; the inbound header is always stripped).
- Consumers can now bind to a group instead of a user: `group_dn` (string, or array that must ALL contain the user), mutually exclusive with `user_dn`. An exact `user_dn` match always wins; among group matches the plugin picks deterministically (alphabetical group-DN order, more-specific array first) and logs a warning naming all candidates when more than one matches.

Two implementation notes for reviewers: the plugin resolves Consumers through a plugin-local index cached per consumer config version instead of `consumer_mod.find_consumer`, because the shared cache error-logs every consumer missing the lookup key, which would spam logs for legitimate group-only consumers (observable behavior, including the 401 messages, is unchanged). Separately, writing a `user_dn` consumer while `group_dn` consumers exist triggers the core write-time duplicate check to error-log "missing consumer auth credential" for the valid group consumers; cosmetic only, and fixing it means touching core beyond this PR's scope.

One existing test expectation was updated (`t/plugin/ldap-auth-advanced.t` TEST 52, one line): with `set_groups_header` defaulting `true`, the echoed headers now legitimately include the collected groups; the spoofed-inbound-value assertion is unchanged.

#### Which issue(s) this PR fixes:

Related: #8958

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (new success-path `X-Authenticated-Groups` header is additive; existing consumer `user_dn` configs are unchanged)
