### PR TITLE
fix(redirect): compare X-Forwarded-Proto case-insensitively

### DIFF
--- a/apisix/plugins/redirect.lua
+++ b/apisix/plugins/redirect.lua
@@ -26,6 +26,7 @@ local ipairs = ipairs
 local ngx = ngx
 local str_find = core.string.find
 local str_sub  = string.sub
+local str_lower = string.lower
 local type = type
 local math_random = math.random
 
@@ -198,7 +199,9 @@ function _M.rewrite(conf, ctx)
     local regex_uri = conf.regex_uri
 
     local proxy_proto = core.request.header(ctx, "X-Forwarded-Proto")
-    local _scheme = proxy_proto or core.request.get_scheme(ctx)
+    -- a URI scheme is case-insensitive (RFC 3986, Section 3.1), so a proxy that
+    -- forwards `HTTPS` is stating the same thing as one that forwards `https`
+    local _scheme = str_lower(proxy_proto or core.request.get_scheme(ctx))
     if conf.http_to_https and _scheme ~= "https" then
         if ret_port == nil or ret_port == 443 or ret_port <= 0 or ret_port > 65535  then
             uri = "https://$host$request_uri"

--- a/docs/en/latest/plugins/redirect.md
+++ b/docs/en/latest/plugins/redirect.md
@@ -46,6 +46,8 @@ The `redirect` Plugin can be used to configure redirects.
 
 * Only one of `http_to_https`, `uri` and `regex_uri` can be configured.
 * Only one of `http_to_https` and `append_query_string` can be configured.
+* When `http_to_https` is enabled, whether the request already used HTTPS is decided by the `X-Forwarded-Proto` header when it is present, and by the scheme of the connection to APISIX otherwise. The value is compared case-insensitively, since a URI scheme is case-insensitive as per [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-3.1).
+* An inbound `X-Forwarded-Proto` is only preserved when the request comes from an address listed in `apisix.trusted_addresses`. Otherwise APISIX overwrites it with the scheme it observes, so a request that reached a TLS-terminating proxy over HTTPS and was forwarded to APISIX over HTTP is treated as HTTP here. See [real-ip](real-ip.md) for the trust boundary.
 * When enabling `http_to_https`, the ports in the redirect URL will pick a value in the following order (in descending order of priority)
   * Read `plugin_attr.redirect.https_port` from the configuration file (`conf/config.yaml`).
   * If `apisix.ssl` is enabled, read `apisix.ssl.listen` and select a port randomly from it.

--- a/docs/zh/latest/plugins/redirect.md
+++ b/docs/zh/latest/plugins/redirect.md
@@ -46,6 +46,8 @@ description: 本文介绍了关于 Apache APISIX `redirect` 插件的基本信�
 
 * `http_to_https`、`uri` 和 `regex_uri` 只能配置其中一个属性。
 * `http_to_https`、和 `append_query_string` 只能配置其中一个属性。
+* 当开启 `http_to_https` 时，请求是否已经是 HTTPS 由 `X-Forwarded-Proto` 请求头决定（该头存在时），否则使用客户端与 APISIX 之间连接的协议。该值按大小写不敏感的方式比较，因为 URI scheme 在 [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-3.1) 中被定义为大小写不敏感。
+* 只有当请求来自 `apisix.trusted_addresses` 中列出的地址时，客户端传入的 `X-Forwarded-Proto` 才会被保留。否则 APISIX 会用自己观测到的协议覆盖它，因此一个以 HTTPS 到达 TLS 终止代理、再以 HTTP 转发到 APISIX 的请求，在这里会被视为 HTTP。信任边界详见 [real-ip](real-ip.md)。
 * 当开启 `http_to_https` 时，重定向 URL 中的端口将按如下顺序选取一个值（按优先级从高到低排列）
   * 从配置文件（`conf/config.yaml`）中读取 `plugin_attr.redirect.https_port`。
   * 如果 `apisix.ssl` 处于开启状态，读取 `apisix.ssl.listen` 并从中随机选一个 `port`。

--- a/t/plugin/redirect.t
+++ b/t/plugin/redirect.t
@@ -1088,3 +1088,74 @@ GET /t
 --- error_code: 400
 --- response_body eval
 qr/error_msg":"failed to check the configuration of plugin redirect err: only one of `http_to_https` and `append_query_string` can be configured."/
+
+
+
+=== TEST 49: set up a route with an upstream, so a request that is not redirected still succeeds
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/hello",
+                    "host": "foo.com",
+                    "plugins": {
+                        "redirect": {
+                            "http_to_https": true
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    }
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 50: uppercase X-Forwarded-Proto is still HTTPS, do not redirect
+--- request
+GET /hello
+--- more_headers
+Host: foo.com
+X-Forwarded-Proto: HTTPS
+--- response_body
+hello world
+
+
+
+=== TEST 51: mixed-case X-Forwarded-Proto is still HTTPS, do not redirect
+--- request
+GET /hello
+--- more_headers
+Host: foo.com
+X-Forwarded-Proto: HtTpS
+--- response_body
+hello world
+
+
+
+=== TEST 52: uppercase X-Forwarded-Proto that is not HTTPS still redirects
+--- request
+GET /hello
+--- more_headers
+Host: foo.com
+X-Forwarded-Proto: HTTP
+--- error_code: 301
+--- response_headers
+Location: https://foo.com:9443/hello


### PR DESCRIPTION
### Description

`redirect`'s `http_to_https` compares `X-Forwarded-Proto` against the lowercase literal `https`, so a proxy that forwards `HTTPS` gets redirected as if the request had arrived over plaintext HTTP.

That comparison is wrong. A URI scheme is case-insensitive per [RFC 3986, Section 3.1](https://datatracker.ietf.org/doc/html/rfc3986#section-3.1), and RFC 7239 requires the `proto` parameter to "conform to the URI scheme name as defined in Section 3.1 in [RFC3986]". A proxy forwarding `HTTPS` is stating exactly what one forwarding `https` states.

Behind a TLS-terminating proxy that does not lowercase the value, this turns into a redirect loop: the client follows the 301 back over HTTPS, the proxy terminates TLS and forwards over HTTP again, and the plugin redirects again. That is the same loop #6242 originally fixed, reintroduced for anyone whose proxy happens to send a different case.

The fix lowercases the value before the comparison. `core.request.header()` already collapses a duplicated header down to its first value, so there is no table to guard against here.

I also documented how the scheme is determined, including the fact that an inbound `X-Forwarded-Proto` is only preserved for peers listed in `apisix.trusted_addresses` — the `redirect` docs did not mention the header at all, which makes `http_to_https` behind a load balancer hard to reason about.

Deliberately out of scope: a multi-valued `X-Forwarded-Proto` such as `https, http` still does not match. `X-Forwarded-Proto` is not part of any specification (RFC 7239's `Forwarded` is the standardized form, and there the chain is expressed as multiple forwarded-elements, each with its own `proto`), so there is no normative basis for deciding which element of a list is authoritative. That deserves its own discussion rather than riding along with a comparison fix.

#### Which issue(s) this PR fixes:

N/A

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
