### PR TITLE
fix(upstream): keep last resolved address on transient DNS failure

### DIFF
--- a/apisix/core/dns/client.lua
+++ b/apisix/core/dns/client.lua
@@ -27,6 +27,8 @@ local table = require("apisix.core.table")
 local gcd = require("apisix.core.math").gcd
 local insert_tab = table.insert
 local math_random = math.random
+local str_match = string.match
+local tonumber = tonumber
 local package_loaded = package.loaded
 local ipairs = ipairs
 local table_remove = table.remove
@@ -36,6 +38,7 @@ local setmetatable = setmetatable
 local _M = {
     RETURN_RANDOM = 1,
     RETURN_ALL = 2,
+    RCODE_NXDOMAIN = 3,
 }
 
 
@@ -98,12 +101,13 @@ function _M.resolve(self, domain, selector)
     -- this function will dereference the CNAME records
     local answers, err = client.resolve(domain)
     if not answers then
-        return nil, "failed to query the DNS server: " .. err
+        local rcode = tonumber(str_match(err, "^dns server error: (%d+) "))
+        return nil, "failed to query the DNS server: " .. err, rcode
     end
 
     if answers.errcode then
         return nil, "server returned error code: " .. answers.errcode
-                    .. ": " .. answers.errstr
+                    .. ": " .. answers.errstr, answers.errcode
     end
 
     if selector == _M.RETURN_ALL then

--- a/apisix/core/resolver.lua
+++ b/apisix/core/resolver.lua
@@ -59,6 +59,8 @@ end
 -- @function core.resolver.parse_domain
 -- @tparam string host Domain name that need to be resolved.
 -- @treturn string The IP of the domain name after being resolved.
+-- @treturn string The error message when the resolution failed.
+-- @treturn number The DNS rcode when the server answered with an error.
 -- @usage
 -- local ip, err = core.resolver.parse_domain("apache.org") -- "198.18.10.114"
 function _M.parse_domain(host)
@@ -78,10 +80,10 @@ function _M.parse_domain(host)
         end
     end
 
-    local ip_info, err = utils.dns_parse(host)
+    local ip_info, err, rcode = utils.dns_parse(host)
     if not ip_info then
         log.error("failed to parse domain: ", host, ", error: ",err)
-        return nil, err
+        return nil, err, rcode
     end
 
     log.info("parse addr: ", json.delay_encode(ip_info))

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -274,7 +274,8 @@ end
 
 local function parse_domain_in_route(route)
     local nodes = route.value.upstream.dns_nodes
-    local new_nodes, err = upstream_util.parse_domain_for_nodes(nodes)
+    local new_nodes, err = upstream_util.parse_domain_for_nodes(nodes,
+                                                                route.value.upstream)
     if not new_nodes then
         return nil, err
     end

--- a/apisix/utils/upstream.lua
+++ b/apisix/utils/upstream.lua
@@ -27,7 +27,11 @@ local _M = {}
 
 
 local function sort_by_key_host(a, b)
-    return a.host < b.host
+    if a.host ~= b.host then
+        return a.host < b.host
+    end
+
+    return (a.port or 0) < (b.port or 0)
 end
 
 
@@ -88,22 +92,53 @@ end
 _M.compare_upstream_node = compare_upstream_node
 
 
