### PR TITLE
chore: add OpenAPI repository topics

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -35,6 +35,9 @@ github:
     - iot
     - devops
     - kubernetes
+    - openapi
+    - openapi3
+    - openapi31
   
   enabled_merge_buttons:
     squash:  true


### PR DESCRIPTION
### Description

Add the `openapi`, `openapi3`, and `openapi31` GitHub repository topics through the `github.labels` field in `.asf.yaml`.

Apache APISIX 3.17.0 supports request validation against OpenAPI 3.x documents through the `oas-validator` plugin. The version-specific topics follow the OpenAPI Initiative Tooling registry's documented GitHub Topics mechanism for OpenAPI 3.0 and 3.1 projects. The general `openapi` topic improves repository discovery and classification on GitHub.

This is a repository metadata change only. It does not change runtime behavior or claim OpenAPI 2.0 support. Inclusion in the external tooling registry remains subject to that project's collection workflow.

#### Which issue(s) this PR fixes:

N/A

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change (Not applicable: metadata-only change)
- [ ] I have updated the documentation to reflect this change (Not applicable: no user-facing behavior changes)
- [x] I have verified that this change is backward compatible
