### PR TITLE
test(skywalking): remove worker-0 dependency in backend timer assertion

### DIFF
--- a/t/plugin/skywalking2.t
+++ b/t/plugin/skywalking2.t
@@ -65,9 +65,8 @@ _EOC_
             end
         end
 
-        if 0 == ngx.worker.id() then
-            -- patch: skywalking2
-            -- Ensure that it is executed only once
+        -- patch: skywalking2
+        if metadata_buffer:add("backend_timer_started", true) then
             ngx.log(ngx.INFO, "start skywalking backend timer")
             local ok, err = new_timer(self.backendTimerDelay, check)
             if not ok then
@@ -149,12 +148,6 @@ passed
             local http = require "resty.http"
             local uri = "http://127.0.0.1:" .. ngx.var.server_port
                         .. "/opentracing"
-            local ports_count = {}
-            -- The patched startBackendTimer only logs when ngx.worker.id()==0,
-            -- so we need at least one connection to land on worker 0. With
-            -- workers(4) and keepalive=false, 12 requests gave a ~3% chance
-            -- of missing worker 0 entirely; bump to 50 to make that vanishingly
-            -- unlikely (~0.0006%).
             for i = 1, 50 do
                 local httpc = http.new()
                 local res, err = httpc:request_uri(uri, {method = "GET", keepalive = false})


### PR DESCRIPTION
### Description

`t/plugin/skywalking2.t` TEST 2 fails intermittently on CI, and since it can fail the flaky-rerun too, it turns whole `build` jobs red.
Example: [run 33146313320](https://github.com/apache/apisix/actions/runs/33146313320/job/98775191319) on #13651, where it failed both the initial pass and the rerun with:

```
Failed test 't/plugin/skywalking2.t TEST 2: trigger skywalking - grep_error_log_out (req 0)'
got: ''
expected: 'start skywalking backend timer'
```

**Cause:** the test's patched `startBackendTimer` logs `start skywalking backend timer` only on `ngx.worker.id() == 0`, so TEST 2 needs worker 0 to accept at least one of its 50 keepalive-off requests.
The comment in the test assumed independent uniform accepts (`(3/4)^50`, "vanishingly unlikely" to miss worker 0), but nginx accept distribution is skewed and correlated: measured locally over 60 runs, the per-worker split of the 50 requests was consistently about 17/16/14/3, with the starved worker receiving as few as 1 request and worker 0 sitting in the starved slot in roughly a quarter of runs.
On a loaded 4-vCPU CI runner the starved worker can receive 0 requests, and when that worker is worker 0 the log line never appears.

**Fix:** replace the worker-id gate with an atomic `ngx.shared.DICT:add()` first-starter guard, so whichever worker handles the first sampled request starts the timer and logs, exactly once.
The assertion no longer depends on which worker the kernel picks; it only needs any request to be handled, which the block already asserts via the 50 expected 200s.
The 50-request loop is kept: with multiple workers each calling `startBackendTimer` on their first request, the expected single log line now also proves the guard dedupes across workers.

**Verification (250 local runs):**

| Experiment | old guard | new guard |
| --- | --- | --- |
| forced worker-0 starvation: 1-request variant, 25 runs | 23 FAIL / 2 pass | 25/25 pass |
| fixed test, idle machine, 100 runs | - | 100/100 pass, one log line each |
| fixed test pinned to 4 CPUs with background load, 100 runs | - | 100/100 pass, one log line each |

The 1-request variant makes the failure condition (worker 0 gets no request) the common case, reproducing the CI failure on demand with the old guard and never with the new one.

#### Which issue(s) this PR fixes:

None filed; flake observed on #13651's CI.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