-local function parse_domain_for_nodes(nodes)
+local function last_resolved_addr(up_conf, domain)
+    if not up_conf then
+        return nil
+    end
+
+    local nodes = up_conf.nodes
+    if type(nodes) ~= "table" then
+        return nil
+    end
+
+    if up_conf.original_nodes and #nodes > 0 then
+        nodes = up_conf.original_nodes
+    end
+
+    for _, node in ipairs(nodes) do
+        if node.domain == domain then
+            return node.host
+        end
+    end
+
+    return nil
+end
+
+
+local function parse_domain_for_nodes(nodes, up_conf)
     local span = tracer.start(ngx.ctx, "resolve_dns", tracer.kind.internal)
     local new_nodes = core.table.new(#nodes, 0)
     for _, node in ipairs(nodes) do
         local host = node.host
         if not ipmatcher.parse_ipv4(host) and
                 not ipmatcher.parse_ipv6(host) then
-            local ip, err = core.resolver.parse_domain(host)
+            local ip, err, rcode = core.resolver.parse_domain(host)
+            if not ip and rcode ~= core.dns_client.RCODE_NXDOMAIN then
+                local last_ip = last_resolved_addr(up_conf, host)
+                if last_ip then
+                    core.log.error("dns resolver domain: ", host, " error: ", err,
+                                   ", keep the last resolved address: ", last_ip)
+                    ip = last_ip
+                end
+            end
+
             if ip then
                 local new_node = core.table.clone(node)
                 new_node.host = ip
                 new_node.domain = host
                 core.table.insert(new_nodes, new_node)
-            end
-
-            if err then
+            else
                 core.log.error("dns resolver domain: ", host, " error: ", err)
             end
         else
@@ -118,7 +153,7 @@ _M.parse_domain_for_nodes = parse_domain_for_nodes
 
 function _M.parse_domain_in_up(up)
     local nodes = up.value.dns_nodes
-    local new_nodes, err = parse_domain_for_nodes(nodes)
+    local new_nodes, err = parse_domain_for_nodes(nodes, up.value)
     if not new_nodes then
         return nil, err
     end

--- a/t/core/resolver.t
+++ b/t/core/resolver.t
@@ -149,3 +149,53 @@ apisix:
     }
 --- error_log
 failed to parse domain
+
+
+
+=== TEST 6: core.dns.client recovers the rcode from resty.dns.client's error
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local resolver = require("apisix.core.resolver")
+            local utils = require("apisix.core.utils")
+            -- creates the dns client (resolved from /etc/hosts, no network)
+            assert(utils.dns_parse("localhost"))
+            local lib = require("resty.dns.client")
+            local original_resolve = lib.resolve
+            local replies = {
+                ["nxdomain.test"] = function()
+                    return nil, "dns server error: 3 name error"
+                end,
+                ["servfail.test"] = function()
+                    return nil, "dns server error: 2 server failure"
+                end,
+                ["timeout.test"] = function()
+                    return nil, "dns lookup pool exceeded retries (1): timeout"
+                end,
+                ["cacheonly.test"] = function()
+                    return {errcode = 100, errstr = "cache only lookup failed"}
+                end,
+            }
+            lib.resolve = function(domain)  -- mock: resty.dns.client
+                return replies[domain]()
+            end
+
+            for _, domain in ipairs({"nxdomain.test", "servfail.test", "timeout.test",
+                                    "cacheonly.test"}) do
+                local ip, err, rcode = resolver.parse_domain(domain)
+                ngx.say(domain, ": ip=", ip, " rcode=", rcode, " err=", err)
+            end
+            lib.resolve = original_resolve
+        }
+    }
+--- response_body
+nxdomain.test: ip=nil rcode=3 err=failed to query the DNS server: dns server error: 3 name error
+servfail.test: ip=nil rcode=2 err=failed to query the DNS server: dns server error: 2 server failure
+timeout.test: ip=nil rcode=nil err=failed to query the DNS server: dns lookup pool exceeded retries (1): timeout
+cacheonly.test: ip=nil rcode=100 err=server returned error code: 100: cache only lookup failed
+--- error_log
+failed to parse domain: nxdomain.test
+failed to parse domain: servfail.test
+failed to parse domain: timeout.test
+failed to parse domain: cacheonly.test

--- a/t/node/healthcheck-dns.t
+++ b/t/node/healthcheck-dns.t
@@ -118,7 +118,7 @@ routes:
             local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/hello"
             local httpc = http.new()
             local res, err = httpc:request_uri(uri, {method = "GET", keepalive = false})
