### PR TITLE
fix(ldap-auth): key the consumer lookup on the escaped bind DN

### DIFF
--- a/apisix/plugins/ldap-auth.lua
+++ b/apisix/plugins/ldap-auth.lua
@@ -138,14 +138,14 @@ function _M.rewrite(conf, ctx)
         attribute = conf.uid,
         keepalive = 60000,
     }
-    local res, err = ldap.ldap_authenticate(user.username, user.password, ldapconf)
+    -- the third return value is the bind DN the client assembled, with the
+    -- username escaped per RFC 4514. Rebuilding it here would drop that escaping.
+    local res, err, user_dn = ldap.ldap_authenticate(user.username, user.password, ldapconf)
     if not res then
         core.log.warn("ldap-auth failed: ", err)
         core.response.set_header("WWW-Authenticate", "Basic realm=\"" .. conf.realm .. "\"")
         return 401, { message = "Invalid user authorization" }
     end
-
-    local user_dn =  conf.uid .. "=" .. user.username .. "," .. conf.base_dn
 
     -- 3. Retrieve consumer for authorization plugin
     local consumer_conf = consumer_mod.plugin(plugin_name)

--- a/ci/pod/openldap/ad.ldif
+++ b/ci/pod/openldap/ad.ldif
@@ -100,3 +100,14 @@ cn: Secret User
 sn: Secret
 uid: secretuser
 userPassword: secretpass
+
+# The RDN value carries a literal comma, so its DN only round-trips when the
+# username is escaped per RFC 4514.
+dn: cn=comma\,user,ou=users,dc=example,dc=org
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+cn: comma,user
+sn: Comma
+uid: commauser
+userPassword: commapass

--- a/docs/en/latest/plugins/ldap-auth.md
+++ b/docs/en/latest/plugins/ldap-auth.md
@@ -44,6 +44,8 @@ For Consumer:
 | ------- | ------ | -------- | -------------------------------------------------------------------------------- |
 | user_dn | string | True     | User dn of the LDAP client. For example, `cn=user01,ou=users,dc=example,dc=org`. This field supports saving the value in Secret Manager using the [APISIX Secret](../terminology/secret.md) resource. |
 
+The Plugin builds the user dn as `<uid>=<username>,<base_dn>`, taking the username from the `Authorization` header. Characters that carry structural meaning in a distinguished name (`,` `+` `=` `<` `>` `;` `"` `\`) are escaped per [RFC 4514](https://datatracker.ietf.org/doc/html/rfc4514#section-2.4), so `user_dn` must use the escaped form to match. A user named `comma,user` under `ou=users,dc=example,dc=org` is configured as `cn=comma\,user,ou=users,dc=example,dc=org`.
+
 For Route:
 
 | Name     | Type    | Required | Default | Description                                                            |

--- a/t/plugin/ldap-auth.t
+++ b/t/plugin/ldap-auth.t
@@ -650,3 +650,84 @@ Authorization: bASiC dXNlcjAxOnBhc3N3b3JkMQ==
 hello world
 --- error_log
 find consumer user01
+
+
+
+=== TEST 29: add consumer whose user_dn drops the RDN escaping
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "commauser",
+                    "plugins": {
+                        "ldap-auth": {
+                            "user_dn": "cn=comma,user,ou=users,dc=example,dc=org"
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 30: a username holding a comma does not match the unescaped user_dn
+--- request
+GET /hello
+--- more_headers
+Authorization: Basic Y29tbWEsdXNlcjpjb21tYXBhc3M=
+--- error_code: 401
+--- response_body
+{"message":"Invalid user authorization"}
+--- no_error_log
+find consumer commauser
+
+
+
+=== TEST 31: repoint the consumer at the escaped user_dn
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "commauser",
+                    "plugins": {
+                        "ldap-auth": {
+                            "user_dn": "cn=comma\\,user,ou=users,dc=example,dc=org"
+                        }
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 32: verify against the escaped user_dn
+--- request
+GET /hello
+--- more_headers
+Authorization: Basic Y29tbWEsdXNlcjpjb21tYXBhc3M=
+--- response_body
+hello world
+--- error_log
+find consumer commauser


### PR DESCRIPTION
### Description

`ldap_authenticate()` returns the bind DN it assembled as its third value, with the username escaped per [RFC 4514 §2.4](https://datatracker.ietf.org/doc/html/rfc4514#section-2.4). The plugin discarded that value and rebuilt the same string by raw concatenation:

```lua
local user_dn = conf.uid .. "=" .. user.username .. "," .. conf.base_dn
```

The two forms diverge as soon as the username carries a character that has structural meaning in a distinguished name (`,` `+` `=` `<` `>` `;` `"` `\`). An entry whose RDN value holds a comma binds against `cn=comma\,user,ou=users,dc=example,dc=org`, a single RDN, and is then looked up under `cn=comma,user,ou=users,dc=example,dc=org`, a two-component path. So the request either matches no consumer or matches one that belongs to a different directory entry.

This PR uses the DN the client already produced instead of rebuilding it, which keeps the bind target and the consumer key the same string by construction.

**Backward compatibility:** a consumer whose `user_dn` was written in the unescaped form to match the previous behaviour stops matching. This only affects directory entries whose RDN value contains one of the characters above, and the doc note added here spells out the escaped form to use. Every DN without those characters is unchanged.

**Tests:** the CI directory fixture gains an entry whose `cn` value is `comma,user`. Two cases assert that a consumer keyed on the escaped DN matches and one keyed on the raw expansion does not.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
