### PR TITLE
fix: write request_type=websocket through ctx.var

### DIFF
--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -1024,13 +1024,17 @@ function _M.http_header_filter_phase()
         set_resp_upstream_status(up_status)
     end
 
+    local api_ctx = ngx_ctx.api_ctx
     if ngx.status == 101 then
-        ngx_var.request_type = "websocket"
+        if api_ctx then
+            api_ctx.var.request_type = "websocket"
+        else
+            ngx_var.request_type = "websocket"
+        end
     end
 
     common_phase("header_filter")
 
-    local api_ctx = ngx.ctx.api_ctx
     if not api_ctx then
         return
     end

--- a/apisix/init.lua
+++ b/apisix/init.lua
@@ -1026,11 +1026,7 @@ function _M.http_header_filter_phase()
 
     local api_ctx = ngx_ctx.api_ctx
     if ngx.status == 101 then
-        if api_ctx then
-            api_ctx.var.request_type = "websocket"
-        else
-            ngx_var.request_type = "websocket"
-        end
+        api_ctx.var.request_type = "websocket"
     end
 
     common_phase("header_filter")

--- a/t/plugin/prometheus-websocket.t
+++ b/t/plugin/prometheus-websocket.t
@@ -181,3 +181,97 @@ GET /apisix/prometheus/metrics
 qr/apisix_http_latency_count\{type="request",route="ws",[^}]*request_type="websocket"[^}]*\} 1\n/
 --- response_body_unlike eval
 qr/apisix_http_latency_count\{type="request",route="ws",[^}]*request_type="websocket"[^}]*\} 2\n/
+
+
+
+=== TEST 9: set up a websocket route whose proxy-rewrite reads $request_type before the upgrade
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/ws-cached',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "prometheus": {},
+                        "proxy-rewrite": {
+                            "uri": "/websocket_handshake",
+                            "headers": {
+                                "set": {"X-Request-Type": "$request_type"}
+                            }
+                        },
+                        "serverless-post-function": {
+                            "phase": "log",
+                            "functions": [
+                                "return function(conf, ctx) ngx.log(ngx.WARN, \"x_request_type=\", ngx.var.http_x_request_type, \" ngx.var.request_type=\", ngx.var.request_type, \" ctx.var.request_type=\", ctx.var.request_type) end"
+                            ]
+                        }
+                    },
+                    "enable_websocket": true,
+                    "upstream": {
+                        "nodes": {"127.0.0.1:1980": 1},
+                        "type": "roundrobin"
+                    },
+                    "uri": "/websocket_cached"
+                }]])
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 10: the early read does not pin the session to traditional_http in either view
+--- config
+    location /t {
+        content_by_lua_block {
+            local client = require("resty.websocket.client")
+            local wb = client:new()
+            local ok, err = wb:connect("ws://127.0.0.1:1984/websocket_cached")
+            if not ok then
+                ngx.say("failed to connect: ", err)
+                return
+            end
+
+            local data, typ, err = wb:recv_frame()
+            if not data then
+                ngx.say("failed to receive frame: ", err)
+                return
+            end
+
+            wb:close()
+            ngx.say("received: ", data, " (", typ, ")")
+        }
+    }
+--- response_body
+received: hello (text)
+--- error_log
+x_request_type=traditional_http ngx.var.request_type=websocket ctx.var.request_type=websocket
+
+
+
+=== TEST 11: the status of the early-read session is labelled request_type=websocket
+--- request
+GET /apisix/prometheus/metrics
+--- response_body eval
+qr/apisix_http_status\{code="101",route="ws-cached",[^}]*request_type="websocket"[^}]*\} 1\n/
+
+
+
+=== TEST 12: the latency of the early-read session is labelled request_type=websocket
+--- request
+GET /apisix/prometheus/metrics
+--- response_body eval
+qr/apisix_http_latency_count\{type="request",route="ws-cached",[^}]*request_type="websocket"[^}]*\} 1\n/
+
+
+
+=== TEST 13: the bandwidth of the early-read session is labelled request_type=websocket
+--- request
+GET /apisix/prometheus/metrics
+--- response_body eval
+qr/apisix_bandwidth\{type="ingress",route="ws-cached",[^}]*request_type="websocket"[^}]*\} \d+\n/


### PR DESCRIPTION
### Description

#### Motivation

Follow-up to #13909, addressing https://github.com/apache/apisix/pull/13909#issuecomment-5520928764.

`ctx.var` caches a variable on its first read. The header filter added in #13909 sets `ngx.var.request_type` directly, so a plugin that already resolved `$request_type` before the `101` upgrade completes leaves the cached value at `traditional_http`. A supported trigger is a WebSocket route whose `proxy-rewrite` sets a header to `$request_type`. The prometheus exporter reads `ctx.var` in the log phase, so `apisix_http_status`, `apisix_http_latency` and `apisix_bandwidth` label the whole session as ordinary HTTP and `request_type!="websocket"` no longer excludes it.

#### What this PR does

- Writes `request_type = "websocket"` through `api_ctx.var`, whose setter updates both the NGINX variable and the cached view, keeping the bare `ngx.var` write as the fallback when no request context exists.
- Adds a regression to `t/plugin/prometheus-websocket.t`: a route whose `proxy-rewrite` sets `X-Request-Type: $request_type` reads the variable before the upgrade. The log phase asserts that the upstream header carried `traditional_http` (the early read happened) and that `ngx.var` and `ctx.var` both report `websocket`, and the three metric families are checked for that route.

No behaviour change for requests that never read `$request_type` before the upgrade.

#### Which issue(s) this PR fixes:
Fixes #

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
