### PR TITLE
test(healthcheck): stop counting probes that land after the threshold

### DIFF
--- a/t/node/healthcheck.t
+++ b/t/node/healthcheck.t
@@ -224,7 +224,7 @@ GET /t
 --- response_body
 [{"count":12,"port":"1980"}]
 --- grep_error_log eval
-qr/\([^)]+\) unhealthy .* for '.*'/
+qr/\([^)]+\) unhealthy TCP increment \([12]\/2\) for '.*'/
 --- grep_error_log_out
 (upstream#/apisix/routes/1) unhealthy TCP increment (1/2) for 'foo.com(127.0.0.1:1970)'
 (upstream#/apisix/routes/1) unhealthy TCP increment (2/2) for 'foo.com(127.0.0.1:1970)'
@@ -910,7 +910,7 @@ GET /t
 --- response_body
 [{"count":12,"port":"1980"}]
 --- grep_error_log eval
-qr/\([^)]+\) unhealthy .* for '.*'/
+qr/\([^)]+\) unhealthy TCP increment \([12]\/2\) for '.*'/
 --- grep_error_log_out
 (upstream#/apisix/upstreams/1) unhealthy TCP increment (1/2) for 'foo.com(127.0.0.1:1970)'
 (upstream#/apisix/upstreams/1) unhealthy TCP increment (2/2) for 'foo.com(127.0.0.1:1970)'

--- a/t/node/healthcheck2.t
+++ b/t/node/healthcheck2.t
@@ -138,7 +138,7 @@ routes:
 --- response_body
 [{"count":12,"port":"1980"}]
 --- grep_error_log eval
-qr/\([^)]+\) unhealthy .* for '.*'/
+qr/\([^)]+\) unhealthy TCP increment \([12]\/2\) for '.*'/
 --- grep_error_log_out
 (upstream#/services/1) unhealthy TCP increment (1/2) for 'foo.com(127.0.0.1:1970)'
 (upstream#/services/1) unhealthy TCP increment (2/2) for 'foo.com(127.0.0.1:1970)'
@@ -227,7 +227,7 @@ routes:
 --- response_body
 [{"count":12,"port":"1980"}]
 --- grep_error_log eval
-qr/\([^)]+\) unhealthy .* for '.*'/
+qr/\([^)]+\) unhealthy TCP increment \([12]\/2\) for '.*'/
 --- grep_error_log_out
 (upstream#/routes/arr_1) unhealthy TCP increment (1/2) for 'foo.com(127.0.0.1:1970)'
 (upstream#/routes/arr_1) unhealthy TCP increment (2/2) for 'foo.com(127.0.0.1:1970)'


### PR DESCRIPTION
### Description

`t/node/healthcheck.t` TEST 4 / TEST 19 and `t/node/healthcheck2.t` TEST 2 / TEST 4 grep every `unhealthy ... for '...'` line out of the error log and compare the result to exactly two lines:

```
--- grep_error_log eval
qr/\([^)]+\) unhealthy .* for '.*'/
--- grep_error_log_out
(upstream#/apisix/routes/1) unhealthy TCP increment (1/2) for 'foo.com(127.0.0.1:1970)'
(upstream#/apisix/routes/1) unhealthy TCP increment (2/2) for 'foo.com(127.0.0.1:1970)'
```

The active checker keeps probing a target after it has been marked unhealthy, and each of those probes logs another increment. The test sleeps 2.5s after the assertion window, i.e. past two more `unhealthy.interval: 1` ticks, so on a loaded runner a third probe lands before the log is read and the test fails on an extra line:

```
 (upstream#/apisix/routes/1) unhealthy TCP increment (1/2) for 'foo.com(127.0.0.1:1970)'
 (upstream#/apisix/routes/1) unhealthy TCP increment (2/2) for 'foo.com(127.0.0.1:1970)'
+(upstream#/apisix/routes/1) unhealthy TCP increment (3/2) for 'foo.com(127.0.0.1:1970)'
```

I hit this three times in a day on CI machines, in all three of those test blocks, including once on the automatic rerun.

The grep now captures only the increments up to the threshold, so a probe that fires after the target is already unhealthy cannot enter the comparison. The assertion still pins that both increments happened, for the right upstream key and the right target; a counter that skipped a step or moved on the wrong target still fails it.

#### Which issue(s) this PR fixes:

N/A

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change — test-only change
- [ ] I have updated the documentation to reflect this change — not user visible
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
