### PR TITLE
docs: sign Digest header in hmac-auth body validation example

### DIFF
--- a/docs/en/latest/plugins/hmac-auth.md
+++ b/docs/en/latest/plugins/hmac-auth.md
@@ -894,27 +894,29 @@ gmt_time = datetime.now(timezone.utc).strftime('%a, %d %b %Y %H:%M:%S GMT')
 # the date and any subsequent custom headers should be lowercased and separated by a
 # single space character, i.e. `<key>:<space><value>`
 # https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12#section-2.1.6
+# create the SHA-256 digest of the request body and base64 encode it
+body_digest = hashlib.sha256(body.encode('utf-8')).digest()
+body_digest_base64 = base64.b64encode(body_digest).decode('utf-8')
+digest_header = f"SHA-256={body_digest_base64}"
+
 signing_string = (
     f"{key_id}\n"
     f"{request_method} {request_path}\n"
     f"date: {gmt_time}\n"
+    f"digest: {digest_header}\n"
 )
 
 # create signature
 signature = hmac.new(secret_key, signing_string.encode('utf-8'), hashlib.sha256).digest()
 signature_base64 = base64.b64encode(signature).decode('utf-8')
 
-# create the SHA-256 digest of the request body and base64 encode it
-body_digest = hashlib.sha256(body.encode('utf-8')).digest()
-body_digest_base64 = base64.b64encode(body_digest).decode('utf-8')
-
 # construct the request headers
 headers = {
     "Date": gmt_time,
-    "Digest": f"SHA-256={body_digest_base64}",
+    "Digest": digest_header,
     "Authorization": (
         f'Signature keyId="{key_id}",algorithm="hmac-sha256",'
-        f'headers="@request-target date",'
+        f'headers="@request-target date digest",'
         f'signature="{signature_base64}"'
     )
 }


### PR DESCRIPTION
### Description

Updates the `hmac-auth` body-validation example so that the generated `Digest` header is included in the HTTP signature.

#### Which issue(s) this PR fixes:

Fixes #13395

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes added
- [ ] I have added tests corresponding to this change (documentation-only change)
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible