### PR TITLE
fix(ci): unbreak CI under pnpm 12

### DIFF
--- a/ci/common.sh
+++ b/ci/common.sh
@@ -108,7 +108,6 @@ install_nodejs () {
     export PNPM_HOME="/pnpm"
     export PATH="$PNPM_HOME:$PATH"
     corepack enable pnpm
-    pnpm setup
 }
 
 install_brotli () {

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -108,6 +108,15 @@ install_nodejs () {
     export PNPM_HOME="/pnpm"
     export PATH="$PNPM_HOME:$PATH"
     corepack enable pnpm
+    # Pin the pnpm used outside t/, which has its own packageManager pin.
+    # pnpm 12 turned two long-standing warnings into hard errors that both
+    # break CI: running "pnpm setup" under sudo, and "pnpm dlx" installing a
+    # package whose dependency has an unapproved build script -- the latter
+    # hits t/plugin/grpc-web.t, which runs the client through "pnpx tsx"
+    # (esbuild). 11.25.0 is the last version CI was green on.
+    # Expiry: drop this pin once grpc-web.t no longer needs pnpm to run
+    # esbuild's build script unprompted.
+    corepack prepare pnpm@11.25.0 --activate
 }
 
 install_brotli () {


### PR DESCRIPTION
CI is red everywhere, and it is not a test failure. Two separate breakages, one root cause: pnpm 12 promoted two long-standing warnings into hard errors, and nothing pins the pnpm used outside `t/`.

**1. Environment setup dies before anything runs.** `install_nodejs()` calls `pnpm setup` under sudo:

```
Error: ERR_PNPM_SUDO_NOT_SUPPORTED
  × Running "pnpm setup" with sudo is not supported
```

pnpm 11.25.0 only warned here ("will fail in pnpm v12"); 12 made it fatal. The call is also redundant — `pnpm setup` exists to write `PNPM_HOME` and its `PATH` entry into a shell profile, and `install_nodejs()` already exports both in the same shell. The pnpm binary comes from the corepack shim on `PATH`, not from `setup`. So this one is removed rather than worked around, which also stops us running a configuration pnpm has said it does not support.

**2. `t/plugin/grpc-web.t` then fails.** With setup fixed, CI got far enough to reveal the second one — `pnpm dlx` now treats an unapproved build script as fatal, and that test runs its client via `pnpx tsx`:

```
Error: ERR_PNPM_IGNORED_BUILDS
  × adding a new package
  ╰─▶ Ignored build scripts: esbuild@0.28.2
```

This is why removing `pnpm setup` alone is not enough, and why the pin is needed: the last green run resolved pnpm to **11.25.0** at the repository root, where nothing pins it, so `corepack prepare pnpm@11.25.0 --activate` puts that back and stops the version moving on its own. Commands under `t/` are unaffected — its `package.json` already pins `packageManager` to 10.14.0.

The pin has a stated expiry in the comment: it can be dropped once `grpc-web.t` no longer needs pnpm to run esbuild's build script unprompted.

Verified in a clean `ubuntu:24.04` container reproducing the CI setup: on 11.25.0 `pnpx tsx` is clean, on 12.3.2 and 12.3.4 it fails as above; `pnpm install`, `pnpm exec jest` and the global `pnpm install -g tsx` in `t/plugin/grpc-web/setup.sh` all work without `pnpm setup`, with `tsx` landing in `PNPM_HOME` on `PATH`.
