### PR TITLE
fix(jwe-decrypt): honor the protected header AAD on every supported OpenResty

### DIFF
--- a/apisix/plugins/jwe-decrypt.lua
+++ b/apisix/plugins/jwe-decrypt.lua
@@ -28,6 +28,11 @@ local plugin_name     = "jwe-decrypt"
 local GCM_IV_LEN      = 12
 local GCM_TAG_LEN     = 16
 
+-- one AES-256-GCM context per worker, created on first use so that it belongs
+-- to the worker that uses it: decrypt() reinitializes it with the key and the
+-- IV on every call and never yields, so there is nothing to keep apart
+local aead
+
 local schema = {
     type = "object",
     properties = {
@@ -165,8 +170,9 @@ local function jwe_decrypt_with_obj(o, consumer)
         return nil, "invalid base64url encoding in the JWE token"
     end
 
-    -- OpenSSL accepts a shorter GCM tag and only verifies as many bits as it
-    -- is given, so the tag length has to be checked before it is handed over
+    -- OpenSSL takes a GCM tag shorter than 128 bits and then verifies only the
+    -- bits it was given, which would cut the cost of forging a token, so both
+    -- of the lengths RFC 7518 fixes are checked before OpenSSL sees them
     if #iv ~= GCM_IV_LEN or #tag ~= GCM_TAG_LEN then
         return nil, "invalid IV or authentication tag length in the JWE token"
     end
@@ -175,9 +181,12 @@ local function jwe_decrypt_with_obj(o, consumer)
     -- lua-resty-string 0.16 on, and drops the argument without a word on the
     -- older OpenResty releases APISIX supports, so the AEAD runs through
     -- resty.openssl, which takes the AAD on every version
-    local aead, err = cipher.new("aes-256-gcm")
     if not aead then
-        return nil, err
+        local err
+        aead, err = cipher.new("aes-256-gcm")
+        if not aead then
+            return nil, err
+        end
     end
 
     -- RFC 7516 authenticates the encoded protected header as the AES-GCM

--- a/apisix/plugins/jwe-decrypt.lua
+++ b/apisix/plugins/jwe-decrypt.lua
@@ -17,12 +17,16 @@
 local core            = require("apisix.core")
 local consumer_mod    = require("apisix.consumer")
 local base64          = require("ngx.base64")
-local aes             = require("resty.aes")
+local cipher          = require("resty.openssl.cipher")
 local sub_str         = string.sub
 local type            = type
-local cipher          = aes.cipher(256, "gcm")
 
 local plugin_name     = "jwe-decrypt"
+
+-- RFC 7518 fixes A256GCM, the only content encryption the plugin implements,
+-- to a 96 bit IV and a 128 bit authentication tag
+local GCM_IV_LEN      = 12
+local GCM_TAG_LEN     = 16
 
 local schema = {
     type = "object",
@@ -161,30 +165,35 @@ local function jwe_decrypt_with_obj(o, consumer)
         return nil, "invalid base64url encoding in the JWE token"
     end
 
-    local aes_default, err = aes:new(
-        secret,
-        nil,
-        cipher,
-        {iv = iv}
-    )
-    if not aes_default then
+    -- OpenSSL accepts a shorter GCM tag and only verifies as many bits as it
+    -- is given, so the tag length has to be checked before it is handed over
+    if #iv ~= GCM_IV_LEN or #tag ~= GCM_TAG_LEN then
+        return nil, "invalid IV or authentication tag length in the JWE token"
+    end
+
+    -- resty.aes forwards additional authenticated data to OpenSSL only from
+    -- lua-resty-string 0.16 on, and drops the argument without a word on the
+    -- older OpenResty releases APISIX supports, so the AEAD runs through
+    -- resty.openssl, which takes the AAD on every version
+    local aead, err = cipher.new("aes-256-gcm")
+    if not aead then
         return nil, err
     end
 
     -- RFC 7516 authenticates the encoded protected header as the AES-GCM
     -- additional authenticated data, which is what JWE libraries produce
-    local decrypted, decrypt_err = aes_default:decrypt(ciphertext, tag, o.header)
-    if decrypted then
-        return decrypted
+    local plaintext, decrypt_err = aead:decrypt(secret, iv, ciphertext, false, o.header, tag)
+    if plaintext then
+        return plaintext
     end
 
     -- tokens built the way APISIX used to build them carry no AAD
-    local plaintext, legacy_err = aes_default:decrypt(ciphertext, tag)
-    if not plaintext then
+    local legacy_plaintext, legacy_err = aead:decrypt(secret, iv, ciphertext, false, nil, tag)
+    if not legacy_plaintext then
         return nil, decrypt_err or legacy_err
     end
 
-    return plaintext
+    return legacy_plaintext
 end
 
 

--- a/docs/en/latest/plugins/jwe-decrypt.md
+++ b/docs/en/latest/plugins/jwe-decrypt.md
@@ -178,7 +178,7 @@ To generate a JWE token for the Consumer, use any JWE library that supports dire
 base64url(header).<empty>.base64url(iv).base64url(ciphertext).base64url(tag)
 ```
 
-where the header is `{"alg":"dir","enc":"A256GCM","kid":"<consumer-key>"}`; `alg` and `enc` are rejected if they are set to anything else. `A256GCM` is defined with a 96-bit IV and a 128-bit authentication tag, and a token carrying either at another length is rejected. The IV must be unique and randomly generated for every token; never reuse an IV with the same key.
+where the header is `{"alg":"dir","enc":"A256GCM","kid":"<consumer-key>"}`; `alg` and `enc` are rejected if they are set to anything else. `A256GCM` is defined with a 96-bit IV and a 128-bit authentication tag, and a token whose IV or authentication tag has another length is rejected. The IV must be unique and randomly generated for every token; never reuse an IV with the same key.
 
 As [RFC 7516](https://datatracker.ietf.org/doc/html/rfc7516#section-5.1) requires, a JWE library authenticates the encoded protected header as the AES-GCM additional authenticated data (AAD), which makes the `kid` tamper-proof. Tokens encrypted without AAD, such as the ones APISIX itself used to generate, are still accepted for backward compatibility.
 

--- a/docs/en/latest/plugins/jwe-decrypt.md
+++ b/docs/en/latest/plugins/jwe-decrypt.md
@@ -178,7 +178,7 @@ To generate a JWE token for the Consumer, use any JWE library that supports dire
 base64url(header).<empty>.base64url(iv).base64url(ciphertext).base64url(tag)
 ```
 
-where the header is `{"alg":"dir","enc":"A256GCM","kid":"<consumer-key>"}`; `alg` and `enc` are rejected if they are set to anything else. The IV must be unique and randomly generated for every token; never reuse an IV with the same key.
+where the header is `{"alg":"dir","enc":"A256GCM","kid":"<consumer-key>"}`; `alg` and `enc` are rejected if they are set to anything else. `A256GCM` is defined with a 96-bit IV and a 128-bit authentication tag, and a token carrying either at another length is rejected. The IV must be unique and randomly generated for every token; never reuse an IV with the same key.
 
 As [RFC 7516](https://datatracker.ietf.org/doc/html/rfc7516#section-5.1) requires, a JWE library authenticates the encoded protected header as the AES-GCM additional authenticated data (AAD), which makes the `kid` tamper-proof. Tokens encrypted without AAD, such as the ones APISIX itself used to generate, are still accepted for backward compatibility.
 

--- a/docs/zh/latest/plugins/jwe-decrypt.md
+++ b/docs/zh/latest/plugins/jwe-decrypt.md
@@ -166,7 +166,7 @@ kubectl apply -f jwe-consumer-ic.yaml
 base64url(header).<empty>.base64url(iv).base64url(ciphertext).base64url(tag)
 ```
 
-其中 header 为 `{"alg":"dir","enc":"A256GCM","kid":"<consumer-key>"}`，`alg` 与 `enc` 若为其他值则会被拒绝。`A256GCM` 规定 IV 为 96 位、认证标签为 128 位，长度不符的令牌会被拒绝。每个令牌的 IV 必须唯一且随机生成，切勿在同一密钥下复用 IV。
+其中 header 为 `{"alg":"dir","enc":"A256GCM","kid":"<consumer-key>"}`，`alg` 与 `enc` 若为其他值则会被拒绝。`A256GCM` 规定 IV 为 96 位、认证标签为 128 位，IV 或认证标签长度不符的令牌会被拒绝。每个令牌的 IV 必须唯一且随机生成，切勿在同一密钥下复用 IV。
 
 按 [RFC 7516](https://datatracker.ietf.org/doc/html/rfc7516#section-5.1) 的要求，JWE 库会将编码后的 protected header 作为 AES-GCM 的附加认证数据（AAD）参与认证，从而使 `kid` 不可篡改。为保持向后兼容，未使用 AAD 加密的令牌（例如 APISIX 早期自行生成的令牌）仍然可以正常解密。
 

--- a/docs/zh/latest/plugins/jwe-decrypt.md
+++ b/docs/zh/latest/plugins/jwe-decrypt.md
@@ -166,7 +166,7 @@ kubectl apply -f jwe-consumer-ic.yaml
 base64url(header).<empty>.base64url(iv).base64url(ciphertext).base64url(tag)
 ```
 
-其中 header 为 `{"alg":"dir","enc":"A256GCM","kid":"<consumer-key>"}`，`alg` 与 `enc` 若为其他值则会被拒绝。每个令牌的 IV 必须唯一且随机生成，切勿在同一密钥下复用 IV。
+其中 header 为 `{"alg":"dir","enc":"A256GCM","kid":"<consumer-key>"}`，`alg` 与 `enc` 若为其他值则会被拒绝。`A256GCM` 规定 IV 为 96 位、认证标签为 128 位，长度不符的令牌会被拒绝。每个令牌的 IV 必须唯一且随机生成，切勿在同一密钥下复用 IV。
 
 按 [RFC 7516](https://datatracker.ietf.org/doc/html/rfc7516#section-5.1) 的要求，JWE 库会将编码后的 protected header 作为 AES-GCM 的附加认证数据（AAD）参与认证，从而使 `kid` 不可篡改。为保持向后兼容，未使用 AAD 加密的令牌（例如 APISIX 早期自行生成的令牌）仍然可以正常解密。
 

--- a/t/plugin/jwe-decrypt.t
+++ b/t/plugin/jwe-decrypt.t
@@ -978,6 +978,10 @@ status: 400 body: {"message":"unsupported alg or enc in JWE token"}
     }
 --- response_body
 status: 400 body: {"message":"failed to decrypt JWE token"}
+--- error_log
+invalid IV or authentication tag length in the JWE token
+--- no_error_log
+[error]
 
 
 
@@ -999,6 +1003,10 @@ status: 400 body: {"message":"failed to decrypt JWE token"}
     }
 --- response_body
 status: 400 body: {"message":"failed to decrypt JWE token"}
+--- error_log
+invalid IV or authentication tag length in the JWE token
+--- no_error_log
+[error]
 
 
 
@@ -1034,3 +1042,29 @@ status: 400 body: {"message":"failed to decrypt JWE token"}
     }
 --- response_body
 status: 200 forwarded: true
+
+
+
+=== TEST 41: token whose authentication tag is truncated is rejected
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+
+            -- the TEST 31 token with its tag cut to its first 8 bytes, which
+            -- OpenSSL accepts as a valid GCM tag and verifies in full, leaving
+            -- 64 bits instead of 128 between an attacker and a forged token
+            local token = "eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIiwia2lkIjoiandlLWZhaWwta2V5In0."
+                          .. ".MTIzNDU2Nzg5MDEy.6JeRgm0.KaxbSD-kuYA"
+
+            local code, body = t('/jwe-decrypt-fail', ngx.HTTP_GET, nil, nil,
+                                 { Authorization = "Bearer " .. token })
+            ngx.say("status: ", code, " body: ", ((body or ""):gsub("%s+$", "")))
+        }
+    }
+--- response_body
+status: 400 body: {"message":"failed to decrypt JWE token"}
+--- error_log
+invalid IV or authentication tag length in the JWE token
+--- no_error_log
+[error]

