### PR TITLE
fix(ai-proxy-multi): keep the client request body intact across fallback retries

### DIFF
--- a/apisix/plugins/ai-proxy/base.lua
+++ b/apisix/plugins/ai-proxy/base.lua
@@ -187,6 +187,8 @@ function _M.before_proxy(conf, ctx, on_error)
             return 400, err
         end
 
+        request_body = core.table.deepcopy(request_body)
+
         local extra_opts = {
             name = ai_instance.name,
             endpoint = ai_instance._resolved_endpoint
@@ -242,10 +244,6 @@ function _M.before_proxy(conf, ctx, on_error)
 
         -- Step 2: Extract model from request
         local request_model = request_body.model
-
-        if request_model then
-            ctx.var.request_llm_model = request_model
-        end
         local model = ai_instance.options and ai_instance.options.model or request_model
         if model then
             ctx.var.llm_model = model

--- a/t/plugin/ai-proxy-multi-retry.t
+++ b/t/plugin/ai-proxy-multi-retry.t
@@ -34,6 +34,7 @@ add_block_preprocessor(sub {
 plugins:
   - ai-proxy-multi
   - prometheus
+  - serverless-post-function
 _EOC_
     $block->set_value("extra_yaml_config", $user_yaml_config);
 
@@ -72,6 +73,33 @@ _EOC_
                 ngx.status = 200
                 ngx.print("success")
                 return
+              }
+            }
+        }
+        # Upstream that echoes the request body it receives inside a well-formed
+        # chat completion so the test can assert exactly what was forwarded to
+        # the fallback instance.
+        server {
+            server_name echo_instance;
+            default_type 'application/json';
+            listen 6734;
+            location / {
+              content_by_lua_block {
+                local json = require("cjson.safe")
+                ngx.req.read_body()
+                local raw = ngx.req.get_body_data() or ""
+                ngx.status = 200
+                ngx.say(json.encode({
+                    id = "chatcmpl-echo",
+                    object = "chat.completion",
+                    model = "echo",
+                    choices = {{
+                        index = 0,
+                        message = { role = "assistant", content = raw },
+                        finish_reason = "stop",
+                    }},
+                    usage = { prompt_tokens = 1, completion_tokens = 1, total_tokens = 2 },
+                }))
               }
             }
         }
@@ -217,3 +245,65 @@ POST /anything
 --- response_body_like: slow internal error
 --- error_log
 exceeding retry_on_failure_within_ms 200
+
+
+
+=== TEST 7: fallback preserves the client body: set up asymmetric instances
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "uri": "/anything",
+                    "plugins": {
+                        "ai-proxy-multi": {
+                            "fallback_strategy": ["http_5xx"],
+                            "instances": [
+                                {"name":"err-a","provider":"openai-compatible","weight":1,"priority":10,"auth":{"header":{"Authorization":"Bearer token"}},"options":{"model":"upstream-model-A","temperature":0.9},"override":{"endpoint":"http://127.0.0.1:6731"}},
+                                {"name":"echo-b","provider":"openai-compatible","weight":1,"priority":0,"auth":{"header":{"Authorization":"Bearer token"}},"options":{"model":"upstream-model-B"},"override":{"endpoint":"http://127.0.0.1:6734"}}
+                            ],
+                            "ssl_verify": false
+                        },
+                        "serverless-post-function": {
+                            "phase": "log",
+                            "functions": ["return function(conf, ctx) ngx.log(ngx.WARN, \"FALLBACKVARS request_llm_model=\", tostring(ctx.var.request_llm_model), \" llm_model=\", tostring(ctx.var.llm_model)) end"]
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 8: retry keeps the original model in vars and does not leak instance A options into instance B
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require("resty.http").new()
+            local cjson = require("cjson.safe")
+            local res = assert(http:request_uri(
+                "http://127.0.0.1:" .. ngx.var.server_port .. "/anything", {
+                method = "POST",
+                body = '{ "model": "client-model", "messages": [ { "role": "user", "content": "What is 1+1?"} ] }',
+                headers = { ["Content-Type"] = "application/json" },
+            }))
+            local completion = cjson.decode(res.body)
+            local forwarded = cjson.decode(completion.choices[1].message.content)
+            ngx.say("model=", forwarded.model)
+            ngx.say(forwarded.temperature == nil and "no temperature leak" or "temperature leaked")
+        }
+    }
+--- response_body
+model=upstream-model-B
+no temperature leak
+--- error_log
+FALLBACKVARS request_llm_model=client-model llm_model=upstream-model-B


### PR DESCRIPTION
### Description

The retry loop in `before_proxy` re-reads the parsed request body from the per-request cache (`ctx._request_body_table`), but `build_request` rewrites that shared table in place with per-instance options. A fallback attempt therefore starts from the previous instance's rewritten body: `$request_llm_model` is clobbered with the first instance's model, and the first instance's options (e.g. `temperature`) leak into the retry request sent to the fallback instance.

This PR deep-copies the parsed body at the start of every attempt so each instance builds its request from the client's original body, and drops the redundant `request_llm_model` re-assignment in `before_proxy` (`detect_request_type` already captures it from the client body in the access phase, for both `ai-proxy` and `ai-proxy-multi`).

The copy is O(body) and cheaper than the JSON decode of the same body already performed in the access phase. Keeping the shared cache pristine also fixes log-phase `post_arg.*` variable reads and the semantic balancer's re-pick on retry, both of which previously saw the instance-rewritten body instead of the client's request.

#### Which issue(s) this PR fixes:
Fixes #13769

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)