### PR TITLE
ci: retry the MCP server download and fail on a bad HTTP status

### DIFF
--- a/ci/prepare_filesystem_mcp.sh
+++ b/ci/prepare_filesystem_mcp.sh
@@ -28,7 +28,7 @@ URL="https://github.com/modelcontextprotocol/servers/archive/refs/tags/${VERSION
 WORKDIR="$(mktemp -d)"
 DEST_DIR="${REPO_ROOT}/t/plugin/mcp/servers"
 
-curl -L "${URL}" | tar -xz -C "${WORKDIR}"
+curl -fsSL --retry 3 --retry-delay 5 "${URL}" | tar -xz -C "${WORKDIR}"
 
 rm -rf "${DEST_DIR}"
 mkdir -p "$(dirname "${DEST_DIR}")"


### PR DESCRIPTION
### Description

`ci/prepare_filesystem_mcp.sh` fetches the MCP servers tarball with a bare `curl -L … | tar -xz`. curl does not treat an HTTP error as a failure unless you ask it to, so when codeload answers with a 5xx the error page goes straight down the pipe and the job dies with:

```
gzip: stdin: not in gzip format
tar: Child returned status 1
##[error]Process completed with exit code 2
```

which says nothing about the download having failed. There is also no retry, so one hiccup fails the whole `CLI Test` job.

Adding `-f` makes curl exit non-zero and print the status instead, and since the script already runs under `set -euo pipefail` it now stops at the download:

```
curl: (22) The requested URL returned error: 404
```

`--retry 3 --retry-delay 5` covers the transient case. Worth noting that plain `--retry` does retry HTTP 5xx, not just connection-level errors — verified against a local server that always answers 502, which curl requested 4 times (1 + 3 retries) before giving up. So `--retry-all-errors` is not needed here, which also keeps the invocation working on the older curl in the UBI image used by `redhat-ci.yaml` (7.61 predates that option).

Two `curl -o … openssl.cnf` calls in `ci/linux-install-openresty.sh` and `ci/redhat-ci.sh` have the same missing `-f`, but they write a file that later steps read, and `ci/redhat-ci.sh` does not run under `set -e` — adding `-f` there would swap "an HTML error page in openssl.cnf" for "an empty openssl.cnf", which can be accepted silently. That needs a write-to-temp-then-move instead, so it is left out of this change.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

### About the red CI on this PR

The failures are the very problem this PR is about, not a regression from it — GitHub is currently rate-limiting these runners. On the `CLI Test` job the changed line now reports the real cause instead of a gzip error:

```
curl: (22) The requested URL returned error: 429
curl: (22) The requested URL returned error: 429
curl: (22) The requested URL returned error: 429
curl: (22) The requested URL returned error: 503
```

That is one attempt plus the three retries, so `-f --retry` behaves as intended; a sustained 429 still fails, and it should — the point is that the reason is now visible. Caching the tarball would be the way to survive rate limiting, which seems worth doing separately.

The other failing jobs do not run the changed script at all: `ci/prepare_filesystem_mcp.sh` is reached only from `.github/workflows/cli.yml` and `ci/init-common-test-service.sh` (`build.yml`, `redhat-ci.yaml`), so `Code Lint`, `CI Tars`, `CI Kubernetes` and `Source Code Install` cannot be affected by it. `Code Lint` and the `CI` shards died on `wget https://raw.githubusercontent.com/iresty/openresty-devel-utils/master/lj-releng` (wget exit 8), and `CI Tars` and `Source Code Install` failed the same way on an unrelated branch in the same window.

The `wget` call sites have the same gap, for what it is worth: `--tries=3 --retry-connrefused` only adds connection-refused to the retry set, so an HTTP 429 or 503 is not retried and wget exits 8 straight away. That is what `Code Lint` (`.../openresty-devel-utils/master/lj-releng`) and `CI Tars` (`.../luarocks/archive/v3.12.0.tar.gz`) have been dying on. `--retry-on-http-error=429,500,502,503,504` would cover it, and setting it once through `WGETRC` in `ci/common.sh` would apply to every call site including future ones — happy to do that here or in a follow-up, whichever the maintainers prefer. Left out of this PR because it changes the download policy repo-wide rather than fixing one script.
