### PR TITLE
test(basic-auth): store the vault secret before the consumer references it

### DIFF
--- a/t/plugin/basic-auth.t
+++ b/t/plugin/basic-auth.t
@@ -475,7 +475,15 @@ Authorization: Basic Zm9vOmJhcg==
 
 
 
-=== TEST 22: set basic-auth conf: password uses secret ref
+=== TEST 22: store secret into vault
+--- exec
+VAULT_TOKEN='root' VAULT_ADDR='http://0.0.0.0:8200' vault kv put kv/apisix/foo passwd=bar
+--- response_body
+Success! Data written to: kv/apisix/foo
+
+
+
+=== TEST 23: set basic-auth conf: password uses secret ref
 --- request
 GET /t
 --- config
@@ -542,14 +550,6 @@ GET /t
     }
 --- response_body
 passed
-
-
-
-=== TEST 23: store secret into vault
---- exec
-VAULT_TOKEN='root' VAULT_ADDR='http://0.0.0.0:8200' vault kv put kv/apisix/foo passwd=bar
---- response_body
-Success! Data written to: kv/apisix/foo
 
 
 


### PR DESCRIPTION
`t/plugin/basic-auth.t` TEST 22 fails in CI with:

```
failed to resolve secret reference: $secret://vault/test1/foo/passwd, field: password, err: no value
failed to resolve secret reference in consumer auth credential, skipping consumer: foo
```

It is not a timing race — it is deterministic given the Vault state the rest of the job leaves behind.

Four test files write the **same** Vault path with different fields, and `vault kv put` replaces the whole secret rather than merging:

| file | writes |
|---|---|
| `ai-aws-content-moderation-secrets.t` | `secret_access_key`, `access_key_id` |
| `authz-keycloak4.t` | `client_secret` |
| `basic-auth.t` | `passwd` |
| `openid-connect9.t` | `client_secret` |

The first two sort before `basic-auth.t` in the `t/plugin/[a-k]*.t` job, so by the time it runs `kv/apisix/foo` holds a `client_secret` and no `passwd`. TEST 22 then creates a consumer whose password is `$secret://vault/test1/foo/passwd`, and the admin write resolves it right there: `admin/consumers.lua` calls `check_duplicate_key()` → `find_consumer()` → `create_consume_cache()` → `fetch_secrets()`, synchronously inside the request — which is why the error carries the `PUT /apisix/admin/consumers` context. The key exists but the field does not, so it logs at error level and the default `no_error_log: [error]` trips.

It looks flaky only because of the rerun harness: after the job fails, `rerun_flaky_tests` re-runs the failed file **on its own** with `FLUSH_ETCD=1`. Alone, nothing has overwritten `kv/apisix/foo`, the path is absent rather than incomplete, that path does not log an error, and the file goes green — which is exactly what happened in the run that prompted this PR.

Writing the secret before the reference is configured makes the file self-sufficient regardless of what ran before it.

Reproduced deterministically, and the fix verified against it:

```
vault kv put kv/apisix/foo client_secret=xyz
FLUSH_ETCD=1 prove -Itest-nginx/lib -I. t/plugin/basic-auth.t
```

before: `Failed 2/179 subtests` with the two error lines above — after: `All tests successful`.

Sharing one Vault path across four unrelated test files is the underlying hazard; giving each file its own path would be the more thorough fix, but it touches four files and this one is enough to make `basic-auth.t` independent of the others.
