### PR TITLE
fix(etcd): watch from the revision the configuration was read at

### DIFF
--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -48,6 +48,7 @@ local debug        = debug
 local string       = string
 local error        = error
 local pairs        = pairs
+local next         = next
 local rand         = math.random
 local constants    = require("apisix.constants")
 local health_check = require("resty.etcd.health_check")
@@ -1216,11 +1217,15 @@ local function init_loaded_configuration()
     end
 
     -- One readdir backs every entry create_formatter() stored, so there is a
-    -- single revision to record, and it is recorded even when the range came
-    -- back empty: the snapshot is still a point in time to watch from.
-    -- get_format() fails the read when the response carries no revision, so
-    -- there is nothing to validate here.
-    loaded_configuration_rev = tonumber(res.headers["X-Etcd-Index"])
+    -- single revision to record. Nothing is consumed yet at this point, so an
+    -- empty table here means the read stored nothing -- unlike the same test
+    -- made at watch time, which is the bug being fixed. Leave that case alone:
+    -- with no preloaded data every resource type reads for itself at first
+    -- sync, which already picks up whatever was written since, and the
+    -- rev == 0 path below keeps handling it exactly as before.
+    if next(loaded_configuration) then
+        loaded_configuration_rev = tonumber(res.headers["X-Etcd-Index"])
+    end
 
     configuration_loaded_time = ngx_time()
 end

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -1218,14 +1218,9 @@ local function init_loaded_configuration()
     -- One readdir backs every entry create_formatter() stored, so there is a
     -- single revision to record, and it is recorded even when the range came
     -- back empty: the snapshot is still a point in time to watch from.
-    local rev = tonumber(res.headers["X-Etcd-Index"])
-    if not rev or rev <= 0 then
-        log.warn("invalid or missing X-Etcd-Index header, the watch will ",
-                 "start from the current revision instead of the revision ",
-                 "this configuration was read at")
-        rev = nil
-    end
-    loaded_configuration_rev = rev
+    -- get_format() fails the read when the response carries no revision, so
+    -- there is nothing to validate here.
+    loaded_configuration_rev = tonumber(res.headers["X-Etcd-Index"])
 
     configuration_loaded_time = ngx_time()
 end

--- a/apisix/core/config_etcd.lua
+++ b/apisix/core/config_etcd.lua
@@ -48,7 +48,6 @@ local debug        = debug
 local string       = string
 local error        = error
 local pairs        = pairs
-local next         = next
 local rand         = math.random
 local constants    = require("apisix.constants")
 local health_check = require("resty.etcd.health_check")
@@ -70,6 +69,9 @@ if not is_http then
 end
 local created_obj  = {}
 local loaded_configuration = {}
+-- the etcd revision loaded_configuration was read at, kept separately because
+-- its entries are removed as they are consumed
+local loaded_configuration_rev
 local configuration_loaded_time
 local watch_ctx
 
@@ -144,18 +146,14 @@ local function do_run_watch(premature)
             error("failed to create etcd instance: " .. string(err))
         end
 
-        local rev = 0
-        if loaded_configuration then
-            local _, res = next(loaded_configuration)
-            if res then
-                rev = tonumber(res.headers["X-Etcd-Index"])
-                if not rev or rev <= 0 then
-                    log.warn("invalid or missing X-Etcd-Index header, ",
-                             "will fetch revision from etcd directly")
-                    rev = 0
-                end
-            end
-        end
+        -- Watch from the revision the preloaded configuration was read at, so
+        -- that everything written after that snapshot is still delivered. The
+        -- revision cannot be read back from loaded_configuration here:
+        -- core.config.new() removes each entry as it consumes it, so the table
+        -- is empty once every preloaded type has been registered -- and then
+        -- the fallback below would start the watch at the current revision and
+        -- drop every write made since the snapshot.
+        local rev = loaded_configuration_rev or 0
 
         if rev == 0 then
             while true do
@@ -1206,6 +1204,7 @@ end
 
 local function init_loaded_configuration()
     loaded_configuration = {}
