### PR TITLE
docs: clarify opentelemetry plugin enablement

### DIFF
--- a/docs/en/latest/plugins/opentelemetry.md
+++ b/docs/en/latest/plugins/opentelemetry.md
@@ -36,11 +36,15 @@ The `opentelemetry` Plugin can be used to report tracing data according to the [
 
 The Plugin only supports binary-encoded [OTLP over HTTP](https://opentelemetry.io/docs/reference/specification/protocol/otlp/#otlphttp).
 
+## Enable `opentelemetry` Plugin
+
+The `opentelemetry` Plugin is disabled by default. In `conf/config.yaml`, keep the complete list of Plugins used by your deployment and add `opentelemetry`. If you are starting from `conf/config.yaml.example`, uncomment the existing `opentelemetry` entry.
+
+Reload APISIX for the change to take effect.
+
 ## Configurations
 
-By default, configurations of the Service name, tenant ID, collector, and batch span processor are pre-configured in [default configuration](https://github.com/apache/apisix/blob/master/apisix/cli/config.lua).
-
-You can change this configuration of the Plugin through the endpoint `apisix/admin/plugin_metadata/opentelemetry` For example:
+The `opentelemetry` Plugin reads its plugin-level settings from Plugin Metadata. Configure the metadata through the endpoint `/apisix/admin/plugin_metadata/opentelemetry`. For example:
 
 :::note
 You can fetch the `admin_key` from `config.yaml` and save to an environment variable with the following command:
@@ -109,18 +113,6 @@ To enable comprehensive tracing across the request lifecycle (SSL/SNI, rewrite/a
 apisix:
   tracing: true
 ```
-
-### Enable `opentelemetry` Plugin
-
-By default, the `opentelemetry` Plugin is disabled in APISIX. To enable, add the Plugin to your configuration file as such:
-
-```yaml title="config.yaml"
-plugins:
-  - ...
-  - opentelemetry
-```
-
-Reload APISIX for changes to take effect.
 
 ### Send Traces to OpenTelemetry
 

--- a/docs/zh/latest/plugins/opentelemetry.md
+++ b/docs/zh/latest/plugins/opentelemetry.md
@@ -35,11 +35,15 @@ description: opentelemetry 插件可用于根据 OpenTelemetry 协议规范上�
 
 `opentelemetry` 插件可用于根据 [OpenTelemetry Specification](https://opentelemetry.io/docs/reference/specification/) 协议规范上报 Traces 数据。该插件仅支持二进制编码的 OTLP over HTTP，即请求类型为 `application/x-protobuf` 的数据上报。
 
+## 启用 opentelemetry 插件
+
+`opentelemetry` 插件默认处于禁用状态。在 `conf/config.yaml` 中保留部署使用的完整插件列表，并添加 `opentelemetry`。如果以 `conf/config.yaml.example` 为基础配置 APISIX，请取消注释已有的 `opentelemetry` 条目。
+
+重新加载 APISIX 以使更改生效。
+
 ## 配置
 
-默认情况下，服务名称、租户 ID、collector 和 batch span processor 的配置已预配置在[默认配置](https://github.com/apache/apisix/blob/master/apisix/cli/config.lua)中。
-
-你可以通过端点 `apisix/admin/plugin_metadata/opentelemetry` 更改插件的配置，例如：
+`opentelemetry` 插件从插件元数据中读取插件级配置。通过端点 `/apisix/admin/plugin_metadata/opentelemetry` 配置插件元数据，例如：
 
 :::note
 你可以从 `config.yaml` 中获取 `admin_key` 并存入环境变量：
@@ -108,18 +112,6 @@ curl http://127.0.0.1:9180/apisix/admin/plugin_metadata/opentelemetry -H "X-API-
 apisix:
   tracing: true
 ```
-
-### 启用 opentelemetry 插件
-
-默认情况下，APISIX 中的 `opentelemetry` 插件是禁用的。要启用它，请将插件添加到配置文件中，如下所示：
-
-```yaml title="config.yaml"
-plugins:
-  - ...
-  - opentelemetry
-```
-
-重新加载 APISIX 以使更改生效。
 
 ### 将 Traces 上报到 OpenTelemetry
 


### PR DESCRIPTION
### Description

The OpenTelemetry documentation previously explained Plugin Metadata before telling readers that the Plugin is disabled by default. This could lead users to configure metadata without loading the Plugin.

This PR:

- moves the enablement section before Plugin Metadata configuration
- tells readers to preserve the complete plugins list when enabling OpenTelemetry
- removes the literal ellipsis list entry from the YAML example
- replaces a stale statement about default settings and tenant ID with the current Plugin Metadata behavior
- applies the same changes to the English and Chinese documentation

Related to #13925.

### Validation

- npx --yes markdownlint-cli@0.25.0 docs/en/latest/plugins/opentelemetry.md docs/zh/latest/plugins/opentelemetry.md
- ./utils/fix-zh-doc-segment.py
- git diff --check

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes in this PR
- [x] I have updated both English and Chinese documentation
- [x] I have verified that this documentation-only change is backward compatible