### PR TITLE
fix(dev-image): add libwww-perl

### DIFF
--- a/example/build-dev-image.dockerfile
+++ b/example/build-dev-image.dockerfile
@@ -19,7 +19,7 @@ FROM ubuntu:20.04
 
 # Install Test::Nginx
 RUN apt update
-RUN apt install -y cpanminus make
+RUN apt install -y cpanminus make libwww-perl
 RUN cpanm --notest Test::Nginx
 
 # Install development utils


### PR DESCRIPTION
### Description

Add `libwww-perl` to the dependencies when installing `Test::Nginx`.

solved build dev image error

```txt
21.53 -> FAIL Installing the dependencies failed: Module 'LWP::UserAgent' is not installed
21.53 -> FAIL Bailing out the installation for Test-Nginx-0.32.
21.53 11 distributions installed
```

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

