### PR TITLE
fix(ai-proxy): return 502 when a streaming upstream produces no output

### DIFF
--- a/apisix/plugins/ai-providers/base.lua
+++ b/apisix/plugins/ai-providers/base.lua
@@ -576,13 +576,15 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
             res._upstream_bytes = bytes_read
             ctx.var.apisix_upstream_response_time = math.floor(
                 (ngx_now() - ctx.llm_request_start_time) * 1000)
-            if converter and not output_sent then
+            if not output_sent then
                 if flush_thread then
                     ngx.thread.kill(flush_thread)
                 end
-                local msg = "streaming response completed without producing "
-                            .. "any output; the upstream likely returned a "
-                            .. "different stream format than the converter expects"
+                local msg = converter
+                    and "streaming response completed without producing "
+                        .. "any output; the upstream likely returned a "
+                        .. "different stream format than the converter expects"
+                    or "upstream returned an empty stream"
                 core.log.error(msg)
                 return 502, msg
             end

--- a/t/plugin/ai-proxy-empty-stream.t
+++ b/t/plugin/ai-proxy-empty-stream.t
@@ -1,0 +1,109 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use t::APISIX 'no_plan';
+
+log_level("info");
+repeat_each(1);
+no_long_string();
+no_root_location();
+
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+    # Mock upstream reproducing the customer incident: the LLM answers with a
+    # 200 and an SSE content type, then closes the connection without ever
+    # writing a single body byte. No converter is involved (OpenAI-format
+    # client against an OpenAI-compatible provider).
+    my $http_config = $block->http_config // <<_EOC_;
+        server {
+            server_name empty_sse;
+            listen 7751;
+
+            location /v1/chat/completions {
+                content_by_lua_block {
+                    ngx.status = 200
+                    ngx.header["Content-Type"] = "text/event-stream"
+                    -- headers only, zero body bytes, then EOF
+                    ngx.eof()
+                }
+            }
+        }
+_EOC_
+
+    $block->set_value("http_config", $http_config);
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: set route with a streaming ai-proxy against the empty-SSE upstream
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "uri": "/anything",
+                    "plugins": {
+                        "ai-proxy": {
+                            "provider": "openai",
+                            "auth": {
+                                "header": {
+                                    "Authorization": "Bearer token"
+                                }
+                            },
+                            "options": {
+                                "model": "gpt-4",
+                                "stream": true
+                            },
+                            "override": {
+                                "endpoint": "http://localhost:7751"
+                            },
+                            "ssl_verify": false
+                        }
+                    }
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 2: upstream returns an empty SSE stream
+--- request
+POST /anything
+{"messages": [{"role": "user", "content": "hi"}]}
+--- more_headers
+Content-Type: application/json
+--- error_code: 502
+--- no_error_log
+attempt to index local 'up_conf'


### PR DESCRIPTION
### Description

A streaming AI request whose upstream answers with an SSE content type and then closes without writing a single body byte crashes the gateway in `balancer_by_lua`.

`body_reader()` returns EOF on its first call, the loop body never runs, nothing is written downstream, and `parse_streaming_response()` returns `nil`. `run_plugin()` only calls `core.response.exit()` when a plugin returns a status code, so returning `nil` leaves the request neither answered nor terminated. It falls through to `proxy_pass` and enters `balancer_by_lua`, where `upstream_conf` is always `nil` because `handle_upstream()` skips `set_upstream()` for `bypass_nginx_upstream` plugins:

```
failed to run balancer_by_lua*: apisix/balancer.lua:
    attempt to index local 'up_conf' (a nil value)
    in function 'pick_server'
    in function 'run'
    in function 'http_balancer_phase'
```

`header_filter` then fails as well, so the client gets no HTTP response at all and the connection is closed.

The `output_sent` guard added in the EOF branch already covers this, but only when a converter is active:

```lua
if converter and not output_sent then
    ...
    return 502, msg
end
return
```

An OpenAI-format client against an OpenAI-compatible provider matches `caps[client_protocol]`, so `converter` is `nil`, the guard is skipped, and the bare `return` below hands `nil` back up — the passthrough case (no protocol conversion) was never covered.

This drops the `converter` condition and words the log message by whether a converter was involved. 502 rather than 504: nothing timed out, the upstream closed cleanly and the request's own timeout never fired; 502 is also what this same guard already returns for the converter case.

`t/plugin/ai-proxy-empty-stream.t` mocks an upstream that answers `200` + SSE headers and closes with a zero-byte body, and asserts a 502 with no `up_conf` error.

#### Which issue(s) this PR fixes:

Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
