### PR TITLE
fix(etcd): do not block writes when the deployment role cannot be read

### DIFF
--- a/apisix/core/etcd.lua
+++ b/apisix/core/etcd.lua
@@ -50,7 +50,7 @@ local function is_data_plane()
 
     local role = try_read_attr(local_conf, "deployment", "role")
     if role == "data_plane" then
-      return true
+        return true
     end
 
     return false
@@ -62,7 +62,9 @@ local function disable_write_if_data_plane()
     local data_plane, err = is_data_plane()
     if err then
         log.error("failed to check data plane role: ", err)
-        return true, err
+        -- the guard only warns for now, so failing to read the local config
+        -- must not be stricter than a confirmed data plane role
+        return false, err
     end
 
     if data_plane then
@@ -144,7 +146,11 @@ local function _new(etcd_conf)
         return nil, nil, err
     end
 
-    etcd_cli = wrap_etcd_client(etcd_cli)
+    local wrap_err
+    etcd_cli, wrap_err = wrap_etcd_client(etcd_cli)
+    if not etcd_cli then
+        return nil, nil, wrap_err
+    end
 
     return etcd_cli, prefix
 end

--- a/t/core/etcd-write.t
+++ b/t/core/etcd-write.t
@@ -1105,3 +1105,102 @@ deployment:
 GET /t
 --- no_error_log
 Data plane role should not write to etcd. This operation will be deprecated in future releases.
+
+
+
+=== TEST 34: an unreadable local config does not block the write
+--- yaml_config
+deployment:
+  role: control_plane
+  role_control_plane:
+    config_provider: etcd
+  etcd:
+    host:
+      - "http://127.0.0.1:2379"
+    prefix: "/apisix"
+    tls:
+      verify: false
+--- config
+    location /t {
+        content_by_lua_block {
+            local config_local = require("apisix.core.config_local")
+            local origin_local_conf = config_local.local_conf
+            local fail = false
+            config_local.local_conf = function(...)
+                if fail then
+                    return nil, "mocked local conf failure"
+                end
+                return origin_local_conf(...)
+            end
+
+            -- reload so that the module picks up the patched local_conf
+            package.loaded["apisix.core.etcd"] = nil
+            local etcd = require("apisix.core.etcd")
+
+            -- the first write caches the etcd client
+            local res, err = etcd.set("/foo", "bar")
+            if not res then
+                ngx.say("first set failed: ", err)
+                return
+            end
+
+            fail = true
+            res, err = etcd.set("/foo", "bar")
+            ngx.say("second set: ", res and "ok" or ("failed: " .. (err or "nil")))
+
+            fail = false
+            etcd.delete("/foo")
+            config_local.local_conf = origin_local_conf
+            package.loaded["apisix.core.etcd"] = nil
+        }
+    }
+--- request
+GET /t
+--- response_body
+second set: ok
+--- error_log
+failed to check data plane role: mocked local conf failure
+--- no_error_log
+Data plane role should not write to etcd. This operation will be deprecated in future releases.
+
+
+
+=== TEST 35: a client missing a wrapped method reports the reason
+--- yaml_config
+deployment:
+  role: control_plane
+  role_control_plane:
+    config_provider: etcd
+  etcd:
+    host:
+      - "http://127.0.0.1:2379"
+    prefix: "/apisix"
+    tls:
+      verify: false
+--- config
+    location /t {
+        content_by_lua_block {
+            local origin_etcd = package.loaded["resty.etcd"]
+            package.loaded["resty.etcd"] = {
+                new = function()
+                    -- every other wrapped method is missing
+                    return {set = function() end}
+                end,
+            }
+
+            package.loaded["apisix.core.etcd"] = nil
+            local etcd = require("apisix.core.etcd")
+
+            local res, err = etcd.set("/foo", "bar")
+            ngx.say("res: ", res and "ok" or "nil", ", err: ", err or "nil")
+
+            package.loaded["resty.etcd"] = origin_etcd
+            package.loaded["apisix.core.etcd"] = nil
+        }
+    }
+--- request
+GET /t
+--- response_body
+res: nil, err: method setnx not found in etcd client
+--- error_log
+method setnx not found in etcd client


### PR DESCRIPTION
### Description

Two defects in the data-plane write guard added by #12241.

**1. The guard fails closed on the one case it does not target.**

```lua
local function disable_write_if_data_plane()
    local data_plane, err = is_data_plane()
    if err then
        log.error("failed to check data plane role: ", err)
        return true, err          -- blocks the write
    end

    if data_plane then
        -- current only warn, will be return false in future releases
        log.warn(NOT_ALLOW_WRITE_ETCD_WARN)
        return false              -- allows the write
    end
```

A confirmed `data_plane` role only warns, but a failure to read the local config blocks every wrapped write. That is backwards, and it is reachable: `get_etcd_cli()` caches the client in an upvalue, so once the client exists `fetch_local_conf()` is never called again from `new()` — only from this guard. If `local_conf()` starts failing afterwards, a control plane with a perfectly usable cached client stops being able to write, while the role the guard exists for keeps writing.

The guard is in its warn-only phase, so it now returns `false` there too.

**2. `wrap_etcd_client` errors are dropped.**

```lua
etcd_cli = wrap_etcd_client(etcd_cli)

return etcd_cli, prefix
```

`wrap_etcd_client` returns `nil, "method ... not found in etcd client"` when the client is missing one of the wrapped methods. The second value is discarded, so `_new` returns `nil, prefix`, `get_etcd_cli` returns `nil, nil, nil`, and callers such as `_M.get` do `return nil, err` with `err == nil` — an undiagnosable failure. The error is now propagated.

Also fixes the six-space indentation in `is_data_plane`.

### Tests

`t/core/etcd-write.t` TEST 34 and TEST 35. Both fail on `master` and pass with this change:

```
TEST 34  got: second set: failed: mocked local conf failure   expected: second set: ok
TEST 35  got: res: nil, err: nil                              expected: res: nil, err: method setnx not found in etcd client
```

The full file (35 tests) passes with the change.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation accordingly
- [x] I have verified that the change is backward compatible