+    loaded_configuration_rev = nil
     local etcd_cli, prefix, err = etcd_apisix.new_without_proxy()
     if not etcd_cli then
         return "failed to start a etcd instance: " .. err
@@ -1215,6 +1214,18 @@ local function init_loaded_configuration()
     if not res then
         return err
     end
+
+    -- One readdir backs every entry create_formatter() stored, so there is a
+    -- single revision to record, and it is recorded even when the range came
+    -- back empty: the snapshot is still a point in time to watch from.
+    local rev = tonumber(res.headers["X-Etcd-Index"])
+    if not rev or rev <= 0 then
+        log.warn("invalid or missing X-Etcd-Index header, the watch will ",
+                 "start from the current revision instead of the revision ",
+                 "this configuration was read at")
+        rev = nil
+    end
+    loaded_configuration_rev = rev
 
     configuration_loaded_time = ngx_time()
 end

--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -605,55 +605,7 @@ etcd watch timeout, upgrade revision to
 
 
 
-=== TEST 15: missing X-Etcd-Index header should not crash init worker
---- yaml_config
-deployment:
-  role: traditional
-  role_traditional:
-    config_provider: etcd
-  etcd:
-    host:
-      - "http://127.0.0.1:2379"
-    prefix: /apisix
---- extra_init_by_lua
-    -- Clear loaded_configuration and inject a fake entry with missing
-    -- X-Etcd-Index header so do_run_watch exercises the fallback path.
-    local config_etcd = require("apisix.core.config_etcd")
-    for i = 1, 256 do
-        local name, val = debug.getupvalue(config_etcd.new, i)
-        if not name then
-            break
-        end
-        if name == "loaded_configuration" and type(val) == "table" then
-            for k in pairs(val) do
-                val[k] = nil
-            end
-            val["__test_fake"] = {
-                body = { nodes = {} },
-                headers = {},
-            }
-            break
-        end
-    end
---- config
-    location /t {
-        content_by_lua_block {
-            ngx.sleep(1)
-            ngx.say("passed")
-        }
-    }
---- request
-GET /t
---- response_body
-passed
---- grep_error_log eval
-qr/invalid or missing X-Etcd-Index header/
---- grep_error_log_out eval
-qr/(invalid or missing X-Etcd-Index header\n){1,}/
-
-
-
-=== TEST 16: full reload keeps the previous value of an item whose new data is invalid
+=== TEST 15: full reload keeps the previous value of an item whose new data is invalid
 --- timeout: 20
 --- yaml_config
 deployment:
@@ -746,7 +698,7 @@ keep the previous configuration
 
 
 
-=== TEST 17: full reload does not resurrect an item that no longer exists in etcd
+=== TEST 16: full reload does not resurrect an item that no longer exists in etcd
 --- timeout: 20
 --- yaml_config
 deployment:
@@ -826,7 +778,7 @@ valid item loaded: true
 
 
 
-=== TEST 18: full reload still skips an invalid item that has no previous value
+=== TEST 17: full reload still skips an invalid item that has no previous value
 --- timeout: 20
 --- yaml_config
 deployment:
@@ -900,7 +852,7 @@ keep the previous configuration
 
 
 
-=== TEST 19: a full reload that changes nothing reuses the items and does not bump conf_version
+=== TEST 18: a full reload that changes nothing reuses the items and does not bump conf_version
 --- timeout: 25
 --- yaml_config
 deployment:
@@ -999,7 +951,7 @@ conf_version bumped once, not twice: true
 
 
 
-=== TEST 20: a full reload that only deletes must still bump conf_version
+=== TEST 19: a full reload that only deletes must still bump conf_version
 --- timeout: 25
 --- yaml_config
 deployment:

--- a/t/core/config_etcd.t
+++ b/t/core/config_etcd.t
@@ -605,7 +605,40 @@ etcd watch timeout, upgrade revision to
 
 
 
