### PR TITLE
fix(basic-auth): reject empty consumer password and fail closed

### DIFF
--- a/apisix/plugins/basic-auth.lua
+++ b/apisix/plugins/basic-auth.lua
@@ -43,7 +43,10 @@ local consumer_schema = {
     title = "work with consumer object",
     properties = {
         username = { type = "string" },
-        password = { type = "string" },
+        password = {
+            type = "string",
+            minLength = 1,
+        },
     },
     encrypt_fields = {"password"},
     required = {"username", "password"},
@@ -145,6 +148,13 @@ local function find_consumer(ctx)
             return nil, nil, err
         end
         core.log.warn(err)
+        return nil, nil, "Invalid user authorization"
+    end
+
+    -- RFC 8265 section 4.1: a password MUST NOT be zero-length. Fail closed
+    -- when the resolved password is empty, which also covers existing data
+    -- and $secret:// / $ENV:// references that resolve to "".
+    if password == "" or cur_consumer.auth_conf.password == "" then
         return nil, nil, "Invalid user authorization"
     end
 

--- a/t/plugin/basic-auth.t
+++ b/t/plugin/basic-auth.t
@@ -708,3 +708,81 @@ Authorization: bASiC Zm9vOmJhcg==
 hello world
 --- error_log
 find consumer foo
+
+
+=== TEST 40: consumer schema rejects empty password
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local plugin = require("apisix.plugins.basic-auth")
+            local ok, err = plugin.check_schema({username = 'foo', password = ''}, core.schema.TYPE_CONSUMER)
+            if ok then
+                ngx.say("unexpected: schema accepted empty password")
+                return
+            end
+            ngx.say(err or "rejected")
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+property "password" validation failed
+--- no_error_log
+unexpected
+
+
+
+=== TEST 41: admin api rejects consumer with empty password
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "empty-pass",
+                    "plugins": {
+                        "basic-auth": {
+                            "username": "empty-pass",
+                            "password": ""
+                        }
+                    }
+                }]]
+                )
+            if code < 400 then
+                ngx.status = 500
+                ngx.say("unexpected: admin api accepted empty password")
+                return
+            end
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- error_code: 400
+--- response_body_like
+property "password" validation failed
+--- no_error_log
+unexpected
+
+
+
+=== TEST 42: empty password in Authorization header is rejected
+--- request
+GET /hello
+--- more_headers
+Authorization: Basic Zm9vOg==
+--- error_code: 401
+
+
+
+=== TEST 43: whitespace-only password in Authorization header is rejected
+--- request
+GET /hello
+--- more_headers
+Authorization: Basic Zm9vOiA=
+--- error_code: 401
+--- response_body
+{"message":"Invalid user authorization"}


### PR DESCRIPTION
### Summary

Fixes #13881 — `basic-auth` currently accepts a consumer with an empty password, allowing passwordless access.

RFC 8265 section 4.1 (the OpaqueString password profile referenced by RFC 7617) requires a password to be non-zero-length. Today the Admin API accepts `password: ""` because `consumer_schema.password` is declared as plain `{ type = "string" }` with no `minLength`. Such a consumer authenticates, so it looks protected while it effectively has no secret. Once #13836 lands (split on the first colon per RFC 7617), `user:` would also return 200 for such a consumer.

### Changes

- **`apisix/plugins/basic-auth.lua`**
  - Add `minLength = 1` to `consumer_schema.password` so the Admin API rejects empty passwords on consumer create/update.
  - Fail closed in `find_consumer` when either the presented or the resolved password is empty. This also covers existing empty-password consumers and `$secret://` / `$ENV://` references that resolve to `""`.

- **`t/plugin/basic-auth.t`** — regression tests:
  - consumer schema rejects an empty password
  - Admin API rejects a consumer with an empty password (400)
  - `foo:` (empty password) returns 401
  - whitespace-only password (`foo: `) returns 401

### Compatibility with #13836

This change is orthogonal to #13836 (which fixes parsing to split on the first colon). With or without #13836, an empty/whitespace-only password now fails closed with a 401.
