### PR TITLE
fix(core): use CSPRNG for admin key auto-generation

### DIFF
--- a/apisix/core/id.lua
+++ b/apisix/core/id.lua
@@ -25,12 +25,12 @@ local profile          = require("apisix.core.profile")
 local log              = require("apisix.core.log")
 local uuid             = require("resty.jit-uuid")
 local lyaml            = require("lyaml")
+local resty_random     = require("resty.random")
+local resty_str        = require("resty.string")
 local smatch           = string.match
 local open             = io.open
 local type             = type
 local ipairs           = ipairs
-local string           = string
-local math             = math
 local prefix           = ngx.config.prefix()
 local pairs            = pairs
 local ngx_exit         = ngx.exit
@@ -105,11 +105,11 @@ local function autogenerate_admin_key(default_conf)
             for i, admin_key in ipairs(admin_keys) do
                 if admin_key.role == "admin" and admin_key.key == "" then
                     changed = true
-                    admin_keys[i].key = ""
-                    for _ = 1, 32 do
-                        admin_keys[i].key = admin_keys[i].key ..
-                        string.char(math.random(65, 90) + math.random(0, 1) * 32)
+                    local random_bytes = resty_random.bytes(16, true)
+                    if not random_bytes then
+                        random_bytes = resty_random.bytes(16)
                     end
+                    admin_keys[i].key = resty_str.to_hex(random_bytes)
                 end
             end
         end

--- a/t/cli/test_admin.sh
+++ b/t/cli/test_admin.sh
@@ -270,6 +270,33 @@ fi
 
 echo "pass: show WARNING message if the user uses empty key"
 
+# auto-generate admin key with CSPRNG when the key is an empty string
+
+git checkout conf/config.yaml
+
+echo '
+deployment:
+  admin:
+    admin_key:
+      - name: admin
+        key: ""
+        role: admin
+' > conf/config.yaml
+
+make init
+make run
+
+admin_key=$(yq '.deployment.admin.admin_key[0].key' conf/config.yaml | sed 's/"//g')
+
+make stop
+
+if ! echo "$admin_key" | grep -E '^[a-f0-9]{32}$' > /dev/null; then
+    echo "failed: auto-generated admin key should be a 32-character hex string, got: $admin_key"
+    exit 1
+fi
+
+echo "pass: auto-generated admin key is a 32-character hex string"
+
 # admin_listen set
 echo '
 deployment:


### PR DESCRIPTION
### Description

`autogenerate_admin_key()` in `apisix/core/id.lua` used `math.random` to generate the admin key when it is configured as an empty string. `math.random` is a PRNG and not suitable for generating security credentials.

This PR replaces it with a CSPRNG: `resty.random.bytes(16, true)`, falling back to `resty.random.bytes(16)` if a strongly-seeded random source is unavailable, encoded with `resty.string.to_hex`. The generated key stays 32 characters long, same as before.

This continues #13099 by @sihyeonn, whose approach was approved; the only remaining review request was a test case, but the PR was closed as stale. This PR picks up the same approach (using 16 random bytes instead of 32 to keep the key length unchanged) and adds the requested test: a case in `t/cli/test_admin.sh` that starts APISIX with an empty admin key and asserts the key written back to `conf/config.yaml` is a 32-character hex string.

#### Which issue(s) this PR fixes:

Fixes #13092

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change (no docs describe the generated key format, so no update is needed)
- [x] I have verified that this change is backward compatible