-=== TEST 15: full reload keeps the previous value of an item whose new data is invalid
+=== TEST 15: a startup without a preloaded revision must not crash the init worker
+The watch takes its start revision from the read that preloads the
+configuration. When there is no such read there is no revision either, and the
+watch has to fall back to asking etcd for the current one rather than failing.
+--- yaml_config
+apisix:
+  disable_sync_configuration_during_start: true
+deployment:
+  role: traditional
+  role_traditional:
+    config_provider: etcd
+  etcd:
+    host:
+      - "http://127.0.0.1:2379"
+    prefix: /apisix
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.sleep(1)
+            ngx.say("passed")
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- grep_error_log eval
+qr/main etcd watcher initialised, revision=\d+/
+--- grep_error_log_out eval
+qr/(main etcd watcher initialised, revision=\d+\n){1,}/
+
+
+
+=== TEST 16: full reload keeps the previous value of an item whose new data is invalid
 --- timeout: 20
 --- yaml_config
 deployment:
@@ -698,7 +731,7 @@ keep the previous configuration
 
 
 
-=== TEST 16: full reload does not resurrect an item that no longer exists in etcd
+=== TEST 17: full reload does not resurrect an item that no longer exists in etcd
 --- timeout: 20
 --- yaml_config
 deployment:
@@ -778,7 +811,7 @@ valid item loaded: true
 
 
 
-=== TEST 17: full reload still skips an invalid item that has no previous value
+=== TEST 18: full reload still skips an invalid item that has no previous value
 --- timeout: 20
 --- yaml_config
 deployment:
@@ -852,7 +885,7 @@ keep the previous configuration
 
 
 
-=== TEST 18: a full reload that changes nothing reuses the items and does not bump conf_version
+=== TEST 19: a full reload that changes nothing reuses the items and does not bump conf_version
 --- timeout: 25
 --- yaml_config
 deployment:
@@ -951,7 +984,7 @@ conf_version bumped once, not twice: true
 
 
 
-=== TEST 19: a full reload that only deletes must still bump conf_version
+=== TEST 20: a full reload that only deletes must still bump conf_version
 --- timeout: 25
 --- yaml_config
 deployment:

--- a/t/core/etcd-watch-start-revision.t
+++ b/t/core/etcd-watch-start-revision.t
@@ -78,8 +78,12 @@ deployment:
     -- run clears up after itself too; this is here for a run that did not.
     etcd_clear()
 
-    -- only /routes exists under this prefix, so the preload table holds exactly
-    -- one entry and registering /routes empties it
+    -- Do not remove: this key is what puts /routes on the preload path. Without
+    -- it the prefix is empty, /routes has nothing to consume and reads for
+    -- itself at first sync, and that read picks the route up whatever revision
+    -- the watch started from -- the test then passes even unpatched. One key
+    -- also means one preload entry, so registering /routes empties the table,
+    -- which is the state being tested.
     etcd_put("/apisix-watch-start-revision/routes/", "init_dir")
 --- extra_init_by_lua
     -- after the snapshot was taken, before any worker starts watching

--- a/t/core/etcd-watch-start-revision.t
+++ b/t/core/etcd-watch-start-revision.t
@@ -19,7 +19,6 @@ use t::APISIX 'no_plan';
 repeat_each(1);
 no_long_string();
 no_root_location();
-no_shuffle();
 
 run_tests;
 
@@ -47,25 +46,37 @@ deployment:
         host:
             - "http://127.0.0.1:2379"
 --- extra_init_by_lua_start
-    local function etcd_put(key, value)
-        local body = '{"key":"' .. ngx.encode_base64(key)
-                     .. '","value":"' .. ngx.encode_base64(value) .. '"}'
-        local f = assert(io.popen("curl -s -X POST http://127.0.0.1:2379/v3/kv/put -d "
-                                  .. "'" .. body .. "'"))
-        f:read("*a")
+    -- io.popen reports nothing about how curl fared, so the etcd response is
+    -- checked instead: a silently failing write here would look exactly like
+    -- the lost event this test is about
+    local function etcd_call(path, body)
+        local f = assert(io.popen("curl -sS --fail-with-body -X POST "
+                                  .. "http://127.0.0.1:2379/v3/kv/" .. path
+                                  .. " -d '" .. body .. "'"))
+        local out = f:read("*a")
         f:close()