-            ngx.say("First request status: ", res.status)
+            ngx.say("First request status: ", res and res.status or err)
 
             -- Wait for healthchecker to be created
             ngx.sleep(2)
@@ -126,7 +126,7 @@ routes:
             -- Second request - should trigger DNS resolution again
             local httpc = http.new()
             local res, err = httpc:request_uri(uri, {method = "GET", keepalive = false})
-            ngx.say("Second request status: ", res.status)
+            ngx.say("Second request status: ", res and res.status or err)
 
             -- Wait for healthchecker recreation
             ngx.sleep(4)

--- a/t/node/healthcheck-dns.t
+++ b/t/node/healthcheck-dns.t
@@ -142,3 +142,101 @@ Second request status: 200
 create new checker
 reused checker with incremental targets
 --- timeout: 10
+
+
+
+=== TEST 2: unhealthy node stays out of rotation across a DNS query failure
+--- apisix_yaml
+routes:
+  -
+    uris:
+        - /hello
+    upstream:
+        type: roundrobin
+        nodes:
+          - host: test.com
+            port: 1970
+            weight: 1
+            priority: 0
+          - host: 127.0.0.1
+            port: 1980
+            weight: 1
+            priority: -1
+        checks:
+            active:
+                http_path: "/status"
+                healthy:
+                    interval: 1
+                    successes: 1
+                unhealthy:
+                    interval: 1
+                    tcp_failures: 1
+                    http_failures: 1
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local original_parse_domain = core.resolver.parse_domain
+            local dns_down = false
+            core.resolver.parse_domain = function(domain)
+                if domain == "test.com" then
+                    if dns_down then
+                        return nil, "failed to query the DNS server: timeout"
+                    end
+                    return "127.0.0.1"
+                end
+                return original_parse_domain(domain)
+            end
+
+            local http = require("resty.http")
+            local uri = "http://127.0.0.1:" .. ngx.var.server_port .. "/hello"
+            local function hit(tag)
+                local httpc = http.new()
+                local res, err = httpc:request_uri(uri, {method = "GET", keepalive = false})
+                ngx.say(tag, ": ", res and res.status or err)
+            end
+
+            -- creates the checker; nothing listens on 1970, so the primary is
+            -- retried onto the fallback and then trips the active check
+            hit("warm-up")
+            ngx.sleep(3)
+            hit("primary unhealthy")
+
+            -- the primary must keep its address and its unhealthy state
+            dns_down = true
+            for i = 1, 3 do
+                ngx.sleep(1.2)
+                hit("dns down " .. i)
+            end
+
+            -- and must not come back as healthy once the name resolves again
+            dns_down = false
+            hit("dns restored 1")
+            hit("dns restored 2")
+
+            core.resolver.parse_domain = original_parse_domain
+        }
+    }
+--- response_body
+warm-up: 200
+primary unhealthy: 200
+dns down 1: 200
+dns down 2: 200
+dns down 3: 200
+dns restored 1: 200
+dns restored 2: 200
+--- grep_error_log eval
+qr/proxy request to 127\.0\.0\.1:19\d\d|keep the last resolved address: 127\.0\.0\.1|reused checker with incremental targets/
+--- grep_error_log_out
+proxy request to 127.0.0.1:1970
+proxy request to 127.0.0.1:1980
+proxy request to 127.0.0.1:1980
+keep the last resolved address: 127.0.0.1
+proxy request to 127.0.0.1:1980
+keep the last resolved address: 127.0.0.1
+proxy request to 127.0.0.1:1980
+keep the last resolved address: 127.0.0.1
+proxy request to 127.0.0.1:1980
+proxy request to 127.0.0.1:1980
+proxy request to 127.0.0.1:1980
+--- timeout: 15

