### PR TITLE
refactor(wolf-rbac): separate route and consumer settings

### DIFF
--- a/apisix/plugins/multi-auth.lua
+++ b/apisix/plugins/multi-auth.lua
@@ -72,6 +72,15 @@ function _M.rewrite(conf, ctx)
     local status_code
     local errors = {}
 
+    for _, auth_plugin in pairs(auth_plugins) do
+        for auth_plugin_name, auth_plugin_conf in pairs(auth_plugin) do
+            local auth = plugin.get(auth_plugin_name)
+            if auth.clear_auth_headers then
+                auth.clear_auth_headers(auth_plugin_conf, ctx)
+            end
+        end
+    end
+
     for k, auth_plugin in pairs(auth_plugins) do
         for auth_plugin_name, auth_plugin_conf in pairs(auth_plugin) do
             local auth = plugin.get(auth_plugin_name)

--- a/apisix/plugins/wolf-rbac.lua
+++ b/apisix/plugins/wolf-rbac.lua
@@ -18,6 +18,7 @@
 local core     = require("apisix.core")
 local consumer = require("apisix.consumer")
 local json     = require("apisix.core.json")
+local auth_utils = require("apisix.utils.auth")
 local sleep    = core.sleep
 local ngx_re = require("ngx.re")
 local http     = require("resty.http")
