### PR TITLE
test(elasticsearch-logger): drop the max_pending_entries metadata after the discard test

### DIFF
--- a/t/plugin/elasticsearch-logger2.t
+++ b/t/plugin/elasticsearch-logger2.t
@@ -136,6 +136,7 @@ location /t {
             keepalive_pool = 1,
         })
         ngx.sleep(2)
+        t('/apisix/admin/plugin_metadata/elasticsearch-logger', ngx.HTTP_DELETE)
     }
 }
 --- error_log


### PR DESCRIPTION
### Description

`t/plugin/elasticsearch-logger2.t` TEST 8 is flaky in CI. It fails on master and on unrelated PRs since 2026-08-20 (for example [this run](https://github.com/apache/apisix/actions/runs/33492069750) on master and [this one](https://github.com/apache/apisix/actions/runs/34152264376/job/101903351536) on #13651), and often survives the automatic rerun.

TEST 1 sets plugin metadata `max_pending_entries = 1` and never removes it, so etcd keeps it for the rest of the file. Since #13826 the batch processor discards a new entry while one is still pending. In TEST 8 the second request's entry is therefore discarded whenever the first bulk request to Elasticsearch is still in flight, which is always the case when ES has to create the index first (fresh ES in CI). The test then never logs `services-second-*`.

This PR deletes the metadata at the end of TEST 1, the way `t/plugin/elasticsearch-logger.t` already does, so the later blocks run with the default limit. Verified locally with a fresh index before every run: 0/3 pass before, 3/3 after.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)
