### PR TITLE
docs: warn on missing docker-start and document custom-image CMD pitfall

### DIFF
--- a/docker/debian-dev/docker-entrypoint.sh
+++ b/docker/debian-dev/docker-entrypoint.sh
@@ -61,4 +61,17 @@ _EOC_
     exec /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'
 fi
 
+# If we get here, the first argument was not "docker-start". The container will
+# run "$@" and exit. That is expected when the user overrides the command on
+# purpose (e.g. to run a shell), but it is the classic symptom of a broken image
+# where `docker commit` baked a shell into CMD and dropped the official
+# `["docker-start"]`. Warn so the silent "exits 0, no logs" failure is obvious.
+if [ -n "$1" ] && [ "$1" != "docker-start" ]; then
+    echo "WARNING: apisix entrypoint received [$1] instead of 'docker-start'." >&2
+    echo "         APISIX did not start. If your image was created with 'docker commit'," >&2
+    echo "         the committed CMD likely replaced the official ['docker-start']." >&2
+    echo "         Fix the image by building from apache/apisix and dropping 'docker commit'," >&2
+    echo "         or run the container with: command: ['/docker-entrypoint.sh'] args: ['docker-start']" >&2
+fi
+
 exec "$@"

--- a/docs/en/latest/FAQ.md
+++ b/docs/en/latest/FAQ.md
@@ -730,6 +730,46 @@ The `tls.client_cert`, `tls.client_key`, and `tls.client_cert_id` in upstream ar
 
 The `ssl_trusted_certificate` in `config.yaml` configures a trusted CA certificate. It is used for verifying some certificates signed by private authorities within APISIX, to avoid APISIX rejects the certificate. Note that APISIX does not verify the certificate of an upstream unless that upstream sets `tls.verify` to `true`, so by default an upstream using an invalid TLS certificate can still be accessed. Once `tls.verify` is enabled, the certificate is checked against the upstream's own `tls.ca_certs` if set, and against `ssl_trusted_certificate` otherwise.
 
+## Why does my custom APISIX image start but APISIX is not running (exits 0, no logs)?
+
+This happens when the image's `CMD` is no longer `["docker-start"]`. The
+`/docker-entrypoint.sh` script only starts APISIX when its first argument is
+`docker-start`; otherwise it falls through to `exec "$@"` and the container
+exits immediately. The usual cause is building the image from a `docker commit`
+of a container that was started with a shell:
+
+```bash
+docker run -it --user root apache/apisix:3.17.0-ubuntu /bin/bash   # shell becomes the runtime CMD
+docker commit <container> my/apisix:custom                         # bakes /bin/bash into CMD
+```
+
+After `commit`, `docker inspect` shows `Config.Cmd` as `["/bin/bash"]` instead
+of `["docker-start"]`, so the entrypoint runs the shell (no stdin) and exits 0.
+
+Fix: build from the official image and switch user inside the Dockerfile instead
+of committing a shell session. `apt-get` works as `root` without changing the
+image's `CMD`:
+
+```dockerfile
+FROM apache/apisix:3.17.0-ubuntu
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends openjdk-21-jdk-headless \
+    && rm -rf /var/lib/apt/lists/*
+COPY target/*.jar /usr/local/apisix/
+RUN chown -R apisix:root /usr/local/apisix/
+
+USER apisix
+```
+
+If you must override the command in Kubernetes, keep the entrypoint and pass the
+argument:
+
+```yaml
+command: ["/docker-entrypoint.sh"]
+args: ["docker-start"]
+```
+
 ## Where can I find more answers?
 
 You can find more answers on:


### PR DESCRIPTION
### Description

A custom image built from `docker commit` of a shell session bakes the shell into `CMD`, replacing the official `["docker-start"]`. The entrypoint then falls through to `exec "$@"` and the container exits 0 with no logs and no APISIX process (apache/apisix#13775).

This PR:
- emits a stderr warning in `/docker-entrypoint.sh` when the first argument is not `docker-start`, so the silent failure is obvious instead of a mysterious exit 0.
- adds an FAQ entry with the correct Dockerfile pattern (switch `USER` inside the Dockerfile instead of committing a shell session), plus the Kubernetes `command`/`args` override.

### Checklist

- [x] I have explained my changes
- [x] Doc/entrypoint change, no behavior change for the normal `docker-start` path

Refs apache/apisix#13775