--- a/t/plugin/jwe-decrypt.t
+++ b/t/plugin/jwe-decrypt.t
@@ -592,6 +592,33 @@ fo4XKdZ1xSrIZyms4q2BwPrW5lMpls9qqy5tiAk2esc=
             )
             if code >= 300 then
                 ngx.status = code
+                ngx.say("failed to add route")
+                return
+            end
+
+            -- the test upstream echoes the request headers back, so the
+            -- plaintext the plugin forwarded can be compared byte for byte
+            code = t('/apisix/admin/routes/12',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "jwe-decrypt": {
+                            "header": "Authorization",
+                            "forward_header": "Authorization"
+                        },
+                        "proxy-rewrite": {
+                            "uri": "/uri"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": { "127.0.0.1:1980": 1 },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/jwe-decrypt-echo"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
             end
             ngx.say("done")
         }
@@ -975,7 +1002,7 @@ status: 400 body: {"message":"failed to decrypt JWE token"}
 
 
 
-=== TEST 40: payload larger than the cipher output buffer is decrypted
+=== TEST 40: payload larger than the cipher output buffer is forwarded whole
 --- config
     location /t {
         content_by_lua_block {
@@ -998,10 +1025,12 @@ status: 400 body: {"message":"failed to decrypt JWE token"}
             local token = header .. ".." .. enc(iv) .. "."
                           .. enc(ciphertext) .. "." .. enc(tag)
 
-            local code = t('/jwe-decrypt-fail', ngx.HTTP_GET, nil, nil,
-                           { Authorization = "Bearer " .. token })
-            ngx.say("status: ", code)
+            -- on success the helper puts the upstream body third
+            local code, _, body = t('/jwe-decrypt-echo', ngx.HTTP_GET, nil, nil,
+                                    { Authorization = "Bearer " .. token })
+            ngx.say("status: ", code, " forwarded: ",
+                    (body or ""):match("authorization: ([^\n]*)") == payload)
         }
     }
 --- response_body
-status: 200
+status: 200 forwarded: true

--- a/t/plugin/jwe-decrypt.t
+++ b/t/plugin/jwe-decrypt.t
@@ -929,3 +929,79 @@ status: 200
     }
 --- response_body
 status: 400 body: {"message":"unsupported alg or enc in JWE token"}
