### PR TITLE
docs(admin-api): clarify Credential name field description and fix typos

### DIFF
--- a/docs/en/latest/admin-api.md
+++ b/docs/en/latest/admin-api.md
@@ -917,17 +917,17 @@ Credential resource request address：/apisix/admin/consumers/{username}/credent
 
 | Method | Request URI                        | Request Body | Description                                    |
 | ------ |----------------------------------------------------------------|--------------|------------------------------------------------|
-| GET    | /apisix/admin/consumers/{username}/credentials                 | NUll         | Fetches list of all credentials of the Consumer |
-| GET    | /apisix/admin/consumers/{username}/credentials/{credential_id} | NUll         | Fetches the Credential by `credential_id`      |
-| PUT    | /apisix/admin/consumers/{username}/credentials/{credential_id} | {...}        | Create or update a Creddential                 |
-| DELETE | /apisix/admin/consumers/{username}/credentials/{credential_id} | NUll         | Delete the Credential                          |
+| GET    | /apisix/admin/consumers/{username}/credentials                 | NULL         | Fetches list of all credentials of the Consumer |
+| GET    | /apisix/admin/consumers/{username}/credentials/{credential_id} | NULL         | Fetches the Credential by `credential_id`      |
+| PUT    | /apisix/admin/consumers/{username}/credentials/{credential_id} | {...}        | Create or update a Credential                  |
+| DELETE | /apisix/admin/consumers/{username}/credentials/{credential_id} | NULL         | Delete the Credential                          |
 
 ### Request Body Parameters
 
 | Parameter   | Required | Type        | Description                                                | Example                                         |
 | ----------- |-----| ------- |------------------------------------------------------------|-------------------------------------------------|
 | plugins     | False    | Plugin      | Auth plugins configuration.                                |                                                 |
-| name        | False    | Auxiliary   | Identifier for the Credential.                             | credential_primary                              |
+| name        | False    | Auxiliary   | Name of the Consumer Credential.                           | credential_primary                              |
 | desc        | False    | Auxiliary   | Description of usage scenarios.                            | credential xxxx                                 |
 | labels      | False    | Match Rules | Attributes of the Credential specified as key-value pairs. | {"version":"v2","build":"16","env":"production"} |
 


### PR DESCRIPTION
### Description

This PR clarifies the description of the `name` field in the Credential API documentation and fixes several typos in the same section.

The `name` field is an optional name for the Consumer Credential, while `{credential_id}` in the request path is used to identify the Credential resource. Updating the description avoids confusion between these two values.

This PR also:
- Fixes three occurrences of `NUll` to `NULL`.
- Fixes the typo `Creddential` to `Credential`.

#### Which issue(s) this PR fixes:

N/A

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community))