### PR TITLE
fix(admin): encrypt the inline upstream client key of a stream route

### DIFF
--- a/apisix/admin/stream_routes.lua
+++ b/apisix/admin/stream_routes.lua
@@ -152,10 +152,6 @@ local function delete_checker(id)
 end
 
 
--- Only the upstream, unlike routes.lua and services.lua which also encrypt
--- their plugin confs: stream_plugin_checker() has no decrypt_conf() step, so
--- an encrypted stream plugin conf would reach the stream runtime as
--- ciphertext.
 local function encrypt_conf(id, conf)
     apisix_upstream.encrypt_conf(conf.upstream)
 end

--- a/apisix/admin/stream_routes.lua
+++ b/apisix/admin/stream_routes.lua
@@ -152,6 +152,10 @@ local function delete_checker(id)
 end
 
 
+-- Only the upstream, unlike routes.lua and services.lua which also encrypt
+-- their plugin confs: stream_plugin_checker() has no decrypt_conf() step, so
+-- an encrypted stream plugin conf would reach the stream runtime as
+-- ciphertext.
 local function encrypt_conf(id, conf)
     apisix_upstream.encrypt_conf(conf.upstream)
 end

--- a/apisix/admin/stream_routes.lua
+++ b/apisix/admin/stream_routes.lua
@@ -16,6 +16,7 @@
 --
 local core = require("apisix.core")
 local resource = require("apisix.admin.resource")
+local apisix_upstream = require("apisix.upstream")
 local stream_route_checker = require("apisix.stream.router.ip_port").stream_route_checker
 local tostring = tostring
 local ipairs = ipairs
@@ -151,12 +152,18 @@ local function delete_checker(id)
 end
 
 
+local function encrypt_conf(id, conf)
+    apisix_upstream.encrypt_conf(conf.upstream)
+end
+
+
 return resource.new({
     name = "stream_routes",
     kind = "stream route",
     schema = core.schema.stream_route,
     checker = check_conf,
     delete_checker = delete_checker,
+    encrypt_conf = encrypt_conf,
     unsupported_methods = { "patch" },
     list_filter_fields = {
         service_id = true,

--- a/t/admin/stream-routes.t
+++ b/t/admin/stream-routes.t
@@ -694,6 +694,7 @@ passed
                    "the client key must be encrypted at rest")
 
             code, body = t.test('/apisix/admin/stream_routes/enc', ngx.HTTP_GET)
+            assert(code == 200, "the admin API must return the stream route")
             assert(not core.string.find(body, "PRIVATE KEY"),
                    "the admin API must not return the plaintext client key")
             ngx.say("encrypted")

--- a/t/admin/stream-routes.t
+++ b/t/admin/stream-routes.t
@@ -690,7 +690,8 @@ passed
 
             local res = assert(etcd.get('/stream_routes/enc'))
             local stored = res.body.node.value.upstream.tls.client_key
-            assert(stored ~= ssl_key, "the client key must be encrypted at rest")
+            assert(not core.string.find(stored, "PRIVATE KEY"),
+                   "the client key must be encrypted at rest")
 
             code, body = t.test('/apisix/admin/stream_routes/enc', ngx.HTTP_GET)
             assert(not core.string.find(body, "PRIVATE KEY"),

--- a/t/admin/stream-routes.t
+++ b/t/admin/stream-routes.t
@@ -654,3 +654,51 @@ passed
 GET /t
 --- response_body
 passed
+
+
+
+=== TEST 18: an inline upstream client key is encrypted at rest
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local etcd = require("apisix.core.etcd")
+            local t = require("lib.test_admin")
+
+            local ssl_cert = t.read_file("t/certs/apisix.crt")
+            local ssl_key = t.read_file("t/certs/apisix.key")
+            local code, body = t.test('/apisix/admin/stream_routes/enc',
+                ngx.HTTP_PUT,
+                core.json.encode({
+                    remote_addr = "127.0.0.1",
+                    upstream = {
+                        nodes = { ["127.0.0.1:8080"] = 1 },
+                        type = "roundrobin",
+                        scheme = "tls",
+                        tls = {
+                            client_cert = ssl_cert,
+                            client_key = ssl_key,
+                        },
+                    },
+                })
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            local res = assert(etcd.get('/stream_routes/enc'))
+            local stored = res.body.node.value.upstream.tls.client_key
+            assert(stored ~= ssl_key, "the client key must be encrypted at rest")
+
+            code, body = t.test('/apisix/admin/stream_routes/enc', ngx.HTTP_GET)
+            assert(not core.string.find(body, "PRIVATE KEY"),
+                   "the admin API must not return the plaintext client key")
+            ngx.say("encrypted")
+        }
+    }
+--- request
+GET /t
+--- response_body
+encrypted

--- a/t/stream-node/upstream-mtls.t
+++ b/t/stream-node/upstream-mtls.t
@@ -218,3 +218,50 @@ mmm
 hello mtls upstream
 --- no_error_log
 [error]
+
+
+
+=== TEST 7: set stream_route with an inline upstream carrying the client cert
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin")
+            local json = require("toolkit.json")
+            local ssl_cert = t.read_file("t/certs/mtls_client.crt")
+            local ssl_key = t.read_file("t/certs/mtls_client.key")
+
+            local code, body = t.test('/apisix/admin/stream_routes/1',
+                ngx.HTTP_PUT,
+                json.encode({
+                    remote_addr = "127.0.0.1",
+                    upstream = {
+                        scheme = "tls",
+                        type = "roundrobin",
+                        nodes = { ["127.0.0.1:8765"] = 1 },
+                        tls = {
+                            client_cert = ssl_cert,
+                            client_key = ssl_key,
+                        },
+                    },
+                })
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 8: hit route, the encrypted inline client key still completes the handshake
+--- stream_request
+mmm
+--- stream_response
+hello mtls upstream
+--- no_error_log
+[error]


### PR DESCRIPTION
### Description

A stream route takes the same upstream schema as an HTTP one, `tls.client_cert`/`tls.client_key` included. `routes`, `services` and `upstreams` all register an `encrypt_conf` hook that runs `apisix_upstream.encrypt_conf()` before the write, so an inline client key is encrypted at rest; `stream_routes` never registered one, so the same key sent to `/apisix/admin/stream_routes/{id}` is stored in etcd verbatim and returned in plaintext by the Admin API.

This registers the hook for `stream_routes` as well. Unlike `routes.lua`/`services.lua`, the hook encrypts only the upstream and not the plugin confs — `stream_plugin_checker()` has no `decrypt_conf()` step, so an encrypted stream plugin conf would reach the stream runtime as ciphertext. There is a comment on the hook saying so, since the asymmetry looks like an oversight otherwise. Keys written before the change keep working — `aes_decrypt_pkey()` passes a PEM through untouched — and the new entry in `t/admin/stream-routes.t` asserts both that etcd no longer holds a PEM and that the Admin API no longer returns it. `t/stream-node/upstream-mtls.t` gains an inline-upstream case as well, so the L4 handshake is now covered for the shape whose storage this PR changes — it only existed for `upstream_id` and `client_cert_id` before.

#### Which issue(s) this PR fixes:

N/A

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change — the encryption of inline upstream keys is already documented for the other resources
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