+
+
+
+=== TEST 38: token whose authentication tag carries trailing bytes is rejected
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+
+            -- the TEST 31 token with 16 bytes appended to its tag: A256GCM
+            -- authenticates 128 bits, so anything past them must not be
+            -- ignored, otherwise the very same token has many encodings
+            local token = "eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIiwia2lkIjoiandlLWZhaWwta2V5In0."
+                          .. ".MTIzNDU2Nzg5MDEy.6JeRgm0.KaxbSD-kuYBVck03POSk73RyYWlsaW5nMTIzNDU2Nzg"
+
+            local code, body = t('/jwe-decrypt-fail', ngx.HTTP_GET, nil, nil,
+                                 { Authorization = "Bearer " .. token })
+            ngx.say("status: ", code, " body: ", ((body or ""):gsub("%s+$", "")))
+        }
+    }
+--- response_body
+status: 400 body: {"message":"failed to decrypt JWE token"}
+
+
+
+=== TEST 39: token whose IV is not 96 bits is rejected
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+
+            -- same plaintext and secret as TEST 31, encrypted under a 128 bit
+            -- IV, which RFC 7518 does not allow for A256GCM
+            local token = "eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIiwia2lkIjoiandlLWZhaWwta2V5In0."
+                          .. ".MTIzNDU2Nzg5MDEyMzQ1Ng.Ptfkx6w.-zpUsv5bSd-Ml5osMyKebw"
+
+            local code, body = t('/jwe-decrypt-fail', ngx.HTTP_GET, nil, nil,
+                                 { Authorization = "Bearer " .. token })
+            ngx.say("status: ", code, " body: ", ((body or ""):gsub("%s+$", "")))
+        }
+    }
+--- response_body
+status: 400 body: {"message":"failed to decrypt JWE token"}
+
+
+
+=== TEST 40: payload larger than the cipher output buffer is decrypted
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local core = require("apisix.core")
+            local cipher = require("resty.openssl.cipher")
+            local enc = require("ngx.base64").encode_base64url
+
+            local header = enc(core.json.encode({
+                alg = "dir", enc = "A256GCM", kid = "jwe-fail-key",
+            }))
+            local iv = "123456789012"
+            -- past the 1024 byte buffer resty.openssl reuses between calls
+            local payload = string.rep("0123456789", 160)
+
+            local c = assert(cipher.new("aes-256-gcm"))
+            local ciphertext = assert(c:encrypt("12345678901234567890123456789012",
+                                                iv, payload, false, header))
+            local tag = assert(c:get_aead_tag(16))
+            local token = header .. ".." .. enc(iv) .. "."
+                          .. enc(ciphertext) .. "." .. enc(tag)
+
+            local code = t('/jwe-decrypt-fail', ngx.HTTP_GET, nil, nil,
+                           { Authorization = "Bearer " .. token })
+            ngx.say("status: ", code)
+        }
+    }
+--- response_body
+status: 200


