### PR TITLE
fix(proxy-rewrite): transform header names to lower case before removal

### DIFF
--- a/apisix/plugins/proxy-rewrite.lua
+++ b/apisix/plugins/proxy-rewrite.lua
@@ -468,7 +468,7 @@ function _M.rewrite(conf, ctx)
 
         local field_cnt = #hdr_op.remove
         for i = 1, field_cnt do
-            core.request.set_header(ctx, hdr_op.remove[i], nil)
+            core.request.set_header(ctx, hdr_op.remove[i]:lower(), nil)
         end
 
     end


### PR DESCRIPTION
### Description

In line with the specification of HTTP/2, APISIX apparently processes all headers in lower case. For this reason, entries of the `headers.remove` section in `proxy-rewrite` that contain capital letters are ignored, also in cases where the client sends them with capital letters. This may lead to unintended data leaks.
This PR transforms headers in `headers.remove` to lower case to ensure removal of all headers intended to be removed.

The [docs](https://github.com/apache/apisix/blob/master/docs/en/latest/plugins/proxy-rewrite.md#remove-existing-header)  seem to intend the behavior this PR establishes.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)