--- a/t/node/upstream-node-dns.t
+++ b/t/node/upstream-node-dns.t
@@ -608,7 +608,7 @@ location /t {
                     return {address = "127.0.0.1"}
                 end
 
-                return nil, "dns server error: 3 name error"
+                return nil, "dns server error: 3 name error", 3
             end
 
             error("unknown domain: " .. domain)
@@ -668,7 +668,7 @@ location /t {
                     return {address = "127.0.0.1"}
                 end
 
-                return nil, "dns server error: 3 name error"
+                return nil, "dns server error: 3 name error", 3
             end
 
             error("unknown domain: " .. domain)
@@ -687,3 +687,198 @@ GET /t
 --- response_body
 200,503,200
 --- ignore_error_log
+
+
+
+=== TEST 19: upstream keeps the last resolved address while the DNS query fails
+--- init_by_lua_block
+    require "resty.core"
+    apisix = require("apisix")
+    core = require("apisix.core")
+    apisix.http_init()
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body = t('/apisix/admin/upstreams/1',
+             ngx.HTTP_PUT,
+             [[{
+                "nodes": {
+                    "test1.com:1980": 1
+                },
+                "type": "roundrobin",
+                "desc": "new upstream"
+            }]]
+            )
+        if code >= 300 then
+            ngx.status = code
+            ngx.say(body)
+            return
+        end
+
+        code, body = t('/apisix/admin/routes/1',
+             ngx.HTTP_PUT,
+             [[{
+                    "uri": "/hello",
+                    "upstream_id": "1"
+            }]]
+            )
+        if code >= 300 then
+            ngx.status = code
+            ngx.say(body)
+            return
+        end
+
+        local utils = require("apisix.core.utils")
+        local original_dns_parse = utils.dns_parse
+        local count = 0
+        utils.dns_parse = function (domain)
+            if domain == "test1.com" then
+                count = count + 1
+                if count == 1 then
+                    return {address = "127.0.0.1"}
+                end
+
+                return nil, "failed to query the DNS server: timeout"
+            end
+
+            error("unknown domain: " .. domain)
+        end
+
+        local code1 = t('/hello', ngx.HTTP_GET)
+        local code2 = t('/hello', ngx.HTTP_GET)
+        local code3 = t('/hello', ngx.HTTP_GET)
+        utils.dns_parse = original_dns_parse
+        ngx.say(code1, ",", code2, ",", code3)
+    }
+}
+--- request
+GET /t
+--- response_body
+200,200,200
+--- grep_error_log eval
+qr/resolve upstream which contain domain|dns resolver domain: test1.com error: [^,]+, keep the last resolved address: 127.0.0.1/
+--- grep_error_log_out
+resolve upstream which contain domain
+dns resolver domain: test1.com error: failed to query the DNS server: timeout, keep the last resolved address: 127.0.0.1
+dns resolver domain: test1.com error: failed to query the DNS server: timeout, keep the last resolved address: 127.0.0.1
+
+
+
+=== TEST 20: route keeps the last resolved address while the DNS query fails
+--- init_by_lua_block
+    require "resty.core"
+    apisix = require("apisix")
+    core = require("apisix.core")
+    apisix.http_init()
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body = t('/apisix/admin/routes/1',
+            ngx.HTTP_PUT,
+            [[{
+                "upstream": {
+                    "nodes": {
+                        "test1.com:1980": 1
+                    },
+                    "type": "roundrobin"
+                },
+                "uri": "/hello"
+            }]]
+            )
+        if code >= 300 then
+            ngx.status = code
+            ngx.say(body)
+            return
+        end
+
+        local utils = require("apisix.core.utils")
+        local original_dns_parse = utils.dns_parse
+        local count = 0
+        utils.dns_parse = function (domain)
+            if domain == "test1.com" then
+                count = count + 1
+                if count == 1 then
+                    return {address = "127.0.0.1"}
+                end
+
+                return nil, "failed to query the DNS server: timeout"
+            end
+
+            error("unknown domain: " .. domain)
+        end
+
+        local code1 = t('/hello', ngx.HTTP_GET)
+        local code2 = t('/hello', ngx.HTTP_GET)
+        local code3 = t('/hello', ngx.HTTP_GET)
+        utils.dns_parse = original_dns_parse
+        ngx.say(code1, ",", code2, ",", code3)
+    }
+}
+--- request
+GET /t
+--- response_body
+200,200,200
+--- grep_error_log eval
+qr/parse route which contain domain|dns resolver domain: test1.com error: [^,]+, keep the last resolved address: 127.0.0.1/
+--- grep_error_log_out
+parse route which contain domain
+dns resolver domain: test1.com error: failed to query the DNS server: timeout, keep the last resolved address: 127.0.0.1
+dns resolver domain: test1.com error: failed to query the DNS server: timeout, keep the last resolved address: 127.0.0.1
+
+
+
+=== TEST 21: a name that never resolved is still dropped while the DNS query fails
+--- init_by_lua_block
+    require "resty.core"
+    apisix = require("apisix")
+    core = require("apisix.core")
+    apisix.http_init()
+--- config
+location /t {
+    content_by_lua_block {
+        local t = require("lib.test_admin").test
+        local code, body = t('/apisix/admin/routes/1',
+            ngx.HTTP_PUT,
+            [[{
+                "upstream": {
+                    "nodes": {
+                        "test1.com:1980": 1
+                    },
+                    "type": "roundrobin"
+                },
+                "uri": "/hello"
+            }]]
+            )
+        if code >= 300 then
+            ngx.status = code
+            ngx.say(body)
+            return
+        end
+
+        local utils = require("apisix.core.utils")
+        local original_dns_parse = utils.dns_parse
+        utils.dns_parse = function (domain)
+            if domain == "test1.com" then
+                return nil, "failed to query the DNS server: timeout"
+            end
+
+            error("unknown domain: " .. domain)
+        end
+
+        local code1 = t('/hello', ngx.HTTP_GET)
+        local code2 = t('/hello', ngx.HTTP_GET)
+        utils.dns_parse = original_dns_parse
+        ngx.say(code1, ",", code2)
+    }
+}
+--- request
+GET /t
+--- response_body
+503,503
+--- grep_error_log eval
+qr/dns resolver domain: test1.com error: [^,\n]+|keep the last resolved address/
+--- grep_error_log_out
+dns resolver domain: test1.com error: failed to query the DNS server: timeout
+dns resolver domain: test1.com error: failed to query the DNS server: timeout


