### PR TITLE
test(ai-rate-limiting): wait for token usage to reach redis between requests

### DIFF
--- a/t/lib/test_redis.lua
+++ b/t/lib/test_redis.lua
@@ -70,7 +70,26 @@ local function auth_if_needed(red, opts)
     return nil, err
 end
 
-local function flush_single(host, port, opts)
+local function release(red, host, port, opts)
+    local keepalive_pool = opts.keepalive_pool
+    if keepalive_pool == nil then
+        keepalive_pool = 0
+    end
+    if keepalive_pool == 0 then
+        local ok_close, close_err = red:close()
+        if not ok_close then
+            log_warn("failed to close redis connection ", host, ":", port, ": ", close_err)
+        end
+    else
+        local keepalive_timeout = opts.keepalive_timeout or 10000
+        local ok_keepalive, keepalive_err = red:set_keepalive(keepalive_timeout, keepalive_pool)
+        if not ok_keepalive then
+            log_warn("failed to set keepalive for redis ", host, ":", port, ": ", keepalive_err)
+        end
+    end
+end
+
+local function connect(host, port, opts)
     local red = redis:new()
     local connect_timeout = opts.connect_timeout or 1000
     local send_timeout = opts.send_timeout or connect_timeout
@@ -85,11 +104,26 @@ local function flush_single(host, port, opts)
 
     local ok_auth, auth_err = auth_if_needed(red, opts)
     if not ok_auth then
-        local ok_close, close_err = red:close()
-        if not ok_close then
-            log_warn("failed to close redis connection ", host, ":", port, ": ", close_err)
-        end
+        release(red, host, port, {})
         return nil, auth_err
+    end
+
+    if opts.database then
+        local ok_select, select_err = red:select(opts.database)
+        if not ok_select then
+            log_warn("failed to select redis db ", opts.database, ": ", select_err)
+            release(red, host, port, {})
+            return nil, select_err
+        end
+    end
+
+    return red
+end
+
+local function flush_single(host, port, opts)
+    local red, err = connect(host, port, opts)
+    if not red then
+        return nil, err
     end
 
     local _, flush_err = red:flushall()
@@ -97,23 +131,7 @@ local function flush_single(host, port, opts)
         log_warn("failed to flush redis ", host, ":", port, ": ", flush_err)
     end
 
-    local keepalive_pool = opts.keepalive_pool
-    if keepalive_pool == nil then
-        keepalive_pool = 0
-    end
-    if keepalive_pool == 0 then
-        local ok_close, close_err = red:close()
-        if not ok_close then
-            log_warn("failed to close redis connection ", host, ":", port, ": ", close_err)
-        end
-    else
-        local keepalive_timeout = opts.keepalive_timeout or 10000
-        keepalive_pool = keepalive_pool or 100
-        local ok_keepalive, keepalive_err = red:set_keepalive(keepalive_timeout, keepalive_pool)
-        if not ok_keepalive then
-            log_warn("failed to set keepalive for redis ", host, ":", port, ": ", keepalive_err)
-        end
-    end
+    release(red, host, port, opts)
 
     return true
 end
@@ -158,6 +176,61 @@ function _M.flush_port(host, port, opts)
     end
 
     return flush_single(host, port, opts)
+end
+
+-- Rate limit counters are committed from a log phase timer, so a request fired
+-- right after the previous one can still be judged against a budget that looks
+-- unspent. Snapshot the counters with sum_counters() before a request and wait
+-- for the total to grow with wait_counters_above() afterwards, rather than
+-- sleeping a fixed amount: a wait long enough to cover a busy machine would roll
+-- over the short time windows some of these tests configure.
+function _M.sum_counters(pattern, opts)
+    opts = opts or {}
+    local host = opts.host or DEFAULT_HOST
+    local port = opts.port or 6379
+
+    local red, err = connect(host, port, opts)
+    if not red then
+        return nil, err
+    end
+
+    local keys, keys_err = red:keys(pattern)
+    if not keys then
+        release(red, host, port, opts)
+        return nil, keys_err
+    end
+
+    local total = 0
+    for _, key in ipairs(keys) do
+        -- a key that expired between keys() and get() reads back as ngx.null,
+        -- which is not an error; keep the two apart so a failed read cannot be
+        -- mistaken for a counter of zero
+        local value, get_err = red:get(key)
+        if not value then
+            release(red, host, port, opts)
+            return nil, get_err
+        end
+        total = total + (tonumber(value) or 0)
+    end
+
+    release(red, host, port, opts)
+
+    return total
+end
+
+function _M.wait_counters_above(pattern, previous, opts)
+    local last_err
+    for _ = 1, 100 do
+        local total, err = _M.sum_counters(pattern, opts)
+        if total and total > previous then
+            return true
+        end
+        last_err = err
+        ngx.sleep(0.01)
+    end
+
+    return nil, "counters matching " .. pattern .. " stayed at " .. previous ..
+                (last_err and (", last error: " .. last_err) or "")
 end
 
 _M.default_ports = DEFAULT_PORTS

