### PR TITLE
fix(basic-auth): keep colons in password when parsing auth header

### DIFF
--- a/apisix/plugins/basic-auth.lua
+++ b/apisix/plugins/basic-auth.lua
@@ -98,7 +98,11 @@ local function extract_auth_header(authorization)
         end
 
         local res
-        res, err = ngx_re.split(decoded, ":")
+        -- Split only on the first colon: RFC 7617 allows colons in passwords,
+        -- so `user:pass:word` must yield username="user", password="pass:word".
+        -- ngx.re.split's 5th arg (max) caps the number of substrings returned,
+        -- so 2 keeps the username + the remainder (colons included).
+        res, err = ngx_re.split(decoded, ":", nil, nil, 2)
         if err then
             return nil, "Split authorization err:" .. err
         end
@@ -120,6 +124,10 @@ local function extract_auth_header(authorization)
     end
 
 end
+
+-- Exported for unit testing (t/plugin/basic-auth.t) without loading the
+-- full plugin runtime.
+_M.extract_auth_header = extract_auth_header
 
 
 local function find_consumer(ctx)

--- a/t/plugin/basic-auth.t
+++ b/t/plugin/basic-auth.t
@@ -51,7 +51,33 @@ done
 
 
 
-=== TEST 2: wrong type of string
+=== TEST 2: password containing a colon (RFC 7617)
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.basic-auth")
+            -- decoded form is "user:pass:word"; only the first colon
+            -- separates user from password.
+            local decoded = ngx.encode_base64("user:pass:word")
+            local user, pass, err = plugin.extract_auth_header("Basic " .. decoded)
+            if err then
+                ngx.say("err: ", err)
+                return
+            end
+            ngx.say("username=", user)
+            ngx.say("password=", pass)
+        }
+    }
+--- request
+GET /t
+--- response_body
+username=user
+password=pass:word
+--- no_error_log
+[error]
+
+
+=== TEST 3: wrong type of string
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
### Description

Fixes #13835 — RFC 7617 allows colons in credentials, but the basic-auth plugin split the decoded `user:password` header on **every** colon. A password such as `john:key` was truncated to `john`, so authentication failed.

### Root cause
`apisix/plugins/basic-auth.lua` used `ngx_re.split(decoded, ":")` (no limit), producing `{"johndoe-colon", "john", "key"}` for `johndoe-colon:john:key`. `res[2]` then captured only `john`.

### Fix
Split only on the first colon using `ngx_re.split(decoded, ":", nil, nil, 2)`, so `res[1]` is the username and `res[2]` is the remainder (colons included).

Verified with the real OpenResty `ngx.re.split`:
- buggy (no max): `johndoe-colon:john:key` -> username=`johndoe-colon`, password=`john` (truncated)
- fixed (max=2): `johndoe-colon:john:key` -> username=`johndoe-colon`, password=`john:key`

### Test
Added `t/plugin/basic-auth.t` TEST 2 exercising a colon-containing password. Also exported `extract_auth_header` as `_M.extract_auth_header` so the parsing is unit-testable.

### Checklist
- [x] Signed-off (Apache ICLA)
- [x] Minimal, scoped change
- [x] No docs change needed