### PR DESCRIPTION
### Description

`jwe-decrypt` rejects every token a standard JWE library produces on the older OpenResty releases APISIX supports.

RFC 7516 authenticates the encoded protected header as the AES-GCM additional authenticated data, and the plugin passes it as the third argument of `aes_default:decrypt(ciphertext, tag, o.header)`. `resty.aes` only grew that parameter in lua-resty-string 0.16; on OpenResty 1.21.4, the oldest release `apisix/cli/ops.lua` accepts, the signature is `decrypt(self, s, tag)` and the argument is dropped without a word. The AAD attempt and the backward compatible attempt then run the exact same decryption without AAD, so a token whose tag covers the header always fails and the request gets `400 failed to decrypt JWE token`. A token built without AAD decrypts fine, which is what makes this look like a key problem rather than an AAD one.

The AEAD now runs through `resty.openssl`, which takes the AAD on every version and is already used by `apisix/upstream.lua`, `jwt-auth`, `cas-auth` and `openid-connect`.

`resty.openssl` also hands the tag to OpenSSL as it is. OpenSSL accepts a GCM tag shorter than the 128 bits RFC 7518 fixes for `A256GCM` and then verifies only the bits it was given, so the IV and tag lengths are checked before the token reaches it. The same check rejects a tag carrying trailing bytes, which `resty.aes` silently truncated to its first 16 — a token had many valid encodings until now.

Behavior change: a token whose IV is not 96 bits, or whose tag is not 128 bits, is now rejected. Both are fixed by RFC 7518 for `A256GCM` and every JWE library emits them, but a token minted through the `/apisix/plugin/jwe/encrypt` endpoint removed in #13464 with an explicit `iv` of another length no longer decrypts.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