--- a/t/plugin/ai-rate-limiting.t
+++ b/t/plugin/ai-rate-limiting.t
@@ -1630,18 +1630,48 @@ passed
 
 
 === TEST 37: redis policy shares counter and rejects the 4th request
---- pipelined_requests eval
-[
-    "POST /ai\n" . "{ \"messages\": [ { \"role\": \"system\", \"content\": \"You are a mathematician\" }, { \"role\": \"user\", \"content\": \"What is 1+1?\"} ] }",
-    "POST /ai\n" . "{ \"messages\": [ { \"role\": \"system\", \"content\": \"You are a mathematician\" }, { \"role\": \"user\", \"content\": \"What is 1+1?\"} ] }",
-    "POST /ai\n" . "{ \"messages\": [ { \"role\": \"system\", \"content\": \"You are a mathematician\" }, { \"role\": \"user\", \"content\": \"What is 1+1?\"} ] }",
-    "POST /ai\n" . "{ \"messages\": [ { \"role\": \"system\", \"content\": \"You are a mathematician\" }, { \"role\": \"user\", \"content\": \"What is 1+1?\"} ] }",
-]
---- more_headers
-Authorization: Bearer token
-X-AI-Fixture: openai/chat-model-echo.json
---- error_code eval
-[200, 200, 200, 503]
+--- config
+    location /t {
+        content_by_lua_block {
+            local http = require("resty.http")
+            local test_redis = require("lib.test_redis")
+            local COUNTERS = "plugin-ai-rate-limiting:*"
+            local OPTS = {database = 1}
+
+            local httpc = http.new()
+            local codes = {}
+            for i = 1, 4 do
+                local before, before_err = test_redis.sum_counters(COUNTERS, OPTS)
+                assert(before, before_err)
+                local res = assert(httpc:request_uri(
+                    "http://127.0.0.1:" .. ngx.var.server_port .. "/ai",
+                    {
+                        method = "POST",
+                        body = [[{
+                            "messages": [
+                                { "role": "system", "content": "You are a mathematician" },
+                                { "role": "user", "content": "What is 1+1?" }
+                            ]
+                        }]],
+                        headers = {
+                            ["Content-Type"] = "application/json",
+                            ["Authorization"] = "Bearer token",
+                            ["X-AI-Fixture"] = "openai/chat-model-echo.json",
+                        }
+                    }
+                ))
+                codes[i] = res.status
+                -- only a request that reached the LLM has usage to commit
+                if res.status == 200 and i < 4 then
+                    assert(test_redis.wait_counters_above(COUNTERS, before, OPTS))
+                end
+            end
+            ngx.say(table.concat(codes, ", "))
+        }
+    }
+--- timeout: 10
+--- response_body
+200, 200, 200, 503
 
 
 


### PR DESCRIPTION
### Description

`t/plugin/ai-rate-limiting.t` TEST 37 pipelines four requests against a redis-policy route and expects the fourth to be rejected. It is racy: `ai-rate-limiting` commits token usage from a log phase timer (`limit-count-redis.log_phase_incoming` schedules `timer_at(0)`), so a request can be evaluated against a budget that still looks unspent and the rejection lands one request late.

```
TEST 37: redis policy shares counter and rejects the 4th request - status code ok
         got: '200'
    expected: '503'
```

Pipelined requests leave no point at which to wait, so the block now sends the four requests sequentially and waits for each one's usage to reach redis before sending the next. Waiting for the commit beats sleeping a fixed amount: it takes only as long as the commit actually needs, and a sleep sized for a busy machine would eat into the rule's own time window.

The helpers go in `t/lib/test_redis.lua`, next to the `flush_all()` this suite already uses — `connect` and `release` are factored out of `flush_single` so both share them, and `connect` grew a `database` option because the route under test keeps its counters in redis db 1.

Verified by delaying the commit in `limit-count-redis.lua` (`timer_at(0)` -> `timer_at(0.3)`), which turns the race into a deterministic failure: TEST 37 fails on current `master` with exactly the mismatch above, and passes with this change. The whole file passes locally either way once the delay is removed (218 subtests).

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