+        if not out or not out:find('"header"', 1, true) then
+            error("etcd " .. path .. " failed: " .. tostring(out))
+        end
+    end
+
+    local function etcd_put(key, value)
+        etcd_call("put", '{"key":"' .. ngx.encode_base64(key)
+                         .. '","value":"' .. ngx.encode_base64(value) .. '"}')
     end
     _G.etcd_put_for_test = etcd_put
 
+    local function etcd_clear()
+        etcd_call("deleterange",
+            '{"key":"' .. ngx.encode_base64("/apisix-watch-start-revision/")
+            .. '","range_end":"' .. ngx.encode_base64("/apisix-watch-start-revision0") .. '"}')
+    end
+    _G.etcd_clear_for_test = etcd_clear
+
     -- start from an empty prefix, so the route written below can only ever
-    -- reach the worker through the watch and never through the snapshot
-    local body = '{"key":"' .. ngx.encode_base64("/apisix-watch-start-revision/")
-                 .. '","range_end":"' .. ngx.encode_base64("/apisix-watch-start-revision0")
-                 .. '"}'
-    local f = assert(io.popen("curl -s -X POST http://127.0.0.1:2379/v3/kv/deleterange -d "
-                              .. "'" .. body .. "'"))
-    f:read("*a")
-    f:close()
+    -- reach the worker through the watch and never through the snapshot. The
+    -- run clears up after itself too; this is here for a run that did not.
+    etcd_clear()
 
     -- only /routes exists under this prefix, so the preload table holds exactly
     -- one entry and registering /routes empties it
@@ -83,6 +94,10 @@ deployment:
 
             local routes = core.config.fetch_created_obj("/routes")
             local route = routes and routes:get("1")
+
+            -- the local etcd is shared, so do not leave this prefix populated
+            _G.etcd_clear_for_test()
+
             if not route then
                 ngx.say("route written during startup was lost")
                 return
@@ -95,58 +110,3 @@ deployment:
 GET /t
 --- response_body
 uri: /hello
-
-
-
-=== TEST 2: the watch still starts when no configuration was preloaded
-With disable_sync_configuration_during_start there is no snapshot and so no
-revision to watch from; the watch has to fall back to reading the current
-revision, which is the path TEST 1 must not have removed.
---- yaml_config
-apisix:
-    node_listen: 1984
-    disable_sync_configuration_during_start: true
-deployment:
-    role: traditional
-    role_traditional:
-        config_provider: etcd
-    admin:
-        admin_key: null
-    etcd:
-        prefix: "/apisix"
-        host:
-            - "http://127.0.0.1:2379"
---- config
-    location /t {
-        content_by_lua_block {
-            local core = require("apisix.core")
-            local t = require("lib.test_admin").test
-
-            local code = t('/apisix/admin/routes/watch-fallback',
-                ngx.HTTP_PUT,
-                [[{
-                    "uri": "/hello",
-                    "upstream": {
-                        "type": "roundrobin",
-                        "nodes": {"127.0.0.1:1980": 1}
-                    }
-                }]]
-            )
-            if code >= 300 then
-                ngx.say("failed to create the route: ", code)
-                return
-            end
-
-            ngx.sleep(1)
-
-            local routes = core.config.fetch_created_obj("/routes")
-            local route = routes and routes:get("watch-fallback")
-            t('/apisix/admin/routes/watch-fallback', ngx.HTTP_DELETE)
-
-            ngx.say(route and "synced" or "not synced")
-        }
-    }
---- request
-GET /t
---- response_body
-synced