@@ -36,10 +37,6 @@ local plugin_name = "wolf-rbac"
 local schema = {
     type = "object",
     properties = {
-        appid = {
-            type = "string",
-            default = "unset"
-        },
         server = {
             type = "string",
             default = "http://127.0.0.1:12180"
@@ -54,16 +51,47 @@ local schema = {
     }
 }
 
+local consumer_schema = {
+    type = "object",
+    properties = {
+        appid = {
+            type = "string",
+        },
+    },
+    required = {"appid"},
+}
+
 local _M = {
     version = 0.1,
     priority = 2555,
     type = 'auth',
     name = plugin_name,
     schema = schema,
+    consumer_schema = consumer_schema,
 }
 
 
 local token_version = 'V1'
+local public_api_uris = {
+    ["/apisix/plugin/wolf-rbac/login"] = true,
+    ["/apisix/plugin/wolf-rbac/change_pwd"] = true,
+    ["/apisix/plugin/wolf-rbac/user_info"] = true,
+}
+
+
+local function clear_identity_headers(conf, ctx)
+    local prefix = conf.header_prefix
+    core.request.set_header(ctx, prefix .. "UserId", nil)
+    core.request.set_header(ctx, prefix .. "Username", nil)
+    core.request.set_header(ctx, prefix .. "Nickname", nil)
+end
+
+
+function _M.clear_auth_headers(conf, ctx)
+    clear_identity_headers(conf, ctx)
+end
+
+
 local function create_rbac_token(appid, wolf_token)
     return token_version .. "#" .. appid .. "#" .. wolf_token
 end
@@ -142,7 +170,11 @@ local function http_get(uri, myheaders, timeout, ssl_verify)
 end
 
 
-function _M.check_schema(conf)
+function _M.check_schema(conf, schema_type)
+    if schema_type == core.schema.TYPE_CONSUMER then
+        return core.schema.check(consumer_schema, conf)
+    end
+
     local ok, err = core.schema.check(schema, conf)
     if not ok then
         return false, err
@@ -155,6 +187,29 @@ function _M.check_schema(conf)
     core.utils.check_tls_bool({"ssl_verify"}, conf, plugin_name)
 
     return true
+end
+
+
+local function get_route_plugin_conf(ctx)
+    for i = 1, #ctx.plugins, 2 do
+        if ctx.plugins[i].name == plugin_name then
+            return ctx.plugins[i + 1]
+        end
+    end
+
+    return core.response.exit(500, fail_response("Missing wolf-rbac configuration"))
+end
+
+
+local function is_wolf_public_api(ctx)
+    for i = 1, #ctx.plugins, 2 do
+        if ctx.plugins[i].name == "public-api" then
+            local conf = ctx.plugins[i + 1]
+            return public_api_uris[conf.uri or ctx.var.uri] == true
+        end
+    end
+
+    return false
 end
 
 
@@ -239,6 +294,14 @@ end
 
 
 function _M.rewrite(conf, ctx)
+    if not auth_utils.is_running_under_multi_auth(ctx) then
+        clear_identity_headers(conf, ctx)
+    end
+
+    if is_wolf_public_api(ctx) then
+        return
+    end
+
     local url = ctx.var.uri
     local action = ctx.var.request_method
     local client_ip = core.request.get_remote_client_ip(ctx)
@@ -276,34 +339,19 @@ function _M.rewrite(conf, ctx)
         return 401, fail_response("Invalid appid in rbac token")
     end
     core.log.info("consumer appid: ", appid)
-    local server = cur_consumer.auth_conf.server
-    local ssl_verify = cur_consumer.auth_conf.ssl_verify
-
-    local res = check_url_permission(server, appid, action, url,
-                    client_ip, wolf_token, ssl_verify)
+    local res = check_url_permission(conf.server, appid, action, url,
+                    client_ip, wolf_token, conf.ssl_verify)
     core.log.info(" check_url_permission(appid: ", appid,
                   ", action: ", action, ", url: ", url,
                   ") res status: ", res.status, ", err: ", res.err)
 
     local username = nil
     local nickname = nil
-    local prefix = cur_consumer.auth_conf.header_prefix or ''
-    -- drop client-supplied identity headers before trusting the auth response
-    core.request.set_header(ctx, prefix .. "UserId", nil)
-    core.request.set_header(ctx, prefix .. "Username", nil)
-    core.request.set_header(ctx, prefix .. "Nickname", nil)
     if type(res.userInfo) == 'table' then
         local userInfo = res.userInfo
         ctx.userInfo = userInfo
-        local userId = userInfo.id
         username = userInfo.username
         nickname = userInfo.nickname or userInfo.username
-        core.response.set_header(prefix .. "UserId", userId)
-        core.response.set_header(prefix .. "Username", username)
-        core.response.set_header(prefix .. "Nickname", ngx.escape_uri(nickname))
-        core.request.set_header(ctx, prefix .. "UserId", userId)
-        core.request.set_header(ctx, prefix .. "Username", username)
-        core.request.set_header(ctx, prefix .. "Nickname", ngx.escape_uri(nickname))
     end
 
     if res.status ~= 200 then
@@ -312,12 +360,21 @@ function _M.rewrite(conf, ctx)
             ") failed, res status: ", res.status, ", err: ", res.err)
         return res.status, fail_response(res.err, { username = username, nickname = nickname })
     end
+    if type(res.userInfo) == 'table' then
+        local prefix = conf.header_prefix
+        local userId = res.userInfo.id
+        core.response.set_header(prefix .. "UserId", userId)
+        core.response.set_header(prefix .. "Username", username)
+        core.response.set_header(prefix .. "Nickname", ngx.escape_uri(nickname))
+        core.request.set_header(ctx, prefix .. "UserId", userId)
+        core.request.set_header(ctx, prefix .. "Username", username)
+        core.request.set_header(ctx, prefix .. "Nickname", ngx.escape_uri(nickname))
+    end
     consumer.attach_consumer(ctx, cur_consumer, consumer_conf)
     core.log.info("wolf-rbac check permission passed")
 end
 
-local function get_args()
-    local ctx = ngx.ctx.api_ctx
+local function get_args(ctx)
     local args, err
     req_read_body()
     if string.find(ctx.var.http_content_type or "","application/json",
@@ -396,8 +453,8 @@ local function request_to_wolf_server(method, uri, headers, body, ssl_verify)
     return body
 end
 
-local function wolf_rbac_login()
-    local args = get_args()
+local function wolf_rbac_login(ctx)
+    local args = get_args(ctx)
     if not args then
         return core.response.exit(400, fail_response("invalid request"))
     end
@@ -406,12 +463,13 @@ local function wolf_rbac_login()
     end
 
     local appid = args.appid
-    local consumer = get_consumer(appid)
+    get_consumer(appid)
     core.log.info("consumer appid: ", appid)
 
-    local uri = consumer.auth_conf.server .. '/wolf/rbac/login.rest'
+    local conf = get_route_plugin_conf(ctx)
+    local uri = conf.server .. '/wolf/rbac/login.rest'
     local headers = new_headers()
-    local body = request_to_wolf_server('POST', uri, headers, args, consumer.auth_conf.ssl_verify)
+    local body = request_to_wolf_server('POST', uri, headers, args, conf.ssl_verify)
 
     local userInfo = body.data.userInfo
     local wolf_token = body.data.token
@@ -442,35 +500,34 @@ local function get_wolf_token(ctx)
     return tokenInfo
 end
 
-local function wolf_rbac_change_pwd()
-    local args = get_args()
-
-    local ctx = ngx.ctx.api_ctx
+local function wolf_rbac_change_pwd(ctx)
+    local args = get_args(ctx)
     local tokenInfo = get_wolf_token(ctx)
     local appid = tokenInfo.appid
     local wolf_token = tokenInfo.wolf_token
-    local consumer = get_consumer(appid)
+    get_consumer(appid)
     core.log.info("consumer appid: ", appid)
 
-    local uri = consumer.auth_conf.server .. '/wolf/rbac/change_pwd'
+    local conf = get_route_plugin_conf(ctx)
+    local uri = conf.server .. '/wolf/rbac/change_pwd'
     local headers = new_headers()
     headers['x-rbac-token'] = wolf_token
-    request_to_wolf_server('POST', uri, headers, args, consumer.auth_conf.ssl_verify)
+    request_to_wolf_server('POST', uri, headers, args, conf.ssl_verify)
     core.response.exit(200, success_response('success to change password', { }))
 end
 
-local function wolf_rbac_user_info()
-    local ctx = ngx.ctx.api_ctx
+local function wolf_rbac_user_info(ctx)
     local tokenInfo = get_wolf_token(ctx)
     local appid = tokenInfo.appid
     local wolf_token = tokenInfo.wolf_token
-    local consumer = get_consumer(appid)
+    get_consumer(appid)
     core.log.info("consumer appid: ", appid)
 
-    local uri = consumer.auth_conf.server .. '/wolf/rbac/user_info'
+    local conf = get_route_plugin_conf(ctx)
+    local uri = conf.server .. '/wolf/rbac/user_info'
     local headers = new_headers()
     headers['x-rbac-token'] = wolf_token
-    local body = request_to_wolf_server('GET', uri, headers, {}, consumer.auth_conf.ssl_verify)
+    local body = request_to_wolf_server('GET', uri, headers, {}, conf.ssl_verify)
     local userInfo = body.data.userInfo
     core.response.exit(200, success_response(nil, {user_info = userInfo}))
 end

--- a/apisix/plugins/wolf-rbac.lua
+++ b/apisix/plugins/wolf-rbac.lua
@@ -32,6 +32,8 @@ local req_read_body = ngx.req.read_body
 local req_get_body_data = ngx.req.get_body_data
 
 local plugin_name = "wolf-rbac"
+local default_server = "http://127.0.0.1:12180"
+local default_header_prefix = "X-"
 
 
 local schema = {
@@ -39,11 +41,11 @@ local schema = {
     properties = {
         server = {
             type = "string",
-            default = "http://127.0.0.1:12180"
+            default = default_server
         },
         header_prefix = {
             type = "string",
-            default = "X-"
+            default = default_header_prefix
         },
         ssl_verify = {
             type = "boolean",
@@ -80,7 +82,7 @@ local public_api_uris = {
 
 
 local function clear_identity_headers(conf, ctx)
-    local prefix = conf.header_prefix
+    local prefix = conf.header_prefix or default_header_prefix
     core.request.set_header(ctx, prefix .. "UserId", nil)
     core.request.set_header(ctx, prefix .. "Username", nil)
     core.request.set_header(ctx, prefix .. "Nickname", nil)
@@ -339,7 +341,7 @@ function _M.rewrite(conf, ctx)
         return 401, fail_response("Invalid appid in rbac token")
     end
     core.log.info("consumer appid: ", appid)
-    local res = check_url_permission(conf.server, appid, action, url,
+    local res = check_url_permission(conf.server or default_server, appid, action, url,
                     client_ip, wolf_token, conf.ssl_verify)
     core.log.info(" check_url_permission(appid: ", appid,
                   ", action: ", action, ", url: ", url,
@@ -361,7 +363,7 @@ function _M.rewrite(conf, ctx)
         return res.status, fail_response(res.err, { username = username, nickname = nickname })
     end
     if type(res.userInfo) == 'table' then
-        local prefix = conf.header_prefix
+        local prefix = conf.header_prefix or default_header_prefix
         local userId = res.userInfo.id
         core.response.set_header(prefix .. "UserId", userId)
         core.response.set_header(prefix .. "Username", username)
@@ -467,7 +469,7 @@ local function wolf_rbac_login(ctx)
     core.log.info("consumer appid: ", appid)
 
     local conf = get_route_plugin_conf(ctx)
-    local uri = conf.server .. '/wolf/rbac/login.rest'
+    local uri = (conf.server or default_server) .. '/wolf/rbac/login.rest'
     local headers = new_headers()
     local body = request_to_wolf_server('POST', uri, headers, args, conf.ssl_verify)
 
@@ -509,7 +511,7 @@ local function wolf_rbac_change_pwd(ctx)
     core.log.info("consumer appid: ", appid)
 
     local conf = get_route_plugin_conf(ctx)
-    local uri = conf.server .. '/wolf/rbac/change_pwd'
+    local uri = (conf.server or default_server) .. '/wolf/rbac/change_pwd'
     local headers = new_headers()
     headers['x-rbac-token'] = wolf_token
     request_to_wolf_server('POST', uri, headers, args, conf.ssl_verify)
@@ -524,7 +526,7 @@ local function wolf_rbac_user_info(ctx)
     core.log.info("consumer appid: ", appid)
 
     local conf = get_route_plugin_conf(ctx)
-    local uri = conf.server .. '/wolf/rbac/user_info'
+    local uri = (conf.server or default_server) .. '/wolf/rbac/user_info'
     local headers = new_headers()
     headers['x-rbac-token'] = wolf_token
     local body = request_to_wolf_server('GET', uri, headers, {}, conf.ssl_verify)

--- a/docs/en/latest/plugins/wolf-rbac.md
+++ b/docs/en/latest/plugins/wolf-rbac.md
@@ -34,11 +34,12 @@ The `wolf-rbac` Plugin provides a [role-based access control](https://en.wikiped
 
 ## Attributes
 
-| Name          | Type   | Required | Default                  | Description                                                                                                                                                                                                                 |
-|---------------|--------|----------|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| server        | string | False    | "http://127.0.0.1:12180" | Service address of wolf server.                                                                                                                                                                                             |
-| appid         | string | False    | "unset"                  | App id added in wolf console. This field supports saving the value in Secret Manager using the [APISIX Secret](../terminology/secret.md) resource.            |
-| header_prefix | string | False    | "X-"                     | Prefix for a custom HTTP header. After authentication is successful, three headers will be added to the request header (for backend) and response header (for frontend) namely: `X-UserId`, `X-Username`, and `X-Nickname`. |
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| appid | string | True | N/A | Consumer application ID configured in Wolf. This field supports saving the value in Secret Manager using the [APISIX Secret](../terminology/secret.md) resource. |
+| server | string | False | "http://127.0.0.1:12180" | Route or Service address of the Wolf server. |
+| header_prefix | string | False | "X-" | Route or Service prefix for the identity headers added after successful authentication: `{prefix}UserId`, `{prefix}Username`, and `{prefix}Nickname`. |
+| ssl_verify | boolean | False | false | Whether to verify the Wolf server's TLS certificate. Configured on a Route or Service. |
 
 ## API
 
@@ -79,7 +80,6 @@ curl http://127.0.0.1:9180/apisix/admin/consumers  -H "X-API-KEY: $admin_key" -X
   "username":"wolf_rbac",
   "plugins":{
     "wolf-rbac":{
-      "server":"http://127.0.0.1:12180",
       "appid":"restful"
     }
   },
@@ -101,7 +101,10 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1  -H "X-API-KEY: $admin_key" -X 
     "methods": ["GET"],
     "uri": "/*",
     "plugins": {
-        "wolf-rbac": {}
+        "wolf-rbac": {
+            "server": "http://127.0.0.1:12180",
+            "header_prefix": "X-"
+        }
     },
     "upstream": {
         "type": "roundrobin",
@@ -113,6 +116,10 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1  -H "X-API-KEY: $admin_key" -X 
 ```
 
 You can also use the [APISIX Dashboard](/docs/dashboard/USER_GUIDE) to complete the operation through a web UI.
+
+## Upgrade
+
+Move `server`, `header_prefix`, and `ssl_verify` from each Consumer to every Route or Service that uses `wolf-rbac`. Keep only `appid` on the Consumer. If Consumers on one Route used different values, split them across Routes or Services, or standardize the values before upgrading.
 
 <!--
 ![add a consumer](https://raw.githubusercontent.com/apache/apisix/master/docs/assets/images/plugin/wolf-rbac-1.png)
@@ -129,12 +136,15 @@ curl http://127.0.0.1:9180/apisix/admin/routes/wal -H "X-API-KEY: $admin_key" -X
 {
     "uri": "/apisix/plugin/wolf-rbac/login",
     "plugins": {
-        "public-api": {}
+        "public-api": {},
+        "wolf-rbac": {
+            "server": "http://127.0.0.1:12180"
+        }
     }
 }'
 ```
 
-Similarly, you can setup the Routes for `change_pwd` and `user_info`.
+Similarly, configure both Plugins on the Routes for `change_pwd` and `user_info`.
 
 You can now login and get a wolf `rbac_token`:
 

--- a/docs/zh/latest/plugins/wolf-rbac.md
+++ b/docs/zh/latest/plugins/wolf-rbac.md
@@ -34,11 +34,12 @@ description: 本文介绍了关于 Apache APISIX `wolf-rbac` 插件的基本信�
 
 ## 属性
 
-| 名称          | 类型   | 必选项  | 默认值                    | 描述                                                                                                                                               |
-| ------------- | ------ | ------ | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| server        | string | 否     | "http://127.0.0.1:12180" |  `wolf-server` 的服务地址。                                                                                                                          |
-| appid         | string | 否     | "unset"                  | 在 `wolf-console` 中已经添加的应用 id。该字段支持使用 [APISIX Secret](../terminology/secret.md) 资源，将值保存在 Secret Manager 中。                                       |
-| header_prefix | string | 否     | "X-"                     | 自定义 HTTP 头的前缀。`wolf-rbac` 在鉴权成功后，会在请求头 (用于传给后端) 及响应头 (用于传给前端) 中添加 3 个 header：`X-UserId`, `X-Username`, `X-Nickname`。|
+| 名称 | 类型 | 必选项 | 默认值 | 描述 |
+| --- | --- | --- | --- | --- |
+| appid | string | 是 | 无 | Consumer 在 Wolf 中配置的应用 ID。该字段支持使用 [APISIX Secret](../terminology/secret.md) 资源，将值保存在 Secret Manager 中。 |
+| server | string | 否 | "http://127.0.0.1:12180" | Route 或 Service 使用的 Wolf 服务地址。 |
+| header_prefix | string | 否 | "X-" | Route 或 Service 的身份 HTTP 头前缀。鉴权成功后添加 `{prefix}UserId`、`{prefix}Username` 和 `{prefix}Nickname`。 |
+| ssl_verify | boolean | 否 | false | 是否验证 Wolf 服务的 TLS 证书。在 Route 或 Service 上配置。 |
 
 ## 接口
 
@@ -81,7 +82,6 @@ curl http://127.0.0.1:9180/apisix/admin/consumers  \
   "username":"wolf_rbac",
   "plugins":{
     "wolf-rbac":{
-      "server":"http://127.0.0.1:12180",
       "appid":"restful"
     }
   },
@@ -104,7 +104,10 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1  \
     "methods": ["GET"],
     "uri": "/*",
     "plugins": {
-        "wolf-rbac": {}
+        "wolf-rbac": {
+            "server": "http://127.0.0.1:12180",
+            "header_prefix": "X-"
+        }
     },
     "upstream": {
         "type": "roundrobin",
@@ -116,6 +119,10 @@ curl http://127.0.0.1:9180/apisix/admin/routes/1  \
 ```
 
 你还可以通过 [APISIX Dashboard](https://github.com/apache/apisix-dashboard) 的 Web 界面完成上述操作。
+
+## 升级
+
+将 `server`、`header_prefix` 和 `ssl_verify` 从 Consumer 移至每个使用 `wolf-rbac` 的 Route 或 Service。Consumer 仅保留 `appid`。如果同一 Route 下的 Consumer 使用不同配置，请在升级前拆分 Route 或 Service，或统一这些配置。
 
 <!--
 ![add a consumer](https://raw.githubusercontent.com/apache/apisix/master/docs/assets/images/plugin/wolf-rbac-1.png)
@@ -133,12 +140,15 @@ curl http://127.0.0.1:9180/apisix/admin/routes/wal \
 {
     "uri": "/apisix/plugin/wolf-rbac/login",
     "plugins": {
-        "public-api": {}
+        "public-api": {},
+        "wolf-rbac": {
+            "server": "http://127.0.0.1:12180"
+        }
     }
 }'
 ```
 
-同样，你需要参考上述命令为 `change_pwd` 和 `user_info` 两个 API 配置路由。
+同样，你需要在 `change_pwd` 和 `user_info` 的 Route 上配置这两个插件。
 
 现在你可以登录并获取 wolf `rbac_token`：
 

--- a/t/plugin/multi-auth.t
+++ b/t/plugin/multi-auth.t
@@ -740,7 +740,7 @@ X-Wolf-Nickname: administrator
 
 
 
-=== TEST 24b: malformed Wolf token does not preserve Route identity headers
+=== TEST 25b: malformed Wolf token does not preserve Route identity headers
 --- request
 GET /hello
 --- more_headers
@@ -754,7 +754,7 @@ X-Wolf-Nickname: forged
 
 
 
-=== TEST 25: Wolf headers are cleared when key-auth succeeds first
+=== TEST 26: Wolf headers are cleared when key-auth succeeds first
 --- config
     location /t {
         content_by_lua_block {
@@ -815,7 +815,7 @@ GET /t
 
 
 
-=== TEST 26: successful Wolf authentication sets the Route header namespace
+=== TEST 27: successful Wolf authentication sets the Route header namespace
 --- request
 GET /hello
 --- more_headers

--- a/t/plugin/multi-auth.t
+++ b/t/plugin/multi-auth.t
@@ -655,3 +655,177 @@ GET /t
 code: 401
 --- no_error_log
 [error]
+
+
+
+=== TEST 23: add a Wolf consumer and configure Wolf before key-auth
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/consumers',
+                ngx.HTTP_PUT,
+                [[{
+                    "username": "wolf-client",
+                    "plugins": {
+                        "wolf-rbac": {
+                            "appid": "multi-auth-wolf-app"
+                        }
+                    }
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "multi-auth": {
+                            "auth_plugins": [
+                                {
+                                    "wolf-rbac": {
+                                        "server": "http://127.0.0.1:1982",
+                                        "header_prefix": "X-Wolf-"
+                                    }
+                                },
+                                {
+                                    "key-auth": {}
+                                }
+                            ]
+                        },
+                        "serverless-post-function": {
+                            "phase": "access",
+                            "functions": [
+                                "return function(conf, ctx) local core = require(\"apisix.core\"); local names = {\"X-Wolf-UserId\", \"X-Wolf-Username\", \"X-Wolf-Nickname\", \"X-Consumer-Username\"}; local values = {}; for i, name in ipairs(names) do values[i] = core.request.header(ctx, name) or \"nil\"; end; core.response.exit(200, table.concat(values, \",\")); end"
+                            ]
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+            )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+
+
+=== TEST 24: Wolf clears its Route header namespace before fallback
+--- request
+GET /hello
+--- more_headers
+apikey: auth-one
+X-Wolf-UserId: admin-001
+X-Wolf-Username: admin
+X-Wolf-Nickname: administrator
+--- response_body eval
+"nil,nil,nil,foo"
+
+
+
+=== TEST 24b: malformed Wolf token does not preserve Route identity headers
+--- request
+GET /hello
+--- more_headers
+x-rbac-token: malformed
+apikey: auth-one
+X-Wolf-UserId: forged
+X-Wolf-Username: forged
+X-Wolf-Nickname: forged
+--- response_body eval
+"nil,nil,nil,foo"
+
+
+
+=== TEST 25: Wolf headers are cleared when key-auth succeeds first
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "multi-auth": {
+                            "auth_plugins": [
+                                {
+                                    "key-auth": {}
+                                },
+                                {
+                                    "wolf-rbac": {
+                                        "server": "http://127.0.0.1:1982",
+                                        "header_prefix": "X-Wolf-"
+                                    }
+                                }
+                            ]
+                        },
+                        "serverless-post-function": {
+                            "phase": "access",
+                            "functions": [
+                                "return function(conf, ctx) local core = require(\"apisix.core\"); local names = {\"X-Wolf-UserId\", \"X-Wolf-Username\", \"X-Wolf-Nickname\", \"X-Consumer-Username\"}; local values = {}; for i, name in ipairs(names) do values[i] = core.request.header(ctx, name) or \"nil\"; end; core.response.exit(200, table.concat(values, \",\")); end"
+                            ]
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            local code, _, body = t('/hello', ngx.HTTP_GET, nil, nil, {
+                apikey = "auth-one",
+                ["X-Wolf-UserId"] = "admin-001",
+                ["X-Wolf-Username"] = "admin",
+                ["X-Wolf-Nickname"] = "administrator",
+            })
+            ngx.status = code
+            ngx.print(body)
+        }
+    }
+--- request
+GET /t
+--- response_body eval
+"nil,nil,nil,foo"
+
+
+
+=== TEST 26: successful Wolf authentication sets the Route header namespace
+--- request
+GET /hello
+--- more_headers
+x-rbac-token: V1#multi-auth-wolf-app#wolf-rbac-token
+X-Wolf-UserId: forged
+X-Wolf-Username: forged
+X-Wolf-Nickname: forged
+--- response_headers
+X-Wolf-UserId: 100
+X-Wolf-Username: admin
+X-Wolf-Nickname: administrator
+--- response_body eval
+"100,admin,administrator,wolf-client"

--- a/t/plugin/multi-auth.t
+++ b/t/plugin/multi-auth.t
@@ -829,3 +829,57 @@ X-Wolf-Username: admin
 X-Wolf-Nickname: administrator
 --- response_body eval
 "100,admin,administrator,wolf-client"
+
+
+
+=== TEST 28: empty Wolf configuration uses the default header prefix
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "multi-auth": {
+                            "auth_plugins": [
+                                {"key-auth": {}},
+                                {"wolf-rbac": {}}
+                            ]
+                        },
+                        "serverless-post-function": {
+                            "phase": "access",
+                            "functions": [
+                                "return function(conf, ctx) local core = require(\"apisix.core\"); local names = {\"X-UserId\", \"X-Username\", \"X-Nickname\", \"X-Consumer-Username\"}; local values = {}; for i, name in ipairs(names) do values[i] = core.request.header(ctx, name) or \"nil\"; end; core.response.exit(200, table.concat(values, \",\")); end"
+                            ]
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+            )
+            if code >= 300 then
+                ngx.status = code
+                ngx.say(body)
+                return
+            end
+
+            code, _, body = t('/hello', ngx.HTTP_GET, nil, nil, {
+                apikey = "auth-one",
+                ["X-UserId"] = "forged",
+                ["X-Username"] = "forged",
+                ["X-Nickname"] = "forged",
+            })
+            ngx.status = code
+            ngx.print(body)
+        }
+    }
+--- request
+GET /t
+--- response_body eval
+"nil,nil,nil,foo"

--- a/t/plugin/security-warning2.t
+++ b/t/plugin/security-warning2.t
@@ -580,7 +580,7 @@ Keeping tls disabled in tcp-logger configuration is a security risk
         }
     }
 --- response_body_like eval
-qr/\{"appid":"unset","header_prefix":"X-","server":"http:\/\/127\.0\.0\.1:12180"\}/
+qr/\{"header_prefix":"X-","server":"http:\/\/127\.0\.0\.1:12180"\}/
 --- error_log
 Using wolf-rbac server with no TLS is a security risk
 
@@ -591,16 +591,15 @@ Using wolf-rbac server with no TLS is a security risk
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/consumers',
+            local code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
                 [[{
-                    "username": "wolf_rbac_unit_test",
                     "plugins": {
                         "wolf-rbac": {
-                            "appid": "wolf-rbac-app",
                             "server": "https://127.0.0.1:1982"
                         }
-                    }
+                    },
+                    "uri": "/hello"
                 }]]
                 )
 

--- a/t/plugin/wolf-rbac.t
+++ b/t/plugin/wolf-rbac.t
@@ -51,10 +51,18 @@ __DATA__
             end
 
             ngx.say(require("toolkit.json").encode(conf))
+
+            local consumer_conf = {appid = "wolf-rbac-app"}
+            ok, err = plugin.check_schema(consumer_conf,
+                require("apisix.core").schema.TYPE_CONSUMER)
+            if not ok then
+                ngx.say(err)
+            end
+            ngx.say(require("toolkit.json").encode(consumer_conf))
         }
     }
 --- response_body_like eval
-qr/\{"appid":"unset","header_prefix":"X-","server":"http:\/\/127\.0\.0\.1:12180"\}/
+qr/\{"header_prefix":"X-","server":"http:\/\/127\.0\.0\.1:12180"\}\n\{"appid":"wolf-rbac-app"\}/
 
 
 
@@ -63,7 +71,8 @@ qr/\{"appid":"unset","header_prefix":"X-","server":"http:\/\/127\.0\.0\.1:12180"
     location /t {
         content_by_lua_block {
             local plugin = require("apisix.plugins.wolf-rbac")
-            local ok, err = plugin.check_schema({appid = 123})
+            local ok, err = plugin.check_schema({appid = 123},
+                require("apisix.core").schema.TYPE_CONSUMER)
             if not ok then
                 ngx.say(err)
             end
@@ -77,6 +86,23 @@ done
 
 
 
+=== TEST 2b: appid is required in Consumer configuration
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.wolf-rbac")
+            local ok, err = plugin.check_schema({},
+                require("apisix.core").schema.TYPE_CONSUMER)
+            if not ok then
+                ngx.say(err)
+            end
+        }
+    }
+--- response_body_like eval
+qr/property "appid" is required/
+
+
+
 === TEST 3: setup public API route
 --- config
     location /t {
@@ -86,7 +112,10 @@ done
                     url = "/apisix/admin/routes/wolf-login",
                     data = [[{
                         "plugins": {
-                            "public-api": {}
+                            "public-api": {},
+                            "wolf-rbac": {
+                                "server": "http://127.0.0.1:1982"
+                            }
                         },
                         "uri": "/apisix/plugin/wolf-rbac/login"
                     }]]
@@ -95,7 +124,10 @@ done
                     url = "/apisix/admin/routes/wolf-userinfo",
                     data = [[{
                         "plugins": {
-                            "public-api": {}
+                            "public-api": {},
+                            "wolf-rbac": {
+                                "server": "http://127.0.0.1:1982"
+                            }
                         },
                         "uri": "/apisix/plugin/wolf-rbac/user_info"
                     }]]
@@ -104,7 +136,10 @@ done
                     url = "/apisix/admin/routes/wolf-change-pwd",
                     data = [[{
                         "plugins": {
-                            "public-api": {}
+                            "public-api": {},
+                            "wolf-rbac": {
+                                "server": "http://127.0.0.1:1982"
+                            }
                         },
                         "uri": "/apisix/plugin/wolf-rbac/change_pwd"
                     }]]
@@ -135,8 +170,7 @@ done
                     "username": "wolf_rbac_unit_test",
                     "plugins": {
                         "wolf-rbac": {
-                            "appid": "wolf-rbac-app",
-                            "server": "http://127.0.0.1:1982"
+                            "appid": "wolf-rbac-app"
                         }
                     }
                 }]]
@@ -162,7 +196,9 @@ passed
                 ngx.HTTP_PUT,
                 [[{
                     "plugins": {
-                        "wolf-rbac": {}
+                        "wolf-rbac": {
+                            "server": "http://127.0.0.1:1982"
+                        }
                     },
                     "upstream": {
                         "nodes": {
@@ -577,8 +613,7 @@ ERR_TOKEN_INVALID
                     "username": "wolf_rbac_unit_test",
                     "plugins": {
                         "wolf-rbac": {
-                            "appid": "$secret://vault/test1/wolf_rbac_unit_test/appid",
-                            "server": "http://127.0.0.1:1982"
+                            "appid": "$secret://vault/test1/wolf_rbac_unit_test/appid"
                         }
                     }
                 }]]
@@ -648,8 +683,7 @@ Success! Data written to: kv/apisix/wolf_rbac_unit_test
                     "username": "wolf_rbac_unit_test",
                     "plugins": {
                         "wolf-rbac": {
-                            "appid": "$secret://vault/test1/wolf_rbac_unit_test/appid",
-                            "server": "http://127.0.0.1:1982"
+                            "appid": "$secret://vault/test1/wolf_rbac_unit_test/appid"
                         }
                     }
                 }]]
@@ -697,8 +731,7 @@ passed
                     "username": "wolf_rbac_with_other_plugins",
                     "plugins": {
                         "wolf-rbac": {
-                            "appid": "wolf-rbac-app",
-                            "server": "http://127.0.0.1:1982"
+                            "appid": "wolf-rbac-app"
                         },
                         "echo": {
                             "body": "consumer merge echo plugins\n"
@@ -755,13 +788,13 @@ consumer merge echo plugins
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/consumers',
+            local code, body = t('/apisix/admin/routes/wolf-login',
                 ngx.HTTP_PUT,
                 [[{
-                    "username": "wolf_rbac_ssl_verify_false",
+                    "uri": "/apisix/plugin/wolf-rbac/login",
                     "plugins": {
+                        "public-api": {},
                         "wolf-rbac": {
-                            "appid": "wolf-rbac-app",
                             "server": "http://127.0.0.1:1982",
                             "ssl_verify": false
                         }
@@ -809,13 +842,13 @@ ssl_verify: false
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
-            local code, body = t('/apisix/admin/consumers',
+            local code, body = t('/apisix/admin/routes/wolf-login',
                 ngx.HTTP_PUT,
                 [[{
-                    "username": "wolf_rbac_ssl_verify_true",
+                    "uri": "/apisix/plugin/wolf-rbac/login",
                     "plugins": {
+                        "public-api": {},
                         "wolf-rbac": {
-                            "appid": "wolf-rbac-app",
                             "server": "http://127.0.0.1:1982",
                             "ssl_verify": true
                         }
@@ -904,8 +937,7 @@ wolf_rbac_access_check clientIP: 192.0.2.10
                     "username": "wolf_rbac_no_echo",
                     "plugins": {
                         "wolf-rbac": {
-                            "appid": "wolf-rbac-app-noecho",
-                            "server": "http://127.0.0.1:1982"
+                            "appid": "wolf-rbac-app-noecho"
                         }
                     }
                 }]]
@@ -920,7 +952,9 @@ wolf_rbac_access_check clientIP: 192.0.2.10
                 ngx.HTTP_PUT,
                 [[{
                     "plugins": {
-                        "wolf-rbac": {},
+                        "wolf-rbac": {
+                            "server": "http://127.0.0.1:1982"
+                        },
                         "serverless-post-function": {
                             "phase": "access",
                             "functions": [

--- a/t/plugin/wolf-rbac.t
+++ b/t/plugin/wolf-rbac.t
@@ -86,7 +86,7 @@ done
 
 
 
-=== TEST 2b: appid is required in Consumer configuration
+=== TEST 3b: appid is required in Consumer configuration
 --- config
     location /t {
         content_by_lua_block {
@@ -103,7 +103,7 @@ qr/property "appid" is required/
 
 
 
-=== TEST 3: setup public API route
+=== TEST 4: setup public API route
 --- config
     location /t {
         content_by_lua_block {
@@ -159,7 +159,7 @@ qr/property "appid" is required/
 
 
 
-=== TEST 4: add consumer with username and plugins
+=== TEST 5: add consumer with username and plugins
 --- config
     location /t {
         content_by_lua_block {
@@ -187,7 +187,7 @@ passed
 
 
 
-=== TEST 5: enable wolf rbac plugin using admin api
+=== TEST 6: enable wolf rbac plugin using admin api
 --- config
     location /t {
         content_by_lua_block {
@@ -221,7 +221,7 @@ passed
 
 
 
-=== TEST 6: login failed, appid is missing
+=== TEST 7: login failed, appid is missing
 --- request
 POST /apisix/plugin/wolf-rbac/login
 username=admin&password=123456
@@ -233,7 +233,7 @@ qr/appid is missing/
 
 
 
-=== TEST 7: login failed, appid not found
+=== TEST 8: login failed, appid not found
 --- request
 POST /apisix/plugin/wolf-rbac/login
 appid=not-found&username=admin&password=123456
@@ -245,7 +245,7 @@ qr/appid not found/
 
 
 
-=== TEST 8: login failed, username missing
+=== TEST 9: login failed, username missing
 --- request
 POST /apisix/plugin/wolf-rbac/login
 appid=wolf-rbac-app&password=123456
@@ -261,7 +261,7 @@ qr/ERR_USERNAME_MISSING/
 
 
 
-=== TEST 9: login failed, password missing
+=== TEST 10: login failed, password missing
 --- request
 POST /apisix/plugin/wolf-rbac/login
 appid=wolf-rbac-app&username=admin
@@ -277,7 +277,7 @@ qr/ERR_PASSWORD_MISSING/
 
 
 
-=== TEST 10: login failed, username not found
+=== TEST 11: login failed, username not found
 --- request
 POST /apisix/plugin/wolf-rbac/login
 appid=wolf-rbac-app&username=not-found&password=123456
@@ -293,7 +293,7 @@ qr/ERR_USER_NOT_FOUND/
 
 
 
-=== TEST 11: login failed, wrong password
+=== TEST 12: login failed, wrong password
 --- request
 POST /apisix/plugin/wolf-rbac/login
 appid=wolf-rbac-app&username=admin&password=wrong-password
@@ -309,7 +309,7 @@ qr/ERR_PASSWORD_ERROR/
 
 
 
-=== TEST 12: login successfully
+=== TEST 13: login successfully
 --- config
     location /t {
         content_by_lua_block {
@@ -330,7 +330,7 @@ qr/ERR_PASSWORD_ERROR/
 
 
 
-=== TEST 13: verify, missing token
+=== TEST 14: verify, missing token
 --- request
 GET /hello
 --- error_code: 401
@@ -339,7 +339,7 @@ GET /hello
 
 
 
-=== TEST 14: verify: invalid rbac token
+=== TEST 15: verify: invalid rbac token
 --- request
 GET /hello
 --- error_code: 401
@@ -350,7 +350,7 @@ x-rbac-token: invalid-rbac-token
 
 
 
-=== TEST 15: verify: invalid appid in rbac token
+=== TEST 16: verify: invalid appid in rbac token
 --- request
 GET /hello
 --- error_code: 401
@@ -363,7 +363,7 @@ consumer [invalid-appid] not found
 
 
 
-=== TEST 16: verify: failed
+=== TEST 17: verify: failed
 --- request
 GET /hello1
 --- error_code: 403
@@ -379,7 +379,7 @@ ERR_ACCESS_DENIED
 
 
 
-=== TEST 17: verify (in argument)
+=== TEST 18: verify (in argument)
 --- request
 GET /hello?rbac_token=V1%23wolf-rbac-app%23wolf-rbac-token
 --- response_headers
@@ -391,7 +391,7 @@ hello world
 
 
 
-=== TEST 18: verify (in header Authorization)
+=== TEST 19: verify (in header Authorization)
 --- request
 GET /hello
 --- more_headers
@@ -405,7 +405,7 @@ hello world
 
 
 
-=== TEST 19: verify (in header x-rbac-token)
+=== TEST 20: verify (in header x-rbac-token)
 --- request
 GET /hello
 --- more_headers
@@ -419,7 +419,7 @@ hello world
 
 
 
-=== TEST 20: verify (in cookie)
+=== TEST 21: verify (in cookie)
 --- request
 GET /hello
 --- more_headers
@@ -433,7 +433,7 @@ hello world
 
 
 
-=== TEST 21: get userinfo failed, missing token
+=== TEST 22: get userinfo failed, missing token
 --- request
 GET /apisix/plugin/wolf-rbac/user_info
 --- error_code: 401
@@ -442,7 +442,7 @@ GET /apisix/plugin/wolf-rbac/user_info
 
 
 
-=== TEST 22: get userinfo failed, invalid rbac token
+=== TEST 23: get userinfo failed, invalid rbac token
 --- request
 GET /apisix/plugin/wolf-rbac/user_info
 --- error_code: 401
@@ -453,7 +453,7 @@ x-rbac-token: invalid-rbac-token
 
 
 
-=== TEST 23: get userinfo
+=== TEST 24: get userinfo
 --- config
     location /t {
         content_by_lua_block {
@@ -472,7 +472,7 @@ x-rbac-token: invalid-rbac-token
 
 
 
-=== TEST 24: change password failed, old password incorrect
+=== TEST 25: change password failed, old password incorrect
 --- request
 PUT /apisix/plugin/wolf-rbac/change_pwd
 {"oldPassword": "error", "newPassword": "abcdef"}
@@ -489,7 +489,7 @@ qr/ERR_OLD_PASSWORD_INCORRECT/
 
 
 
-=== TEST 25: change password
+=== TEST 26: change password
 --- request
 PUT /apisix/plugin/wolf-rbac/change_pwd
 {"oldPassword":"123456", "newPassword": "abcdef"}
@@ -502,7 +502,7 @@ qr/success to change password/
 
 
 
-=== TEST 26: custom headers in request headers
+=== TEST 27: custom headers in request headers
 --- request
 GET /wolf/rbac/custom/headers?rbac_token=V1%23wolf-rbac-app%23wolf-rbac-token
 --- response_headers
@@ -514,7 +514,7 @@ id:100,username:admin,nickname:administrator
 
 
 
-=== TEST 27: change password by post raw args
+=== TEST 28: change password by post raw args
 --- request
 PUT /apisix/plugin/wolf-rbac/change_pwd
 oldPassword=123456&newPassword=abcdef
@@ -526,7 +526,7 @@ qr/success to change password/
 
 
 
-=== TEST 28: change password by post raw args, greater than 100 args is ok
+=== TEST 29: change password by post raw args, greater than 100 args is ok
 --- config
 location /t {
     content_by_lua_block {
@@ -555,7 +555,7 @@ qr/success to change password/
 
 
 
-=== TEST 29: verify: failed, server internal error
+=== TEST 30: verify: failed, server internal error
 --- request
 GET /hello/500
 --- error_code: 500
@@ -571,7 +571,7 @@ request to wolf-server failed, status:500
 
 
 
-=== TEST 30: verify: failed, token is expired
+=== TEST 31: verify: failed, token is expired
 --- request
 GET /hello/401
 --- error_code: 401
@@ -587,7 +587,7 @@ ERR_TOKEN_INVALID
 
 
 
-=== TEST 31: set hmac-auth conf: appid uses secret ref
+=== TEST 32: set hmac-auth conf: appid uses secret ref
 --- config
     location /t {
         content_by_lua_block {
@@ -630,7 +630,7 @@ passed
 
 
 
-=== TEST 32: store secret into vault
+=== TEST 33: store secret into vault
 --- exec
 VAULT_TOKEN='root' VAULT_ADDR='http://0.0.0.0:8200' vault kv put kv/apisix/wolf_rbac_unit_test appid=wolf-rbac-app
 --- response_body
@@ -638,7 +638,7 @@ Success! Data written to: kv/apisix/wolf_rbac_unit_test
 
 
 
-=== TEST 33: login successfully
+=== TEST 34: login successfully
 --- config
     location /t {
         content_by_lua_block {
@@ -659,7 +659,7 @@ Success! Data written to: kv/apisix/wolf_rbac_unit_test
 
 
 
-=== TEST 34: set hmac-auth conf with the token in an env var: appid uses secret ref
+=== TEST 35: set hmac-auth conf with the token in an env var: appid uses secret ref
 --- config
     location /t {
         content_by_lua_block {
@@ -699,7 +699,7 @@ passed
 
 
 
-=== TEST 35: login successfully
+=== TEST 36: login successfully
 --- config
     location /t {
         content_by_lua_block {
@@ -720,7 +720,7 @@ passed
 
 
 
-=== TEST 36: add consumer with echo plugin
+=== TEST 37: add consumer with echo plugin
 --- config
     location /t {
         content_by_lua_block {
@@ -753,7 +753,7 @@ passed
 
 
 
-=== TEST 37: verify echo plugin in consumer
+=== TEST 38: verify echo plugin in consumer
 --- request
 GET /hello
 --- more_headers
@@ -769,7 +769,7 @@ consumer merge echo plugins
 
 
 
-=== TEST 38: ssl_verify=false is passed through to HTTP client
+=== TEST 39: ssl_verify=false is passed through to HTTP client
 --- extra_init_by_lua
     local http = require("resty.http")
     local old_new = http.new
@@ -823,7 +823,7 @@ ssl_verify: false
 
 
 
-=== TEST 39: ssl_verify=true is passed through to HTTP client
+=== TEST 40: ssl_verify=true is passed through to HTTP client
 --- extra_init_by_lua
     local http = require("resty.http")
     local old_new = http.new
@@ -875,7 +875,7 @@ ssl_verify: true
 
 
 
-=== TEST 40: ssl_verify rejects non-boolean value
+=== TEST 41: ssl_verify rejects non-boolean value
 --- config
     location /t {
         content_by_lua_block {
@@ -896,7 +896,7 @@ qr/ssl_verify/
 
 
 
-=== TEST 41: clientIP forwarded from trusted X-Real-IP source
+=== TEST 42: clientIP forwarded from trusted X-Real-IP source
 --- http_config
 real_ip_header X-Real-IP;
 set_real_ip_from 127.0.0.1;
@@ -910,7 +910,7 @@ wolf_rbac_access_check clientIP: 192.0.2.10
 
 
 
-=== TEST 42: spoofed X-Real-IP from untrusted source is ignored
+=== TEST 43: spoofed X-Real-IP from untrusted source is ignored
 --- http_config
 real_ip_header X-Real-IP;
 set_real_ip_from 192.0.2.1;
@@ -926,7 +926,7 @@ wolf_rbac_access_check clientIP: 192.0.2.10
 
 
 
-=== TEST 43: consumer and route that echo upstream-bound request headers
+=== TEST 44: consumer and route that echo upstream-bound request headers
 --- config
     location /t {
         content_by_lua_block {
@@ -983,7 +983,7 @@ passed
 
 
 
-=== TEST 44: client-supplied identity headers dropped when auth response omits userInfo
+=== TEST 45: client-supplied identity headers dropped when auth response omits userInfo
 --- request
 GET /hello/no_userinfo
 --- more_headers


### PR DESCRIPTION
### Description

`wolf-rbac` currently mixes Wolf connection/output settings with Consumer identity. This makes Route behavior depend on Consumer configuration that is unavailable before a Consumer is matched.

This PR:

- keeps only required `appid` in Consumer configuration
- moves `server`, `header_prefix`, and `ssl_verify` to Route/Service configuration
- clears the Route header namespace before authentication and sets it only after Wolf succeeds
- updates public API routes and documentation

This is a breaking schema change.

#### Migration

Before upgrading, move `server`, `header_prefix`, and `ssl_verify` from each Consumer to every Route/Service using `wolf-rbac`; leave only `appid` on the Consumer. If Consumers used different values on one Route, split or standardize those settings. Routes exposing Wolf APIs must configure both `public-api` and `wolf-rbac`.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (this is an intentional breaking schema cleanup)