### PR TITLE
test(cli): wait for the pid file before reading it

### DIFF
--- a/t/cli/common.sh
+++ b/t/cli/common.sh
@@ -39,6 +39,27 @@ exit_if_not_customed_nginx() {
     openresty -V 2>&1 | grep apisix-nginx-module || exit 0
 }
 
+# wait_for_pidfile <path> [timeout_secs]
+# Poll until the pid file exists and is non-empty; default timeout 10s.
+# `apisix start` returns once nginx has daemonized, which is before the master
+# has written its pid file, so reading the file right after is a race.
+wait_for_pidfile() {
+    local path="$1"
+    local timeout="${2:-10}"
+    local deadline=$(( $(date +%s) + timeout ))
+    { set +x; } 2>/dev/null
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        if [ -s "$path" ]; then
+            set -x
+            return 0
+        fi
+        sleep 0.1
+    done
+    set -x
+    echo "wait_for_pidfile: ${path} not written after ${timeout}s" >&2
+    return 1
+}
+
 # wait_for_tcp <host> <port> [timeout_secs]
 # Poll until the port accepts TCP; default timeout 10s. Bash-only (/dev/tcp, local).
 wait_for_tcp() {

--- a/t/cli/test_cmd.sh
+++ b/t/cli/test_cmd.sh
@@ -36,6 +36,7 @@ rm logs/nginx.pid || true
 
 # check no corresponding process
 make run
+wait_for_pidfile logs/nginx.pid
 oldpid=$(< logs/nginx.pid)
 make stop
 sleep 0.5


### PR DESCRIPTION
`t/cli/test_cmd.sh` fails intermittently in CI:

```
./t/cli/test_cmd.sh: line 39: logs/nginx.pid: No such file or directory
```

It reads `logs/nginx.pid` on the line right after `make run`, but `apisix start` returns once nginx has daemonized and the master writes its pid file after that — so the read races the write and the script dies under `set -e`.

Poll for the file first. The helper follows the shape of the existing `wait_for_tcp` in `t/cli/common.sh`. The other places that read the pid file (`test_load_full_data_init_worker.sh`, `test_limit_conn_redis_ttl.sh`) already wait on a request or guard with `-f`, so this is the only racy read.

Verified by running `./t/cli/test_cmd.sh` locally end to end.
