### PR TITLE
fix(graphql-limit-count): measure each fragment once when computing query depth

### DIFF
--- a/apisix/plugins/graphql-limit-count.lua
+++ b/apisix/plugins/graphql-limit-count.lua
@@ -90,17 +90,23 @@ local check_graphql_request = {
 -- Returns the maximum selection nesting depth of the GraphQL query AST.
 -- Fragment spreads are expanded in place using the provided fragment map;
 -- inline fragments are treated as transparent wrappers over their selections.
--- visited guards against fragment definition cycles; memo caches each
--- fragment's resolved depth so a fragment is measured once regardless of how
--- many times it is spread, keeping the traversal linear in the document size.
-local function node_depth(node, fragments, visited, memo)
+-- visited tracks the current recursion path: a spread back onto it is a
+-- fragment cycle (invalid GraphQL), flagged via cycle.found so the caller can
+-- reject the request instead of trusting a traversal-order-dependent depth.
+-- memo caches each fragment's resolved depth so a fragment is measured once,
+-- keeping the traversal linear in the document size.
+local function node_depth(node, fragments, visited, memo, cycle)
     if type(node) ~= "table" then
         return 0
     end
 
     if node.kind == "fragmentSpread" then
         local name = node.name and node.name.value
-        if not name or visited[name] then
+        if not name then
+            return 0
+        end
+        if visited[name] then
+            cycle.found = true
             return 0
         end
         local cached = memo[name]
@@ -112,7 +118,7 @@ local function node_depth(node, fragments, visited, memo)
             return 0
         end
         visited[name] = true
-        local depth = node_depth(frag.selectionSet.selections, fragments, visited, memo)
+        local depth = node_depth(frag.selectionSet.selections, fragments, visited, memo, cycle)
         visited[name] = nil
         memo[name] = depth
         return depth
@@ -122,16 +128,16 @@ local function node_depth(node, fragments, visited, memo)
         if not node.selectionSet then
             return 0
         end
-        return node_depth(node.selectionSet.selections, fragments, visited, memo)
+        return node_depth(node.selectionSet.selections, fragments, visited, memo, cycle)
     end
 
     local depth = 0
     for k, v in pairs(node) do
         local child
         if k == "selections" then
-            child = 1 + node_depth(v, fragments, visited, memo)
+            child = 1 + node_depth(v, fragments, visited, memo, cycle)
         else
-            child = node_depth(v, fragments, visited, memo)
+            child = node_depth(v, fragments, visited, memo, cycle)
         end
         depth = max(depth, child)
     end
@@ -199,10 +205,17 @@ function _M.access(conf, ctx)
 
     local depth = 0
     local memo = {}
+    local cycle = {found = false}
     for _, op in ipairs(operations) do
-        local d = node_depth(op, fragments, {}, memo)
+        local d = node_depth(op, fragments, {}, memo, cycle)
         depth = max(depth, d)
     end
+
+    if cycle.found then
+        core.log.error("invalid graphql request: fragment spreads form a cycle")
+        return 400, {message = "Invalid graphql request: fragment spreads must not form cycles"}
+    end
+
     depth = max(depth, 1)
     core.log.info("graphql query depth: ", depth)
 

--- a/apisix/plugins/graphql-limit-count.lua
+++ b/apisix/plugins/graphql-limit-count.lua
@@ -90,8 +90,10 @@ local check_graphql_request = {
 -- Returns the maximum selection nesting depth of the GraphQL query AST.
 -- Fragment spreads are expanded in place using the provided fragment map;
 -- inline fragments are treated as transparent wrappers over their selections.
--- The visited table guards against fragment definition cycles.
-local function node_depth(node, fragments, visited)
+-- visited guards against fragment definition cycles; memo caches each
+-- fragment's resolved depth so a fragment is measured once regardless of how
+-- many times it is spread, keeping the traversal linear in the document size.
+local function node_depth(node, fragments, visited, memo)
     if type(node) ~= "table" then
         return 0
     end
@@ -101,13 +103,18 @@ local function node_depth(node, fragments, visited)
         if not name or visited[name] then
             return 0
         end
+        local cached = memo[name]
+        if cached then
+            return cached
+        end
         local frag = fragments[name]
         if not frag or not frag.selectionSet then
             return 0
         end
         visited[name] = true
-        local depth = node_depth(frag.selectionSet.selections, fragments, visited)
+        local depth = node_depth(frag.selectionSet.selections, fragments, visited, memo)
         visited[name] = nil
+        memo[name] = depth
         return depth
     end
 
@@ -115,16 +122,16 @@ local function node_depth(node, fragments, visited)
         if not node.selectionSet then
             return 0
         end
-        return node_depth(node.selectionSet.selections, fragments, visited)
+        return node_depth(node.selectionSet.selections, fragments, visited, memo)
     end
 
     local depth = 0
     for k, v in pairs(node) do
         local child
         if k == "selections" then
-            child = 1 + node_depth(v, fragments, visited)
+            child = 1 + node_depth(v, fragments, visited, memo)
         else
-            child = node_depth(v, fragments, visited)
+            child = node_depth(v, fragments, visited, memo)
         end
         depth = max(depth, child)
     end
@@ -191,8 +198,9 @@ function _M.access(conf, ctx)
     end
 
     local depth = 0
+    local memo = {}
     for _, op in ipairs(operations) do
-        local d = node_depth(op, fragments, {})
+        local d = node_depth(op, fragments, {}, memo)
         depth = max(depth, d)
     end
     depth = max(depth, 1)

--- a/t/plugin/graphql-limit-count.t
+++ b/t/plugin/graphql-limit-count.t
@@ -507,7 +507,7 @@ X-RateLimit-Remaining: 16
 
 
 
-=== TEST 22: fragment cycle does not cause infinite recursion
+=== TEST 22: fragment cycle is rejected
 --- request
 POST /hello
 {
@@ -515,9 +515,11 @@ POST /hello
 }
 --- more_headers
 Content-Type: application/json
---- error_code: 200
---- response_headers_like
-X-RateLimit-Remaining: \d+
+--- error_code: 400
+--- error_log
+invalid graphql request: fragment spreads form a cycle
+--- response_body eval
+qr/fragment spreads must not form cycles/
 
 
 
@@ -713,3 +715,35 @@ GET /t
 --- response_body
 200
 97
+
+
+
+=== TEST 29: mutually recursive fragments are rejected
+--- request
+POST /hello
+{
+  "query": "query { ...A } fragment A on Query { x { ...B } } fragment B on Query { y { ...A } }"
+}
+--- more_headers
+Content-Type: application/json
+--- error_code: 400
+--- error_log
+invalid graphql request: fragment spreads form a cycle
+--- response_body eval
+qr/fragment spreads must not form cycles/
+
+
+
+=== TEST 30: mutual recursion reached at a different depth and order is rejected
+--- request
+POST /hello
+{
+  "query": "query { ...B } fragment A on Query { ...B } fragment B on Query { m { n { ...A } } }"
+}
+--- more_headers
+Content-Type: application/json
+--- error_code: 400
+--- error_log
+invalid graphql request: fragment spreads form a cycle
+--- response_body eval
+qr/fragment spreads must not form cycles/

--- a/t/plugin/graphql-limit-count.t
+++ b/t/plugin/graphql-limit-count.t
@@ -633,3 +633,76 @@ Content-Type: application/json
 --- error_code: 200
 --- response_headers
 X-RateLimit-Remaining: 15
+
+
+
+=== TEST 27: set route: nested fragment expansion test
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "plugins": {
+                        "graphql-limit-count": {
+                            "count": 1000000,
+                            "time_window": 60,
+                            "rejected_code": 503,
+                            "key": "remote_addr"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 28: deeply reused fragments are measured once, not re-expanded
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local n = 34
+            local parts = {"fragment f0 on Query { __typename }"}
+            for i = 1, n do
+                parts[#parts + 1] = string.format(
+                    "fragment f%d on Query { ...f%d ...f%d }", i, i - 1, i - 1)
+            end
+            parts[#parts + 1] = string.format("query { ...f%d }", n)
+            local body = table.concat(parts, " ")
+            local httpc = http.new()
+            local res, err = httpc:request_uri(
+                "http://127.0.0.1:" .. ngx.var.server_port .. "/hello", {
+                    method = "POST",
+                    body = body,
+                    headers = { ["Content-Type"] = "application/graphql" },
+                })
+            if not res then
+                ngx.say(err)
+                return
+            end
+            ngx.say(res.status)
+        }
+    }
+--- request
+GET /t
+--- timeout: 10
+--- response_body
+200

--- a/t/plugin/graphql-limit-count.t
+++ b/t/plugin/graphql-limit-count.t
@@ -646,10 +646,11 @@ X-RateLimit-Remaining: 15
                  [[{
                     "plugins": {
                         "graphql-limit-count": {
-                            "count": 1000000,
+                            "count": 100,
                             "time_window": 60,
                             "rejected_code": 503,
-                            "key": "remote_addr"
+                            "key": "remote_addr",
+                            "show_limit_quota_header": true
                         }
                     },
                     "upstream": {
@@ -674,13 +675,17 @@ passed
 
 
 
-=== TEST 28: deeply reused fragments are measured once, not re-expanded
+=== TEST 28: deeply reused fragments are measured once and keep their depth
 --- config
     location /t {
         content_by_lua_block {
+            -- f0 nests three field levels (depth 3); every fN spreads the
+            -- previous fragment twice, so a naive expansion is O(2^N) while
+            -- the result stays depth 3. A completed request with the exact
+            -- quota proves the traversal is both linear and depth-correct.
             local http = require "resty.http"
             local n = 34
-            local parts = {"fragment f0 on Query { __typename }"}
+            local parts = {"fragment f0 on Query { a { b { c } } }"}
             for i = 1, n do
                 parts[#parts + 1] = string.format(
                     "fragment f%d on Query { ...f%d ...f%d }", i, i - 1, i - 1)
@@ -699,6 +704,7 @@ passed
                 return
             end
             ngx.say(res.status)
+            ngx.say(res.headers["X-RateLimit-Remaining"])
         }
     }
 --- request
@@ -706,3 +712,4 @@ GET /t
 --- timeout: 10
 --- response_body
 200
+97


### PR DESCRIPTION
### Description

`graphql-limit-count` computes a query's selection-nesting depth (used as the rate-limit cost) by expanding fragment spreads in place. The cycle guard (`visited`) was cleared after each descent, so a fragment referenced from more than one place was fully re-measured on every occurrence. When fragments reference other fragments repeatedly, the depth computation grows exponentially in the number of fragments, so a small document can become expensive to process in the access phase.

This memoizes each fragment's resolved depth so a fragment is measured once regardless of how many times it is spread. `visited` still guards fragment cycles; a new `memo` table caches the per-fragment result, keeping the traversal linear in the document size. The computed depth is unchanged for existing queries.

Added tests: a route whose query reuses fragments many times now returns normally instead of stalling the worker.

#### Which issue(s) this PR fixes:
<!-- private -->

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
