### PR TITLE
fix(graphql-limit-count): expand each fragment once when measuring depth

### DIFF
--- a/apisix/plugins/graphql-limit-count.lua
+++ b/apisix/plugins/graphql-limit-count.lua
@@ -118,9 +118,9 @@ local function node_depth(node, fragments, visited, depths)
         visited[name] = true
         local depth = node_depth(frag.selectionSet.selections, fragments, visited, depths)
         visited[name] = nil
-        -- a fragment reached through a cycle contributes 0 to its own depth,
-        -- so what is memoized here can be short for a cyclic document; those
-        -- are invalid GraphQL and the traversal already reported them short.
+        -- a spread that closes a cycle contributes 0, so for a cyclic
+        -- document the memoized depth can be short -- as it already was
+        -- before memoization, and such a document is invalid GraphQL anyway.
         depths[name] = depth
         return depth
     end

--- a/apisix/plugins/graphql-limit-count.lua
+++ b/apisix/plugins/graphql-limit-count.lua
@@ -91,7 +91,13 @@ local check_graphql_request = {
 -- Fragment spreads are expanded in place using the provided fragment map;
 -- inline fragments are treated as transparent wrappers over their selections.
 -- The visited table guards against fragment definition cycles.
-local function node_depth(node, fragments, visited)
+-- The depth of a fragment does not depend on where it is spread from, so it is
+-- computed once and memoized in `depths`. Without that, a document whose
+-- fragments each spread the next one twice re-walks the whole remaining chain
+-- per spread, which costs 2^n traversals for n fragments: a request body of a
+-- few hundred bytes is enough to burn a worker's CPU here, before the rate
+-- limit this plugin applies is even consulted.
+local function node_depth(node, fragments, visited, depths)
     if type(node) ~= "table" then
         return 0
     end
@@ -101,13 +107,21 @@ local function node_depth(node, fragments, visited)
         if not name or visited[name] then
             return 0
         end
+        local cached = depths[name]
+        if cached then
+            return cached
+        end
         local frag = fragments[name]
         if not frag or not frag.selectionSet then
             return 0
         end
         visited[name] = true
-        local depth = node_depth(frag.selectionSet.selections, fragments, visited)
+        local depth = node_depth(frag.selectionSet.selections, fragments, visited, depths)
         visited[name] = nil
+        -- a fragment reached through a cycle contributes 0 to its own depth,
+        -- so what is memoized here can be short for a cyclic document; those
+        -- are invalid GraphQL and the traversal already reported them short.
+        depths[name] = depth
         return depth
     end
 
@@ -115,16 +129,16 @@ local function node_depth(node, fragments, visited)
         if not node.selectionSet then
             return 0
         end
-        return node_depth(node.selectionSet.selections, fragments, visited)
+        return node_depth(node.selectionSet.selections, fragments, visited, depths)
     end
 
     local depth = 0
     for k, v in pairs(node) do
         local child
         if k == "selections" then
-            child = 1 + node_depth(v, fragments, visited)
+            child = 1 + node_depth(v, fragments, visited, depths)
         else
-            child = node_depth(v, fragments, visited)
+            child = node_depth(v, fragments, visited, depths)
         end
         depth = max(depth, child)
     end
@@ -190,9 +204,12 @@ function _M.access(conf, ctx)
         return 400, {message = "Invalid graphql request: empty graphql query"}
     end
 
+    -- fragments are document scoped, so their depths are shared by every
+    -- operation in the document
+    local depths = {}
     local depth = 0
     for _, op in ipairs(operations) do
-        local d = node_depth(op, fragments, {})
+        local d = node_depth(op, fragments, {}, depths)
         depth = max(depth, d)
     end
     depth = max(depth, 1)

--- a/apisix/plugins/graphql-limit-count.lua
+++ b/apisix/plugins/graphql-limit-count.lua
@@ -118,9 +118,11 @@ local function node_depth(node, fragments, visited, depths)
         visited[name] = true
         local depth = node_depth(frag.selectionSet.selections, fragments, visited, depths)
         visited[name] = nil
-        -- a spread that closes a cycle contributes 0, so for a cyclic
-        -- document the memoized depth can be short -- as it already was
-        -- before memoization, and such a document is invalid GraphQL anyway.
+        -- exact for a valid document: `visited` only ever holds fragments on
+        -- the current spread chain, which an acyclic fragment can never be a
+        -- member of. A cyclic one can memoize the truncated depth it got on
+        -- the chain that closed the cycle, but fragment cycles are invalid
+        -- GraphQL and were already measured short before memoization.
         depths[name] = depth
         return depth
     end

--- a/t/plugin/graphql-limit-count.t
+++ b/t/plugin/graphql-limit-count.t
@@ -633,3 +633,79 @@ Content-Type: application/json
 --- error_code: 200
 --- response_headers
 X-RateLimit-Remaining: 15
+
+
+
+=== TEST 27: set route: repeated fragment spread test
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "plugins": {
+                        "graphql-limit-count": {
+                            "count": 100,
+                            "time_window": 60,
+                            "rejected_code": 503,
+                            "key": "remote_addr",
+                            "show_limit_quota_header": true
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 28: a fragment spread twice per level is expanded once per fragment
+--- config
+    location /t {
+        content_by_lua_block {
+            -- every fragment spreads the next one twice: expanding each spread
+            -- separately costs 2^n traversals, expanding each fragment once
+            -- costs n
+            local levels = 26
+            local query = {"query { ...F0 }"}
+            for i = 0, levels - 1 do
+                query[#query + 1] = ("fragment F%d on T { x { ...F%d ...F%d } }"):format(i, i + 1, i + 1)
+            end
+            query[#query + 1] = ("fragment F%d on T { x }"):format(levels)
+
+            local httpc = require("resty.http").new()
+            local res, err = httpc:request_uri("http://127.0.0.1:" .. ngx.var.server_port .. "/hello", {
+                method = "POST",
+                body = table.concat(query, "\n"),
+                headers = { ["Content-Type"] = "application/graphql" },
+            })
+            if not res then
+                ngx.say(err)
+                return
+            end
+            ngx.say("status: ", res.status)
+            ngx.say("remaining: ", res.headers["X-RateLimit-Remaining"])
+        }
+    }
+--- request
+GET /t
+--- timeout: 5
+--- response_body
+status: 200
+remaining: 73


### PR DESCRIPTION
### Description

`node_depth()` in `graphql-limit-count` clears `visited[name]` right after walking a fragment spread, so the same fragment is walked again from every spread that references it. A document where each fragment spreads the next one twice therefore costs `2^n` traversals for `n` fragments — a ~1KB body reaches a billion node visits, and that runs in the `access` phase on an unauthenticated request, before the rate limit the plugin enforces. #1389 capped the body at 1MB, which still leaves plenty of room for this.

A fragment's depth doesn't depend on where it is spread from, so it's now computed once per document and memoized. The depth the plugin reports is unchanged; only the traversal cost is, from exponential to linear in the number of fragments.

The new test in `t/plugin/graphql-limit-count.t` sends a 26-fragment document of that shape and asserts the resulting quota consumption. It passes in milliseconds with this change and times out on master.

#### Which issue(s) this PR fixes:

N/A

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change — no user visible behaviour change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
