### PR TITLE
fix(hmac-auth): pass ctx when hiding the Authorization header

### DIFF
--- a/apisix/plugins/hmac-auth.lua
+++ b/apisix/plugins/hmac-auth.lua
@@ -373,7 +373,7 @@ function _M.rewrite(conf, ctx)
     end
 
     if conf.hide_credentials then
-        core.request.set_header("Authorization", nil)
+        core.request.set_header(ctx, "Authorization", nil)
     end
 
     consumer.attach_consumer(ctx, cur_consumer, consumers_conf)


### PR DESCRIPTION
### Description

When hide_credentials is enabled, a deprecated function is used.
align basic-auth, jwt-auth and key-auth plugin implementations

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