--- a/t/core/etcd-watch-start-revision.t
+++ b/t/core/etcd-watch-start-revision.t
@@ -1,0 +1,152 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: a write made after the configuration snapshot is still delivered
+The configuration is preloaded once in init_by_lua and handed to each resource
+type as it registers, which removes it from the preload table. This test drives
+that table empty by giving etcd a prefix holding a single directory, so /routes
+is the only type with anything to consume, and then writes a route between the
+snapshot and the first watch. The route can only reach the worker through the
+watch, so it arrives if and only if the watch starts from the revision the
+snapshot was read at.
+--- yaml_config
+apisix:
+    node_listen: 1984
+deployment:
+    role: traditional
+    role_traditional:
+        config_provider: etcd
+    admin:
+        admin_key: null
+    etcd:
+        prefix: "/apisix-watch-start-revision"
+        host:
+            - "http://127.0.0.1:2379"
+--- extra_init_by_lua_start
+    local function etcd_put(key, value)
+        local body = '{"key":"' .. ngx.encode_base64(key)
+                     .. '","value":"' .. ngx.encode_base64(value) .. '"}'
+        local f = assert(io.popen("curl -s -X POST http://127.0.0.1:2379/v3/kv/put -d "
+                                  .. "'" .. body .. "'"))
+        f:read("*a")
+        f:close()
+    end
+    _G.etcd_put_for_test = etcd_put
+
+    -- start from an empty prefix, so the route written below can only ever
+    -- reach the worker through the watch and never through the snapshot
+    local body = '{"key":"' .. ngx.encode_base64("/apisix-watch-start-revision/")
+                 .. '","range_end":"' .. ngx.encode_base64("/apisix-watch-start-revision0")
+                 .. '"}'
+    local f = assert(io.popen("curl -s -X POST http://127.0.0.1:2379/v3/kv/deleterange -d "
+                              .. "'" .. body .. "'"))
+    f:read("*a")
+    f:close()
+
+    -- only /routes exists under this prefix, so the preload table holds exactly
+    -- one entry and registering /routes empties it
+    etcd_put("/apisix-watch-start-revision/routes/", "init_dir")
+--- extra_init_by_lua
+    -- after the snapshot was taken, before any worker starts watching
+    _G.etcd_put_for_test("/apisix-watch-start-revision/routes/1",
+        '{"uri":"/hello","upstream":{"type":"roundrobin","nodes":{"127.0.0.1:1980":1}}}')
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+
+            ngx.sleep(1)
+
+            local routes = core.config.fetch_created_obj("/routes")
+            local route = routes and routes:get("1")
+            if not route then
+                ngx.say("route written during startup was lost")
+                return
+            end
+
+            ngx.say("uri: ", route.value.uri)
+        }
+    }
+--- request
+GET /t
+--- response_body
+uri: /hello
+
+
+
+=== TEST 2: the watch still starts when no configuration was preloaded
+With disable_sync_configuration_during_start there is no snapshot and so no
+revision to watch from; the watch has to fall back to reading the current
+revision, which is the path TEST 1 must not have removed.
+--- yaml_config
+apisix:
+    node_listen: 1984
+    disable_sync_configuration_during_start: true
+deployment:
+    role: traditional
+    role_traditional:
+        config_provider: etcd
+    admin:
+        admin_key: null
+    etcd:
+        prefix: "/apisix"
+        host:
+            - "http://127.0.0.1:2379"
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local t = require("lib.test_admin").test
+
+            local code = t('/apisix/admin/routes/watch-fallback',
+                ngx.HTTP_PUT,
+                [[{
+                    "uri": "/hello",
+                    "upstream": {
+                        "type": "roundrobin",
+                        "nodes": {"127.0.0.1:1980": 1}
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.say("failed to create the route: ", code)
+                return
+            end
+
+            ngx.sleep(1)
+
+            local routes = core.config.fetch_created_obj("/routes")
+            local route = routes and routes:get("watch-fallback")
+            t('/apisix/admin/routes/watch-fallback', ngx.HTTP_DELETE)
+
+            ngx.say(route and "synced" or "not synced")
+        }
+    }
+--- request
+GET /t
+--- response_body
+synced


### PR DESCRIPTION
### Description

A write made to etcd while APISIX is starting can be lost, permanently and without a log line.

The configuration is read once in `init_by_lua` and the snapshot is kept in `loaded_configuration`. Each resource type takes its own entry when it registers, and `core.config.new()` removes the entry as it does so. When the first worker starts watching, `do_run_watch()` took the start revision from `next(loaded_configuration)` — whatever entry was still there.

Once every preloaded type has registered, there is nothing there. `rev` stays 0, the code falls through to re-reading the current revision with `get(prefix)`, and the watch starts from *now* rather than from the snapshot. Anything written in between is never delivered to that worker, and nothing says so.

What keeps this from being permanently broken today is a coincidence: the http worker registers every type in `HTTP_ETCD_DIRECTORY` except `/stream_routes`, and the stream worker registers every type in `STREAM_ETCD_DIRECTORY` except `/ssls`, so one entry always survives. That balance is not a design — it shifts with the subsystem, with `enable_admin` (which decides whether `/plugins` is registered), and with which plugins are loaded (`/protos` comes from `grpc-transcode`). Registering one more type, or running against an etcd where one of those directories was never created, is enough to turn the loss on.

### The fix

Record the revision where it is produced. `init_loaded_configuration()` performs a single `readdir`, and `create_formatter()` stamps every entry it stores with that one response's headers, so there is exactly one revision to keep and no ambiguity about which entry to read it from. The test for "was anything preloaded" is made there, before anything has been consumed, which is precisely what makes it correct — the same test at watch time is the bug.

**An empty read is deliberately left alone**, and finding that boundary is most of what this PR is. When nothing is preloaded the start revision decides nothing: every resource type has no entry to take, so it reads for itself at first sync, and that read already returns whatever was written since. An empty-prefix version of the test below passes unpatched, 2/2.

Meanwhile that branch does carry something. `rev == 0` runs a `get(prefix)` retry loop, and the loop doubles as an undocumented readiness gate: while the endpoint is unhealthy the watch never starts, and resource types keep polling `readdir`, which still converges. Recording a revision unconditionally skipped the loop, started the watch against an endpoint that could not serve it, and left those types waiting on a watch instead of polling. `t/core/etcd-mtls.t` TEST 3 caught it — 2 failures in 4 runs against a freshly emptied etcd, 0 in 4 without the change, and green at the same sample size once the recording was narrowed. So the `rev == 0` path keeps both of its jobs, untouched.

### On the X-Etcd-Index handling

The check that #13364 added at the watch site is not carried over to the new capture site, because it can no longer be reached there.

This is a consequence of #13361, not a judgement about #13364. When #13364 landed, `get_format()` assigned `res.headers["X-Etcd-Index"]` from `res.body.header.revision` without checking it, so a response missing that field produced an entry with no usable header and the branch was live — its test was guarding something real. #13361 then made `get_format()` call `get_header_revision()` and fail the read when the revision is absent. From that point on a `readdir` can only return successfully with a usable header, and the branch became dead.

So the degradation path for a backend that omits `header.revision` is now the one #13361 established, and it is strictly louder than before: `get_format()` returns `nil, "etcd response missing header.revision"`, `readdir()` propagates it, `init_loaded_configuration()` returns it, and `init.lua` logs `failed to load the configuration:` and continues without rethrowing. `loaded_configuration_rev` is then nil, `rev` is 0, and the `get(prefix)` retry loop takes over — which itself re-checks `body.header.revision` and keeps retrying with a log line until the backend answers properly.

`t/core/config_etcd.t` TEST 15 keeps its slot rather than being deleted. Its injection wrote an entry with empty headers directly into `loaded_configuration`, which no longer reaches anything; it now reaches the same fallback through `disable_sync_configuration_during_start`, a real configuration that needs no stubbing, and asserts that the watch still starts. The numbering of the cases after it is unchanged.

### Tests

`t/core/etcd-watch-start-revision.t` drives the preload table empty using only configuration — an etcd prefix holding a single directory, so `/routes` is the one type with anything to consume — then writes a route between the snapshot and the first watch, from `extra_init_by_lua`. The route is not in the snapshot, so it can only arrive through the watch. It fails on `master` with `route written during startup was lost` and passes with the fix, deterministically in both directions.

The test checks the etcd responses rather than trusting `io.popen`, which reports nothing about how `curl` fared, and it clears its prefix at both ends of the run.
