### PR TITLE
fix(grpc-transcode): resolve proto_id given as an integer

### DIFF
--- a/apisix/plugins/grpc-transcode/proto.lua
+++ b/apisix/plugins/grpc-transcode/proto.lua
@@ -132,8 +132,11 @@ local function create_proto_obj(proto_id)
     end
 
     local content
+    -- `id_schema` accepts a string or an integer, and the two are never equal
+    -- in Lua, so compare them in the same form.
+    proto_id = tostring(proto_id)
     for _, proto in config_util.iterate_values(protos.values) do
-        if proto_id == proto.value.id then
+        if proto_id == tostring(proto.value.id) then
             content = proto.value.content
             break
         end

--- a/t/plugin/grpc-transcode.t
+++ b/t/plugin/grpc-transcode.t
@@ -837,3 +837,55 @@ POST /grpctest
 Content-Type: application/json
 --- response_body eval
 qr/"items":\[\]/
+
+
+
+=== TEST 32: set route with proto_id as an integer
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "methods": ["POST"],
+                    "uri": "/grpctest",
+                    "plugins": {
+                        "grpc-transcode": {
+                            "proto_id": 1,
+                            "service": "helloworld.Greeter",
+                            "method": "SayHello"
+                        }
+                    },
+                    "upstream": {
+                        "scheme": "grpc",
+                        "type": "roundrobin",
+                        "nodes": {
+                            "127.0.0.1:10051": 1
+                        }
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 33: hit route, an integer proto_id resolves the same proto
+--- request
+POST /grpctest
+{"name":"world"}
+--- more_headers
+Content-Type: application/json
+--- response_body eval
+qr/"message":"Hello world"/


### PR DESCRIPTION
### Description

`id_schema` allows a resource id to be either a string or an integer, and the
`grpc-transcode` docs type `proto_id` as `string/integer`. But `create_proto_obj`
compares the configured `proto_id` against the stored id with `==`, and in Lua
`1 == "1"` is false. The admin API stores the id as a string, so any Route
configuring `"proto_id": 1` fails to resolve its proto:

```
proto load error: failed to find proto by id: 1
```

Reproducer against master: two Routes over the same proto, one with the id as a
string and one as an integer.

```shell
curl "http://127.0.0.1:9180/apisix/admin/routes/1" -H "X-API-KEY: $admin_key" -X PUT -d '
{
  "uri": "/str",
  "plugins": { "grpc-transcode": { "proto_id": "1", "service": "helloworld.Greeter", "method": "SayHello" } },
  "upstream": { "scheme": "grpc", "type": "roundrobin", "nodes": { "127.0.0.1:10051": 1 } }
}'

curl "http://127.0.0.1:9180/apisix/admin/routes/2" -H "X-API-KEY: $admin_key" -X PUT -d '
{
  "uri": "/int",
  "plugins": { "grpc-transcode": { "proto_id": 1, "service": "helloworld.Greeter", "method": "SayHello" } },
  "upstream": { "scheme": "grpc", "type": "roundrobin", "nodes": { "127.0.0.1:10051": 1 } }
}'
```

`/str` transcodes, `/int` returns an error and logs `failed to find proto by id: 1`.

This compares both sides as strings, matching how `graphql-proxy-cache` and
`upstream.lua` already normalize ids.

#### Which issue(s) this PR fixes:

Fixes [#8952](https://github.com/apache/apisix/issues/8952), which was closed as
stale without a fix. The report is still reproducible on master.

### Tests

Two blocks added to `t/plugin/grpc-transcode.t`: a Route configured with an
integer `proto_id`, and a request through it. Both fail without the change and
pass with it.

Developed with AI assistance; design decisions, review and testing are my own.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change (not needed: the docs already type `proto_id` as `string/integer`; this makes the code match them)
- [x] I have verified that this change is backward compatible (If it is not backward compatible, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)