### PR TITLE
fix(ai-providers): encode Vertex AI model path segment

### DIFF
--- a/apisix/plugins/ai-providers/vertex-ai.lua
+++ b/apisix/plugins/ai-providers/vertex-ai.lua
@@ -17,6 +17,7 @@
 
 local core = require("apisix.core")
 local str_fmt = string.format
+local ngx_escape_uri = ngx.escape_uri
 
 local host_template_fmt =
         "%s-aiplatform.googleapis.com"
@@ -36,7 +37,7 @@ end
 
 
 local function get_embeddings_path(project_id, region, model)
-    return str_fmt(embeddings_path_template_fmt, project_id, region, model)
+    return str_fmt(embeddings_path_template_fmt, project_id, region, ngx_escape_uri(model))
 end
 
 

--- a/t/plugin/ai-proxy-vertex-ai.t
+++ b/t/plugin/ai-proxy-vertex-ai.t
@@ -471,8 +471,15 @@ request head: GET /status/gpt4
                 ctx2
             )
 
-            -- ctx is nil (no model)
+            -- A model name remains one path segment.
+            local ctx3 = {var = {llm_model = "../../custom-model"}}
             local path3 = cap.path(
+                {project_id = "my-project", region = "us-central1"},
+                ctx3
+            )
+
+            -- ctx is nil (no model)
+            local path4 = cap.path(
                 {project_id = "my-project", region = "us-central1"},
                 nil
             )
@@ -480,9 +487,11 @@ request head: GET /status/gpt4
             ngx.say(path1)
             ngx.say(path2)
             ngx.say(path3)
+            ngx.say(path4)
         }
     }
 --- response_body
 /v1/projects/my-project/locations/us-central1/publishers/google/models/text-embedding-004:predict
 /v1/projects/my-project/locations/us-central1/publishers/google/models/textembedding-gecko:predict
+/v1/projects/my-project/locations/us-central1/publishers/google/models/..%2F..%2Fcustom-model:predict
 nil


### PR DESCRIPTION
### Description

Encode the model value before interpolating it into the Vertex AI prediction path, ensuring it remains a single path segment.

#### Which issue(s) this PR fixes:

N/A

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible