### PR TITLE
test(ai-proxy): cover the AWS moderation path in the truncated-stream suite

### DIFF
--- a/t/lib/truncated_sse.lua
+++ b/t/lib/truncated_sse.lua
@@ -111,4 +111,32 @@ function _M.serve_abort_once()
 end
 
 
+-- Minimal AWS Comprehend detectToxicContent stand-in: answers one clean result
+-- per submitted segment. The truncation tests only need the moderation plugin to
+-- reach its terminator-synthesis branch, not a particular verdict.
+function _M.serve_clean_comprehend()
+    local json = require("cjson.safe")
+    ngx.req.read_body()
+    local body = json.decode(ngx.req.get_body_data() or "{}") or {}
+    local results = {}
+    for i in ipairs(body.TextSegments or {}) do
+        results[i] = {
+            Toxicity = 0.01,
+            Labels = {
+                { Name = "PROFANITY", Score = 0.01 },
+                { Name = "HATE_SPEECH", Score = 0.01 },
+                { Name = "INSULT", Score = 0.01 },
+                { Name = "GRAPHIC", Score = 0.01 },
+                { Name = "HARASSMENT_OR_ABUSE", Score = 0.01 },
+                { Name = "SEXUAL", Score = 0.01 },
+                { Name = "VIOLENCE_OR_THREAT", Score = 0.01 },
+            },
+        }
+    end
+    ngx.status = 200
+    ngx.header["Content-Type"] = "application/json"
+    ngx.say(json.encode({ ResultList = results }))
+end
+
+
 return _M

--- a/t/plugin/ai-proxy-stream-truncated.t
+++ b/t/plugin/ai-proxy-stream-truncated.t
@@ -43,6 +43,7 @@ plugins:
   - ai-proxy
   - ai-proxy-multi
   - ai-aliyun-content-moderation
+  - ai-aws-content-moderation
 plugin_attr:
     ai-proxy:
         http_client: lua-resty-http
@@ -51,7 +52,21 @@ _EOC_
         $block->set_value("extra_yaml_config", $user_yaml_config);
     }
 
+    my $main_config = $block->main_config // <<_EOC_;
+    env AWS_REGION=us-east-1;
+_EOC_
+    $block->set_value("main_config", $main_config);
+
     my $http_config = $block->http_config // <<_EOC_;
+    server {
+        listen 2668;
+        location / {
+            content_by_lua_block {
+                require("lib.truncated_sse").serve_clean_comprehend()
+            }
+        }
+    }
+
     server {
         listen 6724;
 
@@ -372,4 +387,58 @@ qr/^(?!.*message_stop)(?=.*"text":"hello")/s
 --- error_log
 failed to read response chunk: closed
 falling back to
+--- timeout: 10
+
+
+
+=== TEST 11: ai-proxy + ai-aws-content-moderation on the usage-then-truncate upstream
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1', ngx.HTTP_PUT, [[{
+                "uri": "/truncated",
+                "plugins": {
+                    "ai-proxy": {
+                        "provider": "openai",
+                        "auth": {"header": {"Authorization": "Bearer test"}},
+                        "options": {"model": "gpt-4", "stream": true},
+                        "override": {
+                            "endpoint": "http://127.0.0.1:6724/v1/chat/completions-usage-then-truncate"
+                        },
+                        "ssl_verify": false
+                    },
+                    "ai-aws-content-moderation": {
+                        "comprehend": {
+                            "access_key_id": "access",
+                            "secret_access_key": "ea+secret",
+                            "region": "us-east-1",
+                            "endpoint": "http://127.0.0.1:2668"
+                        },
+                        "moderation_categories": {"PROFANITY": 0.5},
+                        "check_request": false,
+                        "check_response": true,
+                        "stream_check_mode": "final_packet"
+                    }
+                }
+            }]])
+            if code >= 300 then ngx.status = code end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 12: the AWS moderation path does not terminate a truncated stream either
+--- request
+POST /truncated
+{"messages":[{"role":"user","content":"hi"}],"model":"gpt-4","stream":true}
+--- response_body_like eval
+# Same assertion as TEST 8, against the second plugin whose terminator
+# synthesis this change gates on ctx.ai_stream_aborted.
+qr/^(?!.*\[DONE\])(?=.*"content":"hello")(?=.*"risk_level":)/s
+--- error_log
+failed to read response chunk: closed
 --- timeout: 10


### PR DESCRIPTION
### Description

Follow-up to the truncated-stream fix: it gated the terminator synthesis in both `ai-aws-content-moderation` and `ai-aliyun-content-moderation` on `ctx.ai_stream_aborted`, but the regression suite that came with it only configured the aliyun plugin. The AWS branch was changed without a test that fails before the gate and passes after — the existing AWS suite exercises synthesis, never with `ctx.ai_stream_aborted` set.

This adds the AWS counterpart of the aliyun case to `t/plugin/ai-proxy-stream-truncated.t`: an upstream that delivers a content event and a usage event and then loses the transport, with `ai-aws-content-moderation` in `final_packet` mode. It asserts the content is annotated and released to the client and that no `[DONE]` is appended to the truncated stream. Removing the `not ctx.ai_stream_aborted` gate makes it fail.

The Comprehend stand-in answers one clean verdict per submitted segment, which is all the terminator branch needs; the verdict itself is not what is under test, so it does not reuse the fixture-driven mock from the AWS suite.

Test-only change; no plugin code is touched.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have verified that this change is backward compatible