### PR DESCRIPTION
### Description

When an upstream uses a domain name in `nodes`, a transient DNS failure (timeout, SERVFAIL) during periodic re-resolution dropped the node from the resolved node list.
When DNS recovered moments later, the node was re-added.
That drop/re-add changes the node list, which rebuilds the health checker, and a re-added target always starts as healthy.
As a result, a node that active checks had correctly marked unhealthy received traffic again without passing any recovery probe, and workers could disagree about its state because each of them resolves independently.

The DNS failure says nothing about the backend's health, so it should not destroy the health checker's state.

This PR:

- returns the DNS rcode from `core.dns.client.resolve()` / `core.resolver.parse_domain()` as a third value, so callers can tell an authoritative NXDOMAIN answer apart from a query that could not be completed at all
- on a failed query that is not NXDOMAIN, keeps the node at its last resolved address instead of dropping it: the node list stays stable, the checker target survives, and the unhealthy state is preserved while probes keep running
- on an authoritative NXDOMAIN, still removes the node, since the server positively stated the name no longer exists
- makes `sort_by_key_host` tie-break on port, so two nodes sharing one IP cannot sort unstably and report a phantom node change

Verified against an end-to-end reproduction (3-node upstream, one node failing its health endpoint, DNS server blipped for 8 seconds): without the fix the unhealthy node returns to rotation on all workers after the blip; with the fix it receives no traffic and stays unhealthy.

#### Which issue(s) this PR fixes:

Fixes #13888

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
