### PR TITLE
docs: fix dead eFactory blog link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Using AWS's eight-core server, APISIX's QPS reaches 140,000 with a latency of on
 
 ## User Stories
 
-- [European eFactory Platform: API Security Gateway – Using APISIX in the eFactory Platform](https://www.efactory-project.eu/post/api-security-gateway-using-apisix-in-the-efactory-platform)
+- [European eFactory Platform: API Security Gateway – Using APISIX in the eFactory Platform](https://web.archive.org/web/20220120184502/https://www.efpf.org/post/api-security-gateway-using-apisix-in-the-efactory-platform)
 - [Copernicus Reference System Software](https://github.com/COPRS/infrastructure/wiki/Networking-trade-off)
 - [More Stories](https://apisix.apache.org/blog/tags/case-studies/)
 


### PR DESCRIPTION
The eFactory blog post link in the "User Cases and Presentations" section is dead — `efactory-project.eu` no longer resolves, and the post is also gone from the successor project domain (`efpf.org` returns 404 for it). Replaced with the Internet Archive snapshot of the article (HTTP 200, "API Security Gateway – Using APISIX in the EFPF Platform").
