### PR TITLE
fix(ai-cache): key the passthrough protocol on the client method, path and query

### DIFF
--- a/apisix/plugins/ai-cache/key.lua
+++ b/apisix/plugins/ai-cache/key.lua
@@ -69,12 +69,22 @@ local function build_repr(ctx, body, messages)
     local proto = ctx.ai_client_protocol and protocols.get(ctx.ai_client_protocol)
     params.stream = (proto and proto.is_streaming(body)) == true
 
+    local client = {
+        protocol = ctx.ai_client_protocol or "",
+        messages = messages,
+        params   = params,
+    }
+    -- passthrough proxies the client's method, path and query string verbatim
+    -- (see ai-proxy/base.lua), so under it they select the upstream endpoint
+    -- and are response-determining.
+    if ctx.ai_client_protocol == "passthrough" then
+        client.method = ctx.var.request_method
+        client.uri    = ctx.var.uri
+        client.args   = ctx.var.args
+    end
+
     return {
-        client = {
-            protocol = ctx.ai_client_protocol or "",
-            messages = messages,
-            params   = params,
-        },
+        client = client,
         effective = {
             provider    = inst.provider,
             -- effective model precedence mirrors ai-proxy/base.lua exactly:

--- a/apisix/plugins/ai-cache/key.lua
+++ b/apisix/plugins/ai-cache/key.lua
@@ -78,7 +78,9 @@ local function build_repr(ctx, body, messages)
     -- (see ai-proxy/base.lua), so under it they select the upstream endpoint
     -- and are response-determining.
     if ctx.ai_client_protocol == "passthrough" then
-        client.method = ctx.var.request_method
+        -- live method: ctx.var.request_method is cached at route match, before
+        -- a proxy-rewrite method change that the upstream request carries.
+        client.method = core.request.get_method()
         client.uri    = ctx.var.uri
         client.args   = ctx.var.args
     end

--- a/docs/en/latest/plugins/ai-cache.md
+++ b/docs/en/latest/plugins/ai-cache.md
@@ -61,6 +61,8 @@ By default the cache is isolated per route, so two routes never serve each other
 
 Even with `cache_key.share_across_routes` enabled, the cache key identifies the *effective* upstream request — the request `ai-proxy` actually sends after applying the AI instance's `provider`, `options` (model, temperature, and other model parameters) and `override`. Routes that would call the model differently therefore keep separate cache entries, so one route's response is never served for another.
 
+For the `passthrough` protocol, `ai-proxy` forwards the client's request method, path and query string verbatim, so the key includes them too: the same body sent to two different upstream paths, or with different query parameters, keeps separate entries.
+
 :::
 
 ## Attributes

--- a/docs/zh/latest/plugins/ai-cache.md
+++ b/docs/zh/latest/plugins/ai-cache.md
@@ -61,6 +61,8 @@ import TabItem from '@theme/TabItem';
 
 即使开启 `cache_key.share_across_routes`，来自不同上游模型或 provider 的响应也会分别存储在各自的缓存条目中，因此某个模型的响应绝不会被返回给另一个模型。
 
+对于 `passthrough` 协议，`ai-proxy` 会原样转发客户端的请求方法、路径和查询字符串，因此缓存键也会包含它们：相同的请求体发送到两个不同的上游路径，或携带不同的查询参数时，会分别保存为独立的缓存条目。
+
 :::
 
 ## 属性

--- a/t/plugin/ai-cache.t
+++ b/t/plugin/ai-cache.t
@@ -1464,25 +1464,30 @@ passed
                 return key.fingerprint(ctx, body)
             end
 
-            local base = { request_method = "POST", uri = "/v1/images/generations", args = nil }
+            local base = { uri = "/v1/images/generations", args = nil }
             local pt   = fp("passthrough", base)
 
             assert(fp("passthrough", base) == pt, "identical passthrough request must match")
-            assert(fp("passthrough", { request_method = "POST", uri = "/v1/images/edits" }) ~= pt,
-                   "different path")
-            assert(fp("passthrough", { request_method = "POST", uri = "/v1/images/generations",
+            assert(fp("passthrough", { uri = "/v1/images/edits" }) ~= pt, "different path")
+            assert(fp("passthrough", { uri = "/v1/images/generations",
                                        args = "api-version=2024-02-01" }) ~= pt,
                    "different query string")
-            assert(fp("passthrough", { request_method = "GET", uri = "/v1/images/generations" }) ~= pt,
-                   "different method")
+
+            -- the method is read live from the request (a rewrite changes it), so
+            -- flip it the way proxy-rewrite does rather than through ctx.var
+            ngx.req.set_method(ngx.HTTP_POST)
+            local posted = fp("passthrough", base)
+            assert(posted ~= pt, "different method")
+            ngx.req.set_method(ngx.HTTP_GET)
+            assert(fp("passthrough", base) == pt, "method restored")
 
             -- other protocols build a fixed upstream request from the body alone,
             -- so the client path stays out of their fingerprint
-            local chat = { request_method = "POST", uri = "/a" }
-            local chat_ctx = { ai_client_protocol = "openai-chat", var = chat, picked_ai_instance = inst }
+            local chat_ctx = { ai_client_protocol = "openai-chat", var = { uri = "/a" },
+                               picked_ai_instance = inst }
             local chat_body = { model = "gpt-4o", messages = {{ role = "user", content = "hi" }} }
             local chat_fp = key.fingerprint(chat_ctx, chat_body)
-            chat_ctx.var = { request_method = "POST", uri = "/b" }
+            chat_ctx.var = { uri = "/b" }
             assert(key.fingerprint(chat_ctx, chat_body) == chat_fp,
                    "non-passthrough fingerprint ignores the client path")
 
@@ -1575,6 +1580,82 @@ qr/baby sea otter/
 --- request
 POST /v1/images/generations
 {"model":"dall-e-3","prompt":"ai-cache passthrough same body"}
+--- response_headers_like
+X-AI-Cache-Status: HIT
+--- response_body_like eval
+qr/baby sea otter/
+
+
+
+=== TEST 64: passthrough route with proxy-rewrite forcing the upstream method to POST
+--- config
+    location /t {
+        content_by_lua_block {
+            require("lib.test_redis").flush_port("127.0.0.1", 6379)
+
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/v1/*",
+                    "plugins": {
+                        "proxy-rewrite": { "method": "POST" },
+                        "ai-proxy": {
+                            "provider": "openai",
+                            "auth": { "header": { "Authorization": "Bearer test-key" } },
+                            "override": { "endpoint": "http://127.0.0.1:1980" }
+                        },
+                        "ai-cache": {
+                            "redis_host": "127.0.0.1",
+                            "redis_port": 6379
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- extra_yaml_config
+plugins:
+  - proxy-rewrite
+  - ai-proxy
+  - ai-cache
+--- response_body
+passed
+
+
+
+=== TEST 65: POST passthrough request is a MISS
+--- request
+POST /v1/images/generations
+{"model":"dall-e-3","prompt":"ai-cache passthrough rewritten method"}
+--- more_headers
+X-AI-Fixture: openai/images-generation.json
+--- extra_yaml_config
+plugins:
+  - proxy-rewrite
+  - ai-proxy
+  - ai-cache
+--- response_headers
+X-AI-Cache-Status: MISS
+--- response_body_like eval
+qr/baby sea otter/
+--- wait: 0.3
+
+
+
+=== TEST 66: PUT with the same body is rewritten to POST upstream, so it is a HIT on the POST entry
+--- request
+PUT /v1/images/generations
+{"model":"dall-e-3","prompt":"ai-cache passthrough rewritten method"}
+--- extra_yaml_config
+plugins:
+  - proxy-rewrite
+  - ai-proxy
+  - ai-cache
 --- response_headers_like
 X-AI-Cache-Status: HIT
 --- response_body_like eval

--- a/t/plugin/ai-cache.t
+++ b/t/plugin/ai-cache.t
@@ -1446,3 +1446,136 @@ X-AI-Cache-Status: MISS
     }
 --- response_body
 passed
+
+
+
+=== TEST 58: passthrough folds the client method, path and query into the fingerprint (key.lua unit)
+--- config
+    location /t {
+        content_by_lua_block {
+            local key = require("apisix.plugins.ai-cache.key")
+
+            local inst = { provider = "openai", options = {}, override = {} }
+            local body = { model = "dall-e-3", prompt = "otter" }
+
+            local function fp(protocol, var)
+                local ctx = { ai_client_protocol = protocol, var = var,
+                              picked_ai_instance = inst }
+                return key.fingerprint(ctx, body)
+            end
+
+            local base = { request_method = "POST", uri = "/v1/images/generations", args = nil }
+            local pt   = fp("passthrough", base)
+
+            assert(fp("passthrough", base) == pt, "identical passthrough request must match")
+            assert(fp("passthrough", { request_method = "POST", uri = "/v1/images/edits" }) ~= pt,
+                   "different path")
+            assert(fp("passthrough", { request_method = "POST", uri = "/v1/images/generations",
+                                       args = "api-version=2024-02-01" }) ~= pt,
+                   "different query string")
+            assert(fp("passthrough", { request_method = "GET", uri = "/v1/images/generations" }) ~= pt,
+                   "different method")
+
+            -- other protocols build a fixed upstream request from the body alone,
+            -- so the client path stays out of their fingerprint
+            local chat = { request_method = "POST", uri = "/a" }
+            local chat_ctx = { ai_client_protocol = "openai-chat", var = chat, picked_ai_instance = inst }
+            local chat_body = { model = "gpt-4o", messages = {{ role = "user", content = "hi" }} }
+            local chat_fp = key.fingerprint(chat_ctx, chat_body)
+            chat_ctx.var = { request_method = "POST", uri = "/b" }
+            assert(key.fingerprint(chat_ctx, chat_body) == chat_fp,
+                   "non-passthrough fingerprint ignores the client path")
+
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 59: wildcard passthrough route: ai-proxy without an endpoint path forwards the client URI
+--- config
+    location /t {
+        content_by_lua_block {
+            require("lib.test_redis").flush_port("127.0.0.1", 6379)
+
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/v1/*",
+                    "plugins": {
+                        "ai-proxy": {
+                            "provider": "openai",
+                            "auth": { "header": { "Authorization": "Bearer test-key" } },
+                            "override": { "endpoint": "http://127.0.0.1:1980" }
+                        },
+                        "ai-cache": {
+                            "redis_host": "127.0.0.1",
+                            "redis_port": 6379
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 60: passthrough body to /v1/images/generations is a MISS and is proxied
+--- request
+POST /v1/images/generations
+{"model":"dall-e-3","prompt":"ai-cache passthrough same body"}
+--- more_headers
+X-AI-Fixture: openai/images-generation.json
+--- response_headers
+X-AI-Cache-Status: MISS
+--- response_body_like eval
+qr/baby sea otter/
+--- wait: 0.3
+
+
+
+=== TEST 61: the SAME body to a different upstream path is a MISS, not the cached images response
+--- request
+POST /v1/chat/completions
+{"model":"dall-e-3","prompt":"ai-cache passthrough same body"}
+--- more_headers
+X-AI-Fixture: openai/chat-basic.json
+--- response_headers
+X-AI-Cache-Status: MISS
+--- response_body_like eval
+qr/1 \+ 1 = 2/
+--- wait: 0.3
+
+
+
+=== TEST 62: the SAME body and path with a different query string is a MISS
+--- request
+POST /v1/images/generations?api-version=2024-02-01
+{"model":"dall-e-3","prompt":"ai-cache passthrough same body"}
+--- more_headers
+X-AI-Fixture: openai/images-generation.json
+--- response_headers
+X-AI-Cache-Status: MISS
+--- response_body_like eval
+qr/baby sea otter/
+--- wait: 0.3
+
+
+
+=== TEST 63: repeating the first passthrough request exactly is a HIT
+--- request
+POST /v1/images/generations
+{"model":"dall-e-3","prompt":"ai-cache passthrough same body"}
+--- response_headers_like
+X-AI-Cache-Status: HIT
+--- response_body_like eval
+qr/baby sea otter/


### PR DESCRIPTION
### Description

For the `passthrough` protocol, `ai-proxy` forwards the client's request method, path and query string verbatim (`ai-proxy/base.lua`), so on a wildcard route they select which upstream endpoint answers. The `ai-cache` fingerprint covered only the client body and the instance config, so the same body sent to `/v1/images/generations` and `/v1/chat/completions` (or to one path with different query parameters) collided on one cache entry and the second request was served the first one's response.

This folds the client method, `uri` and `args` into `build_repr` under a passthrough gate. Other protocols build a fixed upstream request from the body alone, so their fingerprints are unchanged; an existing entry keeps its key.

Tests: a `key.lua` unit block (path, query and method each flip the passthrough fingerprint; the `openai-chat` fingerprint still ignores the client path) plus an end-to-end sequence on a `/v1/*` route: same body to two upstream paths is MISS/MISS, a query-string variant is a MISS, and an exact repeat is a HIT. Without the fix TESTs 58, 61 and 62 fail.

Docs: the `cache_key` note in `ai-cache.md` (en/zh) now states that passthrough keys include the method, path and query.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)